### PR TITLE
Bump python-duco-connectivity to 0.14.0

### DIFF
--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -10,7 +10,6 @@ from duco_connectivity.exceptions import (
     DucoConnectionError,
     DucoError,
     DucoResponseError,
-    DucoUnsupportedCapabilityError,
 )
 from duco_connectivity.models import (
     BoardInfo,
@@ -53,8 +52,6 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
     config_entry: DucoConfigEntry
     board_info: BoardInfo
     _supports_time_filter_remain: bool
-    _supports_ventilation_temperatures: bool
-    _supports_bypass_supply_temperature_targets: bool
     _configured_node_names: dict[int, str]
 
     def __init__(
@@ -74,8 +71,6 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         self.client = client
         self._configured_node_names = {}
         self._supports_time_filter_remain = True
-        self._supports_ventilation_temperatures = True
-        self._supports_bypass_supply_temperature_targets = True
 
     async def _async_load_node_names(self) -> None:
         """Load configured Duco node names during setup."""
@@ -193,38 +188,28 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         ventilation_temperatures = (
             self.data.ventilation_temperatures if self.data else None
         )
-        if self._supports_ventilation_temperatures:
-            try:
-                ventilation_temperatures = (
-                    await self.client.async_get_ventilation_temperature_info()
-                )
-            except DucoUnsupportedCapabilityError:
-                ventilation_temperatures = None
-                self._supports_ventilation_temperatures = False
-            except DucoError as err:
-                _LOGGER.debug(
-                    "Could not fetch Duco ventilation temperatures", exc_info=err
-                )
+        try:
+            ventilation_temperatures = (
+                await self.client.async_get_ventilation_temperature_info()
+            )
+        except DucoError as err:
+            _LOGGER.debug("Could not fetch Duco ventilation temperatures", exc_info=err)
 
         bypass_supply_temperature_targets: dict[int, BypassSupplyTemperatureTarget] = {}
-        if self._supports_bypass_supply_temperature_targets:
-            try:
-                bypass_supply_temperature_targets = (
-                    await self.client.async_get_bypass_supply_temperature_targets()
-                )
-            except DucoUnsupportedCapabilityError:
-                bypass_supply_temperature_targets = {}
-                self._supports_bypass_supply_temperature_targets = False
-            except DucoConnectionError as err:
-                raise UpdateFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="cannot_connect",
-                ) from err
-            except DucoError as err:
-                raise UpdateFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="api_error",
-                ) from err
+        try:
+            bypass_supply_temperature_targets = (
+                await self.client.async_get_bypass_supply_temperature_targets()
+            )
+        except DucoConnectionError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+            ) from err
+        except DucoError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="api_error",
+            ) from err
 
         return DucoData(
             nodes={node.node_id: node for node in nodes},

--- a/homeassistant/components/duco/manifest.json
+++ b/homeassistant/components/duco/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "local_polling",
   "loggers": ["duco_connectivity"],
   "quality_scale": "platinum",
-  "requirements": ["python-duco-connectivity==0.13.1"],
+  "requirements": ["python-duco-connectivity==0.14.0"],
   "zeroconf": [
     {
       "name": "duco [[][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][]].*",

--- a/homeassistant/components/duco/number.py
+++ b/homeassistant/components/duco/number.py
@@ -56,14 +56,6 @@ async def async_setup_entry(
                 if (description.key, zone_id) in known_entities:
                     continue
 
-                # Skip incomplete metadata because guessing valid limits would expose an invalid control.
-                if (
-                    target.minimum is None
-                    or target.maximum is None
-                    or target.increment is None
-                ):
-                    continue
-
                 known_entities.add((description.key, zone_id))
                 new_entities.append(
                     DucoBypassSupplyTemperatureTargetNumber(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2702,7 +2702,7 @@ python-digitalocean==1.13.2
 python-dropbox-api==0.1.4
 
 # homeassistant.components.duco
-python-duco-connectivity==0.13.1
+python-duco-connectivity==0.14.0
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.4.1

--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -13,7 +13,6 @@ from duco_connectivity import (
     DucoConnectionError,
     DucoError,
     DucoResponseError,
-    DucoUnsupportedCapabilityError,
     LanInfo,
     Node,
     NodeListActionItemList,
@@ -268,20 +267,18 @@ async def test_setup_entry_retries_on_bypass_temperature_failure(
     assert mock_config_entry.error_reason_translation_placeholders is None
 
 
-async def test_unsupported_bypass_temperature_capability_is_not_repolled(
+async def test_empty_bypass_temperature_targets_are_retried(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
+    mock_bypass_supply_temperature_targets: dict[int, BypassSupplyTemperatureTarget],
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
 ) -> None:
-    """Test an unsupported bulk bypass target endpoint is not polled again."""
-    mock_duco_client.async_get_bypass_supply_temperature_targets.side_effect = (
-        DucoUnsupportedCapabilityError(
-            400,
-            "/config",
-            '{"Code":3,"Result":"FAILED"}',
-        )
-    )
+    """Test empty bypass targets are retried and can later create entities."""
+    mock_duco_client.async_get_bypass_supply_temperature_targets.side_effect = [
+        {},
+        mock_bypass_supply_temperature_targets.copy(),
+    ]
     mock_config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -296,7 +293,9 @@ async def test_unsupported_bypass_temperature_capability_is_not_repolled(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    mock_duco_client.async_get_bypass_supply_temperature_targets.assert_awaited_once_with()
+    assert mock_duco_client.async_get_bypass_supply_temperature_targets.await_count == 2
+    assert hass.states.get("number.living_bypass_target_1") is not None
+    assert hass.states.get("number.living_bypass_target_2") is not None
 
 
 async def test_missing_bypass_temperature_targets_are_retried(

--- a/tests/components/duco/test_number.py
+++ b/tests/components/duco/test_number.py
@@ -92,32 +92,6 @@ async def test_bypass_supply_temperature_targets_missing_skips_number_creation(
     assert hass.states.get(_ZONE_2_ENTITY_ID) is None
 
 
-@pytest.mark.parametrize(
-    "field",
-    [
-        pytest.param("minimum", id="missing_minimum"),
-        pytest.param("maximum", id="missing_maximum"),
-        pytest.param("increment", id="missing_increment"),
-    ],
-)
-@pytest.mark.usefixtures("mock_duco_client")
-async def test_bypass_supply_temperature_target_incomplete_metadata_skips_number_creation(
-    hass: HomeAssistant,
-    mock_bypass_supply_temperature_targets: dict[int, BypassSupplyTemperatureTarget],
-    mock_config_entry: MockConfigEntry,
-    field: str,
-) -> None:
-    """Test incomplete target metadata does not expose an invalid control."""
-    mock_bypass_supply_temperature_targets[1] = replace(
-        mock_bypass_supply_temperature_targets[1], **{field: None}
-    )
-
-    await setup_platform_integration(hass, mock_config_entry, [Platform.NUMBER])
-
-    assert hass.states.get(_ZONE_1_ENTITY_ID) is None
-    assert hass.states.get(_ZONE_2_ENTITY_ID) is not None
-
-
 @pytest.mark.usefixtures("init_integration")
 async def test_set_bypass_supply_temperature_target(
     hass: HomeAssistant,

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock
 from duco_connectivity import (
     DucoConnectionError,
     DucoError,
-    DucoUnsupportedCapabilityError,
     Node,
     NodeGeneralInfo,
     NodeSensorInfo,
@@ -277,15 +276,15 @@ async def test_time_filter_remaining_missing_skips_sensor_creation(
     assert hass.states.get(FILTER_REMAINING_ENTITY_ID) is None
 
 
-async def test_ventilation_temperatures_missing_skip_sensor_creation(
+async def test_empty_ventilation_temperatures_are_retried(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test unsupported ventilation temperatures never expose temperature states."""
+    """Test empty ventilation temperatures are retried and can appear later."""
     mock_duco_client.async_get_ventilation_temperature_info.side_effect = [
-        DucoUnsupportedCapabilityError(400, "/info", '{"Code":3,"Result":"FAILED"}'),
+        VentilationTemperatureInfo(),
         VentilationTemperatureInfo(temp_oda=5.5),
     ]
 
@@ -298,8 +297,10 @@ async def test_ventilation_temperatures_missing_skip_sensor_creation(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    for entity_id in VENTILATION_TEMPERATURE_ENTITY_IDS:
-        assert hass.states.get(entity_id) is None
+    assert mock_duco_client.async_get_ventilation_temperature_info.await_count == 2
+    state = hass.states.get("sensor.living_outdoor_air_temperature")
+    assert state is not None
+    assert state.state == "5.5"
 
 
 async def test_partial_ventilation_temperatures_only_expose_available_sensor_values(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `python-duco-connectivity` from `0.13.1` to `0.14.0` for the Duco integration. This release guarantees complete bypass target metadata and returns natural empty results for unsupported optional discovery endpoints.

The integration removes the obsolete incomplete-metadata guard and impossible-state tests. It also keeps empty ventilation-temperature and bypass-target results pollable, preserving late entity discovery while retaining the existing handling for operational errors.

- PyPI release: https://pypi.org/project/python-duco-connectivity/0.14.0/
- Release notes: https://github.com/ronaldvdmeer/python-duco-connectivity/releases/tag/v0.14.0
- Comparison: https://github.com/ronaldvdmeer/python-duco-connectivity/compare/v0.13.1...v0.14.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
