### PR TITLE
Fix Music Assistant shared player icons

### DIFF
--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -108,6 +108,33 @@ REPEAT_MODE_MAPPING_TO_HA = {
     # UNKNOWN is intentionally not mapped - will return None
 }
 
+MASS_ICON_TO_MDI: Mapping[str, str] = {
+    "bluetooth": "mdi:bluetooth",
+    "car": "mdi:car",
+    "cast": "mdi:cast",
+    "headphones": "mdi:headphones",
+    "laptop": "mdi:laptop",
+    "monitor": "mdi:monitor",
+    "radio": "mdi:radio",
+    "smartphone": "mdi:cellphone",
+    "soundbar": "mdi:soundbar",
+    "speaker": "mdi:speaker",
+    "speakers": "mdi:speaker-multiple",
+    "sun": "mdi:white-balance-sunny",
+    "tablet": "mdi:tablet",
+    "tv": "mdi:television",
+    "vinyl": "mdi:record-player",
+}
+
+
+def _get_mdi_icon(icon: str) -> str:
+    """Return an MDI icon for a Music Assistant icon."""
+    if icon.startswith("mdi:"):
+        return icon
+    if icon.startswith("mdi-"):
+        return icon.replace("mdi-", "mdi:", 1)
+    return MASS_ICON_TO_MDI.get(icon, "mdi:speaker")
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -136,7 +163,7 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
     def __init__(self, mass: MusicAssistantClient, player_id: str) -> None:
         """Initialize MediaPlayer entity."""
         super().__init__(mass, player_id)
-        self._attr_icon = self.player.icon.replace("mdi-", "mdi:")
+        self._attr_icon = _get_mdi_icon(self.player.icon)
         self._set_supported_features()
         self._attr_device_class = MediaPlayerDeviceClass.SPEAKER
         self._source_list_mapping: dict[str, str] = {}

--- a/tests/components/music_assistant/test_media_player.py
+++ b/tests/components/music_assistant/test_media_player.py
@@ -52,6 +52,7 @@ from homeassistant.components.music_assistant.const import (
     ATTR_USERNAME,
     DOMAIN,
 )
+from homeassistant.components.music_assistant.media_player import MusicAssistantPlayer
 from homeassistant.components.music_assistant.services import (
     SERVICE_GET_QUEUE,
     SERVICE_PLAY_ANNOUNCEMENT,
@@ -81,6 +82,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from .common import (
+    create_players_from_fixture,
     setup_integration_from_fixtures,
     snapshot_music_assistant_entities,
     trigger_subscription_callback,
@@ -94,6 +96,31 @@ MOCK_TRACK = Track(
     name="Test Track",
     provider_mappings={},
 )
+
+
+@pytest.mark.parametrize(
+    ("mass_icon", "mdi_icon"),
+    [
+        pytest.param("speaker", "mdi:speaker", id="speaker"),
+        pytest.param("speakers", "mdi:speaker-multiple", id="speakers"),
+        pytest.param("tv", "mdi:television", id="tv"),
+        pytest.param("smartphone", "mdi:cellphone", id="smartphone"),
+        pytest.param("google-nest", "mdi:speaker", id="fallback"),
+        pytest.param("mdi-speaker", "mdi:speaker", id="legacy-mdi-dash"),
+        pytest.param("mdi:speaker", "mdi:speaker", id="legacy-mdi-colon"),
+    ],
+)
+def test_player_icon(
+    music_assistant_client: MagicMock, mass_icon: str, mdi_icon: str
+) -> None:
+    """Test Music Assistant player icon mapping."""
+    player = create_players_from_fixture()[0]
+    player.icon = mass_icon
+    music_assistant_client.players._players[player.player_id] = player
+
+    entity = MusicAssistantPlayer(music_assistant_client, player.player_id)
+
+    assert entity.icon == mdi_icon
 
 
 async def test_media_player(


### PR DESCRIPTION
Map Music Assistant shared icon identifiers to Home Assistant mdi: icons and keep compatibility with legacy icon formats.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix Music Assistant player icons after the switch to shared icon identifiers.

Music Assistant now exposes player icons using shared icon names such as speaker, tv, google-nest, or wiim, while Home Assistant expects entity icons in mdi: format.

Previously, the integration only handled legacy mdi-* values:

`self.player.icon.replace("mdi-", "mdi:")
`

As a result, shared icon identifiers were passed to Home Assistant unchanged and could not be rendered.

**Changes**
- Map Music Assistant shared icons to an MDI icon when there is a direct equivalent.
- Fall back to mdi:speaker when no suitable MDI equivalent exists.
- Keep compatibility with legacy mdi-* values.
- Keep already valid mdi: values unchanged.
- Add tests for mapped icons, legacy formats, and the fallback behavior.

**Examples**
```
speaker      -> mdi:speaker
speakers     -> mdi:speaker-multiple
tv           -> mdi:television
smartphone   -> mdi:cellphone
vinyl        -> mdi:record-player

google-nest  -> mdi:speaker
homepod-mini -> mdi:speaker

```
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
