### PR TITLE
Deduplicate entity trigger and condition tests

### DIFF
--- a/tests/components/air_quality/test_condition.py
+++ b/tests/components/air_quality/test_condition.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.air_quality.condition import CONDITIONS
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -17,9 +18,11 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     assert_numerical_condition_unit_conversion,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -69,6 +72,29 @@ _UGM3_THRESHOLD = {
 }
 
 
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_gas_detected": TargetSupport.STANDARD,
+    "is_gas_cleared": TargetSupport.STANDARD,
+    "is_co_detected": TargetSupport.STANDARD,
+    "is_co_cleared": TargetSupport.STANDARD,
+    "is_smoke_detected": TargetSupport.STANDARD,
+    "is_smoke_cleared": TargetSupport.STANDARD,
+    "is_co_value": TargetSupport.STANDARD,
+    "is_ozone_value": TargetSupport.STANDARD,
+    "is_voc_value": TargetSupport.STANDARD,
+    "is_voc_ratio_value": TargetSupport.STANDARD,
+    "is_no_value": TargetSupport.STANDARD,
+    "is_no2_value": TargetSupport.STANDARD,
+    "is_so2_value": TargetSupport.STANDARD,
+    "is_co2_value": TargetSupport.STANDARD,
+    "is_pm1_value": TargetSupport.STANDARD,
+    "is_pm25_value": TargetSupport.STANDARD,
+    "is_pm4_value": TargetSupport.STANDARD,
+    "is_pm10_value": TargetSupport.STANDARD,
+    "is_n2o_value": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("condition_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -112,6 +138,11 @@ async def test_air_quality_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/air_quality/test_trigger.py
+++ b/tests/components/air_quality/test_trigger.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.air_quality.trigger import TRIGGERS
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
@@ -18,12 +19,14 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     arm_trigger,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_numerical_state_value_changed_trigger_states,
     parametrize_numerical_state_value_crossed_threshold_trigger_states,
     parametrize_target_entities,
@@ -69,6 +72,42 @@ _UGM3_CROSSED_THRESHOLD = {
             "unit_of_measurement": UnitOfDensity.MICROGRAMS_PER_CUBIC_METER,
         },
     }
+}
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "gas_detected": TargetSupport.STANDARD,
+    "gas_cleared": TargetSupport.STANDARD,
+    "co_detected": TargetSupport.STANDARD,
+    "co_cleared": TargetSupport.STANDARD,
+    "smoke_detected": TargetSupport.STANDARD,
+    "smoke_cleared": TargetSupport.STANDARD,
+    "co_changed": TargetSupport.STANDARD,
+    "co_crossed_threshold": TargetSupport.STANDARD,
+    "ozone_changed": TargetSupport.STANDARD,
+    "ozone_crossed_threshold": TargetSupport.STANDARD,
+    "voc_changed": TargetSupport.STANDARD,
+    "voc_crossed_threshold": TargetSupport.STANDARD,
+    "voc_ratio_changed": TargetSupport.STANDARD,
+    "voc_ratio_crossed_threshold": TargetSupport.STANDARD,
+    "no_changed": TargetSupport.STANDARD,
+    "no_crossed_threshold": TargetSupport.STANDARD,
+    "no2_changed": TargetSupport.STANDARD,
+    "no2_crossed_threshold": TargetSupport.STANDARD,
+    "so2_changed": TargetSupport.STANDARD,
+    "so2_crossed_threshold": TargetSupport.STANDARD,
+    "co2_changed": TargetSupport.STANDARD,
+    "co2_crossed_threshold": TargetSupport.STANDARD,
+    "pm1_changed": TargetSupport.STANDARD,
+    "pm1_crossed_threshold": TargetSupport.STANDARD,
+    "pm25_changed": TargetSupport.STANDARD,
+    "pm25_crossed_threshold": TargetSupport.STANDARD,
+    "pm4_changed": TargetSupport.STANDARD,
+    "pm4_crossed_threshold": TargetSupport.STANDARD,
+    "pm10_changed": TargetSupport.STANDARD,
+    "pm10_crossed_threshold": TargetSupport.STANDARD,
+    "n2o_changed": TargetSupport.STANDARD,
+    "n2o_crossed_threshold": TargetSupport.STANDARD,
 }
 
 
@@ -124,6 +163,11 @@ async def test_air_quality_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/alarm_control_panel/test_condition.py
+++ b/tests/components/alarm_control_panel/test_condition.py
@@ -8,14 +8,17 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntityFeature,
     AlarmControlPanelState,
 )
