### PR TITLE
Filter cancelled events out of remote_calendar

### DIFF
--- a/homeassistant/components/remote_calendar/calendar.py
+++ b/homeassistant/components/remote_calendar/calendar.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import logging
 from typing import override
 
-from ical.event import Event
+from ical.event import Event, EventStatus
 from ical.timeline import Timeline, materialize_timeline
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
@@ -67,7 +67,11 @@ class RemoteCalendarEntity(
         if self._timeline is None:
             return None
         now = dt_util.now()
-        events = self._timeline.active_after(now)
+        events = (
+            event
+            for event in self._timeline.active_after(now)
+            if not _is_cancelled(event)
+        )
         if event := next(events, None):
             return _get_calendar_event(event)
         return None
@@ -84,7 +88,11 @@ class RemoteCalendarEntity(
                 start_date,
                 end_date,
             )
-            return [_get_calendar_event(event) for event in events]
+            return [
+                _get_calendar_event(event)
+                for event in events
+                if not _is_cancelled(event)
+            ]
 
         return await self.hass.async_add_executor_job(events_in_range)
 
@@ -130,6 +138,16 @@ class RemoteCalendarEntity(
         """Refresh the timeline and write state."""
         await self._async_update_timeline()
         self.async_write_ha_state()
+
+
+def _is_cancelled(event: Event) -> bool:
+    """Return whether an event has been called off.
+
+    rfc5545 keeps a cancelled event in the calendar rather than deleting it, so
+    a remote calendar can serve one. A calendar entity does not return such
+    events.
+    """
+    return event.status == EventStatus.CANCELLED
 
 
 def _get_calendar_event(event: Event) -> CalendarEvent:

--- a/tests/components/remote_calendar/test_calendar.py
+++ b/tests/components/remote_calendar/test_calendar.py
@@ -267,6 +267,58 @@ async def test_cancelled_event_does_not_turn_the_entity_on(
     assert state.state == STATE_OFF
 
 
+CANCELLED_OCCURRENCE_ICS = textwrap.dedent(
+    """\
+    BEGIN:VCALENDAR
+    VERSION:2.0
+    BEGIN:VEVENT
+    SUMMARY:Daily series
+    UID:daily-series
+    DTSTART;VALUE=DATE:20261002
+    DTEND;VALUE=DATE:20261003
+    RRULE:FREQ=DAILY;COUNT=5
+    STATUS:CONFIRMED
+    END:VEVENT
+    BEGIN:VEVENT
+    SUMMARY:Daily series
+    UID:daily-series
+    RECURRENCE-ID;VALUE=DATE:20261003
+    DTSTART;VALUE=DATE:20261003
+    DTEND;VALUE=DATE:20261004
+    STATUS:CANCELLED
+    END:VEVENT
+    END:VCALENDAR
+    """
+)
+
+
+@respx.mock
+async def test_cancelled_occurrence_of_a_series_is_not_returned(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    get_events: GetEventsFn,
+) -> None:
+    """Test that only the cancelled occurrence of a recurring series is dropped.
+
+    The filtering has to happen after the series is expanded: dropping the
+    cancelled VEVENT before expansion would remove the override, and the RRULE
+    would then produce that day as an ordinary event again.
+    """
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(status_code=200, text=CANCELLED_OCCURRENCE_ICS)
+    )
+    await setup_integration(hass, config_entry)
+
+    events = await get_events("2026-10-01T00:00:00Z", "2026-10-08T00:00:00Z")
+
+    assert [event["start"] for event in events] == [
+        {"date": "2026-10-02"},
+        {"date": "2026-10-04"},
+        {"date": "2026-10-05"},
+        {"date": "2026-10-06"},
+    ]
+
+
 @pytest.mark.freeze_time(datetime(2007, 6, 28, 12))
 @respx.mock
 async def test_active_event(

--- a/tests/components/remote_calendar/test_calendar.py
+++ b/tests/components/remote_calendar/test_calendar.py
@@ -213,6 +213,60 @@ async def test_api_date_event(
     assert len(events) == 1
 
 
+CANCELLED_EVENT_ICS = textwrap.dedent(
+    """\
+    BEGIN:VCALENDAR
+    VERSION:2.0
+    BEGIN:VEVENT
+    SUMMARY:Festival International de Jazz de Montreal
+    LOCATION:Montreal
+    DTSTART:20070628
+    DTEND:20070709
+    STATUS:CANCELLED
+    END:VEVENT
+    END:VCALENDAR
+    """
+)
+
+
+@respx.mock
+async def test_cancelled_event_is_not_returned(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    get_events: GetEventsFn,
+) -> None:
+    """Test that an event called off is not returned by the API."""
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(status_code=200, text=CANCELLED_EVENT_ICS)
+    )
+    await setup_integration(hass, config_entry)
+
+    events = await get_events("2007-06-28T00:00:00Z", "2007-07-10T00:00:00Z")
+
+    assert events == []
+
+
+@pytest.mark.freeze_time(datetime(2007, 6, 28, 12))
+@respx.mock
+async def test_cancelled_event_does_not_turn_the_entity_on(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test that an event called off is not picked up as the current event.
+
+    The event would be active at this time were it not cancelled, so this
+    covers the state path rather than the API one.
+    """
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(status_code=200, text=CANCELLED_EVENT_ICS)
+    )
+    await setup_integration(hass, config_entry)
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state
+    assert state.state == STATE_OFF
+
+
 @pytest.mark.freeze_time(datetime(2007, 6, 28, 12))
 @respx.mock
 async def test_active_event(


### PR DESCRIPTION
Skip events with `STATUS:CANCELLED` in remote_calendar, so a called-off event from the remote calendar is no longer returned by the API or picked up as the ongoing event.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This follows the review of #179312, where we settled that a calendar entity should not return cancelled events at all. rfc5545 keeps a cancelled event in the calendar rather than deleting it, so a remote ICS feed can serve one like any other event, and Home Assistant currently shows it as if it were still going ahead.

remote_calendar now skips events with `STATUS:CANCELLED` in both places it builds them: the event list `async_get_events()` returns, and the lookup of the ongoing or next event that drives the entity state.

Tests cover both paths: that the API returns nothing for a cancelled event, and that an event that would be active right now does not turn the entity on.

This is based on #179312, which adds the calendar event status this pairs with. Its commits show up in this diff until it is merged.

**Known limitation.** The filtering runs after `materialize_timeline`, which is capped at `MAX_LOOKAHEAD_EVENTS` (20). Cancelled occurrences still consume that budget, so a cancelled series ahead of a real event can leave the entity reporting no upcoming event at all — where it previously reported the cancelled one.

Filtering before expansion is not the fix. A single cancelled occurrence of a series is a separate `VEVENT` carrying the same `UID` and a `RECURRENCE-ID`. Dropping it removes the override, the `RRULE` then expands unimpeded, and the cancelled day comes back as a confirmed event: the cancellation is not hidden but silently undone.

Filtering correctly means materializing until 20 non-cancelled events are retained. `ical` offers no filter hook during expansion, so that requires over-materializing by an unknown factor, or a change upstream in `ical`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/discussions/884
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
