### PR TITLE
Fix collection_image unavailable handling

### DIFF
--- a/homeassistant/components/collection_image/image.py
+++ b/homeassistant/components/collection_image/image.py
@@ -5,9 +5,10 @@ from pathlib import Path
 import random
 from typing import override
 
-from homeassistant.components.image import ImageEntity
+from homeassistant.components.image import DEFAULT_CONTENT_TYPE, ImageEntity
 from homeassistant.components.media_player import (
     BrowseError,
+    BrowseMedia,
     MediaClass,
     async_process_play_media_url,
 )
@@ -51,8 +52,6 @@ async def async_setup_entry(
 class CollectionImageImageEntity(ImageEntity):
     """Implement the image entity for Collection Image."""
 
-    _unavailable_logged: bool = False
-
     path: Path | None
 
     def __init__(
@@ -69,80 +68,80 @@ class CollectionImageImageEntity(ImageEntity):
         self._attr_name = name
         self.media_content_id = media_content_id
 
-    async def get_next_image(self) -> None:
-        """Update the image entity with the next image from the source media."""
-
+    def set_unavailable(self) -> None:
+        """Set the entity to unavailable state."""
+        self._attr_available = False
+        self.path = None
+        self._attr_image_url = UNDEFINED
         self._cached_image = None
+        self.async_write_ha_state()
 
-        def set_unavailable() -> None:
-            self._unavailable_logged = True
-            self._attr_available = False
-            self.path = None
-            self._attr_image_url = UNDEFINED
-            self.async_write_ha_state()
-
+    async def get_valid_images(self) -> list[BrowseMedia]:
+        """Given the configured media directory for the entity, get a list of all child images."""
         try:
             media = await async_browse_media(self.hass, self.media_content_id)
         except BrowseError as err:
-            if not self._unavailable_logged:
-                _LOGGER.info("%s: %s", self.entity_id, str(err))
-            set_unavailable()
-            return
+            _LOGGER.warning("%s: %s", self.entity_id, str(err))
+            return []
 
-        if media.children and (
-            filtered := [
-                item for item in media.children if item.media_class == MediaClass.IMAGE
-            ]
-        ):
-            child = random.choice(filtered)
-            try:
-                resolved = await async_resolve_media(
-                    self.hass, child.media_content_id, self.entity_id
-                )
-            except Unresolvable as err:
-                if not self._unavailable_logged:
-                    _LOGGER.info("%s: %s", self.entity_id, str(err))
-                set_unavailable()
-                return
-
-            if resolved.url:
-                self.path = None
-                self._attr_image_url = async_process_play_media_url(
-                    self.hass, resolved.url
-                )
-            else:
-                self.path = resolved.path
-                self._attr_image_url = UNDEFINED
-
-            self._attr_content_type = resolved.mime_type
-            self._attr_available = True
-            self._attr_image_last_updated = dt_util.utcnow()
-            if self._unavailable_logged:
-                _LOGGER.info(
-                    "%s: Has become available again",
-                    self.entity_id,
-                )
-            self._unavailable_logged = False
-            self.async_write_ha_state()
-            return
-
-        if not self._unavailable_logged:
-            _LOGGER.info(
+        images = [
+            item
+            for item in (media.children or [])
+            if item.media_class == MediaClass.IMAGE
+        ]
+        if not images:
+            _LOGGER.warning(
                 "%s: No valid images in %s",
                 self.entity_id,
                 self.media_content_id,
             )
-        set_unavailable()
-        return
+        return images
+
+    async def get_random_image(self) -> None:
+        """Update the image entity with a random image from the source media."""
+
+        filtered = await self.get_valid_images()
+        if not filtered:
+            self.set_unavailable()
+            return
+
+        child = random.choice(filtered)
+        self._attr_available = True
+        await self.update_image(child.media_content_id)
+
+    async def update_image(self, image_id: str):
+        """Update the entity from the image_id."""
+        self._cached_image = None
+        try:
+            resolved = await async_resolve_media(self.hass, image_id, self.entity_id)
+        except Unresolvable as err:
+            _LOGGER.warning("%s: %s", self.entity_id, str(err))
+            self._attr_image_last_updated = None
+            self.path = None
+            self._attr_image_url = UNDEFINED
+            self._attr_content_type = DEFAULT_CONTENT_TYPE
+            self.async_write_ha_state()
+            return
+
+        if resolved.url:
+            self.path = None
+            self._attr_image_url = async_process_play_media_url(self.hass, resolved.url)
+        else:
+            self.path = resolved.path
+            self._attr_image_url = UNDEFINED
+
+        self._attr_content_type = resolved.mime_type
+        self._attr_image_last_updated = dt_util.utcnow()
+        self.async_write_ha_state()
 
     @override
     async def async_added_to_hass(self) -> None:
         """Initialize the first image after entity has been created."""
 
-        async def get_next_image_on_start(_hass: HomeAssistant) -> None:
-            await self.get_next_image()
+        async def get_random_image_on_start(_hass: HomeAssistant) -> None:
+            await self.get_random_image()
 
-        self.async_on_remove(async_at_started(self.hass, get_next_image_on_start))
+        self.async_on_remove(async_at_started(self.hass, get_random_image_on_start))
 
     @override
     def image(self) -> bytes | None:

--- a/homeassistant/components/collection_image/services.py
+++ b/homeassistant/components/collection_image/services.py
@@ -19,5 +19,5 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_SHUFFLE,
         entity_domain=IMAGE_DOMAIN,
         schema={},
-        func="get_next_image",
+        func="get_random_image",
     )

--- a/tests/components/collection_image/test_image.py
+++ b/tests/components/collection_image/test_image.py
@@ -9,7 +9,11 @@ import pytest
 
 from homeassistant.components.image import Image, async_get_image
 from homeassistant.components.media_source import BrowseMediaSource, PlayMedia
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_UNAVAILABLE
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_STARTED,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -216,7 +220,7 @@ async def test_unresolvable(
 
     state = hass.states.get(DEFAULT_ENTITY_ID)
 
-    assert state and state.state == STATE_UNAVAILABLE
+    assert state and state.state == STATE_UNKNOWN
 
     await hass.async_block_till_done(wait_background_tasks=True)
 

--- a/tests/components/collection_image/test_services.py
+++ b/tests/components/collection_image/test_services.py
@@ -27,14 +27,14 @@ async def test_shuffle_action(
     config_entry: MockConfigEntry,
     mock_media_source,
 ) -> None:
-    """Test that shuffle calls get_next_image on the target entity."""
+    """Test that shuffle calls get_random_image on the target entity."""
     await _setup_integration(hass, config_entry)
 
     with patch.object(
         CollectionImageImageEntity,
-        "get_next_image",
+        "get_random_image",
         new_callable=AsyncMock,
-    ) as mock_get_next_image:
+    ) as mock_get_random_image:
         await hass.services.async_call(
             DOMAIN,
             "shuffle",
@@ -42,4 +42,4 @@ async def test_shuffle_action(
             blocking=True,
         )
 
-    mock_get_next_image.assert_awaited_once()
+    mock_get_random_image.assert_awaited_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some changes to how collection_image handles unavailablity:

I did not realize initially that setting an entity to unavailable would be completely terminal. Once it is unavailable, it is no longer targetable by actions, so there is no action that can trigger a return from unavailable state. Previously, I had set the entity to unavailable in any of these cases:

- BrowseError when calling async_browse_media on a directory
- If browse succeeded, but returned 0 images
- If resolving the randomly selected image failed.

The first two cases will stay as unavailable as they will most likely indicate that no further action (shuffle) can succeed, attempting to shuffle the images again would most likely just get the same result. This can be recovered by reloading the config entry after changing the items in the media directory, but it can't be recovered by interacting with the entity itself.

The third case is changed from `unavailable` to `unknown`, as it is not fatal for the entity. We can't display the selected image, but calling shuffle again has a valid chance to land on a different image that will resolve cleanly, so we leave the entity available but unknown, and log a warning instead. 

This change removes the _unavailable_logged variable, as it was useless. An entity can only go unavailable one time, and then no further action can be taken on it, so no other message would ever be logged. So this variable does not suppress anything. Nor can the entity ever return from being unavailable, so there was no coverable path which led to this variable being reset and logging the restore message. Getting rid of this gets us to 100% coverage.

Some of the image.py functions were also refactored while making this change and broken up to make it a little more maintainable in the future, spitting up one big function into several smaller pieces. 

The function get_next_image was renamed to get_random_image, which more correctly expressed the intent of the function.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
