### PR TITLE
Add panel information to diagnostics for Satel Integra

### DIFF
--- a/homeassistant/components/satel_integra/__init__.py
+++ b/homeassistant/components/satel_integra/__init__.py
@@ -69,8 +69,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: SatelConfigEntry) -> boo
     )
     await coordinator_temperatures.async_config_entry_first_refresh()
 
+    try:
+        panel_info = await client.controller.read_panel_info()
+    except SatelIntegraError:
+        _LOGGER.warning("Unable to read Satel panel information", exc_info=True)
+        panel_info = None
+
     entry.runtime_data = SatelIntegraData(
         client=client,
+        panel_info=panel_info,
         coordinator_zones=coordinator_zones,
         coordinator_outputs=coordinator_outputs,
         coordinator_partitions=coordinator_partitions,
@@ -85,12 +92,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: SatelConfigEntry) -> boo
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_close_connection)
     )
-
-    try:
-        panel_info = await client.controller.read_panel_info()
-    except SatelIntegraError:
-        _LOGGER.warning("Unable to read Satel panel information", exc_info=True)
-        panel_info = None
 
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(

--- a/homeassistant/components/satel_integra/coordinator.py
+++ b/homeassistant/components/satel_integra/coordinator.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import logging
 from typing import override
 
-from satel_integra import AlarmState
+from satel_integra import AlarmState, SatelPanelInfo
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -26,6 +26,7 @@ class SatelIntegraData:
     """Data for the satel_integra integration."""
 
     client: SatelClient
+    panel_info: SatelPanelInfo | None
     coordinator_zones: SatelIntegraZonesCoordinator
     coordinator_outputs: SatelIntegraOutputsCoordinator
     coordinator_partitions: SatelIntegraPartitionsCoordinator

--- a/homeassistant/components/satel_integra/diagnostics.py
+++ b/homeassistant/components/satel_integra/diagnostics.py
@@ -1,26 +1,29 @@
 """Diagnostics support for Satel Integra."""
 
+from dataclasses import asdict
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CODE
 from homeassistant.core import HomeAssistant
 
 from .const import CONF_ENCRYPTION_KEY
+from .coordinator import SatelConfigEntry
 
 TO_REDACT = {CONF_CODE, CONF_ENCRYPTION_KEY}
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: SatelConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for the config entry."""
+    panel_info = await entry.runtime_data.client.controller.read_panel_info()
     diag: dict[str, Any] = {}
 
     diag["config_entry_data"] = async_redact_data(entry.data, TO_REDACT)
     diag["config_entry_options"] = async_redact_data(entry.options, TO_REDACT)
 
     diag["subentries"] = dict(entry.subentries)
+    diag["panel_info"] = asdict(panel_info)
 
     return diag

--- a/homeassistant/components/satel_integra/diagnostics.py
+++ b/homeassistant/components/satel_integra/diagnostics.py
@@ -17,13 +17,13 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: SatelConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for the config entry."""
-    panel_info = await entry.runtime_data.client.controller.read_panel_info()
-    diag: dict[str, Any] = {}
-
-    diag["config_entry_data"] = async_redact_data(entry.data, TO_REDACT)
-    diag["config_entry_options"] = async_redact_data(entry.options, TO_REDACT)
-
-    diag["subentries"] = dict(entry.subentries)
-    diag["panel_info"] = asdict(panel_info)
-
-    return diag
+    return {
+        "config_entry_data": async_redact_data(entry.data, TO_REDACT),
+        "config_entry_options": async_redact_data(entry.options, TO_REDACT),
+        "subentries": dict(entry.subentries),
+        "panel_info": (
+            asdict(entry.runtime_data.panel_info)
+            if entry.runtime_data.panel_info
+            else None
+        ),
+    }

--- a/tests/components/satel_integra/snapshots/test_diagnostics.ambr
+++ b/tests/components/satel_integra/snapshots/test_diagnostics.ambr
@@ -9,6 +9,18 @@
     'config_entry_options': dict({
       'code': '**REDACTED**',
     }),
+    'panel_info': dict({
+      'firmware': dict({
+        'release_date': '2025-03-12',
+        'version': '1.24',
+      }),
+      'language_code': 0,
+      'model': dict({
+        'name': 'INTEGRA 64',
+      }),
+      'settings_stored_in_flash': True,
+      'type_code': 2,
+    }),
     'subentries': dict({
       'ID_OUTPUT': dict({
         'data': dict({
@@ -66,6 +78,18 @@
     }),
     'config_entry_options': dict({
       'code': '**REDACTED**',
+    }),
+    'panel_info': dict({
+      'firmware': dict({
+        'release_date': '2025-03-12',
+        'version': '1.24',
+      }),
+      'language_code': 0,
+      'model': dict({
+        'name': 'INTEGRA 64',
+      }),
+      'settings_stored_in_flash': True,
+      'type_code': 2,
     }),
     'subentries': dict({
       'ID_ZONE': dict({

--- a/tests/components/satel_integra/test_diagnostics.py
+++ b/tests/components/satel_integra/test_diagnostics.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from satel_integra import SatelUnexpectedResponseError
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
 
@@ -10,6 +11,7 @@ from homeassistant.core import HomeAssistant
 
 from . import setup_integration
 
+from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
@@ -35,3 +37,21 @@ async def test_diagnostics(
 
     diagnostics = await get_diagnostics_for_config_entry(hass, hass_client, entry)
     assert diagnostics == snapshot(exclude=props("created_at", "modified_at", "id"))
+
+
+async def test_diagnostics_without_panel_info(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_satel: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test diagnostics when panel information could not be read during setup."""
+    mock_satel.read_panel_info.side_effect = SatelUnexpectedResponseError
+    await setup_integration(hass, mock_config_entry)
+
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    assert diagnostics["panel_info"] is None
+    mock_satel.read_panel_info.assert_awaited_once_with()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/core/pull/169668 Added the ability to read some information (like model and firmware) from the alarm panel. 
This PR reads the information from the panel and adds it to the diagnostics.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