+from homeassistant.components.alarm_control_panel.condition import CONDITIONS
 from homeassistant.const import ATTR_SUPPORTED_FEATURES
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     other_states,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -28,6 +31,17 @@ from tests.components.common import (
 async def target_alarm_control_panels(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create alarm_control_panel entities for different targets."""
     return await target_entities(hass, "alarm_control_panel")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_armed": TargetSupport.STANDARD,
+    "is_armed_away": TargetSupport.STANDARD,
+    "is_armed_home": TargetSupport.STANDARD,
+    "is_armed_night": TargetSupport.STANDARD,
+    "is_armed_vacation": TargetSupport.STANDARD,
+    "is_disarmed": TargetSupport.STANDARD,
+    "is_triggered": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -57,6 +71,11 @@ async def test_alarm_control_panel_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/alarm_control_panel/test_trigger.py
+++ b/tests/components/alarm_control_panel/test_trigger.py
@@ -8,15 +8,18 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntityFeature,
     AlarmControlPanelState,
 )
+from homeassistant.components.alarm_control_panel.trigger import TRIGGERS
 from homeassistant.const import ATTR_SUPPORTED_FEATURES
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     other_states,
     parametrize_target_entities,
     parametrize_trigger_states,
@@ -28,6 +31,17 @@ from tests.components.common import (
 async def target_alarm_control_panels(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create alarm control panel entities for different targets."""
     return await target_entities(hass, "alarm_control_panel")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "armed": TargetSupport.STANDARD,
+    "armed_away": TargetSupport.STANDARD,
+    "armed_home": TargetSupport.STANDARD,
+    "armed_night": TargetSupport.STANDARD,
+    "armed_vacation": TargetSupport.STANDARD,
+    "disarmed": TargetSupport.STANDARD,
+    "triggered": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -57,6 +71,11 @@ async def test_alarm_control_panel_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/assist_satellite/test_condition.py
+++ b/tests/components/assist_satellite/test_condition.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.assist_satellite.condition import CONDITIONS
 from homeassistant.components.assist_satellite.entity import AssistSatelliteState
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     other_states,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -24,6 +27,14 @@ from tests.components.common import (
 async def target_assist_satellites(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple assist satellite entities associated with different targets."""
     return await target_entities(hass, "assist_satellite")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_idle": TargetSupport.STANDARD,
+    "is_listening": TargetSupport.STANDARD,
+    "is_processing": TargetSupport.STANDARD,
+    "is_responding": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -50,6 +61,11 @@ async def test_assist_satellite_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/assist_satellite/test_trigger.py
+++ b/tests/components/assist_satellite/test_trigger.py
@@ -5,14 +5,17 @@ from typing import Any
 import pytest
 
 from homeassistant.components.assist_satellite.entity import AssistSatelliteState
+from homeassistant.components.assist_satellite.trigger import TRIGGERS
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     other_states,
     parametrize_target_entities,
     parametrize_trigger_states,
@@ -24,6 +27,14 @@ from tests.components.common import (
 async def target_assist_satellites(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple assist satellite entities associated with different targets."""
     return await target_entities(hass, "assist_satellite")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "idle": TargetSupport.STANDARD,
+    "listening": TargetSupport.STANDARD,
+    "processing": TargetSupport.STANDARD,
+    "responding": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -50,6 +61,11 @@ async def test_assist_satellite_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/battery/test_condition.py
+++ b/tests/components/battery/test_condition.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.battery.condition import CONDITIONS
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -15,9 +16,11 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_numerical_condition_above_below_all,
@@ -48,6 +51,15 @@ async def target_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
 _LEVEL_THRESHOLD = {"threshold": {"type": "above", "value": {"number": 50}}}
 
 
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_low": TargetSupport.STANDARD,
+    "is_not_low": TargetSupport.STANDARD,
+    "is_charging": TargetSupport.STANDARD,
+    "is_not_charging": TargetSupport.STANDARD,
+    "is_level": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("condition_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -73,6 +85,11 @@ async def test_battery_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/battery/test_trigger.py
+++ b/tests/components/battery/test_trigger.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.battery.trigger import TRIGGERS
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -15,11 +16,13 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_numerical_state_value_changed_trigger_states,
     parametrize_numerical_state_value_crossed_threshold_trigger_states,
     parametrize_target_entities,
@@ -48,6 +51,16 @@ _LEVEL_CHANGED_THRESHOLD = {"threshold": {"type": "any"}}
 _LEVEL_CROSSED_THRESHOLD = {"threshold": {"type": "above", "value": {"number": 50}}}
 
 
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "became_low": TargetSupport.STANDARD,
+    "no_longer_low": TargetSupport.STANDARD,
+    "started_charging": TargetSupport.STANDARD,
+    "stopped_charging": TargetSupport.STANDARD,
+    "level_changed": TargetSupport.STANDARD,
+    "level_crossed_threshold": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -74,6 +87,11 @@ async def test_battery_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/button/test_trigger.py
+++ b/tests/components/button/test_trigger.py
@@ -4,13 +4,16 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.button.trigger import TRIGGERS
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     arm_trigger,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     set_or_remove_state,
     target_entities,
@@ -23,6 +26,11 @@ async def target_entities_indirect(
 ) -> dict[str, list[str]]:
     """Create multiple entities associated with different targets."""
     return await target_entities(hass, request.param)
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "pressed": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -46,6 +54,11 @@ async def test_button_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/calendar/test_condition.py
+++ b/tests/components/calendar/test_condition.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.calendar.condition import CONDITIONS
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_target_entities,
@@ -23,6 +26,11 @@ from tests.components.common import (
 async def target_calendars(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple calendar entities associated with different targets."""
     return await target_entities(hass, "calendar")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_event_active": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -46,6 +54,11 @@ async def test_calendar_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/climate/test_condition.py
+++ b/tests/components/climate/test_condition.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.climate.condition import CONDITIONS
 from homeassistant.components.climate.const import (
     ATTR_HUMIDITY,
     ATTR_HVAC_ACTION,
@@ -19,9 +20,11 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     assert_numerical_condition_unit_conversion,
     other_states,
     parametrize_condition_states_all,
@@ -45,6 +48,18 @@ _TEMPERATURE_THRESHOLD = {
         "type": "above",
         "value": {"number": 20, "unit_of_measurement": UnitOfTemperature.CELSIUS},
     }
+}
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_hvac_mode": TargetSupport.STANDARD,
+    "is_off": TargetSupport.STANDARD,
+    "is_on": TargetSupport.STANDARD,
+    "is_cooling": TargetSupport.STANDARD,
+    "is_drying": TargetSupport.STANDARD,
+    "is_heating": TargetSupport.STANDARD,
+    "is_target_humidity": TargetSupport.STANDARD,
+    "is_target_temperature": TargetSupport.STANDARD,
 }
 
 
@@ -76,6 +91,11 @@ async def test_climate_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/climate/test_trigger.py
+++ b/tests/components/climate/test_trigger.py
@@ -12,7 +12,7 @@ from homeassistant.components.climate.const import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.components.climate.trigger import CONF_HVAC_MODE
+from homeassistant.components.climate.trigger import CONF_HVAC_MODE, TRIGGERS
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_ENTITY_ID,
@@ -24,11 +24,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.trigger import async_validate_trigger_config
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     other_states,
     parametrize_numerical_attribute_changed_trigger_states,
     parametrize_numerical_attribute_crossed_threshold_trigger_states,
@@ -51,6 +53,20 @@ _TEMPERATURE_CROSSED_THRESHOLD = {
         "type": "above",
         "value": {"number": 20, "unit_of_measurement": UnitOfTemperature.CELSIUS},
     }
+}
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "hvac_mode_changed": TargetSupport.STANDARD,
+    "started_cooling": TargetSupport.STANDARD,
+    "started_drying": TargetSupport.STANDARD,
+    "target_humidity_changed": TargetSupport.STANDARD,
+    "target_humidity_crossed_threshold": TargetSupport.STANDARD,
+    "target_temperature_changed": TargetSupport.STANDARD,
+    "target_temperature_crossed_threshold": TargetSupport.STANDARD,
+    "turned_off": TargetSupport.STANDARD,
+    "turned_on": TargetSupport.STANDARD,
+    "started_heating": TargetSupport.STANDARD,
 }
 
 
@@ -94,6 +110,11 @@ async def test_climate_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/common.py
+++ b/tests/components/common.py
@@ -333,7 +333,7 @@ def _init_hygiene_violation(cls: type, key: str, config_cls_name: str) -> str | 
         # upstream would be a stronger, product-side fix.
         if re.search(r"config\.target\b\s*(?:\[[^\]]*\])?\s*=(?!=)", src):
             return f"{key}: __init__ must not assign to config.target"
-        return None
+        continue
     return None
 
 
@@ -347,7 +347,7 @@ def _entity_filter_hygiene_violation(cls: type, key: str) -> str | None:
         src = inspect.getsource(klass.entity_filter)
         if "super().entity_filter(" not in src:
             return f"{key}: entity_filter override must narrow the base result"
-        return None
+        continue
     return None
 
 

--- a/tests/components/common.py
+++ b/tests/components/common.py
@@ -3,18 +3,17 @@
 from collections.abc import Iterable
 import copy
 from enum import StrEnum
+import inspect
 import itertools
 import logging
 from pathlib import Path
+import re
 from typing import Any, TypedDict
 
 import pytest
 import voluptuous as vol
 
 from homeassistant.const import (
-    ATTR_AREA_ID,
-    ATTR_DEVICE_ID,
-    ATTR_FLOOR_ID,
     ATTR_LABEL_ID,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_CONDITION,
@@ -29,17 +28,22 @@ from homeassistant.const import (
 from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.helpers import (
     area_registry as ar,
+    config_validation as cv,
     device_registry as dr,
     entity_registry as er,
     floor_registry as fr,
     label_registry as lr,
 )
 from homeassistant.helpers.condition import (
+    Condition,
     ConditionCheckerTypeOptional,
+    EntityConditionBase,
     async_from_config as async_condition_from_config,
     async_validate_condition_config,
 )
 from homeassistant.helpers.trigger import (
+    EntityTriggerBase,
+    Trigger,
     async_initialize_triggers,
     async_validate_trigger_config,
 )
@@ -185,7 +189,31 @@ async def target_entities(
 def parametrize_target_entities(domain: str) -> list[tuple[dict, str, int]]:
     """Parametrize target entities for different target types.
 
-    Meant to be used with target_entities.
+    Meant to be used with target_entities. Each row is a
+    ``(target_config, entity_id, entities_in_target)`` triple.
+
+    Only two representative rows are kept:
+
+    - ``entity`` — a direct ``entity_id`` reference to two standalone entities.
+      This preserves the direct-reference resolution path (state-machine-only,
+      non-registry entities) and a guaranteed multi-entity target, so the
+      all/first/count behavior assertions stay non-vacuous.
+    - ``label-entity`` — a ``label_id`` reference that resolves to three
+      entities: the labeled entity directly and, via label->device expansion,
+      the device-attached entities. This preserves indirect resolution
+      end-to-end plus everything that only fires when excluded entities sit
+      inside the resolved target scope: in-scope cross-domain exclusion (E2),
+      in-scope device_class/feature-filter negatives (E3), and battery's
+      ``primary_entities_only=False`` flag, which only has an observable effect
+      when a categorized entity is reached through device expansion (E1).
+
+    The dropped rows (area, floor, device_id, and the label/area/floor rows
+    that drive the device-attached entity) only varied *how* a target config
+    resolves to an entity set. That resolution is domain-independent machinery
+    covered centrally by ``tests/helpers/test_target.py`` (area->entity,
+    floor->area, area/label/floor->device, direct device incl. child devices,
+    and the ``primary_entities_only`` category asymmetry), so re-exercising it
+    per domain was pure duplication.
     """
     return [
         (
@@ -199,13 +227,267 @@ def parametrize_target_entities(domain: str) -> list[tuple[dict, str, int]]:
             2,
         ),
         ({ATTR_LABEL_ID: "test_label"}, f"{domain}.label_{domain}", 3),
-        ({ATTR_AREA_ID: "test_area"}, f"{domain}.area_{domain}", 3),
-        ({ATTR_FLOOR_ID: "test_floor"}, f"{domain}.area_{domain}", 3),
-        ({ATTR_LABEL_ID: "test_label"}, f"{domain}.device_{domain}", 3),
-        ({ATTR_AREA_ID: "test_area"}, f"{domain}.device_{domain}", 3),
-        ({ATTR_FLOOR_ID: "test_floor"}, f"{domain}.device_{domain}", 3),
-        ({ATTR_DEVICE_ID: "test_device"}, f"{domain}.device_{domain}", 2),
     ]
+
+
+class TargetSupport(StrEnum):
+    """Declared level of user-target support for a registered trigger/condition."""
+
+    # Supports a user target via the shared entity base-class machinery: fully
+    # certified (subclasses the entity base, inherits the target machinery
+    # unmodified, carries the `target: cv.TARGET_FIELDS` slot, and passes
+    # init/entity_filter hygiene).
+    STANDARD = "standard"
+    # Does not support a user target (synthesized or absent); asserted to expose
+    # no `target` schema slot.
+    NONE = "none"
+    # Supports a user target but resolves it with its own machinery; only a
+    # `target: cv.TARGET_FIELDS` slot is asserted, and the machinery/entity-base
+    # checks are skipped (its own dedicated tests cover resolution correctness).
+    CUSTOM = "custom"
+
+
+# Target-resolution machinery a target-supporting trigger/condition class must
+# inherit unchanged from its entity base class. ``entity_filter`` is intentionally
+# absent: it runs inside the resolution choke point on the already-resolved entity
+# set, so an override that narrows the base result is allowed and is checked
+# separately by _entity_filter_hygiene_violation.
+_TRIGGER_TARGET_MACHINERY = frozenset(
+    {
+        "async_validate_complete_config",
+        "async_validate_config",
+        "async_attach_action",
+        "async_attach_runner",
+        "count_matches",
+        "_cancel_invalidated_timers",
+        "_combined_state_still_valid",
+    }
+)
+_CONDITION_TARGET_MACHINERY = frozenset(
+    {
+        "async_validate_complete_config",
+        "async_validate_config",
+        "async_check",
+        "async_unload",
+        "_async_unload",
+        "_async_setup",
+        "_async_check",
+        "_check_any_match_state",
+        "_check_all_match_state",
+        "_async_on_entities_update",
+        "_async_prime_valid_since",
+        "_async_refine_anchors_from_history",
+        "_valid_since_from_history",
+        "_update_valid_since",
+    }
+)
+_TARGET_HELPER_MODULES = frozenset(
+    {"homeassistant.helpers.trigger", "homeassistant.helpers.condition"}
+)
+
+
+def _foreign_names(cls: type) -> set[str]:
+    """Return names defined by MRO classes outside the trigger/condition helpers."""
+    names: set[str] = set()
+    for klass in cls.__mro__:
+        if klass.__module__ in _TARGET_HELPER_MODULES:
+            continue
+        names.update(vars(klass))
+    return names
+
+
+def _target_slot_validator(cls: type) -> object | None:
+    """Return the ``target`` schema validator for a class, or None if it has none.
+
+    A class exposes a user-configurable target iff its ``_schema`` carries a
+    ``target`` marker. Bespoke or synthesized-target classes (e.g. zone.occupancy_*
+    or the legacy ``_`` platforms) have no such marker.
+    """
+    mapping = getattr(getattr(cls, "_schema", None), "schema", None)
+    if not isinstance(mapping, dict):
+        return None
+    for marker, validator in mapping.items():
+        if str(marker) == "target":
+            return validator
+    return None
+
+
+def _init_hygiene_violation(cls: type, key: str, config_cls_name: str) -> str | None:
+    """Return an error if an __init__ override rewrites the config or target."""
+    for klass in cls.__mro__:
+        if klass.__module__ in _TARGET_HELPER_MODULES:
+            return None
+        if "__init__" not in vars(klass):
+            continue
+        src = inspect.getsource(klass.__init__)
+        if "super().__init__(hass, config)" not in src:
+            return f"{key}: __init__ must delegate the unmodified config to super()"
+        if re.search(r"self\._target\b\s*=", src):
+            return f"{key}: __init__ must not assign self._target"
+        if f"{config_cls_name}(" in src or "replace(config" in src:
+            return f"{key}: __init__ must not rebuild the config object"
+        # ConditionConfig is @dataclass(slots=True) but NOT frozen (unlike
+        # TriggerConfig), so a mutation would rewrite the user target at runtime
+        # while passing the checks above. The (?!=) excludes the `==` comparison
+        # and the optional subscript excludes reads. Freezing ConditionConfig
+        # upstream would be a stronger, product-side fix.
+        if re.search(r"config\.target\b\s*(?:\[[^\]]*\])?\s*=(?!=)", src):
+            return f"{key}: __init__ must not assign to config.target"
+        return None
+    return None
+
+
+def _entity_filter_hygiene_violation(cls: type, key: str) -> str | None:
+    """Return an error if an entity_filter override does not narrow the base."""
+    for klass in cls.__mro__:
+        if klass.__module__ in _TARGET_HELPER_MODULES:
+            return None
+        if "entity_filter" not in vars(klass):
+            continue
+        src = inspect.getsource(klass.entity_filter)
+        if "super().entity_filter(" not in src:
+            return f"{key}: entity_filter override must narrow the base result"
+        return None
+    return None
+
+
+def _target_supporting_violations(
+    cls: type,
+    key: str,
+    *,
+    entity_base: type,
+    machinery: frozenset[str],
+    config_cls: str,
+) -> list[str]:
+    """Return violations for a class declared to support a user target."""
+    if not issubclass(cls, entity_base):
+        return [
+            f"{key} ({cls.__name__}): declared target-supporting but does not "
+            f"subclass {entity_base.__name__}"
+        ]
+    violations: list[str] = []
+    overridden = _foreign_names(cls) & machinery
+    if overridden:
+        violations.append(
+            f"{key} overrides target machinery {sorted(overridden)}; it no longer "
+            "inherits the shared target resolution"
+        )
+    if _target_slot_validator(cls) is not cv.TARGET_FIELDS:
+        violations.append(
+            f"{key}: schema does not carry the standard `target: cv.TARGET_FIELDS` slot"
+        )
+    violations.extend(
+        violation
+        for violation in (
+            _init_hygiene_violation(cls, key, config_cls),
+            _entity_filter_hygiene_violation(cls, key),
+        )
+        if violation is not None
+    )
+    return violations
+
+
+def _assert_target_support(
+    registry: dict[str, type],
+    declaration: dict[str, TargetSupport],
+    *,
+    entity_base: type,
+    machinery: frozenset[str],
+    config_cls: str,
+    kind: str,
+) -> None:
+    """Certify one registry against its ``key -> TargetSupport`` declaration."""
+    missing = set(registry) - set(declaration)
+    extra = set(declaration) - set(registry)
+    assert not missing, (
+        f"{kind}s registered but not declared: {sorted(missing)} -- add them to the "
+        "target-support declaration"
+    )
+    assert not extra, (
+        f"{kind}s declared but not registered: {sorted(extra)} -- remove them from "
+        "the target-support declaration"
+    )
+
+    violations: list[str] = []
+    for key in sorted(registry):
+        cls = registry[key]
+        support = declaration[key]
+        if support is TargetSupport.STANDARD:
+            violations.extend(
+                _target_supporting_violations(
+                    cls,
+                    key,
+                    entity_base=entity_base,
+                    machinery=machinery,
+                    config_cls=config_cls,
+                )
+            )
+        elif support is TargetSupport.NONE:
+            if _target_slot_validator(cls) is not None:
+                violations.append(
+                    f"{key}: declared TargetSupport.NONE, but its schema exposes a "
+                    "`target` slot"
+                )
+        elif support is TargetSupport.CUSTOM:
+            # Custom-machinery target: only require that a user target slot
+            # exists; the class's own tests cover resolution correctness. The
+            # standard machinery/entity-base checks are intentionally skipped,
+            # and this state must be opted into explicitly -- a class declared
+            # STANDARD that forgot to subclass the entity base still fails above.
+            if _target_slot_validator(cls) is not cv.TARGET_FIELDS:
+                violations.append(
+                    f"{key}: declared TargetSupport.CUSTOM but its schema does not "
+                    "carry a `target: cv.TARGET_FIELDS` slot"
+                )
+        else:
+            violations.append(
+                f"{key}: invalid target-support declaration value {support!r}; use a "
+                "TargetSupport member"
+            )
+    assert not violations, f"{kind} target-support violations:\n" + "\n".join(
+        violations
+    )
+
+
+def assert_triggers_target_support(
+    registry: dict[str, type[Trigger]], declaration: dict[str, TargetSupport]
+) -> None:
+    """Certify a domain's trigger registry against its target-support declaration.
+
+    ``declaration`` maps every registered trigger key to a ``TargetSupport`` member:
+    ``STANDARD`` (inherits the shared target-resolution machinery unmodified, so the
+    collapsed two-row target axis still certifies it), ``NONE`` (exposes no
+    ``target`` schema slot -- bespoke or synthesized target, e.g. zone.occupancy_*),
+    or ``CUSTOM`` (exposes a ``target`` slot but resolves it with its own machinery,
+    e.g. timer.remaining_time_reached). Battery's ``primary_entities_only=False`` is
+    intentionally not pinned here -- its behavior tests with DIAGNOSTIC fixtures
+    already fail loudly on a silent flip.
+    """
+    _assert_target_support(
+        registry,
+        declaration,
+        entity_base=EntityTriggerBase,
+        machinery=_TRIGGER_TARGET_MACHINERY,
+        config_cls="TriggerConfig",
+        kind="trigger",
+    )
+
+
+def assert_conditions_target_support(
+    registry: dict[str, type[Condition]], declaration: dict[str, TargetSupport]
+) -> None:
+    """Certify a domain's condition registry against its target-support declaration.
+
+    See assert_triggers_target_support; the same contract on the condition base.
+    """
+    _assert_target_support(
+        registry,
+        declaration,
+        entity_base=EntityConditionBase,
+        machinery=_CONDITION_TARGET_MACHINERY,
+        config_cls="ConditionConfig",
+        kind="condition",
+    )
 
 
 class StateDescription(TypedDict):

--- a/tests/components/counter/test_condition.py
+++ b/tests/components/counter/test_condition.py
@@ -4,13 +4,16 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.counter.condition import CONDITIONS
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_target_entities,
@@ -25,6 +28,11 @@ async def target_counters(hass: HomeAssistant) -> dict[str, list[str]]:
 
 
 _PLAIN_THRESHOLD = {"threshold": {"type": "above", "value": {"number": 50}}}
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_value": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +56,11 @@ async def test_counter_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/counter/test_trigger.py
+++ b/tests/components/counter/test_trigger.py
@@ -10,17 +10,20 @@ from homeassistant.components.counter import (
     CONF_MINIMUM,
     DOMAIN,
 )
+from homeassistant.components.counter.trigger import TRIGGERS
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     BasicTriggerStateDescription,
+    TargetSupport,
     TriggerStateDescription,
     arm_trigger,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     set_or_remove_state,
@@ -52,6 +55,15 @@ async def target_counters(hass: HomeAssistant) -> dict[str, list[str]]:
     return await target_entities(hass, DOMAIN)
 
 
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "decremented": TargetSupport.STANDARD,
+    "incremented": TargetSupport.STANDARD,
+    "maximum_reached": TargetSupport.STANDARD,
+    "minimum_reached": TargetSupport.STANDARD,
+    "reset": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -77,6 +89,11 @@ async def test_counter_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/cover/test_condition.py
+++ b/tests/components/cover/test_condition.py
@@ -5,14 +5,17 @@ from typing import Any
 import pytest
 
 from homeassistant.components.cover import ATTR_IS_CLOSED, CoverState
+from homeassistant.components.cover.condition import CONDITIONS
 from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     create_target_condition,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -33,6 +36,20 @@ DEVICE_CLASS_CONDITIONS = [
 async def target_covers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple cover entities associated with different targets."""
     return await target_entities(hass, "cover")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "awning_is_closed": TargetSupport.STANDARD,
+    "awning_is_open": TargetSupport.STANDARD,
+    "blind_is_closed": TargetSupport.STANDARD,
+    "blind_is_open": TargetSupport.STANDARD,
+    "curtain_is_closed": TargetSupport.STANDARD,
+    "curtain_is_open": TargetSupport.STANDARD,
+    "shade_is_closed": TargetSupport.STANDARD,
+    "shade_is_open": TargetSupport.STANDARD,
+    "shutter_is_closed": TargetSupport.STANDARD,
+    "shutter_is_open": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -65,6 +82,11 @@ async def test_cover_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/cover/test_trigger.py
+++ b/tests/components/cover/test_trigger.py
@@ -5,15 +5,18 @@ from typing import Any
 import pytest
 
 from homeassistant.components.cover import ATTR_IS_CLOSED, CoverDeviceClass, CoverState
+from homeassistant.components.cover.trigger import TRIGGERS
 from homeassistant.const import ATTR_DEVICE_CLASS
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -32,6 +35,20 @@ DEVICE_CLASS_TRIGGERS = [
 async def target_covers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple cover entities associated with different targets."""
     return await target_entities(hass, "cover")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "awning_opened": TargetSupport.STANDARD,
+    "awning_closed": TargetSupport.STANDARD,
+    "blind_opened": TargetSupport.STANDARD,
+    "blind_closed": TargetSupport.STANDARD,
+    "curtain_opened": TargetSupport.STANDARD,
+    "curtain_closed": TargetSupport.STANDARD,
+    "shade_opened": TargetSupport.STANDARD,
+    "shade_closed": TargetSupport.STANDARD,
+    "shutter_opened": TargetSupport.STANDARD,
+    "shutter_closed": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -64,6 +81,11 @@ async def test_cover_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/door/test_condition.py
+++ b/tests/components/door/test_condition.py
@@ -5,14 +5,17 @@ from typing import Any
 import pytest
 
 from homeassistant.components.cover import ATTR_IS_CLOSED, CoverState
+from homeassistant.components.door.condition import CONDITIONS
 from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     create_target_condition,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -31,6 +34,12 @@ async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
 async def target_covers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple cover entities associated with different targets."""
     return await target_entities(hass, "cover")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_closed": TargetSupport.STANDARD,
+    "is_open": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -55,6 +64,11 @@ async def test_door_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 # --- binary_sensor tests ---

--- a/tests/components/door/test_trigger.py
+++ b/tests/components/door/test_trigger.py
@@ -6,15 +6,18 @@ import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.cover import ATTR_IS_CLOSED, CoverDeviceClass, CoverState
+from homeassistant.components.door.trigger import TRIGGERS
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -31,6 +34,12 @@ async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
 async def target_covers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple cover entities associated with different targets."""
     return await target_entities(hass, "cover")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "opened": TargetSupport.STANDARD,
+    "closed": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -55,6 +64,11 @@ async def test_door_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/doorbell/test_trigger.py
+++ b/tests/components/doorbell/test_trigger.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.doorbell.trigger import TRIGGERS
 from homeassistant.components.event import ATTR_EVENT_TYPE
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     BasicTriggerStateDescription,
+    TargetSupport,
     arm_trigger,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     set_or_remove_state,
     target_entities,
@@ -22,6 +25,11 @@ from tests.components.common import (
 async def target_events(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple event entities associated with different targets."""
     return await target_entities(hass, "event")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "rang": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -45,6 +53,11 @@ async def test_doorbell_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/event/test_trigger.py
+++ b/tests/components/event/test_trigger.py
@@ -7,15 +7,18 @@ import pytest
 
 from homeassistant.components.event import DOMAIN, EventEntity
 from homeassistant.components.event.const import ATTR_EVENT_TYPE
+from homeassistant.components.event.trigger import TRIGGERS
 from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockEntity, setup_test_component_platform
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     arm_trigger,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     set_or_remove_state,
     target_entities,
@@ -48,6 +51,11 @@ async def target_events(hass: HomeAssistant) -> dict[str, list[str]]:
     return await target_entities(hass, "event")
 
 
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "received": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -69,6 +77,11 @@ async def test_event_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/fan/test_condition.py
+++ b/tests/components/fan/test_condition.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.fan.condition import CONDITIONS
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_target_entities,
@@ -23,6 +26,12 @@ from tests.components.common import (
 async def target_fans(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple fan entities associated with different targets."""
     return await target_entities(hass, "fan", domain_excluded="switch")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_off": TargetSupport.STANDARD,
+    "is_on": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -47,6 +56,11 @@ async def test_fan_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/fan/test_trigger.py
+++ b/tests/components/fan/test_trigger.py
@@ -4,15 +4,18 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.fan.trigger import TRIGGERS
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -23,6 +26,12 @@ from tests.components.common import (
 async def target_fans(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple fan entities associated with different targets."""
     return await target_entities(hass, "fan")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "turned_off": TargetSupport.STANDARD,
+    "turned_on": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -47,6 +56,11 @@ async def test_fan_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/garage_door/test_condition.py
+++ b/tests/components/garage_door/test_condition.py
@@ -5,14 +5,17 @@ from typing import Any
 import pytest
 
 from homeassistant.components.cover import ATTR_IS_CLOSED, CoverState
+from homeassistant.components.garage_door.condition import CONDITIONS
 from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     create_target_condition,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -31,6 +34,12 @@ async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
 async def target_covers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple cover entities associated with different targets."""
     return await target_entities(hass, "cover")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_closed": TargetSupport.STANDARD,
+    "is_open": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -55,6 +64,11 @@ async def test_garage_door_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 # --- binary_sensor tests ---

--- a/tests/components/garage_door/test_trigger.py
+++ b/tests/components/garage_door/test_trigger.py
@@ -6,15 +6,18 @@ import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.cover import ATTR_IS_CLOSED, CoverDeviceClass, CoverState
+from homeassistant.components.garage_door.trigger import TRIGGERS
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -31,6 +34,12 @@ async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
 async def target_covers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple cover entities associated with different targets."""
     return await target_entities(hass, "cover")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "opened": TargetSupport.STANDARD,
+    "closed": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -55,6 +64,11 @@ async def test_garage_door_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/gate/test_condition.py
+++ b/tests/components/gate/test_condition.py
@@ -5,14 +5,17 @@ from typing import Any
 import pytest
 
 from homeassistant.components.cover import ATTR_IS_CLOSED, CoverState
+from homeassistant.components.gate.condition import CONDITIONS
 from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     create_target_condition,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -25,6 +28,12 @@ from tests.components.common import (
 async def target_covers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple cover entities associated with different targets."""
     return await target_entities(hass, "cover")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_closed": TargetSupport.STANDARD,
+    "is_open": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -49,6 +58,11 @@ async def test_gate_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/gate/test_trigger.py
+++ b/tests/components/gate/test_trigger.py
@@ -5,15 +5,18 @@ from typing import Any
 import pytest
 
 from homeassistant.components.cover import ATTR_IS_CLOSED, CoverDeviceClass, CoverState
+from homeassistant.components.gate.trigger import TRIGGERS
 from homeassistant.const import ATTR_DEVICE_CLASS
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -24,6 +27,12 @@ from tests.components.common import (
 async def target_covers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple cover entities associated with different targets."""
     return await target_entities(hass, "cover")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "opened": TargetSupport.STANDARD,
+    "closed": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +57,11 @@ async def test_gate_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/humidifier/test_condition.py
+++ b/tests/components/humidifier/test_condition.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 import voluptuous as vol
 
+from homeassistant.components.humidifier.condition import CONDITIONS
 from homeassistant.components.humidifier.const import (
     ATTR_ACTION,
     ATTR_HUMIDITY,
@@ -27,9 +28,11 @@ from homeassistant.helpers.condition import async_validate_condition_config
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_numerical_attribute_condition_above_below_all,
@@ -46,6 +49,16 @@ async def target_humidifiers(hass: HomeAssistant) -> dict[str, list[str]]:
 
 
 _HUMIDITY_THRESHOLD = {"threshold": {"type": "above", "value": {"number": 50}}}
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_off": TargetSupport.STANDARD,
+    "is_on": TargetSupport.STANDARD,
+    "is_drying": TargetSupport.STANDARD,
+    "is_humidifying": TargetSupport.STANDARD,
+    "is_mode": TargetSupport.STANDARD,
+    "is_target_humidity": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -74,6 +87,11 @@ async def test_humidifier_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/humidifier/test_trigger.py
+++ b/tests/components/humidifier/test_trigger.py
@@ -11,6 +11,7 @@ from homeassistant.components.humidifier.const import (
     HumidifierAction,
     HumidifierEntityFeature,
 )
+from homeassistant.components.humidifier.trigger import TRIGGERS
 from homeassistant.const import (
     ATTR_MODE,
     ATTR_SUPPORTED_FEATURES,
@@ -25,11 +26,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.trigger import async_validate_trigger_config
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -40,6 +43,15 @@ from tests.components.common import (
 async def target_humidifiers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple humidifier entities associated with different targets."""
     return await target_entities(hass, "humidifier")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "mode_changed": TargetSupport.STANDARD,
+    "started_drying": TargetSupport.STANDARD,
+    "started_humidifying": TargetSupport.STANDARD,
+    "turned_off": TargetSupport.STANDARD,
+    "turned_on": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -67,6 +79,11 @@ async def test_humidifier_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/humidity/test_condition.py
+++ b/tests/components/humidity/test_condition.py
@@ -11,15 +11,18 @@ from homeassistant.components.climate import (
 from homeassistant.components.humidifier import (
     ATTR_CURRENT_HUMIDITY as HUMIDIFIER_ATTR_CURRENT_HUMIDITY,
 )
+from homeassistant.components.humidity.condition import CONDITIONS
 from homeassistant.components.weather import ATTR_WEATHER_HUMIDITY
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_numerical_attribute_condition_above_below_all,
     parametrize_numerical_attribute_condition_above_below_any,
     parametrize_numerical_condition_above_below_all,
@@ -58,6 +61,11 @@ async def target_weathers(hass: HomeAssistant) -> dict[str, list[str]]:
 _PLAIN_THRESHOLD = {"threshold": {"type": "above", "value": {"number": 50}}}
 
 
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_value": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("condition_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -79,6 +87,11 @@ async def test_humidity_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/humidity/test_trigger.py
+++ b/tests/components/humidity/test_trigger.py
@@ -11,18 +11,21 @@ from homeassistant.components.climate import (
 from homeassistant.components.humidifier import (
     ATTR_CURRENT_HUMIDITY as HUMIDIFIER_ATTR_CURRENT_HUMIDITY,
 )
+from homeassistant.components.humidity.trigger import TRIGGERS
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.weather import ATTR_WEATHER_HUMIDITY
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_ignores_limit_entities_with_wrong_unit,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_numerical_attribute_changed_trigger_states,
     parametrize_numerical_attribute_crossed_threshold_trigger_states,
     parametrize_numerical_state_value_changed_trigger_states,
@@ -66,6 +69,12 @@ _PERCENT_CROSSED_THRESHOLD = {
 }
 
 
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "changed": TargetSupport.STANDARD,
+    "crossed_threshold": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -88,6 +97,11 @@ async def test_humidity_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 # --- Sensor domain tests (value in state.state) ---

--- a/tests/components/illuminance/test_condition.py
+++ b/tests/components/illuminance/test_condition.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.illuminance.condition import CONDITIONS
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -14,9 +15,11 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_numerical_condition_above_below_all,
@@ -43,6 +46,13 @@ async def target_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
 _ILLUMINANCE_THRESHOLD = {"threshold": {"type": "above", "value": {"number": 50}}}
 
 
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_detected": TargetSupport.STANDARD,
+    "is_not_detected": TargetSupport.STANDARD,
+    "is_value": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("condition_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -66,6 +76,11 @@ async def test_illuminance_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/illuminance/test_trigger.py
+++ b/tests/components/illuminance/test_trigger.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.illuminance.trigger import TRIGGERS
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -16,11 +17,13 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_numerical_state_value_changed_trigger_states,
     parametrize_numerical_state_value_crossed_threshold_trigger_states,
     parametrize_target_entities,
@@ -43,6 +46,14 @@ async def target_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
 
 _CHANGED_THRESHOLD = {"threshold": {"type": "any"}}
 _CROSSED_THRESHOLD = {"threshold": {"type": "above", "value": {"number": 50}}}
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "detected": TargetSupport.STANDARD,
+    "cleared": TargetSupport.STANDARD,
+    "changed": TargetSupport.STANDARD,
+    "crossed_threshold": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -69,6 +80,11 @@ async def test_illuminance_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 # --- Binary sensor detected/cleared tests ---

--- a/tests/components/lawn_mower/test_condition.py
+++ b/tests/components/lawn_mower/test_condition.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.lawn_mower.condition import CONDITIONS
 from homeassistant.components.lawn_mower.const import LawnMowerActivity
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     other_states,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -24,6 +27,15 @@ from tests.components.common import (
 async def target_lawn_mowers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple lawn mower entities associated with different targets."""
     return await target_entities(hass, "lawn_mower")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_docked": TargetSupport.STANDARD,
+    "is_encountering_an_error": TargetSupport.STANDARD,
+    "is_mowing": TargetSupport.STANDARD,
+    "is_paused": TargetSupport.STANDARD,
+    "is_returning": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -51,6 +63,11 @@ async def test_lawn_mower_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/lawn_mower/test_trigger.py
+++ b/tests/components/lawn_mower/test_trigger.py
@@ -5,14 +5,17 @@ from typing import Any
 import pytest
 
 from homeassistant.components.lawn_mower import LawnMowerActivity
+from homeassistant.components.lawn_mower.trigger import TRIGGERS
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     other_states,
     parametrize_target_entities,
     parametrize_trigger_states,
@@ -24,6 +27,15 @@ from tests.components.common import (
 async def target_lawn_mowers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple lawn mower entities associated with different targets."""
     return await target_entities(hass, "lawn_mower")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "returned_to_dock": TargetSupport.STANDARD,
+    "errored": TargetSupport.STANDARD,
+    "paused_mowing": TargetSupport.STANDARD,
+    "started_mowing": TargetSupport.STANDARD,
+    "started_returning": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -51,6 +63,11 @@ async def test_lawn_mower_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/light/test_condition.py
+++ b/tests/components/light/test_condition.py
@@ -5,14 +5,17 @@ from typing import Any
 import pytest
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
+from homeassistant.components.light.condition import CONDITIONS
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_numerical_attribute_condition_above_below_all,
@@ -32,6 +35,13 @@ async def target_lights(hass: HomeAssistant) -> dict[str, list[str]]:
 
 
 _BRIGHTNESS_THRESHOLD = {"threshold": {"type": "above", "value": {"number": 50}}}
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_brightness": TargetSupport.STANDARD,
+    "is_off": TargetSupport.STANDARD,
+    "is_on": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -57,6 +67,11 @@ async def test_light_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/light/test_trigger.py
+++ b/tests/components/light/test_trigger.py
@@ -5,16 +5,19 @@ from typing import Any
 import pytest
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
+from homeassistant.components.light.trigger import TRIGGERS
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_ignores_limit_entities_with_wrong_unit,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_numerical_attribute_changed_trigger_states,
     parametrize_numerical_attribute_crossed_threshold_trigger_states,
     parametrize_target_entities,
@@ -39,6 +42,14 @@ async def target_lights(hass: HomeAssistant) -> dict[str, list[str]]:
 _CHANGED_THRESHOLD = {"threshold": {"type": "any"}}
 _BRIGHTNESS_CROSSED_THRESHOLD = {
     "threshold": {"type": "above", "value": {"number": 50}}
+}
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "brightness_changed": TargetSupport.STANDARD,
+    "brightness_crossed_threshold": TargetSupport.STANDARD,
+    "turned_off": TargetSupport.STANDARD,
+    "turned_on": TargetSupport.STANDARD,
 }
 
 
@@ -71,6 +82,11 @@ async def test_light_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/lock/test_condition.py
+++ b/tests/components/lock/test_condition.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.lock.condition import CONDITIONS
 from homeassistant.components.lock.const import LockState
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     other_states,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -24,6 +27,14 @@ from tests.components.common import (
 async def target_locks(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple lock entities associated with different targets."""
     return await target_entities(hass, "lock")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_jammed": TargetSupport.STANDARD,
+    "is_locked": TargetSupport.STANDARD,
+    "is_open": TargetSupport.STANDARD,
+    "is_unlocked": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -50,6 +61,11 @@ async def test_lock_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/lock/test_trigger.py
+++ b/tests/components/lock/test_trigger.py
@@ -5,14 +5,17 @@ from typing import Any
 import pytest
 
 from homeassistant.components.lock import DOMAIN, LockState
+from homeassistant.components.lock.trigger import TRIGGERS
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     other_states,
     parametrize_target_entities,
     parametrize_trigger_states,
@@ -24,6 +27,14 @@ from tests.components.common import (
 async def target_locks(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple lock entities associated with different targets."""
     return await target_entities(hass, DOMAIN)
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "jammed": TargetSupport.STANDARD,
+    "locked": TargetSupport.STANDARD,
+    "opened": TargetSupport.STANDARD,
+    "unlocked": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -50,6 +61,11 @@ async def test_lock_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/media_player/test_condition.py
+++ b/tests/components/media_player/test_condition.py
@@ -8,14 +8,17 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_VOLUME_LEVEL,
     ATTR_MEDIA_VOLUME_MUTED,
 )
+from homeassistant.components.media_player.condition import CONDITIONS
 from homeassistant.components.media_player.const import MediaPlayerState
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     other_states,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -95,6 +98,18 @@ async def target_media_players(hass: HomeAssistant) -> dict[str, list[str]]:
     return await target_entities(hass, "media_player")
 
 
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_muted": TargetSupport.STANDARD,
+    "is_not_playing": TargetSupport.STANDARD,
+    "is_off": TargetSupport.STANDARD,
+    "is_on": TargetSupport.STANDARD,
+    "is_paused": TargetSupport.STANDARD,
+    "is_playing": TargetSupport.STANDARD,
+    "is_unmuted": TargetSupport.STANDARD,
+    "is_volume": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("condition_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -123,6 +138,11 @@ async def test_media_player_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/media_player/test_trigger.py
+++ b/tests/components/media_player/test_trigger.py
@@ -9,10 +9,12 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_VOLUME_MUTED,
     MediaPlayerState,
 )
+from homeassistant.components.media_player.trigger import TRIGGERS
 from homeassistant.const import CONF_ENTITY_ID
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     arm_trigger,
     assert_trigger_behavior_all,
@@ -20,6 +22,7 @@ from tests.components.common import (
     assert_trigger_behavior_first,
     assert_trigger_ignores_limit_entities_with_wrong_unit,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_numerical_attribute_changed_trigger_states,
     parametrize_numerical_attribute_crossed_threshold_trigger_states,
     parametrize_target_entities,
@@ -93,6 +96,19 @@ def parametrize_muted_trigger_states(
     )
 
 
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "muted": TargetSupport.STANDARD,
+    "unmuted": TargetSupport.STANDARD,
+    "volume_changed": TargetSupport.STANDARD,
+    "volume_crossed_threshold": TargetSupport.STANDARD,
+    "paused_playing": TargetSupport.STANDARD,
+    "started_playing": TargetSupport.STANDARD,
+    "stopped_playing": TargetSupport.STANDARD,
+    "turned_off": TargetSupport.STANDARD,
+    "turned_on": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -127,6 +143,11 @@ async def test_media_player_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/moisture/test_condition.py
+++ b/tests/components/moisture/test_condition.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.moisture.condition import CONDITIONS
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -14,9 +15,11 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_numerical_condition_above_below_all,
@@ -43,6 +46,13 @@ async def target_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
 _MOISTURE_THRESHOLD = {"threshold": {"type": "above", "value": {"number": 50}}}
 
 
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_detected": TargetSupport.STANDARD,
+    "is_not_detected": TargetSupport.STANDARD,
+    "is_value": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("condition_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -66,6 +76,11 @@ async def test_moisture_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/moisture/test_trigger.py
+++ b/tests/components/moisture/test_trigger.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.moisture.trigger import TRIGGERS
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -15,12 +16,14 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_ignores_limit_entities_with_wrong_unit,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_numerical_state_value_changed_trigger_states,
     parametrize_numerical_state_value_crossed_threshold_trigger_states,
     parametrize_target_entities,
@@ -43,6 +46,14 @@ async def target_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
 
 _CHANGED_THRESHOLD = {"threshold": {"type": "any"}}
 _CROSSED_THRESHOLD = {"threshold": {"type": "above", "value": {"number": 50}}}
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "detected": TargetSupport.STANDARD,
+    "cleared": TargetSupport.STANDARD,
+    "changed": TargetSupport.STANDARD,
+    "crossed_threshold": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -69,6 +80,11 @@ async def test_moisture_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/motion/test_condition.py
+++ b/tests/components/motion/test_condition.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.motion.condition import CONDITIONS
 from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     create_target_condition,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -24,6 +27,12 @@ from tests.components.common import (
 async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple binary sensor entities associated with different targets."""
     return await target_entities(hass, "binary_sensor")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_detected": TargetSupport.STANDARD,
+    "is_not_detected": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +57,11 @@ async def test_motion_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/motion/test_trigger.py
+++ b/tests/components/motion/test_trigger.py
@@ -5,15 +5,18 @@ from typing import Any
 import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.motion.trigger import TRIGGERS
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -24,6 +27,12 @@ from tests.components.common import (
 async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple binary sensor entities associated with different targets."""
     return await target_entities(hass, "binary_sensor")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "detected": TargetSupport.STANDARD,
+    "cleared": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +57,11 @@ async def test_motion_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/occupancy/test_condition.py
+++ b/tests/components/occupancy/test_condition.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.occupancy.condition import CONDITIONS
 from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     create_target_condition,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -24,6 +27,12 @@ from tests.components.common import (
 async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple binary sensor entities associated with different targets."""
     return await target_entities(hass, "binary_sensor")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_detected": TargetSupport.STANDARD,
+    "is_not_detected": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +57,11 @@ async def test_occupancy_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/occupancy/test_trigger.py
+++ b/tests/components/occupancy/test_trigger.py
@@ -5,15 +5,18 @@ from typing import Any
 import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.occupancy.trigger import TRIGGERS
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -24,6 +27,12 @@ from tests.components.common import (
 async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple binary sensor entities associated with different targets."""
     return await target_entities(hass, "binary_sensor")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "detected": TargetSupport.STANDARD,
+    "cleared": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +57,11 @@ async def test_occupancy_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/power/test_condition.py
+++ b/tests/components/power/test_condition.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.power.condition import CONDITIONS
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, UnitOfPower
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     assert_numerical_condition_unit_conversion,
     parametrize_numerical_condition_above_below_all,
     parametrize_numerical_condition_above_below_any,
@@ -31,6 +34,11 @@ _WATT_THRESHOLD = {
         "type": "above",
         "value": {"number": 50, "unit_of_measurement": "W"},
     }
+}
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_value": TargetSupport.STANDARD,
 }
 
 
@@ -55,6 +63,11 @@ async def test_power_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/power/test_trigger.py
+++ b/tests/components/power/test_trigger.py
@@ -4,16 +4,19 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.power.trigger import TRIGGERS
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, UnitOfPower
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_numerical_state_value_changed_trigger_states,
     parametrize_numerical_state_value_crossed_threshold_trigger_states,
     parametrize_target_entities,
@@ -39,6 +42,12 @@ _WATT_CROSSED_THRESHOLD = {
 }
 
 
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "changed": TargetSupport.STANDARD,
+    "crossed_threshold": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -61,6 +70,11 @@ async def test_power_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/remote/test_condition.py
+++ b/tests/components/remote/test_condition.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.remote.condition import CONDITIONS
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_target_entities,
@@ -23,6 +26,12 @@ from tests.components.common import (
 async def target_remotes(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple remote entities associated with different targets."""
     return await target_entities(hass, "remote", domain_excluded="switch")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_off": TargetSupport.STANDARD,
+    "is_on": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -47,6 +56,11 @@ async def test_remote_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/remote/test_trigger.py
+++ b/tests/components/remote/test_trigger.py
@@ -5,15 +5,18 @@ from typing import Any
 import pytest
 
 from homeassistant.components.remote import DOMAIN
+from homeassistant.components.remote.trigger import TRIGGERS
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -24,6 +27,12 @@ from tests.components.common import (
 async def target_remotes(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple remotes entities associated with different targets."""
     return await target_entities(hass, DOMAIN)
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "turned_on": TargetSupport.STANDARD,
+    "turned_off": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +57,11 @@ async def test_remote_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/scene/test_trigger.py
+++ b/tests/components/scene/test_trigger.py
@@ -4,13 +4,16 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.scene.trigger import TRIGGERS
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     arm_trigger,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     set_or_remove_state,
     target_entities,
@@ -21,6 +24,11 @@ from tests.components.common import (
 async def target_scenes(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple scene entities associated with different targets."""
     return await target_entities(hass, "scene")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "activated": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -44,6 +52,11 @@ async def test_scene_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/schedule/test_condition.py
+++ b/tests/components/schedule/test_condition.py
@@ -4,15 +4,18 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.schedule.condition import CONDITIONS
 from homeassistant.components.schedule.const import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_target_entities,
@@ -24,6 +27,12 @@ from tests.components.common import (
 async def target_schedules(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple schedule entities associated with different targets."""
     return await target_entities(hass, DOMAIN)
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_off": TargetSupport.STANDARD,
+    "is_on": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +57,11 @@ async def test_schedule_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/schedule/test_trigger.py
+++ b/tests/components/schedule/test_trigger.py
@@ -13,17 +13,20 @@ from homeassistant.components.schedule.const import (
     CONF_TO,
     DOMAIN,
 )
+from homeassistant.components.schedule.trigger import TRIGGERS
 from homeassistant.const import CONF_ICON, CONF_NAME, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.common import async_fire_time_changed
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     arm_trigger,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -34,6 +37,12 @@ from tests.components.common import (
 async def target_schedules(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple schedule entities associated with different targets."""
     return await target_entities(hass, DOMAIN)
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "block_started": TargetSupport.STANDARD,
+    "block_ended": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -58,6 +67,11 @@ async def test_schedule_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/select/test_condition.py
+++ b/tests/components/select/test_condition.py
@@ -6,16 +6,18 @@ from typing import Any
 import pytest
 import voluptuous as vol
 
-from homeassistant.components.select.condition import CONF_OPTION
+from homeassistant.components.select.condition import CONDITIONS, CONF_OPTION
 from homeassistant.const import CONF_ENTITY_ID, CONF_OPTIONS, CONF_TARGET
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.condition import async_validate_condition_config
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     create_target_condition,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -34,6 +36,11 @@ async def target_selects(hass: HomeAssistant) -> dict[str, list[str]]:
 async def target_input_selects(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple input_select entities associated with different targets."""
     return await target_entities(hass, "input_select")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_option_selected": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -57,6 +64,11 @@ async def test_select_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/select/test_trigger.py
+++ b/tests/components/select/test_trigger.py
@@ -4,13 +4,16 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.select.trigger import TRIGGERS
 from homeassistant.const import CONF_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     arm_trigger,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     set_or_remove_state,
     target_entities,
@@ -27,6 +30,11 @@ async def target_selects(hass: HomeAssistant) -> dict[str, list[str]]:
 async def target_input_selects(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple input_select entities associated with different targets."""
     return await target_entities(hass, "input_select")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "selection_changed": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -50,6 +58,11 @@ async def test_select_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 STATE_SEQUENCE = [

--- a/tests/components/siren/test_condition.py
+++ b/tests/components/siren/test_condition.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.siren.condition import CONDITIONS
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_target_entities,
@@ -23,6 +26,12 @@ from tests.components.common import (
 async def target_sirens(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple siren entities associated with different targets."""
     return await target_entities(hass, "siren", domain_excluded="switch")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_off": TargetSupport.STANDARD,
+    "is_on": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -47,6 +56,11 @@ async def test_siren_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/siren/test_trigger.py
+++ b/tests/components/siren/test_trigger.py
@@ -5,15 +5,18 @@ from typing import Any
 import pytest
 
 from homeassistant.components.siren import DOMAIN
+from homeassistant.components.siren.trigger import TRIGGERS
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -24,6 +27,12 @@ from tests.components.common import (
 async def target_sirens(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple siren entities associated with different targets."""
     return await target_entities(hass, DOMAIN)
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "turned_on": TargetSupport.STANDARD,
+    "turned_off": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +57,11 @@ async def test_siren_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/switch/test_condition.py
+++ b/tests/components/switch/test_condition.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.switch.condition import CONDITIONS
 from homeassistant.const import CONF_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     create_target_condition,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -30,6 +33,12 @@ async def target_switches(hass: HomeAssistant) -> dict[str, list[str]]:
 async def target_input_booleans(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple input_boolean entities associated with different targets."""
     return await target_entities(hass, "input_boolean")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_off": TargetSupport.STANDARD,
+    "is_on": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -54,6 +63,11 @@ async def test_switch_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/switch/test_trigger.py
+++ b/tests/components/switch/test_trigger.py
@@ -5,16 +5,19 @@ from typing import Any
 import pytest
 
 from homeassistant.components.switch import DOMAIN
+from homeassistant.components.switch.trigger import TRIGGERS
 from homeassistant.const import CONF_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     arm_trigger,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -46,6 +49,12 @@ async def target_input_booleans(hass: HomeAssistant) -> dict[str, list[str]]:
     return await target_entities(hass, "input_boolean")
 
 
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "turned_on": TargetSupport.STANDARD,
+    "turned_off": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -68,6 +77,11 @@ async def test_switch_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 # --- Switch domain tests ---

--- a/tests/components/temperature/test_condition.py
+++ b/tests/components/temperature/test_condition.py
@@ -5,15 +5,18 @@ from typing import Any
 import pytest
 
 from homeassistant.components.climate import HVACMode
+from homeassistant.components.temperature.condition import CONDITIONS
 from homeassistant.components.weather import ATTR_WEATHER_TEMPERATURE_UNIT
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     assert_numerical_condition_unit_conversion,
     parametrize_numerical_attribute_condition_above_below_all,
     parametrize_numerical_attribute_condition_above_below_any,
@@ -58,6 +61,11 @@ _CELSIUS_THRESHOLD = {
 }
 
 
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_value": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("condition_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -79,6 +87,11 @@ async def test_temperature_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/temperature/test_trigger.py
+++ b/tests/components/temperature/test_trigger.py
@@ -9,6 +9,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.temperature.trigger import TRIGGERS
 from homeassistant.components.water_heater import (
     ATTR_CURRENT_TEMPERATURE as WATER_HEATER_ATTR_CURRENT_TEMPERATURE,
 )
@@ -25,12 +26,14 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     arm_trigger,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_numerical_attribute_changed_trigger_states,
     parametrize_numerical_attribute_crossed_threshold_trigger_states,
     parametrize_numerical_state_value_changed_trigger_states,
@@ -81,6 +84,12 @@ _CELSIUS_CROSSED_THRESHOLD = {
 _CHANGED_THRESHOLD = {"threshold": {"type": "any"}}
 
 
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "changed": TargetSupport.STANDARD,
+    "crossed_threshold": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -103,6 +112,11 @@ async def test_temperature_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 # --- Sensor domain tests (value in state.state) ---

--- a/tests/components/test_shared_test_helpers.py
+++ b/tests/components/test_shared_test_helpers.py
@@ -1,0 +1,352 @@
+"""Tests for the shared trigger/condition target-support test helpers.
+
+`assert_triggers_target_support` and `assert_conditions_target_support` (in
+`tests.components.common`) let each modern trigger/condition test module certify,
+against its own registry, that every trigger it tests either supports a user
+target via the shared machinery (``STANDARD``), exposes no target
+(``NONE``), or resolves a target with its own machinery (``CUSTOM``). The
+per-domain axis reduction relies on that certification, so these tests pin that
+the helpers actually reject the violations they are meant to catch, using
+synthetic classes that each introduce exactly one defect.
+"""
+
+from typing import Any, cast
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.const import CONF_TARGET, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.condition import (
+    Condition,
+    ConditionConfig,
+    make_entity_state_condition,
+)
+from homeassistant.helpers.trigger import (
+    Trigger,
+    TriggerConfig,
+    make_entity_target_state_trigger,
+)
+
+from .common import (
+    TargetSupport,
+    assert_conditions_target_support,
+    assert_triggers_target_support,
+)
+
+# Valid baselines created by the public factories: proper entity-base classes that
+# inherit the target machinery unmodified and carry the standard target slot.
+_ValidTrigger = make_entity_target_state_trigger("test", STATE_ON)
+_ValidCondition = make_entity_state_condition("test", STATE_ON)
+
+# A schema without a ``target`` marker (a class that does not expose a user target).
+_NO_TARGET_SCHEMA = vol.Schema({vol.Optional("options"): dict})
+# A schema that does expose the standard user target slot.
+_TARGET_SCHEMA = vol.Schema({vol.Required(CONF_TARGET): cv.TARGET_FIELDS})
+
+
+class _MachineryOverrideTrigger(_ValidTrigger):
+    """Overrides target-resolution machinery (``count_matches``)."""
+
+    def count_matches(self, *args: Any, **kwargs: Any) -> Any:
+        """Trip the machinery-override check."""
+        raise NotImplementedError
+
+
+class _NoTargetSlotTrigger(_ValidTrigger):
+    """Entity-base class whose schema drops the standard ``target`` slot."""
+
+    _schema = _NO_TARGET_SCHEMA
+
+
+class _MutatesConfigTargetTrigger(_ValidTrigger):
+    """``__init__`` rewrites the user target before delegating."""
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Rewrite the user target."""
+        config.target = {CONF_TARGET: {}}
+        super().__init__(hass, config)
+
+
+class _InitNoSuperTrigger(_ValidTrigger):
+    """``__init__`` does not delegate the config to super."""
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Fail to delegate to super."""
+        # pylint: disable=super-init-not-called,unused-argument
+        self._hass = hass
+
+
+class _RebuildsConfigTrigger(_ValidTrigger):
+    """``__init__`` rebuilds the config object."""
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Rebuild the config."""
+        config = TriggerConfig(target=config.target)
+        super().__init__(hass, config)
+
+
+class _AssignsTargetTrigger(_ValidTrigger):
+    """``__init__`` assigns ``self._target``."""
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Assign the resolved target directly."""
+        super().__init__(hass, config)
+        self._target = config.target
+
+
+class _WideningEntityFilterTrigger(_ValidTrigger):
+    """``entity_filter`` override that does not narrow the base result."""
+
+    def entity_filter(self, entities: set[str]) -> set[str]:
+        """Return the input unchanged instead of narrowing it."""
+        return entities
+
+
+class _CustomTargetTrigger(Trigger):
+    """Not an entity-base class; exposes a target slot but resolves it itself."""
+
+    _schema = _TARGET_SCHEMA
+
+
+class _MachineryOverrideCondition(_ValidCondition):
+    """Overrides target-resolution machinery (``_async_check``)."""
+
+    async def _async_check(self, *args: Any, **kwargs: Any) -> Any:
+        """Trip the machinery-override check."""
+        raise NotImplementedError
+
+
+class _NoTargetSlotCondition(_ValidCondition):
+    """Entity-base class whose schema drops the standard ``target`` slot."""
+
+    _schema = _NO_TARGET_SCHEMA
+
+
+class _MutatesConfigTargetCondition(_ValidCondition):
+    """``__init__`` rewrites the user target.
+
+    ``ConditionConfig`` is not frozen, so this would rewrite the target at
+    runtime; the helper must catch it statically.
+    """
+
+    def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
+        """Rewrite the user target."""
+        config.target = {CONF_TARGET: {}}
+        super().__init__(hass, config)
+
+
+class _RebuildsConfigCondition(_ValidCondition):
+    """``__init__`` rebuilds the config object (exercises the ConditionConfig wiring)."""
+
+    def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
+        """Rebuild the config."""
+        config = ConditionConfig(target=config.target)
+        super().__init__(hass, config)
+
+
+class _CustomTargetCondition(Condition):
+    """Not an entity-base class; exposes a target slot but resolves it itself."""
+
+    _schema = _TARGET_SCHEMA
+
+
+@pytest.mark.parametrize(
+    ("registry", "declaration", "match"),
+    [
+        pytest.param(
+            {"x": _MachineryOverrideTrigger},
+            {"x": TargetSupport.STANDARD},
+            "overrides target machinery",
+            id="standard-overrides-machinery",
+        ),
+        pytest.param(
+            {"x": _NoTargetSlotTrigger},
+            {"x": TargetSupport.STANDARD},
+            "does not carry the standard",
+            id="standard-missing-target-slot",
+        ),
+        pytest.param(
+            {"x": _MutatesConfigTargetTrigger},
+            {"x": TargetSupport.STANDARD},
+            "must not assign to config.target",
+            id="standard-mutates-config-target",
+        ),
+        pytest.param(
+            {"x": _InitNoSuperTrigger},
+            {"x": TargetSupport.STANDARD},
+            "must delegate the unmodified config",
+            id="standard-init-no-super",
+        ),
+        pytest.param(
+            {"x": _RebuildsConfigTrigger},
+            {"x": TargetSupport.STANDARD},
+            "must not rebuild the config object",
+            id="standard-rebuilds-config",
+        ),
+        pytest.param(
+            {"x": _AssignsTargetTrigger},
+            {"x": TargetSupport.STANDARD},
+            "must not assign self._target",
+            id="standard-assigns-target",
+        ),
+        pytest.param(
+            {"x": _WideningEntityFilterTrigger},
+            {"x": TargetSupport.STANDARD},
+            "entity_filter override must narrow",
+            id="standard-widens-entity-filter",
+        ),
+        pytest.param(
+            {"x": _CustomTargetTrigger},
+            {"x": TargetSupport.STANDARD},
+            "does not subclass",
+            id="standard-not-entity-base",
+        ),
+        pytest.param(
+            {"x": _ValidTrigger},
+            {"x": TargetSupport.NONE},
+            "declared TargetSupport.NONE",
+            id="none-exposes-target-slot",
+        ),
+        pytest.param(
+            {"x": _NoTargetSlotTrigger},
+            {"x": TargetSupport.CUSTOM},
+            "declared TargetSupport.CUSTOM",
+            id="custom-missing-target-slot",
+        ),
+        pytest.param(
+            {"x": _ValidTrigger, "y": _ValidTrigger},
+            {"x": TargetSupport.STANDARD},
+            "registered but not declared",
+            id="registry-key-undeclared",
+        ),
+        pytest.param(
+            {"x": _ValidTrigger},
+            {"x": TargetSupport.STANDARD, "y": TargetSupport.STANDARD},
+            "declared but not registered",
+            id="declared-key-unregistered",
+        ),
+        pytest.param(
+            {"x": _ValidTrigger},
+            {"x": cast(TargetSupport, "standard")},
+            "invalid target-support declaration value",
+            id="raw-string-not-enum-member",
+        ),
+    ],
+)
+def test_assert_triggers_target_support_rejects(
+    registry: dict[str, type[Trigger]],
+    declaration: dict[str, TargetSupport],
+    match: str,
+) -> None:
+    """Each synthetic defect is rejected by the trigger helper."""
+    with pytest.raises(AssertionError, match=match):
+        assert_triggers_target_support(registry, declaration)
+
+
+@pytest.mark.parametrize(
+    ("registry", "declaration", "match"),
+    [
+        pytest.param(
+            {"x": _MachineryOverrideCondition},
+            {"x": TargetSupport.STANDARD},
+            "overrides target machinery",
+            id="standard-overrides-machinery",
+        ),
+        pytest.param(
+            {"x": _NoTargetSlotCondition},
+            {"x": TargetSupport.STANDARD},
+            "does not carry the standard",
+            id="standard-missing-target-slot",
+        ),
+        pytest.param(
+            {"x": _MutatesConfigTargetCondition},
+            {"x": TargetSupport.STANDARD},
+            "must not assign to config.target",
+            id="standard-mutates-config-target",
+        ),
+        pytest.param(
+            {"x": _RebuildsConfigCondition},
+            {"x": TargetSupport.STANDARD},
+            "must not rebuild the config object",
+            id="standard-rebuilds-config",
+        ),
+        pytest.param(
+            {"x": _CustomTargetCondition},
+            {"x": TargetSupport.STANDARD},
+            "does not subclass",
+            id="standard-not-entity-base",
+        ),
+        pytest.param(
+            {"x": _ValidCondition},
+            {"x": TargetSupport.NONE},
+            "declared TargetSupport.NONE",
+            id="none-exposes-target-slot",
+        ),
+        pytest.param(
+            {"x": _NoTargetSlotCondition},
+            {"x": TargetSupport.CUSTOM},
+            "declared TargetSupport.CUSTOM",
+            id="custom-missing-target-slot",
+        ),
+        pytest.param(
+            {"x": _ValidCondition, "y": _ValidCondition},
+            {"x": TargetSupport.STANDARD},
+            "registered but not declared",
+            id="registry-key-undeclared",
+        ),
+        pytest.param(
+            {"x": _ValidCondition},
+            {"x": TargetSupport.STANDARD, "y": TargetSupport.STANDARD},
+            "declared but not registered",
+            id="declared-key-unregistered",
+        ),
+        pytest.param(
+            {"x": _ValidCondition},
+            {"x": cast(TargetSupport, "standard")},
+            "invalid target-support declaration value",
+            id="raw-string-not-enum-member",
+        ),
+    ],
+)
+def test_assert_conditions_target_support_rejects(
+    registry: dict[str, type[Condition]],
+    declaration: dict[str, TargetSupport],
+    match: str,
+) -> None:
+    """Each synthetic defect is rejected by the condition helper."""
+    with pytest.raises(AssertionError, match=match):
+        assert_conditions_target_support(registry, declaration)
+
+
+def test_assert_triggers_target_support_accepts_valid_declaration() -> None:
+    """A registry matching a correct declaration passes for all three states."""
+    assert_triggers_target_support(
+        {
+            "standard": _ValidTrigger,
+            "none": _NoTargetSlotTrigger,
+            "custom": _CustomTargetTrigger,
+        },
+        {
+            "standard": TargetSupport.STANDARD,
+            "none": TargetSupport.NONE,
+            "custom": TargetSupport.CUSTOM,
+        },
+    )
+
+
+def test_assert_conditions_target_support_accepts_valid_declaration() -> None:
+    """A registry matching a correct declaration passes for all three states."""
+    assert_conditions_target_support(
+        {
+            "standard": _ValidCondition,
+            "none": _NoTargetSlotCondition,
+            "custom": _CustomTargetCondition,
+        },
+        {
+            "standard": TargetSupport.STANDARD,
+            "none": TargetSupport.NONE,
+            "custom": TargetSupport.CUSTOM,
+        },
+    )

--- a/tests/components/test_shared_test_helpers.py
+++ b/tests/components/test_shared_test_helpers.py
@@ -110,6 +110,31 @@ class _CustomTargetTrigger(Trigger):
     _schema = _TARGET_SCHEMA
 
 
+class _NestedBadInitTrigger(_MutatesConfigTargetTrigger):
+    """Clean delegating ``__init__`` above a parent that rewrites the target.
+
+    The child initializer is hygienic on its own; the defect lives on the
+    parent, so this only fails if the MRO scan continues past the clean child.
+    """
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        # pylint: disable=useless-parent-delegation
+        """Delegate cleanly to super."""
+        super().__init__(hass, config)
+
+
+class _NestedWideningEntityFilterTrigger(_WideningEntityFilterTrigger):
+    """Narrowing ``entity_filter`` above a parent that widens the base result.
+
+    The child override narrows correctly; the defect lives on the parent, so
+    this only fails if the MRO scan continues past the clean child.
+    """
+
+    def entity_filter(self, entities: set[str]) -> set[str]:
+        """Narrow the base result."""
+        return super().entity_filter(entities) & entities
+
+
 class _MachineryOverrideCondition(_ValidCondition):
     """Overrides target-resolution machinery (``_async_check``)."""
 
@@ -152,6 +177,19 @@ class _CustomTargetCondition(Condition):
     _schema = _TARGET_SCHEMA
 
 
+class _NestedBadInitCondition(_MutatesConfigTargetCondition):
+    """Clean delegating ``__init__`` above a parent that rewrites the target.
+
+    Mirrors ``_NestedBadInitTrigger`` on the condition side, where
+    ``_init_hygiene_violation`` is wired with ``config_cls="ConditionConfig"``.
+    """
+
+    def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
+        # pylint: disable=useless-parent-delegation
+        """Delegate cleanly to super."""
+        super().__init__(hass, config)
+
+
 @pytest.mark.parametrize(
     ("registry", "declaration", "match"),
     [
@@ -172,6 +210,12 @@ class _CustomTargetCondition(Condition):
             {"x": TargetSupport.STANDARD},
             "must not assign to config.target",
             id="standard-mutates-config-target",
+        ),
+        pytest.param(
+            {"x": _NestedBadInitTrigger},
+            {"x": TargetSupport.STANDARD},
+            "must not assign to config.target",
+            id="standard-nested-bad-init",
         ),
         pytest.param(
             {"x": _InitNoSuperTrigger},
@@ -196,6 +240,12 @@ class _CustomTargetCondition(Condition):
             {"x": TargetSupport.STANDARD},
             "entity_filter override must narrow",
             id="standard-widens-entity-filter",
+        ),
+        pytest.param(
+            {"x": _NestedWideningEntityFilterTrigger},
+            {"x": TargetSupport.STANDARD},
+            "entity_filter override must narrow",
+            id="standard-nested-widening-filter",
         ),
         pytest.param(
             {"x": _CustomTargetTrigger},
@@ -265,6 +315,12 @@ def test_assert_triggers_target_support_rejects(
             {"x": TargetSupport.STANDARD},
             "must not assign to config.target",
             id="standard-mutates-config-target",
+        ),
+        pytest.param(
+            {"x": _NestedBadInitCondition},
+            {"x": TargetSupport.STANDARD},
+            "must not assign to config.target",
+            id="standard-nested-bad-init",
         ),
         pytest.param(
             {"x": _RebuildsConfigCondition},

--- a/tests/components/text/test_condition.py
+++ b/tests/components/text/test_condition.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from homeassistant.components.text.condition import CONF_VALUE
+from homeassistant.components.text.condition import CONDITIONS, CONF_VALUE
 from homeassistant.const import (
     CONF_CONDITION,
     CONF_ENTITY_ID,
@@ -18,9 +18,11 @@ from homeassistant.helpers.condition import (
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_target_entities,
@@ -38,6 +40,11 @@ async def target_texts(hass: HomeAssistant) -> dict[str, list[str]]:
 async def target_input_texts(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple input_text entities associated with different targets."""
     return await target_entities(hass, "input_text")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_equal_to": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -61,6 +68,11 @@ async def test_text_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 CONDITION_STATES_ANY = [

--- a/tests/components/text/test_trigger.py
+++ b/tests/components/text/test_trigger.py
@@ -6,13 +6,16 @@ import pytest
 
 from homeassistant.components.input_text import DOMAIN as INPUT_TEXT_DOMAIN
 from homeassistant.components.text.const import DOMAIN
+from homeassistant.components.text.trigger import TRIGGERS
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     BasicTriggerStateDescription,
+    TargetSupport,
     arm_trigger,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     set_or_remove_state,
     target_entities,
@@ -128,6 +131,11 @@ async def target_input_texts(hass: HomeAssistant) -> dict[str, list[str]]:
     return await target_entities(hass, INPUT_TEXT_DOMAIN)
 
 
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "changed": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -149,6 +157,11 @@ async def test_text_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/timer/test_condition.py
+++ b/tests/components/timer/test_condition.py
@@ -5,13 +5,16 @@ from typing import Any
 import pytest
 
 from homeassistant.components.timer import STATUS_ACTIVE, STATUS_IDLE, STATUS_PAUSED
+from homeassistant.components.timer.condition import CONDITIONS
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_target_entities,
@@ -23,6 +26,13 @@ from tests.components.common import (
 async def target_timers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple timer entities associated with different targets."""
     return await target_entities(hass, "timer")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_active": TargetSupport.STANDARD,
+    "is_paused": TargetSupport.STANDARD,
+    "is_idle": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +58,11 @@ async def test_timer_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/timer/test_trigger.py
+++ b/tests/components/timer/test_trigger.py
@@ -16,6 +16,7 @@ from homeassistant.components.timer import (
     STATUS_IDLE,
     STATUS_PAUSED,
 )
+from homeassistant.components.timer.trigger import TRIGGERS
 from homeassistant.const import (
     ATTR_LABEL_ID,
     CONF_ENTITY_ID,
@@ -34,11 +35,13 @@ from homeassistant.util import dt as dt_util
 
 from tests.common import async_fire_time_changed
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -49,6 +52,16 @@ from tests.components.common import (
 async def target_timers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple timer entities associated with different targets."""
     return await target_entities(hass, DOMAIN)
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "cancelled": TargetSupport.STANDARD,
+    "finished": TargetSupport.STANDARD,
+    "paused": TargetSupport.STANDARD,
+    "restarted": TargetSupport.STANDARD,
+    "started": TargetSupport.STANDARD,
+    "remaining_time_reached": TargetSupport.CUSTOM,
+}
 
 
 @pytest.mark.parametrize(
@@ -77,6 +90,11 @@ async def test_timer_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/todo/test_condition.py
+++ b/tests/components/todo/test_condition.py
@@ -4,13 +4,16 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.todo.condition import CONDITIONS
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_target_entities,
@@ -25,6 +28,12 @@ async def target_todos(hass: HomeAssistant) -> dict[str, list[str]]:
 
 
 _TODO_THRESHOLD = {"threshold": {"type": "above", "value": {"number": 5}}}
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "all_completed": TargetSupport.STANDARD,
+    "incomplete": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -49,6 +58,11 @@ async def test_todo_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/update/test_condition.py
+++ b/tests/components/update/test_condition.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.update.condition import CONDITIONS
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_target_entities,
@@ -23,6 +26,12 @@ from tests.components.common import (
 async def target_updates(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple update entities associated with different targets."""
     return await target_entities(hass, "update", domain_excluded="switch")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_available": TargetSupport.STANDARD,
+    "is_not_available": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -47,6 +56,11 @@ async def test_update_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/update/test_trigger.py
+++ b/tests/components/update/test_trigger.py
@@ -5,15 +5,18 @@ from typing import Any
 import pytest
 
 from homeassistant.components.update import DOMAIN
+from homeassistant.components.update.trigger import TRIGGERS
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -24,6 +27,11 @@ from tests.components.common import (
 async def target_updates(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple update entities associated with different targets."""
     return await target_entities(hass, DOMAIN)
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "became_available": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -47,6 +55,11 @@ async def test_update_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/vacuum/test_condition.py
+++ b/tests/components/vacuum/test_condition.py
@@ -5,13 +5,16 @@ from typing import Any
 import pytest
 
 from homeassistant.components.vacuum import VacuumActivity
+from homeassistant.components.vacuum.condition import CONDITIONS
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     other_states,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -24,6 +27,15 @@ from tests.components.common import (
 async def target_vacuums(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple vacuum entities associated with different targets."""
     return await target_entities(hass, "vacuum")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_cleaning": TargetSupport.STANDARD,
+    "is_docked": TargetSupport.STANDARD,
+    "is_encountering_an_error": TargetSupport.STANDARD,
+    "is_paused": TargetSupport.STANDARD,
+    "is_returning": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -51,6 +63,11 @@ async def test_vacuum_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/vacuum/test_trigger.py
+++ b/tests/components/vacuum/test_trigger.py
@@ -5,14 +5,17 @@ from typing import Any
 import pytest
 
 from homeassistant.components.vacuum import VacuumActivity
+from homeassistant.components.vacuum.trigger import TRIGGERS
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     other_states,
     parametrize_target_entities,
     parametrize_trigger_states,
@@ -24,6 +27,15 @@ from tests.components.common import (
 async def target_vacuums(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple vacuum entities associated with different targets."""
     return await target_entities(hass, "vacuum")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "returned_to_dock": TargetSupport.STANDARD,
+    "errored": TargetSupport.STANDARD,
+    "paused_cleaning": TargetSupport.STANDARD,
+    "started_cleaning": TargetSupport.STANDARD,
+    "started_returning": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -51,6 +63,11 @@ async def test_vacuum_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/valve/test_condition.py
+++ b/tests/components/valve/test_condition.py
@@ -5,14 +5,17 @@ from typing import Any
 import pytest
 
 from homeassistant.components.valve import ATTR_IS_CLOSED
+from homeassistant.components.valve.condition import CONDITIONS
 from homeassistant.components.valve.const import ValveState
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_target_entities,
@@ -24,6 +27,12 @@ from tests.components.common import (
 async def target_valves(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple valve entities associated with different targets."""
     return await target_entities(hass, "valve")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_open": TargetSupport.STANDARD,
+    "is_closed": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +57,11 @@ async def test_valve_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/valve/test_trigger.py
+++ b/tests/components/valve/test_trigger.py
@@ -5,14 +5,17 @@ from typing import Any
 import pytest
 
 from homeassistant.components.valve import ATTR_IS_CLOSED, DOMAIN, ValveState
+from homeassistant.components.valve.trigger import TRIGGERS
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -60,6 +63,12 @@ async def target_valves(hass: HomeAssistant) -> dict[str, list[str]]:
     return await target_entities(hass, DOMAIN)
 
 
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "closed": TargetSupport.STANDARD,
+    "opened": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -82,6 +91,11 @@ async def test_valve_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/vibration/test_condition.py
+++ b/tests/components/vibration/test_condition.py
@@ -4,14 +4,17 @@ from typing import Any
 
 import pytest
 
+from homeassistant.components.vibration.condition import CONDITIONS
 from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     create_target_condition,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -24,6 +27,12 @@ from tests.components.common import (
 async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple binary sensor entities associated with different targets."""
     return await target_entities(hass, "binary_sensor")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_detected": TargetSupport.STANDARD,
+    "is_not_detected": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +57,11 @@ async def test_vibration_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/vibration/test_trigger.py
+++ b/tests/components/vibration/test_trigger.py
@@ -5,15 +5,18 @@ from typing import Any
 import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.vibration.trigger import TRIGGERS
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -24,6 +27,12 @@ from tests.components.common import (
 async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple binary sensor entities associated with different targets."""
     return await target_entities(hass, "binary_sensor")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "detected": TargetSupport.STANDARD,
+    "cleared": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -48,6 +57,11 @@ async def test_vibration_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/water_heater/test_condition.py
+++ b/tests/components/water_heater/test_condition.py
@@ -12,6 +12,7 @@ from homeassistant.components.water_heater import (
     STATE_HIGH_DEMAND,
     STATE_PERFORMANCE,
 )
+from homeassistant.components.water_heater.condition import CONDITIONS
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -23,9 +24,11 @@ from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     assert_numerical_condition_unit_conversion,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -63,6 +66,14 @@ _TEMPERATURE_THRESHOLD = {
 }
 
 
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_off": TargetSupport.STANDARD,
+    "is_on": TargetSupport.STANDARD,
+    "is_operation_mode": TargetSupport.STANDARD,
+    "is_target_temperature": TargetSupport.STANDARD,
+}
+
+
 @pytest.mark.parametrize(
     ("condition_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -92,6 +103,11 @@ async def test_water_heater_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/water_heater/test_trigger.py
+++ b/tests/components/water_heater/test_trigger.py
@@ -12,15 +12,18 @@ from homeassistant.components.water_heater import (
     STATE_HIGH_DEMAND,
     STATE_PERFORMANCE,
 )
+from homeassistant.components.water_heater.trigger import TRIGGERS
 from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, STATE_ON, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_numerical_attribute_changed_trigger_states,
     parametrize_numerical_attribute_crossed_threshold_trigger_states,
     parametrize_target_entities,
@@ -53,6 +56,15 @@ _CROSSED_THRESHOLD = {
         "type": "above",
         "value": {"number": 20, "unit_of_measurement": UnitOfTemperature.CELSIUS},
     }
+}
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "operation_mode_changed": TargetSupport.STANDARD,
+    "target_temperature_changed": TargetSupport.STANDARD,
+    "target_temperature_crossed_threshold": TargetSupport.STANDARD,
+    "turned_off": TargetSupport.STANDARD,
+    "turned_on": TargetSupport.STANDARD,
 }
 
 
@@ -96,6 +108,11 @@ async def test_water_heater_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/window/test_condition.py
+++ b/tests/components/window/test_condition.py
@@ -5,14 +5,17 @@ from typing import Any
 import pytest
 
 from homeassistant.components.cover import ATTR_IS_CLOSED, CoverState
+from homeassistant.components.window.condition import CONDITIONS
 from homeassistant.const import ATTR_DEVICE_CLASS, CONF_ENTITY_ID, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     create_target_condition,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
@@ -31,6 +34,12 @@ async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
 async def target_covers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple cover entities associated with different targets."""
     return await target_entities(hass, "cover")
+
+
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "is_closed": TargetSupport.STANDARD,
+    "is_open": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -55,6 +64,11 @@ async def test_window_condition_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 # --- binary_sensor tests ---

--- a/tests/components/window/test_trigger.py
+++ b/tests/components/window/test_trigger.py
@@ -6,15 +6,18 @@ import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.cover import ATTR_IS_CLOSED, CoverDeviceClass, CoverState
+from homeassistant.components.window.trigger import TRIGGERS
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -31,6 +34,12 @@ async def target_binary_sensors(hass: HomeAssistant) -> dict[str, list[str]]:
 async def target_covers(hass: HomeAssistant) -> dict[str, list[str]]:
     """Create multiple cover entities associated with different targets."""
     return await target_entities(hass, "cover")
+
+
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "opened": TargetSupport.STANDARD,
+    "closed": TargetSupport.STANDARD,
+}
 
 
 @pytest.mark.parametrize(
@@ -55,6 +64,11 @@ async def test_window_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/zone/test_condition.py
+++ b/tests/components/zone/test_condition.py
@@ -8,6 +8,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components.zone import condition as zone_condition
+from homeassistant.components.zone.condition import CONDITIONS
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConditionError
@@ -15,9 +16,11 @@ from homeassistant.helpers import condition, config_validation as cv
 
 from tests.components.common import (
     ConditionStateDescription,
+    TargetSupport,
     assert_condition_behavior_all,
     assert_condition_behavior_any,
     assert_condition_options_supported,
+    assert_conditions_target_support,
     parametrize_condition_states_all,
     parametrize_condition_states_any,
     parametrize_target_entities,
@@ -334,6 +337,15 @@ IN_ZONES_NONE: dict[str, list[str]] = {"in_zones": []}
 TARGET_ZONE = ZONE_HOME
 
 
+_CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "_": TargetSupport.NONE,
+    "in_zone": TargetSupport.STANDARD,
+    "not_in_zone": TargetSupport.STANDARD,
+    "occupancy_is_detected": TargetSupport.NONE,
+    "occupancy_is_not_detected": TargetSupport.NONE,
+}
+
+
 @pytest.mark.parametrize(
     (
         "condition_key",
@@ -366,6 +378,11 @@ async def test_zone_condition_options_validation(
         supports_duration=supports_duration,
         supports_target=supports_target,
     )
+
+
+def test_condition_target_support() -> None:
+    """Certify the condition registry matches its declared target support."""
+    assert_conditions_target_support(CONDITIONS, _CONDITION_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize(

--- a/tests/components/zone/test_trigger.py
+++ b/tests/components/zone/test_trigger.py
@@ -8,6 +8,7 @@ import pytest
 import voluptuous as vol
 
 from homeassistant.components import automation, zone
+from homeassistant.components.zone.trigger import TRIGGERS
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ENTITY_MATCH_ALL,
@@ -22,11 +23,13 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import async_fire_time_changed, mock_component
 from tests.components.common import (
+    TargetSupport,
     TriggerStateDescription,
     assert_trigger_behavior_all,
     assert_trigger_behavior_each,
     assert_trigger_behavior_first,
     assert_trigger_options_supported,
+    assert_triggers_target_support,
     parametrize_target_entities,
     parametrize_trigger_states,
     target_entities,
@@ -526,6 +529,15 @@ IN_ZONES_NONE: dict[str, list[str]] = {"in_zones": []}
 TRIGGER_ZONE = ZONE_HOME
 
 
+_TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
+    "_": TargetSupport.NONE,
+    "entered": TargetSupport.STANDARD,
+    "left": TargetSupport.STANDARD,
+    "occupancy_detected": TargetSupport.NONE,
+    "occupancy_cleared": TargetSupport.NONE,
+}
+
+
 @pytest.mark.parametrize(
     ("trigger_key", "base_options", "supports_behavior", "supports_duration"),
     [
@@ -548,6 +560,11 @@ async def test_zone_trigger_options_validation(
         supports_behavior=supports_behavior,
         supports_duration=supports_duration,
     )
+
+
+def test_trigger_target_support() -> None:
+    """Certify the trigger registry matches its declared target support."""
+    assert_triggers_target_support(TRIGGERS, _TRIGGER_TARGET_SUPPORT)
 
 
 @pytest.mark.parametrize("trigger_key", ["zone.entered", "zone.left"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deduplicate entity trigger and condition tests

Integrations declare in their test if their conditions and triggers reuse the base class functionality, and we do a best effort check to validate that. This is meant to guard against forgetting to update tests if the implementation changes.

Measured by `pytest --collect-only` across all tests/components/*/test_trigger.py + test_condition.py:

- Before: 56,817 tests
- After: 14,855 tests
- Decrease: 41,962 tests — about 74% (−73.9%).

Needs https://github.com/home-assistant/core/pull/180938 which adds tests of shared entity condition functionality

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
