### PR TITLE
Add service to update individual day restrictions in Nintendo Parental Controls

### DIFF
--- a/homeassistant/components/nintendo_parental_controls/const.py
+++ b/homeassistant/components/nintendo_parental_controls/const.py
@@ -15,3 +15,7 @@ APP_SETUP_URL = (
     "https://www.nintendo.com/my/support/switch/parentalcontrols/app/setup.html"
 )
 ATTR_BONUS_TIME = "bonus_time"
+ATTR_DAY_OF_WEEK = "day_of_week"
+ATTR_BEDTIME_START = "bedtime_start"
+ATTR_BEDTIME_END = "bedtime_end"
+ATTR_MAX_PLAY_TIME = "max_play_time"

--- a/homeassistant/components/nintendo_parental_controls/icons.json
+++ b/homeassistant/components/nintendo_parental_controls/icons.json
@@ -9,6 +9,9 @@
     "player_usage_report": {
       "service": "mdi:account-clock-outline"
     },
+    "update_daily_restrictions": {
+      "service": "mdi:calendar-clock-outline"
+    },
     "update_pin_code": {
       "service": "mdi:lock-open-outline"
     }

--- a/homeassistant/components/nintendo_parental_controls/services.py
+++ b/homeassistant/components/nintendo_parental_controls/services.py
@@ -6,7 +6,11 @@ import logging
 from pynintendoparental.const import DAYS_OF_WEEK
 from pynintendoparental.device import Device
 from pynintendoparental.enum import SafeLaunchSetting
-from pynintendoparental.exceptions import InvalidDeviceStateError
+from pynintendoparental.exceptions import (
+    BedtimeOutOfRangeError,
+    ExtraPlayingTimeActiveError,
+    InvalidDeviceStateError,
+)
 from pynintendoparental.player import Player
 import voluptuous as vol
 
@@ -26,6 +30,10 @@ from .const import (
     ATTR_BONUS_TIME,
     ATTR_DAY_OF_WEEK,
     ATTR_MAX_PLAY_TIME,
+    BEDTIME_ALARM_MAX,
+    BEDTIME_ALARM_MIN,
+    BEDTIME_END_TIME_MAX,
+    BEDTIME_END_TIME_MIN,
     DOMAIN,
 )
 from .coordinator import NintendoParentalControlsConfigEntry
@@ -234,4 +242,20 @@ async def async_set_per_day_controls(call: ServiceCall) -> None:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="requires_daily_restrictions",
+        ) from err
+    except ExtraPlayingTimeActiveError as err:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="extra_playing_time_active",
+        ) from err
+    except BedtimeOutOfRangeError as err:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="bedtime_out_of_range",
+            translation_placeholders={
+                "bedtime_alarm_min": BEDTIME_ALARM_MIN,
+                "bedtime_alarm_max": BEDTIME_ALARM_MAX,
+                "bedtime_end_time_min": BEDTIME_END_TIME_MIN,
+                "bedtime_end_time_max": BEDTIME_END_TIME_MAX,
+            },
         ) from err

