### PR TITLE
Make Subaru buttons and locks coordinator-backed

### DIFF
--- a/homeassistant/components/subaru/button.py
+++ b/homeassistant/components/subaru/button.py
@@ -17,7 +17,7 @@ from .const import (
     VEHICLE_HAS_REMOTE_START,
 )
 from .coordinator import SubaruConfigEntry, SubaruDataUpdateCoordinator
-from .entity import SubaruEntity
+from .entity import SubaruCoordinatorEntity
 from .remote_service import async_call_remote_service
 
 
@@ -58,7 +58,7 @@ async def async_setup_entry(
     )
 
 
-class SubaruButton(SubaruEntity, ButtonEntity):
+class SubaruButton(SubaruCoordinatorEntity, ButtonEntity):
     """Class for a Subaru button."""
 
     entity_description: SubaruButtonEntityDescription
@@ -71,9 +71,8 @@ class SubaruButton(SubaruEntity, ButtonEntity):
         description: SubaruButtonEntityDescription,
     ) -> None:
         """Initialize the button for the vehicle."""
-        super().__init__(vehicle_info, description.key)
+        super().__init__(vehicle_info, coordinator, description.key)
         self.controller = controller
-        self.coordinator = coordinator
         self.entity_description = description
 
     @override

--- a/homeassistant/components/subaru/lock.py
+++ b/homeassistant/components/subaru/lock.py
@@ -20,7 +20,7 @@ from .const import (
     VEHICLE_NAME,
 )
 from .coordinator import SubaruConfigEntry
-from .entity import SubaruEntity
+from .entity import SubaruCoordinatorEntity
 from .remote_service import async_call_remote_service
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,10 +32,11 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Subaru locks by config_entry."""
+    coordinator = config_entry.runtime_data.coordinator
     controller = config_entry.runtime_data.controller
     vehicle_info = config_entry.runtime_data.vehicles
     async_add_entities(
-        SubaruLock(vehicle, controller)
+        SubaruLock(vehicle, controller, coordinator)
         for vehicle in vehicle_info.values()
         if vehicle[VEHICLE_HAS_REMOTE_SERVICE]
     )
@@ -49,7 +50,7 @@ async def async_setup_entry(
     )
 
 
-class SubaruLock(SubaruEntity, LockEntity):
+class SubaruLock(SubaruCoordinatorEntity, LockEntity):
     """Representation of a Subaru door lock.
 
     Note that the Subaru API currently does not support
@@ -59,9 +60,9 @@ class SubaruLock(SubaruEntity, LockEntity):
 
     _attr_translation_key = "door_locks"
 
-    def __init__(self, vehicle_info, controller):
+    def __init__(self, vehicle_info, controller, coordinator):
         """Initialize the locks for the vehicle."""
-        super().__init__(vehicle_info, "door_locks")
+        super().__init__(vehicle_info, coordinator, "door_locks")
         self.controller = controller
         self.car_name = vehicle_info[VEHICLE_NAME]
 

--- a/tests/components/subaru/test_button.py
+++ b/tests/components/subaru/test_button.py
@@ -10,7 +10,7 @@ from homeassistant.components.subaru.const import (
     VEHICLE_HAS_EV,
     VEHICLE_HAS_REMOTE_START,
 )
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -299,3 +299,15 @@ async def test_no_buttons_without_remote_start(
     assert entry is None
     entry = entity_registry.async_get(VEHICLE_BUTTONS[TEST_VIN_3_G3]["remote_stop"])
     assert entry is None
+
+
+async def test_button_unavailable_on_fetch_failure(
+    hass: HomeAssistant, subaru_config_entry: MockConfigEntry
+) -> None:
+    """Test button goes unavailable when the coordinator fails to fetch data."""
+    await setup_subaru_config_entry(
+        hass, subaru_config_entry, fetch_effect=SubaruException("403 Error")
+    )
+
+    state = hass.states.get(VEHICLE_BUTTONS[TEST_VIN_2_EV]["remote_start"])
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/subaru/test_lock.py
+++ b/tests/components/subaru/test_lock.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+from subarulink import SubaruException
 from voluptuous.error import MultipleInvalid
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
@@ -12,12 +13,19 @@ from homeassistant.components.subaru.const import (
     SERVICE_UNLOCK_SPECIFIC_DOOR,
     UNLOCK_DOOR_DRIVERS,
 )
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_LOCK,
+    SERVICE_UNLOCK,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import MOCK_API
+from .conftest import MOCK_API, setup_subaru_config_entry
+
+from tests.common import MockConfigEntry
 
 MOCK_API_LOCK = f"{MOCK_API}lock"
 MOCK_API_UNLOCK = f"{MOCK_API}unlock"
@@ -87,3 +95,15 @@ async def test_unlock_specific_door_invalid(hass: HomeAssistant, ev_entry) -> No
             blocking=True,
         )
     mock_unlock.assert_not_called()
+
+
+async def test_lock_unavailable_on_fetch_failure(
+    hass: HomeAssistant, subaru_config_entry: MockConfigEntry
+) -> None:
+    """Test lock goes unavailable when the coordinator fails to fetch data."""
+    await setup_subaru_config_entry(
+        hass, subaru_config_entry, fetch_effect=SubaruException("403 Error")
+    )
+
+    state = hass.states.get(DEVICE_ID)
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change

`SubaruButton` and `SubaruLock` extended the plain `SubaruEntity` base instead of `SubaruCoordinatorEntity`, so unlike sensors and binary sensors, they never reported `unavailable` when the coordinator failed to fetch data (device unreachable, dropped from the API response, etc). This wires both platforms onto the coordinator base and adds test coverage for the fetch-failure case. Split out from #178638 per reviewer feedback.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #178638
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
