### PR TITLE
Improve PostgreSQL recorder purge query plan

### DIFF
--- a/homeassistant/components/recorder/queries.py
+++ b/homeassistant/components/recorder/queries.py
@@ -286,6 +286,7 @@ def find_states_to_purge(
         lambda: (
             select(States.state_id, States.attributes_id)
             .filter(States.last_updated_ts < purge_before)
+            .order_by(States.last_updated_ts.asc())
             .limit(max_bind_vars)
         )
     )

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from freezegun import freeze_time
 import pytest
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import DatabaseError, OperationalError
 from sqlalchemy.orm.session import Session
 from voluptuous.error import MultipleInvalid
@@ -26,7 +27,10 @@ from homeassistant.components.recorder.db_schema import (
 )
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.components.recorder.purge import purge_old_data
-from homeassistant.components.recorder.queries import select_event_type_ids
+from homeassistant.components.recorder.queries import (
+    find_states_to_purge,
+    select_event_type_ids,
+)
 from homeassistant.components.recorder.services import (
     SERVICE_PURGE,
     SERVICE_PURGE_ENTITIES,
@@ -61,6 +65,22 @@ TEST_EVENT_TYPES = (
     "EVENT_TEST_PURGE_WITH_EVENT_DATA",
     "EVENT_TEST_WITH_EVENT_DATA",
 )
+
+
+def test_find_states_to_purge_orders_by_last_updated_ts() -> None:
+    """Test states to purge are ordered by last_updated_ts."""
+    query = find_states_to_purge(1724206320.099243, 4000)
+
+    compiled_query = " ".join(
+        str(
+            query.compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        ).split()
+    )
+
+    assert "ORDER BY states.last_updated_ts ASC LIMIT 4000" in compiled_query
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Order recorder state purge batches by `last_updated_ts` so PostgreSQL can use the existing index instead of a sequential scan when statistics overestimate old rows.

### Benchmarks

A temporary local benchmark harness (not included in this PR) invoked the public `recorder.purge` service with:

`RECORDER_BENCH_DB_URL=postgresql://postgres:password@127.0.0.1:54329/homeassistant-benchmark uv run --no-sync pytest tests/components/recorder/test_purge_benchmark_tmp.py --dburl=postgresql://postgres:password@127.0.0.1:54329/homeassistant-benchmark --drop-existing-db -q -s`

On PostgreSQL 15.19, the harness seeded 5,000,000 states (3,000,000 recent and 2,000,000 old), ran `ANALYZE`, deleted the 2,000,000 old states, ran `VACUUM` without `ANALYZE`, disabled autovacuum, and inserted 4,000 eligible old states before each run. Each measured run therefore had approximately 3,004,000 live states, including 4,000 eligible states. The results below use one warmup per variant followed by five alternating measured runs.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| `recorder.purge` wall time, median (IQR) | 0.5831s (0.1459s) | 0.2814s (0.0803s) | -51.7% |

The base query used a sequential scan; the updated query used an index scan.

### Validation

- `uv run --no-sync pytest tests/components/recorder/test_purge.py -q`
- `uv run --no-sync pytest tests/components/recorder/test_purge.py --dburl=postgresql://postgres:password@127.0.0.1:54329/homeassistant-test --drop-existing-db -k 'test_purge_method or test_find_states_to_purge_orders_by_last_updated_ts' -q`
- `uv run --no-sync prek run mypy --files homeassistant/components/recorder/queries.py tests/components/recorder/test_purge.py && uv run --no-sync prek run pylint --files homeassistant/components/recorder/queries.py tests/components/recorder/test_purge.py`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #179907
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