--- a/homeassistant/components/nintendo_parental_controls/services.py
+++ b/homeassistant/components/nintendo_parental_controls/services.py
@@ -83,11 +83,12 @@ def async_setup_services(
             }
         ),
     )
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=NintendoParentalServices.UPDATE_DAILY_RESTRICTIONS,
-        service_func=async_set_per_day_controls,
-        schema=vol.Schema(
+    service.async_register_admin_service(
+        hass,
+        DOMAIN,
+        NintendoParentalServices.UPDATE_DAILY_RESTRICTIONS,
+        async_set_per_day_controls,
+        vol.Schema(
             {
                 vol.Required(ATTR_DEVICE_ID): cv.string,
                 vol.Required(ATTR_DAY_OF_WEEK): vol.In(DAYS_OF_WEEK),

--- a/homeassistant/components/nintendo_parental_controls/services.py
+++ b/homeassistant/components/nintendo_parental_controls/services.py
@@ -3,8 +3,10 @@
 from enum import StrEnum
 import logging
 
+from pynintendoparental.const import DAYS_OF_WEEK
 from pynintendoparental.device import Device
 from pynintendoparental.enum import SafeLaunchSetting
+from pynintendoparental.exceptions import InvalidDeviceStateError
 from pynintendoparental.player import Player
 import voluptuous as vol
 
@@ -18,7 +20,14 @@ from homeassistant.helpers import (
 )
 from homeassistant.util.json import JsonValueType
 
-from .const import ATTR_BONUS_TIME, DOMAIN
+from .const import (
+    ATTR_BEDTIME_END,
+    ATTR_BEDTIME_START,
+    ATTR_BONUS_TIME,
+    ATTR_DAY_OF_WEEK,
+    ATTR_MAX_PLAY_TIME,
+    DOMAIN,
+)
 from .coordinator import NintendoParentalControlsConfigEntry
 from .sensor import NintendoParentalControlsSensor
 
@@ -32,6 +41,7 @@ class NintendoParentalServices(StrEnum):
     UPDATE_PIN_CODE = "update_pin_code"
     PLAYER_USAGE_REPORT = "player_usage_report"
     DEVICE_USAGE_REPORT = "device_usage_report"
+    UPDATE_DAILY_RESTRICTIONS = "update_daily_restrictions"
 
 
 @callback
@@ -70,6 +80,22 @@ def async_setup_services(
         schema=vol.Schema(
             {
                 vol.Required(ATTR_DEVICE_ID): cv.string,
+            }
+        ),
+    )
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=NintendoParentalServices.UPDATE_DAILY_RESTRICTIONS,
+        service_func=async_set_per_day_controls,
+        schema=vol.Schema(
+            {
+                vol.Required(ATTR_DEVICE_ID): cv.string,
+                vol.Required(ATTR_DAY_OF_WEEK): vol.In(DAYS_OF_WEEK),
+                vol.Inclusive(ATTR_BEDTIME_START, "bedtime"): cv.time,
+                vol.Inclusive(ATTR_BEDTIME_END, "bedtime"): cv.time,
+                vol.Optional(ATTR_MAX_PLAY_TIME): vol.All(
+                    int, vol.Range(min=0, max=360)
+                ),
             }
         ),
     )
@@ -183,3 +209,28 @@ async def async_get_device_usage_report(call: ServiceCall) -> dict:
     return {
         player.nickname: _build_player_app_report(player) for player in device.players
     }
+
+
+async def async_set_per_day_controls(call: ServiceCall) -> None:
+    """Set per-day restrictions for a given device."""
+    data = call.data
+    device_id: str = data[ATTR_DEVICE_ID]
+    device = _get_nintendo_device(call.hass, device_id)
+    restriction_enabled = data.get(ATTR_MAX_PLAY_TIME) is not None
+    bedtime_enabled = (
+        data.get(ATTR_BEDTIME_START) and data.get(ATTR_BEDTIME_END)
+    ) is not None
+    try:
+        await device.set_daily_restrictions(
+            enabled=restriction_enabled,
+            bedtime_enabled=bedtime_enabled,
+            day_of_week=data[ATTR_DAY_OF_WEEK],
+            bedtime_start=data.get(ATTR_BEDTIME_END),
+            bedtime_end=data.get(ATTR_BEDTIME_START),
+            max_daily_playtime=data.get(ATTR_MAX_PLAY_TIME),
+        )
+    except InvalidDeviceStateError as err:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="requires_daily_restrictions",
+        ) from err

--- a/homeassistant/components/nintendo_parental_controls/services.yaml
+++ b/homeassistant/components/nintendo_parental_controls/services.yaml
@@ -75,11 +75,11 @@ update_daily_restrictions:
             - "saturday"
             - "sunday"
     bedtime_start:
-      example: "07:00:00"
+      example: "20:00:00"
       selector:
         time:
     bedtime_end:
-      example: "20:00:00"
+      example: "07:00:00"
       selector:
         time:
     max_play_time:

--- a/homeassistant/components/nintendo_parental_controls/services.yaml
+++ b/homeassistant/components/nintendo_parental_controls/services.yaml
@@ -52,3 +52,41 @@ device_usage_report:
       selector:
         device:
           integration: nintendo_parental_controls
+update_daily_restrictions:
+  fields:
+    device_id:
+      required: true
+      example: 1234567890abcdef1234567890abcdef
+      selector:
+        device:
+          integration: nintendo_parental_controls
+    day_of_week:
+      required: true
+      example: "monday"
+      selector:
+        select:
+          translation_key: day_of_week
+          options:
+            - "monday"
+            - "tuesday"
+            - "wednesday"
+            - "thursday"
+            - "friday"
+            - "saturday"
+            - "sunday"
+    bedtime_start:
+      example: "07:00:00"
+      selector:
+        time:
+    bedtime_end:
+      example: "20:00:00"
+      selector:
+        time:
+    max_play_time:
+      example: 120
+      selector:
+        number:
+          min: 0
+          max: 360
+          unit_of_measurement: minutes
+          mode: box

--- a/homeassistant/components/nintendo_parental_controls/strings.json
+++ b/homeassistant/components/nintendo_parental_controls/strings.json
@@ -162,7 +162,7 @@
       "name": "Player usage report"
     },
     "update_daily_restrictions": {
-      "description": "Update restrictions for a specific day of the week on the selected Nintendo Switch.",
+      "description": "Updates restrictions for a specific day of the week on the selected Nintendo Switch.",
       "fields": {
         "bedtime_end": {
           "description": "The time from which play is allowed. Must be between 05:00 and 09:00.",

--- a/homeassistant/components/nintendo_parental_controls/strings.json
+++ b/homeassistant/components/nintendo_parental_controls/strings.json
@@ -102,8 +102,24 @@
     "no_devices_found": {
       "message": "No Nintendo devices found for this account."
     },
+    "requires_daily_restrictions": {
+      "message": "Daily restrictions can only be set when restriction mode is set to different for each day."
+    },
     "update_required": {
       "message": "The Nintendo Switch parental controls integration requires an update due to changes in Nintendo's API."
+    }
+  },
+  "selector": {
+    "day_of_week": {
+      "options": {
+        "friday": "[%key:common::time::friday%]",
+        "monday": "[%key:common::time::monday%]",
+        "saturday": "[%key:common::time::saturday%]",
+        "sunday": "[%key:common::time::sunday%]",
+        "thursday": "[%key:common::time::thursday%]",
+        "tuesday": "[%key:common::time::tuesday%]",
+        "wednesday": "[%key:common::time::wednesday%]"
+      }
     }
   },
   "services": {
@@ -144,6 +160,32 @@
         }
       },
       "name": "Player usage report"
+    },
+    "update_daily_restrictions": {
+      "description": "Update restrictions for a specific day of the week on the selected Nintendo Switch.",
+      "fields": {
+        "bedtime_end": {
+          "description": "The time from which play is allowed. Must be between 05:00 and 09:00.",
+          "name": "Bedtime end"
+        },
+        "bedtime_start": {
+          "description": "The time when bedtime restrictions start. Must be between 16:00 and 23:00, or 00:00.",
+          "name": "Bedtime start"
+        },
+        "day_of_week": {
+          "description": "The day of the week to update restrictions for.",
+          "name": "Day of the week"
+        },
+        "device_id": {
+          "description": "The ID of the device to update daily restrictions for.",
+          "name": "Device"
+        },
+        "max_play_time": {
+          "description": "The maximum playtime allowed in minutes for this day (0 to 360).",
+          "name": "Max playtime"
+        }
+      },
+      "name": "Update daily restrictions"
     },
     "update_pin_code": {
       "description": "Update the PIN code for the selected Nintendo Switch.",

--- a/homeassistant/components/nintendo_parental_controls/strings.json
+++ b/homeassistant/components/nintendo_parental_controls/strings.json
@@ -84,8 +84,14 @@
     "bedtime_end_time_out_of_range": {
       "message": "{value} not accepted. Bedtime End Time must be between {bedtime_end_time_min} and {bedtime_end_time_max}. To disable, set to {bedtime_alarm_disable}."
     },
+    "bedtime_out_of_range": {
+      "message": "The specified bedtime start or end time is outside of the allowed range. Please ensure this is between {bedtime_alarm_min} and {bedtime_alarm_max} for bedtime start, and between {bedtime_end_time_min} and {bedtime_end_time_max} for bedtime end."
+    },
     "config_entry_not_found": {
       "message": "Config entry not found."
+    },
+    "extra_playing_time_active": {
+      "message": "Extra playing time is currently active. Please wait until it expires before updating daily restrictions."
     },
     "invalid_device": {
       "message": "The specified device is not a Nintendo device."

--- a/tests/components/nintendo_parental_controls/test_services.py
+++ b/tests/components/nintendo_parental_controls/test_services.py
@@ -209,15 +209,39 @@ async def test_update_pin_code(
     assert len(mock_nintendo_device.set_new_pin.mock_calls) == 1
 
 
-async def test_update_pin_code_requires_admin(
+@pytest.mark.parametrize(
+    ("service", "payload", "func"),
+    [
+        (
+            NintendoParentalServices.UPDATE_PIN_CODE,
+            {
+                CONF_PIN: "1234",
+            },
+            "set_new_pin",
+        ),
+        (
+            NintendoParentalServices.UPDATE_DAILY_RESTRICTIONS,
+            {
+                ATTR_DAY_OF_WEEK: "monday",
+                ATTR_BEDTIME_START: "20:00",
+                ATTR_BEDTIME_END: "22:00",
+            },
+            "set_daily_restrictions",
+        ),
+    ],
+)
+async def test_service_requires_admin(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     hass_read_only_user: MockUser,
     mock_config_entry: MockConfigEntry,
     mock_nintendo_client: AsyncMock,
     mock_nintendo_device: AsyncMock,
+    service: NintendoParentalServices,
+    payload: dict[str, Any],
+    func: str,
 ) -> None:
-    """Test updating the PIN code requires administrator access."""
+    """Test admin only services actually requires administrator access."""
     await setup_integration(hass, mock_config_entry)
     device_entry = device_registry.async_get_device_by_identifier(
         (DOMAIN, "testdevid"), mock_config_entry.entry_id
@@ -226,15 +250,12 @@ async def test_update_pin_code_requires_admin(
     with pytest.raises(Unauthorized):
         await hass.services.async_call(
             DOMAIN,
-            NintendoParentalServices.UPDATE_PIN_CODE,
-            {
-                ATTR_DEVICE_ID: device_entry.id,
-                CONF_PIN: "1234",
-            },
+            service,
+            {**payload, ATTR_DEVICE_ID: device_entry.id},
             blocking=True,
             context=Context(user_id=hass_read_only_user.id),
         )
-    mock_nintendo_device.set_new_pin.assert_not_called()
+    getattr(mock_nintendo_device, func).assert_not_called()
 
 
 async def test_get_player_application_report(

--- a/tests/components/nintendo_parental_controls/test_services.py
+++ b/tests/components/nintendo_parental_controls/test_services.py
@@ -4,7 +4,11 @@ from datetime import time
 from typing import Any
 from unittest.mock import AsyncMock
 
-from pynintendoparental.exceptions import InvalidDeviceStateError
+from pynintendoparental.exceptions import (
+    BedtimeOutOfRangeError,
+    ExtraPlayingTimeActiveError,
+    InvalidDeviceStateError,
+)
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -14,6 +18,10 @@ from homeassistant.components.nintendo_parental_controls.const import (
     ATTR_BONUS_TIME,
     ATTR_DAY_OF_WEEK,
     ATTR_MAX_PLAY_TIME,
+    BEDTIME_ALARM_MAX,
+    BEDTIME_ALARM_MIN,
+    BEDTIME_END_TIME_MAX,
+    BEDTIME_END_TIME_MIN,
     DOMAIN,
 )
 from homeassistant.components.nintendo_parental_controls.services import (
@@ -398,17 +406,46 @@ async def test_update_daily_restrictions(
     )
 
 
-async def test_update_daily_restrictions_invalid_state(
+@pytest.mark.parametrize(
+    ("side_effect", "translation_key", "translation_placeholders"),
+    [
+        pytest.param(
+            InvalidDeviceStateError("Invalid device state"),
+            "requires_daily_restrictions",
+            None,
+            id="requires_daily_restrictions",
+        ),
+        pytest.param(
+            ExtraPlayingTimeActiveError("Extra playing time active"),
+            "extra_playing_time_active",
+            None,
+            id="extra_playing_time_active",
+        ),
+        pytest.param(
+            BedtimeOutOfRangeError("Bedtime out of range"),
+            "bedtime_out_of_range",
+            {
+                "bedtime_alarm_min": BEDTIME_ALARM_MIN,
+                "bedtime_alarm_max": BEDTIME_ALARM_MAX,
+                "bedtime_end_time_min": BEDTIME_END_TIME_MIN,
+                "bedtime_end_time_max": BEDTIME_END_TIME_MAX,
+            },
+            id="bedtime_out_of_range",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_nintendo_client")
+async def test_update_daily_restrictions_exceptions(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
-    mock_nintendo_client: AsyncMock,
     mock_nintendo_device: AsyncMock,
+    side_effect: Exception,
+    translation_key: str,
+    translation_placeholders: dict[str, str] | None,
 ) -> None:
-    """Test update daily restrictions raises when device is in invalid state."""
-    mock_nintendo_device.set_daily_restrictions.side_effect = InvalidDeviceStateError(
-        "Invalid device state"
-    )
+    """Test update daily restrictions raises expected exceptions."""
+    mock_nintendo_device.set_daily_restrictions.side_effect = side_effect
     await setup_integration(hass, mock_config_entry)
     device_entry = device_registry.async_get_device_by_identifier(
         (DOMAIN, "testdevid"), mock_config_entry.entry_id
@@ -426,4 +463,5 @@ async def test_update_daily_restrictions_invalid_state(
             blocking=True,
         )
     assert err.value.translation_domain == DOMAIN
-    assert err.value.translation_key == "requires_daily_restrictions"
+    assert err.value.translation_key == translation_key
+    assert err.value.translation_placeholders == translation_placeholders

--- a/tests/components/nintendo_parental_controls/test_services.py
+++ b/tests/components/nintendo_parental_controls/test_services.py
@@ -1,13 +1,19 @@
 """Test Nintendo Parental Controls service calls."""
 
+from datetime import time
 from typing import Any
 from unittest.mock import AsyncMock
 
+from pynintendoparental.exceptions import InvalidDeviceStateError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.nintendo_parental_controls.const import (
+    ATTR_BEDTIME_END,
+    ATTR_BEDTIME_START,
     ATTR_BONUS_TIME,
+    ATTR_DAY_OF_WEEK,
+    ATTR_MAX_PLAY_TIME,
     DOMAIN,
 )
 from homeassistant.components.nintendo_parental_controls.services import (
@@ -105,6 +111,13 @@ async def test_add_bonus_time(
             NintendoParentalServices.PLAYER_USAGE_REPORT,
             {ATTR_DEVICE_ID: "invalid_device", ATTR_ENTITY_ID: PLAYER_ENTITY_ID},
             True,
+            HOMEASSISTANT_DOMAIN,
+            "service_device_not_found",
+        ),
+        (
+            NintendoParentalServices.UPDATE_DAILY_RESTRICTIONS,
+            {ATTR_DEVICE_ID: "invalid_device", ATTR_DAY_OF_WEEK: "monday"},
+            False,
             HOMEASSISTANT_DOMAIN,
             "service_device_not_found",
         ),
@@ -326,3 +339,68 @@ async def test_player_service_failures(
         )
     assert err.value.translation_domain == exception_domain
     assert err.value.translation_key == exception_key
+
+
+async def test_update_daily_restrictions(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_nintendo_client: AsyncMock,
+    mock_nintendo_device: AsyncMock,
+) -> None:
+    """Ensure that the daily restrictions update as expected."""
+    await setup_integration(hass, mock_config_entry)
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "testdevid"), mock_config_entry.entry_id
+    )
+    assert device_entry
+    await hass.services.async_call(
+        DOMAIN,
+        NintendoParentalServices.UPDATE_DAILY_RESTRICTIONS,
+        {
+            ATTR_DEVICE_ID: device_entry.id,
+            ATTR_DAY_OF_WEEK: "monday",
+            ATTR_BEDTIME_START: time(21, 0, 0),
+            ATTR_BEDTIME_END: time(9, 0, 0),
+            ATTR_MAX_PLAY_TIME: 360,
+        },
+        blocking=True,
+    )
+    assert len(mock_nintendo_device.set_daily_restrictions.mock_calls) == 1
+    mock_nintendo_device.set_daily_restrictions.assert_called_once_with(
+        enabled=True,
+        bedtime_enabled=True,
+        day_of_week="monday",
+        bedtime_start=time(9, 0, 0),
+        bedtime_end=time(21, 0, 0),
+        max_daily_playtime=360,
+    )
+
+
+async def test_update_daily_restrictions_invalid_state(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_nintendo_client: AsyncMock,
+    mock_nintendo_device: AsyncMock,
+) -> None:
+    """Test update daily restrictions raises when device is in invalid state."""
+    mock_nintendo_device.set_daily_restrictions.side_effect = InvalidDeviceStateError()
+    await setup_integration(hass, mock_config_entry)
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "testdevid"), mock_config_entry.entry_id
+    )
+    assert device_entry
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            NintendoParentalServices.UPDATE_DAILY_RESTRICTIONS,
+            {
+                ATTR_DEVICE_ID: device_entry.id,
+                ATTR_DAY_OF_WEEK: "monday",
+                ATTR_MAX_PLAY_TIME: 360,
+            },
+            blocking=True,
+        )
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "requires_daily_restrictions"

--- a/tests/components/nintendo_parental_controls/test_services.py
+++ b/tests/components/nintendo_parental_controls/test_services.py
@@ -385,7 +385,9 @@ async def test_update_daily_restrictions_invalid_state(
     mock_nintendo_device: AsyncMock,
 ) -> None:
     """Test update daily restrictions raises when device is in invalid state."""
-    mock_nintendo_device.set_daily_restrictions.side_effect = InvalidDeviceStateError()
+    mock_nintendo_device.set_daily_restrictions.side_effect = InvalidDeviceStateError(
+        "Invalid device state"
+    )
     await setup_integration(hass, mock_config_entry)
     device_entry = device_registry.async_get_device_by_identifier(
         (DOMAIN, "testdevid"), mock_config_entry.entry_id

--- a/tests/components/nintendo_parental_controls/test_services.py
+++ b/tests/components/nintendo_parental_controls/test_services.py
@@ -241,7 +241,7 @@ async def test_service_requires_admin(
     payload: dict[str, Any],
     func: str,
 ) -> None:
-    """Test admin only services actually requires administrator access."""
+    """Test that admin-only services require administrator access."""
     await setup_integration(hass, mock_config_entry)
     device_entry = device_registry.async_get_device_by_identifier(
         (DOMAIN, "testdevid"), mock_config_entry.entry_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a service to update the daily restrictions for an individual day. The current entities that are exposed will update for whatever the current day is automatically, however if you wanted to update for a specific day, currently you would need to wait until that day to do so.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47797
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
