### PR TITLE
Delegate Duco bypass target policy to the library

### DIFF
--- a/homeassistant/components/duco/number.py
+++ b/homeassistant/components/duco/number.py
@@ -1,6 +1,5 @@
 """Number platform for the Duco integration."""
 
-from decimal import ROUND_DOWN, ROUND_HALF_UP, Decimal
 import logging
 from typing import override
 
@@ -122,32 +121,18 @@ class DucoBypassSupplyTemperatureTargetNumber(DucoEntity, NumberEntity):
         )
         return target.value if target else None
 
-    def _normalize_step_value(self, value: float) -> float:
-        """Normalize converted temperature values to the nearest supported native step."""
-        if self.unit_of_measurement == self.native_unit_of_measurement:
-            return value
-
-        # Home Assistant converts service values from the configured temperature
-        # unit first, which can land between valid Duco Celsius increments.
-        minimum = Decimal(str(self.native_min_value))
-        step = Decimal(str(self.native_step))
-        steps = ((Decimal(str(value)) - minimum) / step).to_integral_value(
-            rounding=ROUND_HALF_UP
-        )
-        # Rounding up may overshoot when the range is not a whole number of steps.
-        max_steps = (
-            (Decimal(str(self.native_max_value)) - minimum) / step
-        ).to_integral_value(rounding=ROUND_DOWN)
-        return float(minimum + (min(steps, max_steps) * step))
-
     @override
     async def async_set_native_value(self, value: float) -> None:
         """Set the bypass supply temperature target."""
-        value = self._normalize_step_value(value)
-        if (
-            (Decimal(str(value)) - Decimal(str(self.native_min_value)))
-            / Decimal(str(self.native_step))
-        ) % 1 != 0:
+        target = self.coordinator.data.bypass_supply_temperature_targets[self._zone_id]
+
+        try:
+            if self.unit_of_measurement != self.native_unit_of_measurement:
+                value = target.normalize_value(value)
+            await self.coordinator.client.async_set_bypass_supply_temperature_target(
+                self._zone_id, value, target=target
+            )
+        except ValueError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="invalid_bypass_supply_temperature_target_step",
@@ -156,12 +141,7 @@ class DucoBypassSupplyTemperatureTargetNumber(DucoEntity, NumberEntity):
                     "minimum": str(self.native_min_value),
                     "increment": str(self.native_step),
                 },
-            )
-
-        try:
-            await self.coordinator.client.async_set_bypass_supply_temperature_target(
-                self._zone_id, value
-            )
+            ) from err
         except DucoRateLimitError as err:
             _LOGGER.warning(
                 "Duco write rate limit exceeded for bypass target zone %s",

--- a/tests/components/duco/conftest.py
+++ b/tests/components/duco/conftest.py
@@ -276,6 +276,18 @@ def mock_duco_client(
     mock_ventilation_temperature_info: VentilationTemperatureInfo,
 ) -> Generator[AsyncMock]:
     """Return a mocked DucoClient used by both the integration and config flow."""
+
+    def set_bypass_supply_temperature_target(
+        zone_id: int,
+        temperature: float,
+        *,
+        target: BypassSupplyTemperatureTarget,
+    ) -> None:
+        target.validate_value(temperature)
+        mock_bypass_supply_temperature_targets[zone_id] = replace(
+            target, value=temperature
+        )
+
     with (
         patch(
             "homeassistant.components.duco.DucoClient",
@@ -301,15 +313,7 @@ def mock_duco_client(
             mock_bypass_supply_temperature_targets.copy
         )
         client.async_set_bypass_supply_temperature_target.side_effect = (
-            lambda zone_id, temperature: (
-                mock_bypass_supply_temperature_targets.__setitem__(
-                    zone_id,
-                    replace(
-                        mock_bypass_supply_temperature_targets[zone_id],
-                        value=temperature,
-                    ),
-                )
-            )
+            set_bypass_supply_temperature_target
         )
         client.async_get_diagnostics.return_value = [
             DiagComponent(component="Ventilation", status="Ok")

--- a/tests/components/duco/test_number.py
+++ b/tests/components/duco/test_number.py
@@ -95,9 +95,12 @@ async def test_bypass_supply_temperature_targets_missing_skips_number_creation(
 @pytest.mark.usefixtures("init_integration")
 async def test_set_bypass_supply_temperature_target(
     hass: HomeAssistant,
+    mock_bypass_supply_temperature_targets: dict[int, BypassSupplyTemperatureTarget],
     mock_duco_client: AsyncMock,
 ) -> None:
     """Test setting a bypass target refreshes the number from the box."""
+    target = mock_bypass_supply_temperature_targets[1]
+
     await hass.services.async_call(
         NUMBER_DOMAIN,
         SERVICE_SET_VALUE,
@@ -106,7 +109,7 @@ async def test_set_bypass_supply_temperature_target(
     )
 
     mock_duco_client.async_set_bypass_supply_temperature_target.assert_awaited_once_with(
-        1, 20.5
+        1, 20.5, target=target
     )
     state = hass.states.get(_ZONE_1_ENTITY_ID)
     assert state is not None
@@ -126,6 +129,7 @@ async def test_set_bypass_supply_temperature_target_honors_increment_metadata(
         increment=0.5,
         maximum=25.5,
     )
+    target = mock_bypass_supply_temperature_targets[1]
 
     await setup_platform_integration(hass, mock_config_entry, [Platform.NUMBER])
 
@@ -137,7 +141,7 @@ async def test_set_bypass_supply_temperature_target_honors_increment_metadata(
     )
 
     mock_duco_client.async_set_bypass_supply_temperature_target.assert_awaited_once_with(
-        1, 20.5
+        1, 20.5, target=target
     )
 
     with pytest.raises(
@@ -166,6 +170,7 @@ async def test_set_bypass_supply_temperature_target_in_fahrenheit_units(
         increment=0.5,
         maximum=25.5,
     )
+    target = mock_bypass_supply_temperature_targets[1]
 
     await setup_platform_integration(hass, mock_config_entry, [Platform.NUMBER])
 
@@ -177,7 +182,7 @@ async def test_set_bypass_supply_temperature_target_in_fahrenheit_units(
     )
 
     mock_duco_client.async_set_bypass_supply_temperature_target.assert_awaited_once_with(
-        1, 20.5
+        1, 20.5, target=target
     )
     state = hass.states.get(_ZONE_1_ENTITY_ID)
     assert state is not None
@@ -198,6 +203,7 @@ async def test_set_bypass_supply_temperature_target_stays_within_maximum(
         increment=0.5,
         maximum=24.8,
     )
+    target = mock_bypass_supply_temperature_targets[1]
 
     await setup_platform_integration(hass, mock_config_entry, [Platform.NUMBER])
 
@@ -209,7 +215,7 @@ async def test_set_bypass_supply_temperature_target_stays_within_maximum(
     )
 
     mock_duco_client.async_set_bypass_supply_temperature_target.assert_awaited_once_with(
-        1, 24.5
+        1, 24.5, target=target
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Moves bypass supply target normalization and validation from the Duco Number platform to `BypassSupplyTemperatureTarget` in `python-duco-connectivity`.

Home Assistant still deliberately normalizes values after preferred-unit conversion, then passes the already-polled target metadata to the library's metadata-aware setter. This removes duplicate Decimal step arithmetic and maximum clamping while preserving translated errors, rate-limit handling, entity availability, and refreshes after writes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes ronaldvdmeer/python-duco-connectivity#135
- This PR is related to issue: ronaldvdmeer/python-duco-connectivity#121
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr