### PR TITLE
Start Imou reauthentication when the cloud rejects the credentials

### DIFF
--- a/homeassistant/components/imou/coordinator.py
+++ b/homeassistant/components/imou/coordinator.py
@@ -6,11 +6,12 @@ from datetime import timedelta
 import logging
 from typing import override
 
-from pyimouapi.exceptions import ImouException
+from pyimouapi.exceptions import ImouException, InvalidAppIdOrSecretException
 from pyimouapi.ha_device import ImouHaDevice, ImouHaDeviceManager
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -83,6 +84,11 @@ class ImouDataUpdateCoordinator(DataUpdateCoordinator[None]):
                 fresh_devices = await self._device_manager.async_get_devices()
         except TimeoutError as err:
             raise UpdateFailed(f"Timeout while fetching data: {err}") from err
+        except InvalidAppIdOrSecretException as err:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="invalid_auth",
+            ) from err
         except ImouException as err:
             raise UpdateFailed(f"Error fetching Imou devices: {err}") from err
 

--- a/homeassistant/components/imou/strings.json
+++ b/homeassistant/components/imou/strings.json
@@ -143,6 +143,9 @@
     "get_stream_failed": {
       "message": "Could not get the live stream URL from Imou: {error}"
     },
+    "invalid_auth": {
+      "message": "Imou rejected the App ID and App secret"
+    },
     "press_button_failed": {
       "message": "Imou rejected the button press: {error}"
     },

--- a/tests/components/imou/test_init.py
+++ b/tests/components/imou/test_init.py
@@ -4,14 +4,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 from pyimouapi.const import PARAM_STATE, PARAM_STATUS
-from pyimouapi.exceptions import ImouException
+from pyimouapi.exceptions import ImouException, InvalidAppIdOrSecretException
 from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 import pytest
 
 from homeassistant.components.imou.button import PARAM_MUTE, PARAM_PTZ_UP
 from homeassistant.components.imou.const import DOMAIN
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -58,6 +58,28 @@ async def test_setup_entry_failed_on_refresh(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.usefixtures("mock_imou_openapi_client", "mock_imou_ha_device_manager")
+async def test_setup_entry_auth_failed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_imou_ha_device_manager: AsyncMock,
+) -> None:
+    """Rejected credentials while listing devices start reauthentication."""
+    mock_imou_ha_device_manager.async_get_devices.side_effect = (
+        InvalidAppIdOrSecretException("fail")
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == SOURCE_REAUTH
+    assert flows[0]["step_id"] == "reauth_confirm"
 
 
 @pytest.mark.usefixtures("init_integration")

--- a/tests/components/imou/test_init.py
+++ b/tests/components/imou/test_init.py
@@ -11,7 +11,7 @@ import pytest
 from homeassistant.components.imou.button import PARAM_MUTE, PARAM_PTZ_UP
 from homeassistant.components.imou.const import DOMAIN
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -42,44 +42,34 @@ async def test_setup_and_unload_entry(
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
+@pytest.mark.parametrize(
+    ("exception", "expected_state"),
+    [
+        (
+            InvalidAppIdOrSecretException("bad credentials"),
+            ConfigEntryState.SETUP_ERROR,
+        ),
+        (ImouException("cloud failure"), ConfigEntryState.SETUP_RETRY),
+        (TimeoutError("timeout"), ConfigEntryState.SETUP_RETRY),
+        (RuntimeError("unexpected"), ConfigEntryState.SETUP_RETRY),
+    ],
+)
 @pytest.mark.usefixtures("mock_imou_openapi_client", "mock_imou_ha_device_manager")
-async def test_setup_entry_failed_on_refresh(
+async def test_setup_entry_exceptions(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_imou_ha_device_manager: AsyncMock,
+    exception: Exception,
+    expected_state: ConfigEntryState,
 ) -> None:
-    """Device fetch failure during coordinator setup surfaces as setup retry."""
-    mock_imou_ha_device_manager.async_get_devices.side_effect = RuntimeError(
-        "Setup failed"
-    )
+    """Test the coordinator errors while listing devices during setup."""
+    mock_imou_ha_device_manager.async_get_devices.side_effect = exception
     mock_config_entry.add_to_hass(hass)
 
     assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-@pytest.mark.usefixtures("mock_imou_openapi_client", "mock_imou_ha_device_manager")
-async def test_setup_entry_auth_failed(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_imou_ha_device_manager: AsyncMock,
-) -> None:
-    """Rejected credentials while listing devices start reauthentication."""
-    mock_imou_ha_device_manager.async_get_devices.side_effect = (
-        InvalidAppIdOrSecretException("fail")
-    )
-    mock_config_entry.add_to_hass(hass)
-
-    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
-    flows = hass.config_entries.flow.async_progress()
-    assert len(flows) == 1
-    assert flows[0]["context"]["source"] == SOURCE_REAUTH
-    assert flows[0]["step_id"] == "reauth_confirm"
+    assert mock_config_entry.state is expected_state
 
 
 @pytest.mark.usefixtures("init_integration")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

<!-- N/A -->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #180975, which added the [Imou](https://www.home-assistant.io/integrations/imou) reauthentication flow. Nothing raised `ConfigEntryAuthFailed`, so the flow was never started: a user who changed their App secret on the [Imou Open Platform](https://open.imoulife.com) only saw failing updates.

`ImouDataUpdateCoordinator._async_update_data()` now converts `InvalidAppIdOrSecretException` from `async_get_devices()` into `ConfigEntryAuthFailed`, so Home Assistant asks for a new App secret. Other `ImouException` errors keep raising `UpdateFailed`. The message is translated through `strings.json`.

Per-entity actions are not wrapped here; that comes in a separate PR using a decorator.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #180975
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr