### PR TITLE
Build the homematicip_cloud switches from channels, not device classes

### DIFF
--- a/homeassistant/components/homematicip_cloud/switch.py
+++ b/homeassistant/components/homematicip_cloud/switch.py
@@ -3,25 +3,6 @@
 from typing import Any, override
 
 from homematicip.base.enums import DeviceType, FunctionalChannelType
-from homematicip.device import (
-    BrandSwitch2,
-    DinRailSwitch,
-    DinRailSwitch4,
-    FullFlushInputSwitch,
-    HeatingSwitch2,
-    MotionDetectorSwitchOutdoor,
-    MultiIOBox,
-    OpenCollector8Module,
-    PlugableSwitch,
-    PrintedCircuitBoardSwitch2,
-    PrintedCircuitBoardSwitchBattery,
-    StatusBoard8,
-    SwitchMeasuring,
-    WiredInput32,
-    WiredInputSwitch6,
-    WiredSwitch4,
-    WiredSwitch8,
-)
 from homematicip.group import ExtendedLinkedSwitchingGroup, SwitchingGroup
 
 from homeassistant.components.switch import SwitchEntity
@@ -30,6 +11,21 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .entity import ATTR_GROUP_MEMBER_UNREACHABLE, HomematicipGenericEntity
 from .hap import HomematicIPConfigEntry, HomematicipHAP
+
+SWITCH_CHANNEL_TYPES = (
+    FunctionalChannelType.SWITCH_CHANNEL,
+    FunctionalChannelType.SWITCH_MEASURING_CHANNEL,
+    FunctionalChannelType.MULTI_MODE_INPUT_SWITCH_CHANNEL,
+)
+
+# these carry a switch channel, but their entity is a light
+LIGHT_OWNED_DEVICE_TYPES = (
+    DeviceType.BRAND_SWITCH_NOTIFICATION_LIGHT,
+    DeviceType.BRAND_SWITCH_MEASURING,
+)
+
+# a single channel, but named after it, so renaming would break their entity ids
+CHANNEL_NAMED_DEVICE_TYPES = (DeviceType.DIN_RAIL_SWITCH,)
 
 
 async def async_setup_entry(
@@ -45,52 +41,28 @@ async def async_setup_entry(
         if isinstance(group, (ExtendedLinkedSwitchingGroup, SwitchingGroup))
     ]
     for device in hap.home.devices:
-        if (
-            isinstance(device, SwitchMeasuring)
-            and getattr(device, "deviceType", None) != DeviceType.BRAND_SWITCH_MEASURING
-        ):
-            entities.append(HomematicipSwitchMeasuring(hap, device))
-        elif isinstance(
-            device,
-            (
-                WiredSwitch4,
-                WiredSwitch8,
-                OpenCollector8Module,
-                StatusBoard8,
-                BrandSwitch2,
-                PrintedCircuitBoardSwitch2,
-                HeatingSwitch2,
-                MultiIOBox,
-                MotionDetectorSwitchOutdoor,
-                DinRailSwitch,
-                DinRailSwitch4,
-                WiredInput32,
-                WiredInputSwitch6,
-            ),
-        ):
-            channel_indices = [
-                ch.index
-                for ch in device.functionalChannels
-                if ch.functionalChannelType
-                in (
-                    FunctionalChannelType.SWITCH_CHANNEL,
-                    FunctionalChannelType.MULTI_MODE_INPUT_SWITCH_CHANNEL,
-                )
-            ]
-            entities.extend(
-                HomematicipMultiSwitch(hap, device, channel=channel)
-                for channel in channel_indices
+        device_type = getattr(device, "deviceType", None)
+        if device_type in LIGHT_OWNED_DEVICE_TYPES:
+            continue
+        channels = [
+            channel
+            for channel in device.functionalChannels
+            if channel.functionalChannelType in SWITCH_CHANNEL_TYPES
+        ]
+        # a lone channel is the device itself, so it keeps the device name
+        is_multi_channel = (
+            len(channels) > 1 or device_type in CHANNEL_NAMED_DEVICE_TYPES
+        )
+        entities.extend(
+            HomematicipMultiSwitch(
+                hap,
+                device,
+                channel=channel.index,
+                channel_real_index=channel.index,
+                is_multi_channel=is_multi_channel,
             )
-
-        elif isinstance(
-            device,
-            (
-                PlugableSwitch,
-                PrintedCircuitBoardSwitchBattery,
-                FullFlushInputSwitch,
-            ),
-        ):
-            entities.append(HomematicipSwitch(hap, device))
+            for channel in channels
+        )
 
     async_add_entities(entities)
 
@@ -103,6 +75,7 @@ class HomematicipMultiSwitch(HomematicipGenericEntity, SwitchEntity):
         hap: HomematicipHAP,
         device,
         channel=1,
+        channel_real_index=None,
         is_multi_channel=True,
     ) -> None:
         """Initialize the multi switch device."""
@@ -110,6 +83,7 @@ class HomematicipMultiSwitch(HomematicipGenericEntity, SwitchEntity):
             hap,
             device,
             channel=channel,
+            channel_real_index=channel_real_index,
             is_multi_channel=is_multi_channel,
             feature_id="switch",
         )
