### PR TITLE
Add UI support for standalone google assistant

### DIFF
--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -16,7 +16,14 @@ from yarl import URL
 
 from homeassistant.components import webhook
 from homeassistant.const import CONF_NAME, STATE_UNAVAILABLE, EntityStateAttribute
-from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, State, callback
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    Context,
+    CoreState,
+    HomeAssistant,
+    State,
+    callback,
+)
 from homeassistant.helpers import (
     area_registry as ar,
     device_registry as dr,
@@ -281,7 +288,7 @@ class AbstractConfig(ABC):
     @callback
     def async_schedule_google_sync_all(self) -> None:
         """Schedule a sync for all registered agents."""
-        if not self.hass.is_running:
+        if self.hass.state is not CoreState.running:
             _LOGGER.debug("Sync skipped when not fully running")
             return
         for agent_user_id in self.async_get_agent_users():

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -281,6 +281,9 @@ class AbstractConfig(ABC):
     @callback
     def async_schedule_google_sync_all(self) -> None:
         """Schedule a sync for all registered agents."""
+        if not self.hass.is_running:
+            _LOGGER.debug("Sync skipped when not fully running")
+            return
         for agent_user_id in self.async_get_agent_users():
             self.async_schedule_google_sync(agent_user_id)
 

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -14,13 +14,22 @@ from homeassistant.components import webhook
 from homeassistant.components.homeassistant.exposed_entities import (
     async_expose_entity,
     async_listen_entity_updates,
+    async_set_entity_locked,
     async_should_expose,
 )
 from homeassistant.components.http import KEY_HASS, HomeAssistantView
-from homeassistant.core import Event, HomeAssistant, callback, split_entity_id
+from homeassistant.const import MATCH_ALL
+from homeassistant.core import (
+    Event,
+    EventStateChangedData,
+    HomeAssistant,
+    callback,
+    split_entity_id,
+)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_state_added_domain
 from homeassistant.helpers.storage import STORAGE_DIR, Store
 from homeassistant.util import dt as dt_util, json as json_util
 
@@ -49,7 +58,6 @@ from .smart_home import async_handle_message
 
 _LOGGER = logging.getLogger(__name__)
 
-# Registry attributes that affect whether an entity is exposed by default.
 EXPOSURE_ATTRIBUTES = {"entity_category", "hidden_by"}
 
 
@@ -117,32 +125,48 @@ class GoogleConfig(AbstractConfig):
                 self._async_entity_registry_updated,
             )
         )
+        self._on_deinitialize.append(
+            async_track_state_added_domain(
+                self.hass, MATCH_ALL, self._async_state_added
+            )
+        )
+        for state in self.hass.states.async_all():
+            self._async_update_legacy_exposure(state.entity_id)
 
         self.async_enable_local_sdk()
+
+    @callback
+    def _async_state_added(self, event: Event[EventStateChangedData]) -> None:
+        """Push YAML exposure for a newly added entity and schedule a sync."""
+        entity_id = event.data["entity_id"]
+        self._async_update_legacy_exposure(entity_id)
+        if self.should_expose(entity_id):
+            self.async_schedule_google_sync_all()
 
     @callback
     def _async_entity_registry_updated(
         self, event: Event[er.EventEntityRegistryUpdatedData]
     ) -> None:
-        """Schedule a sync for a new or changed entity that should be exposed."""
+        """Schedule a sync for an updated or removed entity."""
         entity_id = event.data["entity_id"]
-        action = event.data["action"]
-        exposure_changed = False
 
-        if event.data["action"] == "update":
-            changes = set(event.data["changes"])
-            if not changes & (er.ENTITY_DESCRIBING_ATTRIBUTES | EXPOSURE_ATTRIBUTES):
-                return
-            exposure_changed = bool(changes & EXPOSURE_ATTRIBUTES)
-
-        if (
-            action != "remove"
-            and not exposure_changed
-            and not self.should_expose(entity_id)
-        ):
+        if event.data["action"] == "remove":
+            self.async_schedule_google_sync_all()
             return
 
-        self.async_schedule_google_sync_all()
+        if event.data["action"] != "update":
+            return
+
+        changes = set(event.data["changes"])
+        if not changes & (er.ENTITY_DESCRIBING_ATTRIBUTES | EXPOSURE_ATTRIBUTES):
+            return
+
+        exposure_changed = bool(changes & EXPOSURE_ATTRIBUTES)
+        if exposure_changed:
+            self._async_update_legacy_exposure(entity_id)
+
+        if exposure_changed or self.should_expose(entity_id):
+            self.async_schedule_google_sync_all()
 
     @property
     @override
@@ -214,7 +238,6 @@ class GoogleConfig(AbstractConfig):
     @override
     def should_expose(self, entity_id: str) -> bool:
         """Return if entity should be exposed."""
