### PR TITLE
Declare Teslemetry tire pressure sensors in native atmospheres

### DIFF
--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -33,6 +33,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_conversion import PressureConverter
 from homeassistant.util.variance import ignore_variance
 
 from . import TeslemetryConfigEntry
@@ -48,9 +49,6 @@ from .entity import (
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
 
 PARALLEL_UPDATES = 0
-
-# Teslemetry streams TPMS pressure in atmospheres; entities are declared in bar.
-ATM_TO_BAR = 1.01325
 
 # Tesla only reports the self-driving/mileage-since-reset fields (258-259) on HW4
 # vehicles, identified by this driver-assist capability in the vehicle config.
@@ -401,11 +399,16 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="vehicle_state_tpms_pressure_fl",
         polling=True,
+        polling_value_fn=lambda x: (
+            PressureConverter.convert(x, UnitOfPressure.BAR, UnitOfPressure.ATM)
+            if isinstance(x, (int, float))
+            else x
+        ),
         streaming_listener=lambda vehicle, callback: vehicle.listen_TpmsPressureFl(
-            lambda x: callback(None) if x is None else callback(x * ATM_TO_BAR)
+            callback
         ),
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfPressure.BAR,
+        native_unit_of_measurement=UnitOfPressure.ATM,
         suggested_unit_of_measurement=UnitOfPressure.PSI,
         device_class=SensorDeviceClass.PRESSURE,
         suggested_display_precision=1,
@@ -415,11 +418,16 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="vehicle_state_tpms_pressure_fr",
         polling=True,
+        polling_value_fn=lambda x: (
+            PressureConverter.convert(x, UnitOfPressure.BAR, UnitOfPressure.ATM)
+            if isinstance(x, (int, float))
+            else x
+        ),
         streaming_listener=lambda vehicle, callback: vehicle.listen_TpmsPressureFr(
-            lambda x: callback(None) if x is None else callback(x * ATM_TO_BAR)
+            callback
         ),
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfPressure.BAR,
+        native_unit_of_measurement=UnitOfPressure.ATM,
         suggested_unit_of_measurement=UnitOfPressure.PSI,
         device_class=SensorDeviceClass.PRESSURE,
         suggested_display_precision=1,
@@ -429,11 +437,16 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="vehicle_state_tpms_pressure_rl",
         polling=True,
+        polling_value_fn=lambda x: (
+            PressureConverter.convert(x, UnitOfPressure.BAR, UnitOfPressure.ATM)
+            if isinstance(x, (int, float))
+            else x
+        ),
         streaming_listener=lambda vehicle, callback: vehicle.listen_TpmsPressureRl(
-            lambda x: callback(None) if x is None else callback(x * ATM_TO_BAR)
+            callback
         ),
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfPressure.BAR,
+        native_unit_of_measurement=UnitOfPressure.ATM,
         suggested_unit_of_measurement=UnitOfPressure.PSI,
         device_class=SensorDeviceClass.PRESSURE,
         suggested_display_precision=1,
@@ -443,11 +456,16 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
     TeslemetryVehicleSensorEntityDescription(
         key="vehicle_state_tpms_pressure_rr",
         polling=True,
+        polling_value_fn=lambda x: (
+            PressureConverter.convert(x, UnitOfPressure.BAR, UnitOfPressure.ATM)
+            if isinstance(x, (int, float))
+            else x
+        ),
         streaming_listener=lambda vehicle, callback: vehicle.listen_TpmsPressureRr(
-            lambda x: callback(None) if x is None else callback(x * ATM_TO_BAR)
+            callback
         ),
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfPressure.BAR,
+        native_unit_of_measurement=UnitOfPressure.ATM,
         suggested_unit_of_measurement=UnitOfPressure.PSI,
         device_class=SensorDeviceClass.PRESSURE,
         suggested_display_precision=1,

--- a/tests/components/teslemetry/test_sensor.py
+++ b/tests/components/teslemetry/test_sensor.py
@@ -321,29 +321,25 @@ async def test_hw4_mileage_sensors_gating(
             Signal.TPMS_PRESSURE_FL,
             "sensor.test_tire_pressure_front_left",
             2.7,
-            # 2.7 atm independently hand-converted to bar (2.7 * 1.01325 = 2.735775)
-            PressureConverter.convert(2.735775, UnitOfPressure.BAR, UnitOfPressure.PSI),
+            PressureConverter.convert(2.7, UnitOfPressure.ATM, UnitOfPressure.PSI),
         ),
         (
             Signal.TPMS_PRESSURE_FR,
             "sensor.test_tire_pressure_front_right",
             2.7,
-            # 2.7 atm independently hand-converted to bar (2.7 * 1.01325 = 2.735775)
-            PressureConverter.convert(2.735775, UnitOfPressure.BAR, UnitOfPressure.PSI),
+            PressureConverter.convert(2.7, UnitOfPressure.ATM, UnitOfPressure.PSI),
         ),
         (
             Signal.TPMS_PRESSURE_RL,
             "sensor.test_tire_pressure_rear_left",
             2.7,
-            # 2.7 atm independently hand-converted to bar (2.7 * 1.01325 = 2.735775)
-            PressureConverter.convert(2.735775, UnitOfPressure.BAR, UnitOfPressure.PSI),
+            PressureConverter.convert(2.7, UnitOfPressure.ATM, UnitOfPressure.PSI),
         ),
         (
             Signal.TPMS_PRESSURE_RR,
             "sensor.test_tire_pressure_rear_right",
             2.7,
-            # 2.7 atm independently hand-converted to bar (2.7 * 1.01325 = 2.735775)
-            PressureConverter.convert(2.735775, UnitOfPressure.BAR, UnitOfPressure.PSI),
+            PressureConverter.convert(2.7, UnitOfPressure.ATM, UnitOfPressure.PSI),
         ),
         (
             Signal.ISOLATION_RESISTANCE,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Not a breaking change. `suggested_unit_of_measurement` stays `PSI`, so the
displayed value and unit are unchanged for existing installs. See the unit
analysis below for why the `native_unit_of_measurement` change is safe for
existing entities and their long-term statistics.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Now that `UnitOfPressure.ATM` exists in core, the four `teslemetry` TPMS
pressure sensors can declare their real native unit instead of hand-rolling
a conversion:

- The Teslemetry **streaming** API already reports TPMS pressure in
  atmospheres. The integration previously declared the entities in `bar` and
  multiplied every streamed value by a local `ATM_TO_BAR = 1.01325` constant
  to fit. That constant and multiply are removed; the streaming listeners
  now pass the value straight through and the sensors declare
  `native_unit_of_measurement=UnitOfPressure.ATM`.
- The **polling** (REST `vehicle_state.tpms_pressure_*`) API reports the
  value in `bar`, confirmed against Tesla's published tire placard spec
  (42 PSI / 290 kPa matches the fixture's `tpms_rcp_front_value: 2.9`
  exactly as bar → kPa/100; it does not round-trip as atm) and against
  `tesla_fleet`/`tessie`, which read the same REST field and already declare
  it `bar` with no conversion. That path previously had no conversion since
  its native unit was already `bar`; it now needs one, added via
  `polling_value_fn` using core's own `PressureConverter.convert(x,
  UnitOfPressure.BAR, UnitOfPressure.ATM)` rather than a second hand-rolled
  constant.
- `suggested_unit_of_measurement=UnitOfPressure.PSI` is unchanged, so the
  entities keep displaying PSI exactly as before.

**Why this doesn't disrupt existing entities or their statistics:** a
sensor's displayed/recorded unit comes from the registry-stored
`suggested_unit_of_measurement` (`homeassistant/components/sensor/__init__.py`,
`unit_of_measurement` property and the `async_added_to_hass` unit-priming
logic), not from `native_unit_of_measurement` directly, and the recorder's
`_normalize_states` keys off that same displayed unit. Since the suggested
unit stays `PSI` and `atm`/`bar`/`psi` are all members of the same
`PressureConverter` unit class, existing entities keep resolving to the
identical displayed unit and value, and the recorder sees no unit
discontinuity. Verified: the full `tests/components/teslemetry` suite,
including the entity-registry and state snapshots, passes unchanged with no
snapshot regeneration needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  NOTE for the captain: the two attestation checkboxes above
  ("I understand the code...", "I have followed the development
  checklist / perfect PR recommendations") are left unchecked
  deliberately — those are your personal sign-off, not mine to tick.
-->
