### PR TITLE
Filter cancelled events out of caldav

### DIFF
--- a/homeassistant/components/caldav/coordinator.py
+++ b/homeassistant/components/caldav/coordinator.py
@@ -30,11 +30,10 @@ OFFSET = "!!"
 def _get_status(vevent: caldav.CalendarObjectResource) -> CalendarEventStatus | None:
     """Return the rfc5545 STATUS of a VEVENT, if a calendar entity reports it.
 
-    Anything outside the supported set is dropped rather than passed on, which
-    covers both the cancelled status a calendar entity does not report and the
-    iana-tokens and x-names that rfc5545 also permits here: reporting no status
-    at all is closer to the truth than reporting one the consumer cannot
-    interpret.
+    Anything outside the supported set is dropped rather than passed on: the
+    iana-tokens and x-names rfc5545 also permits here cannot be interpreted by
+    a consumer, so reporting no status is closer to the truth. Cancelled events
+    never reach this, they are filtered out before an event is built.
     """
     if (value := get_attr_value(vevent, "status")) is None:
         return None
@@ -43,6 +42,17 @@ def _get_status(vevent: caldav.CalendarObjectResource) -> CalendarEventStatus | 
     except ValueError:
         _LOGGER.debug("Ignoring unsupported event status %s", value)
         return None
+
+
+def _is_cancelled(vevent: caldav.CalendarObjectResource) -> bool:
+    """Return whether a VEVENT has been called off.
+
+    rfc5545 keeps a cancelled event in the calendar rather than deleting it, so
+    a calendar has to be read to find out. A calendar entity does not return
+    such events.
+    """
+    value = get_attr_value(vevent, "status")
+    return value is not None and value.lower() == "cancelled"
 
 
 class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
@@ -94,6 +104,8 @@ class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
                 continue
             vevent = event.vobject_instance.vevent
             if not self.is_matching(vevent, self.search):
+                continue
+            if _is_cancelled(vevent):
                 continue
             event_list.append(
                 CalendarEvent(
@@ -187,6 +199,7 @@ class CalDavUpdateCoordinator(DataUpdateCoordinator[CalendarEvent | None]):
                     self.is_matching(vevent, self.search)
                     and (not self.is_all_day(vevent) or self.include_all_day)
                     and not self.is_over(vevent)
+                    and not _is_cancelled(vevent)
                 )
             ),
             None,

--- a/homeassistant/components/caldav/coordinator.py
+++ b/homeassistant/components/caldav/coordinator.py
@@ -30,10 +30,9 @@ OFFSET = "!!"
 def _get_status(vevent: caldav.CalendarObjectResource) -> CalendarEventStatus | None:
     """Return the rfc5545 STATUS of a VEVENT, if a calendar entity reports it.
 
-    Anything outside the supported set is dropped rather than passed on: the
-    iana-tokens and x-names rfc5545 also permits here cannot be interpreted by
-    a consumer, so reporting no status is closer to the truth. Cancelled events
-    never reach this, they are filtered out before an event is built.
+    Cancelled events never reach this, they are filtered out before an event is
+    built. Anything else outside the supported set is dropped: rfc5545 also
+    permits iana-tokens and x-names here, which a consumer cannot interpret.
     """
     if (value := get_attr_value(vevent, "status")) is None:
         return None

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -1172,7 +1172,6 @@ END:VCALENDAR"""
         pytest.param("TENTATIVE", "tentative", id="tentative"),
         pytest.param("CONFIRMED", "confirmed", id="confirmed"),
         pytest.param("Tentative", "tentative", id="mixed_case"),
-        pytest.param("CANCELLED", None, id="cancelled_is_not_reported"),
         pytest.param("X-VENDOR-SPECIFIC", None, id="unsupported_value"),
     ],
 )
@@ -1189,6 +1188,56 @@ async def test_get_events_with_status(
 
     assert len(events) == 1
     assert events[0]["status"] == expected_status
+
+
+def _mock_calendar_holding(name: str, vevents: list[str]) -> Mock:
+    """Return a mock calendar holding exactly the given VEVENTs."""
+    calendar = Mock()
+    calendar.name = name
+    calendar.get_supported_components = MagicMock(return_value=["VEVENT"])
+    calendar.search = MagicMock(
+        return_value=[
+            Event(None, f"{idx}.ics", vevent, calendar, str(idx))
+            for idx, vevent in enumerate(vevents)
+        ]
+    )
+    return calendar
+
+
+async def test_cancelled_event_is_not_returned(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test that an event called off is not returned by the API."""
+    events = await _get_api_events_for_vevent(
+        hass,
+        hass_client,
+        ICS_WITH_STATUS.format(status="CANCELLED"),
+        "status-event-uid",
+    )
+
+    assert events == []
+
+
+@pytest.mark.parametrize("tz", [UTC])
+@pytest.mark.parametrize(
+    ("calendars"),
+    [[_mock_calendar_holding("Example", [ICS_WITH_STATUS.format(status="CANCELLED")])]],
+)
+@pytest.mark.freeze_time(_local_datetime(17, 30))
+async def test_cancelled_event_is_not_the_ongoing_event(
+    hass: HomeAssistant, setup_platform_cb: Callable[[], Awaitable[None]]
+) -> None:
+    """Test that an event called off does not turn the entity on.
+
+    The event would be ongoing at this time were it not cancelled, so this
+    covers the state path rather than the API one.
+    """
+    await setup_platform_cb()
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state
+    assert state.state == STATE_OFF
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Skip events with `STATUS:CANCELLED` in caldav, so a called-off event is no longer returned by the API or picked up as the ongoing event.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This follows the review of #179312, where we settled that a calendar entity should not return cancelled events at all. rfc5545 keeps a cancelled event in the calendar rather than deleting it, so a CalDAV server serves it like any other event, and Home Assistant currently shows it as if it were still going ahead. I ran into this with my own Nextcloud calendar.

caldav now skips events with `STATUS:CANCELLED` in both places it builds them: the event list `async_get_events()` returns, and the search for the ongoing or next event that drives the entity state. `_get_status()` no longer has to account for cancelled, since those events never reach it; its docstring is updated to say so, and the parametrized case asserting `cancelled` maps to no status is replaced by the two new tests.

Tests cover both paths: that the API returns nothing for a cancelled event, and that an event that would be ongoing right now does not turn the entity on.

This is based on #179312, which adds `CalendarEventStatus` and the status tests this builds on. Its commits show up in this diff until it is merged.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/discussions/884
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