-        self._async_reconcile_yaml_exposure(entity_id)
         return async_should_expose(self.hass, DOMAIN, entity_id)
 
     def _should_expose_by_default(
@@ -239,15 +262,16 @@ class GoogleConfig(AbstractConfig):
         return result
 
     @callback
-    def _async_reconcile_yaml_exposure(self, entity_id: str) -> None:
-        """Align one entity's shared exposure setting with YAML configuration.
+    def _async_update_legacy_exposure(self, entity_id: str) -> None:
+        """Push the entity's YAML-configured exposure into the shared store.
 
-        Called on every should_expose(), so a UI change to an entity YAML
-        has an opinion on only lasts until the next such call.
+        Also locks the entity, so websocket updates to its exposure setting
+        are rejected as long as YAML has an opinion on it.
         """
         explicit_expose = self.entity_config.get(entity_id, {}).get(CONF_EXPOSE)
         if explicit_expose is not None:
             async_expose_entity(self.hass, DOMAIN, entity_id, explicit_expose)
+            async_set_entity_locked(self.hass, DOMAIN, entity_id, True)
             return
 
         entity_registry = er.async_get(self.hass)
@@ -260,7 +284,11 @@ class GoogleConfig(AbstractConfig):
         else:
             auxiliary_entity = False
 
-        if self._should_expose_by_default(entity_id, auxiliary_entity=auxiliary_entity):
+        should_expose_by_default = self._should_expose_by_default(
+            entity_id, auxiliary_entity=auxiliary_entity
+        )
+        async_set_entity_locked(self.hass, DOMAIN, entity_id, should_expose_by_default)
+        if should_expose_by_default:
             async_expose_entity(self.hass, DOMAIN, entity_id, True)
 
     @override

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -140,8 +140,16 @@ class GoogleConfig(AbstractConfig):
 
     @callback
     def _async_state_added(self, event: Event[EventStateChangedData]) -> None:
-        """Push YAML exposure for a newly added entity and schedule a sync."""
+        """Push YAML exposure for a newly added entity and schedule a sync.
+
+        This only need to handle states not registered in entity registry.
+        """
         entity_id = event.data["entity_id"]
+        entity_registry = er.async_get(self.hass)
+
+        if entity_registry.async_get(entity_id):
+            return
+
         self._async_update_legacy_exposure(entity_id)
         if self.should_expose(entity_id):
             self.async_schedule_google_sync_all()
@@ -155,6 +163,10 @@ class GoogleConfig(AbstractConfig):
 
         if event.data["action"] == "remove":
             self.async_schedule_google_sync_all()
+            return
+
+        if event.data["action"] == "create":
+            self._async_update_legacy_exposure(entity_id)
             return
 
         if event.data["action"] != "update":

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -12,8 +12,6 @@ import jwt
 
 from homeassistant.components import webhook
 from homeassistant.components.homeassistant.exposed_entities import (
-    async_expose_entity,
-    async_is_entity_locked,
     async_listen_entity_updates,
     async_set_entity_locked,
     async_should_expose,
@@ -264,15 +262,15 @@ class GoogleConfig(AbstractConfig):
 
     @callback
     def _async_update_legacy_exposure(self, entity_id: str) -> None:
-        """Push the entity's YAML-configured exposure into the shared store.
+        """Set the entity's YAML-configured exposure in the shared store.
 
-        Also locks the entity, so websocket updates to its exposure setting
-        are rejected as long as YAML has an opinion on it.
+        Kept in memory only, so exposure reverts to the UI-driven store as
+        soon as YAML no longer has an opinion, including across a restart
+        with the domain, or the whole configuration, removed.
         """
         explicit_expose = self.entity_config.get(entity_id, {}).get(CONF_EXPOSE)
         if explicit_expose is not None:
-            async_expose_entity(self.hass, DOMAIN, entity_id, explicit_expose)
-            async_set_entity_locked(self.hass, DOMAIN, entity_id, True)
+            async_set_entity_locked(self.hass, DOMAIN, entity_id, explicit_expose)
             return
 
         entity_registry = er.async_get(self.hass)
@@ -288,13 +286,9 @@ class GoogleConfig(AbstractConfig):
         should_expose_by_default = self._should_expose_by_default(
             entity_id, auxiliary_entity=auxiliary_entity
         )
-        was_locked = async_is_entity_locked(self.hass, DOMAIN, entity_id)
-        async_set_entity_locked(self.hass, DOMAIN, entity_id, should_expose_by_default)
-        if should_expose_by_default:
-            async_expose_entity(self.hass, DOMAIN, entity_id, True)
-        elif was_locked:
-            # Was locked, so the stored value is ours to clear.
-            async_expose_entity(self.hass, DOMAIN, entity_id, False)
+        async_set_entity_locked(
+            self.hass, DOMAIN, entity_id, True if should_expose_by_default else None
+        )
 
     @override
     def should_2fa(self, state):

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -49,6 +49,9 @@ from .smart_home import async_handle_message
 
 _LOGGER = logging.getLogger(__name__)
 
+# Registry attributes that affect whether an entity is exposed by default.
+EXPOSURE_ATTRIBUTES = {"entity_category", "hidden_by"}
+
 
 def _get_homegraph_jwt(time, iss, key):
     now = int(time.timestamp())
@@ -124,18 +127,18 @@ class GoogleConfig(AbstractConfig):
         """Schedule a sync for a new or changed entity that should be exposed."""
         entity_id = event.data["entity_id"]
         action = event.data["action"]
-        changes = set(event.data.get("changes", ()))
-        exposure_attributes = {"entity_category", "hidden_by"}
-        exposure_changed = bool(changes & exposure_attributes)
-        if action == "update" and not (
-            changes & (er.ENTITY_DESCRIBING_ATTRIBUTES | exposure_attributes)
-        ):
-            return
+        exposure_changed = False
+
+        if event.data["action"] == "update":
+            changes = set(event.data["changes"])
+            if not changes & (er.ENTITY_DESCRIBING_ATTRIBUTES | EXPOSURE_ATTRIBUTES):
+                return
+            exposure_changed = bool(changes & EXPOSURE_ATTRIBUTES)
 
         if (
             action != "remove"
-            and not self.should_expose(entity_id)
             and not exposure_changed
+            and not self.should_expose(entity_id)
         ):
             return
 

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -179,6 +179,10 @@ class GoogleConfig(AbstractConfig):
             return
 
         exposure_changed = bool(changes & EXPOSURE_ATTRIBUTES)
+        if old_entity_id := event.data.get("old_entity_id"):
+            async_set_entity_locked(self.hass, DOMAIN, old_entity_id, None)
+            exposure_changed = True
+
         if exposure_changed:
             self._async_update_legacy_exposure(entity_id)
 

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -17,7 +17,7 @@ from homeassistant.components.homeassistant.exposed_entities import (
     async_should_expose,
 )
 from homeassistant.components.http import KEY_HASS, HomeAssistantView
-from homeassistant.const import MATCH_ALL
+from homeassistant.const import EVENT_STATE_CHANGED
 from homeassistant.core import (
     Event,
     EventStateChangedData,
@@ -28,7 +28,6 @@ from homeassistant.core import (
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.event import async_track_state_added_domain
 from homeassistant.helpers.storage import STORAGE_DIR, Store
 from homeassistant.util import dt as dt_util, json as json_util
 
@@ -125,8 +124,10 @@ class GoogleConfig(AbstractConfig):
             )
         )
         self._on_deinitialize.append(
-            async_track_state_added_domain(
-                self.hass, MATCH_ALL, self._async_state_added
+            self.hass.bus.async_listen(
+                EVENT_STATE_CHANGED,
+                self._async_state_changed,
+                event_filter=self._async_filter_state_changed,
             )
         )
 
@@ -139,15 +140,25 @@ class GoogleConfig(AbstractConfig):
         self.async_enable_local_sdk()
 
     @callback
-    def _async_state_added(self, event: Event[EventStateChangedData]) -> None:
-        """Push YAML exposure for a newly added entity and schedule a sync.
+    def _async_filter_state_changed(self, event_data: EventStateChangedData) -> bool:
+        """Return True for a non-registry entity's state being added or removed.
 
-        This only needs to handle states not registered in entity registry.
+        Registered entities are ignored; a registered entity's changes are
+        handled by _async_entity_registry_updated instead.
         """
-        entity_id = event.data["entity_id"]
+        if event_data["old_state"] is not None and event_data["new_state"] is not None:
+            return False
         entity_registry = er.async_get(self.hass)
+        return not entity_registry.async_get(event_data["entity_id"])
 
-        if entity_registry.async_get(entity_id):
+    @callback
+    def _async_state_changed(self, event: Event[EventStateChangedData]) -> None:
+        """Push or clear YAML exposure when a non-registry entity is added or removed."""
+        entity_id = event.data["entity_id"]
+
+        if event.data["new_state"] is None:
+            async_set_entity_locked(self.hass, DOMAIN, entity_id, None)
+            self.async_schedule_google_sync_all()
             return
 
         self._async_update_legacy_exposure(entity_id)

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -142,7 +142,7 @@ class GoogleConfig(AbstractConfig):
     def _async_state_added(self, event: Event[EventStateChangedData]) -> None:
         """Push YAML exposure for a newly added entity and schedule a sync.
 
-        This only need to handle states not registered in entity registry.
+        This only needs to handle states not registered in entity registry.
         """
         entity_id = event.data["entity_id"]
         entity_registry = er.async_get(self.hass)
@@ -167,6 +167,8 @@ class GoogleConfig(AbstractConfig):
 
         if event.data["action"] == "create":
             self._async_update_legacy_exposure(entity_id)
+            if self.should_expose(entity_id):
+                self.async_schedule_google_sync_all()
             return
 
         if event.data["action"] != "update":

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -123,12 +123,20 @@ class GoogleConfig(AbstractConfig):
     ) -> None:
         """Schedule a sync for a new or changed entity that should be exposed."""
         entity_id = event.data["entity_id"]
-        if event.data["action"] == "update" and not (
-            set(event.data["changes"]) & er.ENTITY_DESCRIBING_ATTRIBUTES
+        action = event.data["action"]
+        changes = set(event.data.get("changes", ()))
+        exposure_attributes = {"entity_category", "hidden_by"}
+        exposure_changed = bool(changes & exposure_attributes)
+        if action == "update" and not (
+            changes & (er.ENTITY_DESCRIBING_ATTRIBUTES | exposure_attributes)
         ):
             return
 
-        if event.data["action"] != "remove" and not self.should_expose(entity_id):
+        if (
+            action != "remove"
+            and not self.should_expose(entity_id)
+            and not exposure_changed
+        ):
             return
 
         self.async_schedule_google_sync_all()

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -13,6 +13,7 @@ import jwt
 from homeassistant.components import webhook
 from homeassistant.components.homeassistant.exposed_entities import (
     async_expose_entity,
+    async_is_entity_locked,
     async_listen_entity_updates,
     async_set_entity_locked,
     async_should_expose,
@@ -287,9 +288,13 @@ class GoogleConfig(AbstractConfig):
         should_expose_by_default = self._should_expose_by_default(
             entity_id, auxiliary_entity=auxiliary_entity
         )
+        was_locked = async_is_entity_locked(self.hass, DOMAIN, entity_id)
         async_set_entity_locked(self.hass, DOMAIN, entity_id, should_expose_by_default)
         if should_expose_by_default:
             async_expose_entity(self.hass, DOMAIN, entity_id, True)
+        elif was_locked:
+            # Was locked, so the stored value is ours to clear.
+            async_expose_entity(self.hass, DOMAIN, entity_id, False)
 
     @override
     def should_2fa(self, state):

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -129,8 +129,12 @@ class GoogleConfig(AbstractConfig):
                 self.hass, MATCH_ALL, self._async_state_added
             )
         )
-        for state in self.hass.states.async_all():
-            self._async_update_legacy_exposure(state.entity_id)
+
+        entity_ids = set(self.hass.states.async_entity_ids())
+        entity_ids.update(er.async_get(self.hass).entities)
+        entity_ids.update(self.entity_config)
+        for entity_id in entity_ids:
+            self._async_update_legacy_exposure(entity_id)
 
         self.async_enable_local_sdk()
 

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -11,8 +11,13 @@ from aiohttp.web import Request, Response
 import jwt
 
 from homeassistant.components import webhook
+from homeassistant.components.homeassistant.exposed_entities import (
+    async_expose_entity,
+    async_listen_entity_updates,
+    async_should_expose,
+)
 from homeassistant.components.http import KEY_HASS, HomeAssistantView
-from homeassistant.core import HomeAssistant, callback, split_entity_id
+from homeassistant.core import Event, HomeAssistant, callback, split_entity_id
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -87,6 +92,7 @@ class GoogleConfig(AbstractConfig):
         self._config = config
         self._access_token = None
         self._access_token_renew = None
+        self._should_expose_by_default_cache: dict[tuple[str, bool], bool] = {}
 
     @override
     async def async_initialize(self):
@@ -97,7 +103,35 @@ class GoogleConfig(AbstractConfig):
 
         await super().async_initialize()
 
+        self._on_deinitialize.append(
+            async_listen_entity_updates(
+                self.hass, DOMAIN, self.async_schedule_google_sync_all
+            )
+        )
+        self._on_deinitialize.append(
+            self.hass.bus.async_listen(
+                er.EVENT_ENTITY_REGISTRY_UPDATED,
+                self._async_entity_registry_updated,
+            )
+        )
+
         self.async_enable_local_sdk()
+
+    @callback
+    def _async_entity_registry_updated(
+        self, event: Event[er.EventEntityRegistryUpdatedData]
+    ) -> None:
+        """Schedule a sync for a new or changed entity that should be exposed."""
+        entity_id = event.data["entity_id"]
+        if event.data["action"] == "update" and not (
+            set(event.data["changes"]) & er.ENTITY_DESCRIBING_ATTRIBUTES
+        ):
+            return
+
+        if event.data["action"] != "remove" and not self.should_expose(entity_id):
+            return
+
+        self.async_schedule_google_sync_all()
 
     @property
     @override
@@ -169,8 +203,41 @@ class GoogleConfig(AbstractConfig):
     @override
     def should_expose(self, entity_id: str) -> bool:
         """Return if entity should be exposed."""
+        self._async_reconcile_yaml_exposure(entity_id)
+        return async_should_expose(self.hass, DOMAIN, entity_id)
+
+    def _should_expose_by_default(
+        self, entity_id: str, *, auxiliary_entity: bool
+    ) -> bool:
+        """Return if entity's domain is exposed by default per YAML configuration."""
+        cache_key = (entity_id, auxiliary_entity)
+        if (cached := self._should_expose_by_default_cache.get(cache_key)) is not None:
+            return cached
+
         expose_by_default = self._config.get(CONF_EXPOSE_BY_DEFAULT)
         exposed_domains = self._config.get(CONF_EXPOSED_DOMAINS)
+
+        domain_exposed_by_default = (
+            expose_by_default and split_entity_id(entity_id)[0] in exposed_domains
+        )
+
+        # Expose an entity by default if the entity's domain is exposed by default
+        # and the entity is not a config or diagnostic entity
+        result = domain_exposed_by_default and not auxiliary_entity
+        self._should_expose_by_default_cache[cache_key] = result
+        return result
+
+    @callback
+    def _async_reconcile_yaml_exposure(self, entity_id: str) -> None:
+        """Align one entity's shared exposure setting with YAML configuration.
+
+        Called on every should_expose(), so a UI change to an entity YAML
+        has an opinion on only lasts until the next such call.
+        """
+        explicit_expose = self.entity_config.get(entity_id, {}).get(CONF_EXPOSE)
+        if explicit_expose is not None:
+            async_expose_entity(self.hass, DOMAIN, entity_id, explicit_expose)
+            return
 
         entity_registry = er.async_get(self.hass)
         registry_entry = entity_registry.async_get(entity_id)
@@ -182,22 +249,8 @@ class GoogleConfig(AbstractConfig):
         else:
             auxiliary_entity = False
 
-        explicit_expose = self.entity_config.get(entity_id, {}).get(CONF_EXPOSE)
-
-        domain_exposed_by_default = (
-            expose_by_default and split_entity_id(entity_id)[0] in exposed_domains
-        )
-
-        # Expose an entity by default if the entity's domain is exposed by default
-        # and the entity is not a config or diagnostic entity
-        entity_exposed_by_default = domain_exposed_by_default and not auxiliary_entity
-
-        # Expose an entity if the entity's is exposed by default and
-        # the configuration doesn't explicitly exclude it from being
-        # exposed, or if the entity is explicitly exposed
-        is_default_exposed = entity_exposed_by_default and explicit_expose is not False
-
-        return is_default_exposed or explicit_expose
+        if self._should_expose_by_default(entity_id, auxiliary_entity=auxiliary_entity):
+            async_expose_entity(self.hass, DOMAIN, entity_id, True)
 
     @override
     def should_2fa(self, state):

--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -153,8 +153,8 @@ class ExposedEntities:
         """Mark whether an entity's exposure is controlled outside the UI.
 
         A locked entity's exposure is kept in sync with an external source,
-        such as YAML configuration, so changes made through the UI or the
-        websocket API are temporary and will be reverted.
+        such as YAML configuration, changes made through the websockets
+        will be rejected.
         """
         locked_entities = self._locked_entities.setdefault(assistant, set())
         if locked:

--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -119,7 +119,7 @@ class ExposedEntities:
         """Initialize."""
         self._hass = hass
         self._listeners: dict[str, list[Callable[[], None]]] = {}
-        self._locked_entities: dict[str, set[str]] = {}
+        self.locked_entities: dict[str, dict[str, bool]] = {}
         self._store: Store[SerializedExposedEntities] = Store(
             hass, STORAGE_VERSION, STORAGE_KEY
         )
@@ -148,29 +148,36 @@ class ExposedEntities:
 
     @callback
     def async_set_entity_locked(
-        self, assistant: str, entity_id: str, locked: bool
+        self, assistant: str, entity_id: str, should_expose: bool | None
     ) -> None:
-        """Mark whether an entity's exposure is controlled outside the UI.
+        """Set an entity's exposure from an external source, such as YAML.
 
-        A locked entity's exposure is kept in sync with an external source,
-        such as YAML configuration, changes made through the websockets
-        will be rejected.
+        The value is kept in memory only, never persisted: it disappears,
+        handing control back to the UI-driven store, as soon as the source
+        stops providing it, including across a restart. Changes made
+        through the websocket API are rejected while an entity is locked.
+
+        Pass should_expose=None to release the entity back to the UI.
         """
-        locked_entities = self._locked_entities.setdefault(assistant, set())
-        if locked:
-            locked_entities.add(entity_id)
+        locked = self.locked_entities.get(entity_id, {})
+        if locked.get(assistant) == should_expose:
+            return
+
+        if should_expose is None:
+            del locked[assistant]
+            if not locked:
+                del self.locked_entities[entity_id]
         else:
-            locked_entities.discard(entity_id)
+            locked[assistant] = should_expose
+            self.locked_entities[entity_id] = locked
+
+        for listener in self._listeners.get(assistant, []):
+            listener()
 
     @callback
-    def async_is_entity_locked(self, assistant: str, entity_id: str) -> bool:
-        """Return True if an entity's exposure is locked for an assistant."""
-        return entity_id in self._locked_entities.get(assistant, ())
-
-    @callback
-    def async_get_locked_entities(self, assistant: str) -> set[str]:
-        """Return the entity_ids whose exposure is locked for an assistant."""
-        return self._locked_entities.get(assistant, set())
+    def async_get_entity_locked(self, assistant: str, entity_id: str) -> bool | None:
+        """Return the locked exposure value for an entity, or None if unlocked."""
+        return self.locked_entities.get(entity_id, {}).get(assistant)
 
     @callback
     def async_set_assistant_option(
@@ -279,6 +286,10 @@ class ExposedEntities:
     def async_should_expose(self, assistant: str, entity_id: str) -> bool:
         """Return True if an entity should be exposed to an assistant."""
         should_expose: bool
+
+        locked = self.async_get_entity_locked(assistant, entity_id)
+        if locked is not None:
+            return locked
 
         entity_registry = er.async_get(self._hass)
         if not (registry_entry := entity_registry.async_get(entity_id)):
@@ -443,7 +454,8 @@ def ws_expose_entity(
 
     for entity_id in entity_ids:
         for assistant in msg["assistants"]:
-            if exposed_entities.async_is_entity_locked(assistant, entity_id):
+            locked = exposed_entities.async_get_entity_locked(assistant, entity_id)
+            if locked is not None:
                 connection.send_error(
                     msg["id"],
                     websocket_api.ERR_NOT_ALLOWED,
@@ -470,7 +482,7 @@ def ws_list_exposed_entities(
 ) -> None:
     """List entities which are exposed to assistants."""
     result: dict[str, Any] = {}
-    locked_result: dict[str, Any] = {}
+    locked_entities: dict[str, Any] = {}
 
     exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
     entity_registry = er.async_get(hass)
@@ -485,12 +497,21 @@ def ws_list_exposed_entities(
             continue
         result[entity_id] = exposed_to
 
-    for assistant in KNOWN_ASSISTANTS:
-        for entity_id in exposed_entities.async_get_locked_entities(assistant):
-            locked_result.setdefault(entity_id, {})[assistant] = True
+    # Locked (YAML-controlled) entities override
+    for entity_id, locked in exposed_entities.locked_entities.items():
+        exposed_to = result.setdefault(entity_id, {})
+        for assistant, should_expose in locked.items():
+            if should_expose:
+                exposed_to[assistant] = True
+            else:
+                exposed_to.pop(assistant, None)
+        if not exposed_to:
+            del result[entity_id]
+
+        locked_entities[entity_id] = dict.fromkeys(locked, True)
 
     connection.send_result(
-        msg["id"], {"exposed_entities": result, "locked_entities": locked_result}
+        msg["id"], {"exposed_entities": result, "locked_entities": locked_entities}
     )
 
 
@@ -540,18 +561,11 @@ def async_listen_entity_updates(
 
 @callback
 def async_set_entity_locked(
-    hass: HomeAssistant, assistant: str, entity_id: str, locked: bool
+    hass: HomeAssistant, assistant: str, entity_id: str, should_expose: bool | None
 ) -> None:
-    """Mark whether an entity's exposure is controlled outside the UI."""
+    """Set an entity's exposure from an external source, such as YAML."""
     exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
-    exposed_entities.async_set_entity_locked(assistant, entity_id, locked)
-
-
-@callback
-def async_is_entity_locked(hass: HomeAssistant, assistant: str, entity_id: str) -> bool:
-    """Return True if an entity's exposure is locked for an assistant."""
-    exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
-    return exposed_entities.async_is_entity_locked(assistant, entity_id)
+    exposed_entities.async_set_entity_locked(assistant, entity_id, should_expose)
 
 
 @callback

--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -22,7 +22,12 @@ from homeassistant.util.read_only_dict import ReadOnlyDict
 
 from .const import DATA_EXPOSED_ENTITIES, DOMAIN
 
-KNOWN_ASSISTANTS = ("cloud.alexa", "cloud.google_assistant", "conversation")
+KNOWN_ASSISTANTS = (
+    "cloud.alexa",
+    "cloud.google_assistant",
+    "conversation",
+    "google_assistant",
+)
 
 STORAGE_KEY = f"{DOMAIN}.exposed_entities"
 STORAGE_VERSION = 1

--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -119,6 +119,7 @@ class ExposedEntities:
         """Initialize."""
         self._hass = hass
         self._listeners: dict[str, list[Callable[[], None]]] = {}
+        self._locked_entities: dict[str, set[str]] = {}
         self._store: Store[SerializedExposedEntities] = Store(
             hass, STORAGE_VERSION, STORAGE_KEY
         )
@@ -144,6 +145,32 @@ class ExposedEntities:
         self._listeners.setdefault(assistant, []).append(listener)
 
         return unsubscribe
+
+    @callback
+    def async_set_entity_locked(
+        self, assistant: str, entity_id: str, locked: bool
+    ) -> None:
+        """Mark whether an entity's exposure is controlled outside the UI.
+
+        A locked entity's exposure is kept in sync with an external source,
+        such as YAML configuration, so changes made through the UI or the
+        websocket API are temporary and will be reverted.
+        """
+        locked_entities = self._locked_entities.setdefault(assistant, set())
+        if locked:
+            locked_entities.add(entity_id)
+        else:
+            locked_entities.discard(entity_id)
+
+    @callback
+    def async_is_entity_locked(self, assistant: str, entity_id: str) -> bool:
+        """Return True if an entity's exposure is locked for an assistant."""
+        return entity_id in self._locked_entities.get(assistant, ())
+
+    @callback
+    def async_get_locked_entities(self, assistant: str) -> set[str]:
+        """Return the entity_ids whose exposure is locked for an assistant."""
+        return self._locked_entities.get(assistant, set())
 
     @callback
     def async_set_assistant_option(
@@ -412,6 +439,18 @@ def ws_expose_entity(
 ) -> None:
     """Expose an entity to an assistant."""
     entity_ids: list[str] = msg["entity_ids"]
+    exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
+
+    for entity_id in entity_ids:
+        for assistant in msg["assistants"]:
+            if exposed_entities.async_is_entity_locked(assistant, entity_id):
+                connection.send_error(
+                    msg["id"],
+                    websocket_api.ERR_NOT_ALLOWED,
+                    f"{entity_id} exposure to {assistant} is controlled outside "
+                    "the UI and cannot be changed here",
+                )
+                return
 
     for entity_id in entity_ids:
         for assistant in msg["assistants"]:
@@ -431,6 +470,7 @@ def ws_list_exposed_entities(
 ) -> None:
     """List entities which are exposed to assistants."""
     result: dict[str, Any] = {}
+    locked_result: dict[str, Any] = {}
 
     exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
     entity_registry = er.async_get(hass)
@@ -444,7 +484,14 @@ def ws_list_exposed_entities(
         if not exposed_to:
             continue
         result[entity_id] = exposed_to
-    connection.send_result(msg["id"], {"exposed_entities": result})
+
+    for assistant in KNOWN_ASSISTANTS:
+        for entity_id in exposed_entities.async_get_locked_entities(assistant):
+            locked_result.setdefault(entity_id, {})[assistant] = True
+
+    connection.send_result(
+        msg["id"], {"exposed_entities": result, "locked_entities": locked_result}
+    )
 
 
 @callback
@@ -489,6 +536,22 @@ def async_listen_entity_updates(
     """Listen for updates to entity expose settings."""
     exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
     return exposed_entities.async_listen_entity_updates(assistant, listener)
+
+
+@callback
+def async_set_entity_locked(
+    hass: HomeAssistant, assistant: str, entity_id: str, locked: bool
+) -> None:
+    """Mark whether an entity's exposure is controlled outside the UI."""
+    exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
+    exposed_entities.async_set_entity_locked(assistant, entity_id, locked)
+
+
+@callback
+def async_is_entity_locked(hass: HomeAssistant, assistant: str, entity_id: str) -> bool:
+    """Return True if an entity's exposure is locked for an assistant."""
+    exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
+    return exposed_entities.async_is_entity_locked(assistant, entity_id)
 
 
 @callback

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -117,6 +117,7 @@ ENTITY_DESCRIBING_ATTRIBUTES = {
     "original_name",
     "supported_features",
     "unit_of_measurement",
+    "aliases",
 }
 
 

--- a/tests/components/google_assistant/conftest.py
+++ b/tests/components/google_assistant/conftest.py
@@ -1,0 +1,16 @@
+"""Fixtures for google_assistant tests."""
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+
+@pytest.fixture(autouse=True)
+async def load_homeassistant(hass: HomeAssistant) -> None:
+    """Load the homeassistant integration.
+
+    This is needed for GoogleConfig.should_expose to work, since it relies on
+    the shared exposed entities store.
+    """
+    assert await async_setup_component(hass, "homeassistant", {})

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -707,6 +707,29 @@ async def test_registry_rename_transfers_yaml_lock(
     mock_sync.assert_called_once_with("mock-user-id")
 
 
+async def test_legacy_entity_removal_triggers_sync(hass: HomeAssistant) -> None:
+    """Test removing a non-registry entity's state schedules a sync."""
+    config = GoogleConfig(hass, DUMMY_CONFIG)
+    await config.async_initialize()
+    await config.async_connect_agent_user("mock-user-id")
+
+    # "light" is exposed by default; its YAML exposure is applied as soon
+    # as its state is added, since the listener is already active.
+    hass.states.async_set("light.legacy", "on")
+    assert config.should_expose("light.legacy") is True
+
+    with (
+        patch.object(config, "async_sync_entities") as mock_sync,
+        patch.object(helpers, "SYNC_DELAY", 0),
+    ):
+        hass.states.async_remove("light.legacy")
+        await hass.async_block_till_done()
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done()
+
+    mock_sync.assert_called_once_with("mock-user-id")
+
+
 async def test_async_enable_local_sdk(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -3,17 +3,16 @@
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 import json
-import os
 from pathlib import Path
 from typing import Any
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, call, patch
 from uuid import uuid4
 
-import py
 import pytest
 
-from homeassistant.components.google_assistant import GOOGLE_ASSISTANT_SCHEMA
+from homeassistant.components.google_assistant import GOOGLE_ASSISTANT_SCHEMA, helpers
 from homeassistant.components.google_assistant.const import (
+    DOMAIN,
     EVENT_COMMAND_RECEIVED,
     HOMEGRAPH_TOKEN_URL,
     REPORT_STATE_BASE_URL,
@@ -27,8 +26,15 @@ from homeassistant.components.google_assistant.http import (
     _get_homegraph_token,
     async_get_users,
 )
+from homeassistant.components.homeassistant.const import DATA_EXPOSED_ENTITIES
+from homeassistant.components.homeassistant.exposed_entities import (
+    async_expose_entity,
+    async_get_entity_settings,
+)
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -36,7 +42,6 @@ from tests.common import (
     async_capture_events,
     async_fire_time_changed,
     async_mock_service,
-    async_test_home_assistant,
 )
 from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
@@ -381,6 +386,270 @@ async def test_missing_service_account(hass: HomeAssistant) -> None:
     assert config._access_token_renew is renew
 
 
+async def test_should_expose_uses_exposed_entities_store(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test should_expose delegates to the shared store for entities YAML doesn't cover."""
+    config = GOOGLE_ASSISTANT_SCHEMA(
+        {"project_id": "1234", "exposed_domains": ["light"]}
+    )
+    google_config = GoogleConfig(hass, config)
+    await google_config.async_initialize()
+
+    entry = entity_registry.async_get_or_create(
+        "switch", "test", "unique", suggested_object_id="ac"
+    )
+    hass.states.async_set(entry.entity_id, "on")
+
+    async_expose_entity(hass, DOMAIN, entry.entity_id, False)
+    assert google_config.should_expose(entry.entity_id) is False
+
+    async_expose_entity(hass, DOMAIN, entry.entity_id, True)
+    assert google_config.should_expose(entry.entity_id) is True
+
+
+async def test_should_expose_reconciles_yaml_domain_exposure(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test should_expose exposes an entity matched by expose_by_default/exposed_domains."""
+    entry = entity_registry.async_get_or_create(
+        "light", "test", "unique", suggested_object_id="kitchen"
+    )
+    config = GOOGLE_ASSISTANT_SCHEMA(
+        {"project_id": "1234", "exposed_domains": ["light"]}
+    )
+    google_config = GoogleConfig(hass, config)
+    await google_config.async_initialize()
+
+    # Nothing is written until should_expose is actually queried.
+    assert async_get_entity_settings(hass, entry.entity_id) == {}
+    assert google_config.should_expose(entry.entity_id) is True
+
+
+async def test_should_expose_reconciles_yaml_explicit_exclude(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test an explicit entity_config exclude wins over a matching domain default."""
+    entry = entity_registry.async_get_or_create(
+        "light", "test", "unique", suggested_object_id="kitchen"
+    )
+    config = GOOGLE_ASSISTANT_SCHEMA(
+        {
+            "project_id": "1234",
+            "exposed_domains": ["light"],
+            "entity_config": {entry.entity_id: {"expose": False}},
+        }
+    )
+    google_config = GoogleConfig(hass, config)
+    await google_config.async_initialize()
+
+    assert google_config.should_expose(entry.entity_id) is False
+
+
+async def test_should_expose_reconciles_yaml_explicit_include(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test an explicit entity_config include applies even outside exposed_domains."""
+    entry = entity_registry.async_get_or_create(
+        "switch", "test", "unique", suggested_object_id="ac"
+    )
+    config = GOOGLE_ASSISTANT_SCHEMA(
+        {
+            "project_id": "1234",
+            "exposed_domains": ["light"],
+            "entity_config": {entry.entity_id: {"expose": True}},
+        }
+    )
+    google_config = GoogleConfig(hass, config)
+    await google_config.async_initialize()
+
+    assert google_config.should_expose(entry.entity_id) is True
+
+
+async def test_should_expose_defers_to_ui_when_yaml_has_no_opinion(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test should_expose leaves an entity YAML doesn't mention to the shared store."""
+    entry = entity_registry.async_get_or_create(
+        "sensor", "test", "unique", suggested_object_id="not_exposed"
+    )
+    config = GOOGLE_ASSISTANT_SCHEMA(
+        {"project_id": "1234", "exposed_domains": ["light"]}
+    )
+    google_config = GoogleConfig(hass, config)
+    await google_config.async_initialize()
+
+    # Not written by YAML reconciliation; falls through to (and is cached
+    # by) the shared store's own generic fallback.
+    assert google_config.should_expose(entry.entity_id) is False
+
+
+async def test_ui_exposure_change_is_reverted_on_next_should_expose(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test a UI change to a YAML-matched entity is reverted on the next query."""
+    entry = entity_registry.async_get_or_create(
+        "light", "test", "unique", suggested_object_id="kitchen"
+    )
+    config = GOOGLE_ASSISTANT_SCHEMA(
+        {"project_id": "1234", "exposed_domains": ["light"]}
+    )
+    google_config = GoogleConfig(hass, config)
+    await google_config.async_initialize()
+
+    assert google_config.should_expose(entry.entity_id) is True
+
+    # The user unexposes it via the UI...
+    async_expose_entity(hass, DOMAIN, entry.entity_id, False)
+    assert (
+        async_get_entity_settings(hass, entry.entity_id)[DOMAIN]["should_expose"]
+        is False
+    )
+
+    # ...but the change doesn't survive the next should_expose query, e.g.
+    # from an incoming request from Google.
+    assert google_config.should_expose(entry.entity_id) is True
+
+
+async def test_ui_exposure_change_persists_when_yaml_has_no_opinion(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test a UI change to an entity YAML doesn't cover survives should_expose queries."""
+    entry = entity_registry.async_get_or_create(
+        "sensor", "test", "unique", suggested_object_id="not_exposed"
+    )
+    config = GOOGLE_ASSISTANT_SCHEMA(
+        {"project_id": "1234", "exposed_domains": ["light"]}
+    )
+    google_config = GoogleConfig(hass, config)
+    await google_config.async_initialize()
+
+    async_expose_entity(hass, DOMAIN, entry.entity_id, True)
+
+    assert google_config.should_expose(entry.entity_id) is True
+
+
+async def test_new_entity_matching_yaml_domain_triggers_sync(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test a newly registered entity matching exposed_domains schedules a sync."""
+    config = GOOGLE_ASSISTANT_SCHEMA(
+        {"project_id": "1234", "expose_by_default": True, "exposed_domains": ["light"]}
+    )
+    google_config = GoogleConfig(hass, config)
+    await google_config.async_initialize()
+    await google_config.async_connect_agent_user("mock-user-id")
+
+    with (
+        patch.object(google_config, "async_sync_entities") as mock_sync,
+        patch.object(helpers, "SYNC_DELAY", 0),
+    ):
+        entry = entity_registry.async_get_or_create(
+            "light", "test", "unique", suggested_object_id="kitchen"
+        )
+        await hass.async_block_till_done()
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done()
+
+    assert google_config.should_expose(entry.entity_id) is True
+    mock_sync.assert_called_once_with("mock-user-id")
+
+
+async def test_new_entity_exposed_via_expose_new_triggers_sync(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test a newly registered entity exposed via expose_new schedules a sync."""
+    config = GOOGLE_ASSISTANT_SCHEMA(
+        {"project_id": "1234", "expose_by_default": False, "exposed_domains": []}
+    )
+    google_config = GoogleConfig(hass, config)
+    await google_config.async_initialize()
+    await google_config.async_connect_agent_user("mock-user-id")
+
+    hass.data[DATA_EXPOSED_ENTITIES].async_set_expose_new_entities(DOMAIN, True)
+
+    with (
+        patch.object(google_config, "async_sync_entities") as mock_sync,
+        patch.object(helpers, "SYNC_DELAY", 0),
+    ):
+        entity_registry.async_get_or_create(
+            "light", "test", "unique", suggested_object_id="kitchen"
+        )
+        await hass.async_block_till_done()
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done()
+
+    mock_sync.assert_called_once_with("mock-user-id")
+
+
+async def test_expose_update_triggers_sync(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test that updating exposed entities schedules a Google sync."""
+    config = GoogleConfig(hass, DUMMY_CONFIG)
+    await config.async_initialize()
+    await config.async_connect_agent_user("mock-user-id")
+
+    # "light" is exposed by default; the entity is reconciled as soon as
+    # it's registered, since the listener is already active.
+    entry = entity_registry.async_get_or_create(
+        "light", "test", "unique", suggested_object_id="kitchen"
+    )
+    assert config.should_expose(entry.entity_id) is True
+
+    with (
+        patch.object(config, "async_sync_entities") as mock_sync,
+        patch.object(helpers, "SYNC_DELAY", 0),
+    ):
+        async_expose_entity(hass, DOMAIN, entry.entity_id, False)
+        await hass.async_block_till_done()
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done()
+
+    mock_sync.assert_called_once_with("mock-user-id")
+
+
+@pytest.mark.parametrize(
+    ("update_kwargs", "expected_calls"),
+    [
+        pytest.param(
+            {"aliases": ["Kitchen Light"]},
+            [call("mock-user-id")],
+            id="aliases_changed",
+        ),
+        pytest.param({"icon": "mdi:lightbulb"}, [], id="unrelated_field_changed"),
+    ],
+)
+async def test_registry_update_triggers_sync_only_for_aliases(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    update_kwargs: dict[str, Any],
+    expected_calls: list[Any],
+) -> None:
+    """Test only alias changes on an exposed entity schedule a Google sync."""
+    config = GoogleConfig(hass, DUMMY_CONFIG)
+    await config.async_initialize()
+    await config.async_connect_agent_user("mock-user-id")
+
+    # "light" is exposed by default; the entity is reconciled as soon as
+    # it's registered, since the listener is already active.
+    entry = entity_registry.async_get_or_create(
+        "light", "test", "unique", suggested_object_id="kitchen"
+    )
+    assert config.should_expose(entry.entity_id) is True
+
+    with (
+        patch.object(config, "async_sync_entities") as mock_sync,
+        patch.object(helpers, "SYNC_DELAY", 0),
+    ):
+        entity_registry.async_update_entity(entry.entity_id, **update_kwargs)
+        await hass.async_block_till_done()
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done()
+
+    assert mock_sync.call_args_list == expected_calls
+
+
 async def test_async_enable_local_sdk(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -599,26 +868,25 @@ async def test_async_get_users_no_store(hass: HomeAssistant) -> None:
     assert await async_get_users(hass) == []
 
 
-async def test_async_get_users_from_store(tmpdir: py.path.local) -> None:
+async def test_async_get_users_from_store(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
     """Test async_get_users from a store.
 
     This test ensures we can load from data saved by GoogleConfigStore.
     """
-    async with async_test_home_assistant() as hass:
-        hass.config.config_dir = await hass.async_add_executor_job(
-            tmpdir.mkdir, "temp_storage"
-        )
+    store = GoogleConfigStore(hass)
+    await store.async_initialize()
 
-        store = GoogleConfigStore(hass)
-        await store.async_initialize()
+    store.add_agent_user_id("agent_1")
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
+    await hass.async_block_till_done()
 
-        store.add_agent_user_id("agent_1")
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
-        await hass.async_block_till_done()
-
+    with patch(
+        "homeassistant.components.google_assistant.http.json_util.load_json",
+        return_value=hass_storage["google_assistant"],
+    ):
         assert await async_get_users(hass) == ["agent_1"]
-
-        await hass.async_stop()
 
 
 VALID_STORE_DATA = json.dumps(
@@ -687,16 +955,11 @@ AGENT_USER_IDS_NOT_DICT = json.dumps(
     ],
 )
 async def test_async_get_users(
-    tmpdir: py.path.local, store_data: str, expected_users: list[str]
+    hass: HomeAssistant, tmp_path: Path, store_data: str, expected_users: list[str]
 ) -> None:
     """Test async_get_users from stored JSON data."""
-    async with async_test_home_assistant() as hass:
-        hass.config.config_dir = await hass.async_add_executor_job(
-            tmpdir.mkdir, "temp_storage"
-        )
-        path = hass.config.config_dir / ".storage" / GoogleConfigStore._STORAGE_KEY
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        await hass.async_add_executor_job(Path(path).write_text, store_data)
-        assert await async_get_users(hass) == expected_users
-
-        await hass.async_stop()
+    hass.config.config_dir = str(tmp_path)
+    path = tmp_path / STORAGE_DIR / GoogleConfigStore._STORAGE_KEY
+    await hass.async_add_executor_job(path.parent.mkdir)
+    await hass.async_add_executor_job(path.write_text, store_data)
+    assert await async_get_users(hass) == expected_users

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -27,11 +27,7 @@ from homeassistant.components.google_assistant.http import (
     async_get_users,
 )
 from homeassistant.components.homeassistant.const import DATA_EXPOSED_ENTITIES
-from homeassistant.components.homeassistant.exposed_entities import (
-    async_expose_entity,
-    async_get_entity_settings,
-    async_is_entity_locked,
-)
+from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     EVENT_HOMEASSISTANT_STARTED,
@@ -428,10 +424,6 @@ async def test_should_expose_applies_yaml_domain_exposure(
     await google_config.async_initialize()
 
     # Reconciled eagerly against YAML once Home Assistant has started.
-    assert (
-        async_get_entity_settings(hass, entry.entity_id)[DOMAIN]["should_expose"]
-        is True
-    )
     assert google_config.should_expose(entry.entity_id) is True
 
 
@@ -493,7 +485,6 @@ async def test_should_expose_defers_to_ui_when_yaml_has_no_opinion(
     # Not written by YAML reconciliation; falls through to (and is cached
     # by) the shared store's own generic fallback.
     assert google_config.should_expose(entry.entity_id) is False
-    assert async_is_entity_locked(hass, DOMAIN, entry.entity_id) is False
 
 
 async def test_should_expose_locks_yaml_matched_entities(
@@ -511,7 +502,10 @@ async def test_should_expose_locks_yaml_matched_entities(
     await google_config.async_initialize()
 
     assert google_config.should_expose(entry.entity_id) is True
-    assert async_is_entity_locked(hass, DOMAIN, entry.entity_id) is True
+
+    # A UI-driven change doesn't stick while YAML has an opinion.
+    async_expose_entity(hass, DOMAIN, entry.entity_id, False)
+    assert google_config.should_expose(entry.entity_id) is True
 
 
 async def test_should_expose_clears_stale_yaml_exposure_on_unlock(
@@ -529,14 +523,12 @@ async def test_should_expose_clears_stale_yaml_exposure_on_unlock(
     await google_config.async_initialize()
 
     assert google_config.should_expose(entry.entity_id) is True
-    assert async_is_entity_locked(hass, DOMAIN, entry.entity_id) is True
 
     entity_registry.async_update_entity(
         entry.entity_id, entity_category=EntityCategory.DIAGNOSTIC
     )
     await hass.async_block_till_done()
 
-    assert async_is_entity_locked(hass, DOMAIN, entry.entity_id) is False
     assert google_config.should_expose(entry.entity_id) is False
 
 
@@ -596,7 +588,8 @@ async def test_new_entity_exposed_via_expose_new_triggers_sync(
     await google_config.async_initialize()
     await google_config.async_connect_agent_user("mock-user-id")
 
-    hass.data[DATA_EXPOSED_ENTITIES].async_set_expose_new_entities(DOMAIN, True)
+    exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
+    exposed_entities.async_set_expose_new_entities(DOMAIN, True)
 
     with (
         patch.object(google_config, "async_sync_entities") as mock_sync,

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -32,7 +32,11 @@ from homeassistant.components.homeassistant.exposed_entities import (
     async_get_entity_settings,
     async_is_entity_locked,
 )
-from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STARTED,
+    EntityCategory,
+)
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.storage import STORAGE_DIR
@@ -508,6 +512,32 @@ async def test_should_expose_locks_yaml_matched_entities(
 
     assert google_config.should_expose(entry.entity_id) is True
     assert async_is_entity_locked(hass, DOMAIN, entry.entity_id) is True
+
+
+async def test_should_expose_clears_stale_yaml_exposure_on_unlock(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test becoming an auxiliary entity clears a previously locked exposure."""
+    entry = entity_registry.async_get_or_create(
+        "light", "test", "unique", suggested_object_id="kitchen"
+    )
+    hass.states.async_set(entry.entity_id, "on")
+    config = GOOGLE_ASSISTANT_SCHEMA(
+        {"project_id": "1234", "exposed_domains": ["light"]}
+    )
+    google_config = GoogleConfig(hass, config)
+    await google_config.async_initialize()
+
+    assert google_config.should_expose(entry.entity_id) is True
+    assert async_is_entity_locked(hass, DOMAIN, entry.entity_id) is True
+
+    entity_registry.async_update_entity(
+        entry.entity_id, entity_category=EntityCategory.DIAGNOSTIC
+    )
+    await hass.async_block_till_done()
+
+    assert async_is_entity_locked(hass, DOMAIN, entry.entity_id) is False
+    assert google_config.should_expose(entry.entity_id) is False
 
 
 async def test_ui_exposure_change_persists_when_yaml_has_no_opinion(

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -676,6 +676,37 @@ async def test_registry_update_triggers_sync_only_for_aliases(
     assert mock_sync.call_args_list == expected_calls
 
 
+async def test_registry_rename_transfers_yaml_lock(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test a YAML lock follows an entity through a rename."""
+    config = GoogleConfig(hass, DUMMY_CONFIG)
+    await config.async_initialize()
+    await config.async_connect_agent_user("mock-user-id")
+
+    # "light" is exposed by default; its YAML exposure is applied as soon
+    # as its state is added, since the listener is already active.
+    entry = entity_registry.async_get_or_create(
+        "light", "test", "unique", suggested_object_id="kitchen"
+    )
+    hass.states.async_set(entry.entity_id, "on")
+    assert config.should_expose(entry.entity_id) is True
+
+    with (
+        patch.object(config, "async_sync_entities") as mock_sync,
+        patch.object(helpers, "SYNC_DELAY", 0),
+    ):
+        entity_registry.async_update_entity(
+            entry.entity_id, new_entity_id="light.new_kitchen"
+        )
+        await hass.async_block_till_done()
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done()
+
+    assert config.should_expose("light.new_kitchen") is True
+    mock_sync.assert_called_once_with("mock-user-id")
+
+
 async def test_async_enable_local_sdk(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -30,6 +30,7 @@ from homeassistant.components.homeassistant.const import DATA_EXPOSED_ENTITIES
 from homeassistant.components.homeassistant.exposed_entities import (
     async_expose_entity,
     async_get_entity_settings,
+    async_is_entity_locked,
 )
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, HomeAssistant
@@ -408,31 +409,36 @@ async def test_should_expose_uses_exposed_entities_store(
     assert google_config.should_expose(entry.entity_id) is True
 
 
-async def test_should_expose_reconciles_yaml_domain_exposure(
+async def test_should_expose_applies_yaml_domain_exposure(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test should_expose exposes an entity matched by expose_by_default/exposed_domains."""
     entry = entity_registry.async_get_or_create(
         "light", "test", "unique", suggested_object_id="kitchen"
     )
+    hass.states.async_set(entry.entity_id, "on")
     config = GOOGLE_ASSISTANT_SCHEMA(
         {"project_id": "1234", "exposed_domains": ["light"]}
     )
     google_config = GoogleConfig(hass, config)
     await google_config.async_initialize()
 
-    # Nothing is written until should_expose is actually queried.
-    assert async_get_entity_settings(hass, entry.entity_id) == {}
+    # Reconciled eagerly against YAML once Home Assistant has started.
+    assert (
+        async_get_entity_settings(hass, entry.entity_id)[DOMAIN]["should_expose"]
+        is True
+    )
     assert google_config.should_expose(entry.entity_id) is True
 
 
-async def test_should_expose_reconciles_yaml_explicit_exclude(
+async def test_should_expose_applies_yaml_explicit_exclude(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test an explicit entity_config exclude wins over a matching domain default."""
     entry = entity_registry.async_get_or_create(
         "light", "test", "unique", suggested_object_id="kitchen"
     )
+    hass.states.async_set(entry.entity_id, "on")
     config = GOOGLE_ASSISTANT_SCHEMA(
         {
             "project_id": "1234",
@@ -446,13 +452,14 @@ async def test_should_expose_reconciles_yaml_explicit_exclude(
     assert google_config.should_expose(entry.entity_id) is False
 
 
-async def test_should_expose_reconciles_yaml_explicit_include(
+async def test_should_expose_applies_yaml_explicit_include(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test an explicit entity_config include applies even outside exposed_domains."""
     entry = entity_registry.async_get_or_create(
         "switch", "test", "unique", suggested_object_id="ac"
     )
+    hass.states.async_set(entry.entity_id, "on")
     config = GOOGLE_ASSISTANT_SCHEMA(
         {
             "project_id": "1234",
@@ -482,15 +489,17 @@ async def test_should_expose_defers_to_ui_when_yaml_has_no_opinion(
     # Not written by YAML reconciliation; falls through to (and is cached
     # by) the shared store's own generic fallback.
     assert google_config.should_expose(entry.entity_id) is False
+    assert async_is_entity_locked(hass, DOMAIN, entry.entity_id) is False
 
 
-async def test_ui_exposure_change_is_reverted_on_next_should_expose(
+async def test_should_expose_locks_yaml_matched_entities(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
-    """Test a UI change to a YAML-matched entity is reverted on the next query."""
+    """Test a YAML-matched entity is locked against exposure changes from the UI."""
     entry = entity_registry.async_get_or_create(
         "light", "test", "unique", suggested_object_id="kitchen"
     )
+    hass.states.async_set(entry.entity_id, "on")
     config = GOOGLE_ASSISTANT_SCHEMA(
         {"project_id": "1234", "exposed_domains": ["light"]}
     )
@@ -498,17 +507,7 @@ async def test_ui_exposure_change_is_reverted_on_next_should_expose(
     await google_config.async_initialize()
 
     assert google_config.should_expose(entry.entity_id) is True
-
-    # The user unexposes it via the UI...
-    async_expose_entity(hass, DOMAIN, entry.entity_id, False)
-    assert (
-        async_get_entity_settings(hass, entry.entity_id)[DOMAIN]["should_expose"]
-        is False
-    )
-
-    # ...but the change doesn't survive the next should_expose query, e.g.
-    # from an incoming request from Google.
-    assert google_config.should_expose(entry.entity_id) is True
+    assert async_is_entity_locked(hass, DOMAIN, entry.entity_id) is True
 
 
 async def test_ui_exposure_change_persists_when_yaml_has_no_opinion(
@@ -547,6 +546,7 @@ async def test_new_entity_matching_yaml_domain_triggers_sync(
         entry = entity_registry.async_get_or_create(
             "light", "test", "unique", suggested_object_id="kitchen"
         )
+        hass.states.async_set(entry.entity_id, "on")
         await hass.async_block_till_done()
         async_fire_time_changed(hass, dt_util.utcnow())
         await hass.async_block_till_done()
@@ -572,9 +572,10 @@ async def test_new_entity_exposed_via_expose_new_triggers_sync(
         patch.object(google_config, "async_sync_entities") as mock_sync,
         patch.object(helpers, "SYNC_DELAY", 0),
     ):
-        entity_registry.async_get_or_create(
+        entry = entity_registry.async_get_or_create(
             "light", "test", "unique", suggested_object_id="kitchen"
         )
+        hass.states.async_set(entry.entity_id, "on")
         await hass.async_block_till_done()
         async_fire_time_changed(hass, dt_util.utcnow())
         await hass.async_block_till_done()
@@ -590,11 +591,12 @@ async def test_expose_update_triggers_sync(
     await config.async_initialize()
     await config.async_connect_agent_user("mock-user-id")
 
-    # "light" is exposed by default; the entity is reconciled as soon as
-    # it's registered, since the listener is already active.
+    # "light" is exposed by default; its YAML exposure is applied as soon
+    # as its state is added, since the listener is already active.
     entry = entity_registry.async_get_or_create(
         "light", "test", "unique", suggested_object_id="kitchen"
     )
+    hass.states.async_set(entry.entity_id, "on")
     assert config.should_expose(entry.entity_id) is True
 
     with (
@@ -631,11 +633,12 @@ async def test_registry_update_triggers_sync_only_for_aliases(
     await config.async_initialize()
     await config.async_connect_agent_user("mock-user-id")
 
-    # "light" is exposed by default; the entity is reconciled as soon as
-    # it's registered, since the listener is already active.
+    # "light" is exposed by default; its YAML exposure is applied as soon
+    # as its state is added, since the listener is already active.
     entry = entity_registry.async_get_or_create(
         "light", "test", "unique", suggested_object_id="kitchen"
     )
+    hass.states.async_set(entry.entity_id, "on")
     assert config.should_expose(entry.entity_id) is True
 
     with (

--- a/tests/components/homeassistant/test_exposed_entities.py
+++ b/tests/components/homeassistant/test_exposed_entities.py
@@ -529,7 +529,69 @@ async def test_list_exposed_entities(
             "test.test": {"cloud.alexa": True, "cloud.google_assistant": True},
             "test.test_unique1": {"cloud.alexa": True, "cloud.google_assistant": True},
         },
+        "locked_entities": {},
     }
+
+
+async def test_list_exposed_entities_locked(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test list exposed entities includes a locked entity that isn't exposed.
+
+    The entity is neither registered nor has any assistant option set, so it
+    only shows up through the lock store, not through the exposed-entities
+    iteration.
+    """
+    ws_client = await hass_ws_client(hass)
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    entity_id = "test.not_exposed"
+    exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
+    exposed_entities.async_set_entity_locked("cloud.google_assistant", entity_id, True)
+
+    await ws_client.send_json_auto_id({"type": "homeassistant/expose_entity/list"})
+    response = await ws_client.receive_json()
+    assert response["success"]
+    assert response["result"]["exposed_entities"] == {}
+    assert response["result"]["locked_entities"] == {
+        entity_id: {"cloud.google_assistant": True},
+    }
+
+
+async def test_expose_entity_locked(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test that a locked entity's exposure cannot be changed over the websocket API."""
+    ws_client = await hass_ws_client(hass)
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get_or_create("test", "test", "unique1")
+
+    exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
+    exposed_entities.async_set_entity_locked(
+        "cloud.google_assistant", entry.entity_id, True
+    )
+
+    await ws_client.send_json_auto_id(
+        {
+            "type": "homeassistant/expose_entity",
+            "assistants": ["cloud.google_assistant"],
+            "entity_ids": [entry.entity_id],
+            "should_expose": True,
+        }
+    )
+
+    response = await ws_client.receive_json()
+    assert not response["success"]
+    assert response["error"]["code"] == "not_allowed"
+    assert entry.entity_id not in async_get_assistant_settings(
+        hass, "cloud.google_assistant"
+    )
 
 
 async def test_listeners(

--- a/tests/components/homeassistant/test_exposed_entities.py
+++ b/tests/components/homeassistant/test_exposed_entities.py
@@ -549,7 +549,7 @@ async def test_list_exposed_entities_locked(
 
     entity_id = "test.not_exposed"
     exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
-    exposed_entities.async_set_entity_locked("cloud.google_assistant", entity_id, True)
+    exposed_entities.async_set_entity_locked("cloud.google_assistant", entity_id, False)
 
     await ws_client.send_json_auto_id({"type": "homeassistant/expose_entity/list"})
     response = await ws_client.receive_json()

--- a/tests/components/homeassistant/test_exposed_entities.py
+++ b/tests/components/homeassistant/test_exposed_entities.py
@@ -594,6 +594,47 @@ async def test_expose_entity_locked(
     )
 
 
+async def test_set_entity_locked_noop_leaves_no_stray_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test unlocking an entity that was never locked doesn't leave an entry."""
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
+    exposed_entities.async_set_entity_locked("test1", "light.kitchen", None)
+
+    assert exposed_entities.locked_entities == {}
+
+
+async def test_set_entity_locked(hass: HomeAssistant) -> None:
+    """Test locking, updating, and unlocking an entity's exposure."""
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
+    callbacks = []
+    exposed_entities.async_listen_entity_updates("test1", lambda: callbacks.append(1))
+
+    exposed_entities.async_set_entity_locked("test1", "light.kitchen", True)
+    assert exposed_entities.locked_entities == {"light.kitchen": {"test1": True}}
+    assert len(callbacks) == 1
+
+    # Setting the same value again is a no-op.
+    exposed_entities.async_set_entity_locked("test1", "light.kitchen", True)
+    assert len(callbacks) == 1
+
+    exposed_entities.async_set_entity_locked("test1", "light.kitchen", False)
+    assert exposed_entities.locked_entities == {"light.kitchen": {"test1": False}}
+    assert len(callbacks) == 2
+
+    exposed_entities.async_set_entity_locked("test1", "light.kitchen", None)
+    assert exposed_entities.locked_entities == {}
+    assert len(callbacks) == 3
+
+    # Unlocking again is a no-op.
+    exposed_entities.async_set_entity_locked("test1", "light.kitchen", None)
+    assert len(callbacks) == 3
+
+
 async def test_listeners(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for using UI to control exposed entities for google assistant.

- YAML configuration is authoritative, expose there and it applies. explicitly deny there and it applies. Attempt to change these entities are blocked by backend.
- Adds a locked_entites to the exposed websocket so UI can display entities it is now allowed to change settings for.
- Anything not affected by above can be controlled by UI

This is a alternative to the migration proposed in https://github.com/home-assistant/core/pull/180575

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47778
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53869

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