@@ -132,14 +106,6 @@ class HomematicipMultiSwitch(HomematicipGenericEntity, SwitchEntity):
         """Turn the switch off."""
         channel = self.get_channel_or_raise()
         await channel.async_turn_off()
-
-
-class HomematicipSwitch(HomematicipMultiSwitch, SwitchEntity):
-    """Representation of the HomematicIP switch."""
-
-    def __init__(self, hap: HomematicipHAP, device) -> None:
-        """Initialize the switch device."""
-        super().__init__(hap, device, is_multi_channel=False)
 
 
 class HomematicipGroupSwitch(HomematicipGenericEntity, SwitchEntity):
@@ -188,7 +154,3 @@ class HomematicipGroupSwitch(HomematicipGenericEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the group off."""
         await self._device.turn_off_async()
-
-
-class HomematicipSwitchMeasuring(HomematicipSwitch):
-    """Representation of the HomematicIP measuring switch."""

--- a/tests/components/homematicip_cloud/test_switch.py
+++ b/tests/components/homematicip_cloud/test_switch.py
@@ -1,10 +1,13 @@
 """Tests for HomematicIP Cloud switch."""
 
+from typing import Any
+
 from homeassistant.components.homematicip_cloud.entity import (
     ATTR_GROUP_MEMBER_UNREACHABLE,
 )
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .helper import HomeFactory, async_manipulate_test_data, get_and_check_entity_basics
 
@@ -46,6 +49,34 @@ async def test_hmip_switch(
     await async_manipulate_test_data(hass, hmip_device, "on", True)
     ha_state = hass.states.get(entity_id)
     assert ha_state.state == STATE_ON
+
+
+async def test_hmip_switch_on_a_sensor_device(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    default_mock_hap_factory: HomeFactory,
+    carbon_dioxide_sensor_device_data: dict[str, Any],
+) -> None:
+    """Test the switch actuator of a device that is not a switch device class."""
+    entity_id = "switch.co2_sensor_miko"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["CO2 Sensor miko "],
+        extra_devices=[carbon_dioxide_sensor_device_data],
+    )
+
+    ha_state, hmip_device = get_and_check_entity_basics(
+        hass, mock_hap, entity_id, "CO2 Sensor miko ", "HmIP-SCTH230"
+    )
+    assert ha_state.state == STATE_OFF
+
+    # the switch channel sits at index 2, next to the sensor channel at 1
+    entity = entity_registry.async_get(entity_id)
+    assert entity.unique_id == "3014F711000000000SCTH230_2_switch"
+
+    await hass.services.async_call(
+        "switch", "turn_on", {"entity_id": entity_id}, blocking=True
+    )
+    assert hmip_device.functionalChannels[2].mock_calls[-1][0] == "async_turn_on"
 
 
 async def test_hmip_switch_input(


### PR DESCRIPTION
## Proposed change

Another step towards channel-based entities: any device with a switch channel gets a switch entity now, so new hardware works without a library class and a version bump. Devices that carry a switch actuator alongside another function gain one that way.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

