### PR TITLE
Populate Satel Integra model and firmware

### DIFF
--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from satel_integra import SatelIntegraError
+
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, device_registry as dr
@@ -84,7 +86,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: SatelConfigEntry) -> boo
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_close_connection)
     )
 
-    panel_info = await client.controller.read_panel_info()
+    try:
+        panel_info = await client.controller.read_panel_info()
+    except SatelIntegraError:
+        _LOGGER.warning("Unable to read Satel panel information", exc_info=True)
+        panel_info = None
+
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,

--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -84,11 +84,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: SatelConfigEntry) -> boo
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_close_connection)
     )
 
+    panel_info = await client.controller.read_panel_info()
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, entry.entry_id)},
         manufacturer="Satel",
+        model=panel_info.model.name if panel_info and panel_info.model else None,
+        sw_version=str(panel_info.firmware) if panel_info else None,
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/tests/components/satel_integra/conftest.py
+++ b/tests/components/satel_integra/conftest.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from satel_integra import SatelFirmwareVersion, SatelPanelInfo, SatelPanelModel
 
 from homeassistant.components.satel_integra.config_flow import SatelConfigFlow
 from homeassistant.components.satel_integra.const import DOMAIN
@@ -64,6 +65,17 @@ def mock_satel() -> Generator[AsyncMock]:
         client.violated_zones = []
 
         client.connect = AsyncMock(return_value=True)
+        client.read_panel_info = AsyncMock(
+            return_value=SatelPanelInfo(
+                type_code=2,
+                model=SatelPanelModel("INTEGRA 64"),
+                firmware=SatelFirmwareVersion(
+                    version="1.24", release_date="2025-03-12"
+                ),
+                language_code=0,
+                settings_stored_in_flash=True,
+            )
+        )
         client.read_temperature = AsyncMock(return_value=21.5)
         client.read_temperatures = AsyncMock(return_value={1: 21.5})
         client.set_output = AsyncMock()

--- a/tests/components/satel_integra/snapshots/test_init.ambr
+++ b/tests/components/satel_integra/snapshots/test_init.ambr
@@ -20,12 +20,12 @@
     'labels': set({
     }),
     'manufacturer': 'Satel',
-    'model': None,
+    'model': 'INTEGRA 64',
     'model_id': None,
     'name': '192.168.0.2',
     'name_by_user': None,
     'serial_number': None,
-    'sw_version': None,
+    'sw_version': '1.24 (2025-03-12)',
     'via_device_id': None,
   })
 # ---

--- a/tests/components/satel_integra/test_init.py
+++ b/tests/components/satel_integra/test_init.py
@@ -8,6 +8,7 @@ from satel_integra import (
     SatelConnectFailedError,
     SatelConnectionInitializationError,
     SatelPanelBusyError,
+    SatelUnexpectedResponseError,
 )
 from syrupy.assertion import SnapshotAssertion
 
@@ -223,6 +224,26 @@ async def test_parent_device_exists(
     )
     assert device_entry == snapshot(name="parent-device")
     mock_satel.read_panel_info.assert_awaited_once_with()
+
+
+async def test_panel_info_read_error(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    device_registry: DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a panel information read error does not prevent setup."""
+    mock_satel.read_panel_info.side_effect = SatelUnexpectedResponseError
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_ENTRY_ID), mock_config_entry.entry_id
+    )
+    assert device_entry is not None
+    assert device_entry.model is None
+    assert device_entry.sw_version is None
 
 
 @pytest.mark.parametrize(

--- a/tests/components/satel_integra/test_init.py
+++ b/tests/components/satel_integra/test_init.py
@@ -222,6 +222,7 @@ async def test_parent_device_exists(
         (DOMAIN, MOCK_ENTRY_ID), mock_config_entry.entry_id
     )
     assert device_entry == snapshot(name="parent-device")
+    mock_satel.read_panel_info.assert_awaited_once_with()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Read alarm panel information during startup. This information is used to populate the model and firmware version on the main device that represents the physical Satel Integra alarm panel. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
