### PR TITLE
Align recorder hourly statistics with local hours

### DIFF
--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -550,9 +550,8 @@ def _compile_hourly_statistics(session: Session, start: datetime) -> None:
     - average, min max is computed by a database query
     - sum is taken from the last 5-minute entry during the hour
     """
-    start_time = start.replace(minute=0)
-    start_time_ts = start_time.timestamp()
-    end_time = start_time + Statistics.duration
+    start_time_ts = start.timestamp()
+    end_time = start + Statistics.duration
     end_time_ts = end_time.timestamp()
 
     # Compute last hour's average, min, max
@@ -615,8 +614,11 @@ def compile_missing_statistics(instance: Recorder) -> bool:
     period_size = 5
     last_period_minutes = now.minute - now.minute % period_size
     last_period = now.replace(minute=last_period_minutes, second=0, microsecond=0)
-    start = now - timedelta(days=instance.keep_days)
-    start = start.replace(minute=0, second=0, microsecond=0)
+    start = dt_util.as_utc(
+        dt_util.as_local(now - timedelta(days=instance.keep_days)).replace(
+            minute=0, second=0, microsecond=0
+        )
+    )
     # Commit every 12 hours of data
     commit_interval = 60 / period_size * 12
 
@@ -808,7 +810,9 @@ def _compile_statistics(
         ):
             new_short_term_stats.append(new_stat)
 
-    if start.minute == 50:
+    end_local = dt_util.as_local(end)
+
+    if end_local.minute == 55:
         # Once every hour, update issues
         for platform in instance.hass.data[DATA_RECORDER].recorder_platforms.values():
             if not (
@@ -821,15 +825,15 @@ def _compile_statistics(
                 instance.hass, session, custom_equivalent_units_per_entity
             )
 
-    if start.minute == 55:
+    if end_local.minute == 0:
         # A full hour is ready, summarize it
-        _compile_hourly_statistics(session, start)
+        _compile_hourly_statistics(session, end - Statistics.duration)
 
     session.add(StatisticsRuns(start=start))
 
     if fire_events:
         instance.hass.bus.fire(EVENT_RECORDER_5MIN_STATISTICS_GENERATED)
-        if start.minute == 55:
+        if end_local.minute == 0:
             instance.hass.bus.fire(EVENT_RECORDER_HOURLY_STATISTICS_GENERATED)
 
     if updated_metadata_ids:

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -3846,6 +3846,46 @@ async def test_recorder_platform_with_statistics(
     recorder_platform.validate_statistics.assert_called_once_with(hass, {})
 
 
+@pytest.mark.parametrize(
+    ("timezone", "period_start", "hour_start"),
+    [
+        (
+            "Australia/Adelaide",
+            "2026-01-01T13:25:00+00:00",
+            "2026-01-01T12:30:00+00:00",
+        ),
+        (
+            "Asia/Kathmandu",
+            "2026-01-01T18:10:00+00:00",
+            "2026-01-01T17:15:00+00:00",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("setup_recorder")
+async def test_hourly_statistics_align_with_local_hour(
+    hass: HomeAssistant,
+    timezone: str,
+    period_start: str,
+    hour_start: str,
+) -> None:
+    """Test hourly statistics align with the local hour."""
+    await hass.config.async_set_time_zone(timezone)
+    instance = recorder.get_instance(hass)
+    start = dt_util.parse_datetime(period_start)
+    expected_start = dt_util.parse_datetime(hour_start)
+    assert start is not None
+    assert expected_start is not None
+
+    with patch(
+        "homeassistant.components.recorder.statistics._compile_hourly_statistics"
+    ) as compile_hourly_statistics:
+        await instance.async_add_executor_job(
+            statistics.compile_statistics, instance, start, False
+        )
+
+    compile_hourly_statistics.assert_called_once_with(ANY, expected_start)
+
+
 async def test_recorder_platform_without_statistics(
     hass: HomeAssistant,
     setup_recorder: None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Align recorder hourly statistics with local civil-hour boundaries instead of UTC hour boundaries. This makes hourly statistics usable in time zones with non-whole-hour UTC offsets, such as Australia/Adelaide and Asia/Kathmandu.

The five-minute statistics schedule remains unchanged. Hourly summaries and their generated events now occur when a complete local hour is available, and missing-statistics backfill begins on a local-hour boundary.

Existing hourly rows are not rewritten. Installations upgrading with retained long-term statistics can therefore have historical UTC-aligned rows followed by locally aligned rows, with a partial overlap or gap at the transition boundary. Retained five-minute statistics could support a separate migration strategy if maintainers prefer existing rows to be rebuilt.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating a PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging the code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
