### PR TITLE
Raise ServiceValidationError for missing code in arming actions for Satel Integra

### DIFF
--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -144,4 +144,5 @@ class SatelIntegraAlarmPanel(
 
     @override
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
+        """Send arm home command."""
         await self._controller.arm(code, [self._device_number], self._arm_home_mode)

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -72,7 +72,6 @@ class SatelIntegraAlarmPanel(
 ):
     """Representation of a Satel Integra-based alarm panel."""
 
-    _attr_code_arm_required = True
     _attr_code_format = CodeFormat.NUMBER
     _attr_supported_features = (
         AlarmControlPanelEntityFeature.ARM_HOME

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -72,6 +72,7 @@ class SatelIntegraAlarmPanel(
 ):
     """Representation of a Satel Integra-based alarm panel."""
 
+    _attr_code_arm_required = True
     _attr_code_format = CodeFormat.NUMBER
     _attr_supported_features = (
         AlarmControlPanelEntityFeature.ARM_HOME
@@ -140,13 +141,8 @@ class SatelIntegraAlarmPanel(
     @override
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
-
-        if code:
-            await self._controller.arm(code, [self._device_number])
+        await self._controller.arm(code, [self._device_number])
 
     @override
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
-        """Send arm home command."""
-
-        if code:
-            await self._controller.arm(code, [self._device_number], self._arm_home_mode)
+        await self._controller.arm(code, [self._device_number], self._arm_home_mode)

--- a/homeassistant/components/satel_integra/alarm_control_panel.py
+++ b/homeassistant/components/satel_integra/alarm_control_panel.py
@@ -1,7 +1,6 @@
 """Support for Satel Integra alarm, using ETHM module."""
 
 import asyncio
-import logging
 from typing import override
 
 from satel_integra import AlarmState
@@ -14,9 +13,15 @@ from homeassistant.components.alarm_control_panel import (
 )
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import CONF_ARM_HOME_MODE, CONF_PARTITION_NUMBER, SUBENTRY_TYPE_PARTITION
+from .const import (
+    CONF_ARM_HOME_MODE,
+    CONF_PARTITION_NUMBER,
+    DOMAIN,
+    SUBENTRY_TYPE_PARTITION,
+)
 from .coordinator import SatelConfigEntry, SatelIntegraPartitionsCoordinator
 from .entity import SatelIntegraEntity
 
@@ -31,8 +36,6 @@ ALARM_STATE_MAP = {
     AlarmState.EXIT_COUNTDOWN_OVER_10: AlarmControlPanelState.ARMING,
     AlarmState.EXIT_COUNTDOWN_UNDER_10: AlarmControlPanelState.ARMING,
 }
-
-_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
@@ -118,8 +121,10 @@ class SatelIntegraAlarmPanel(
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
         if not code:
-            _LOGGER.debug("Code was empty or None")
-            return
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="missing_alarm_access_code",
+            )
 
         clear_alarm_necessary = (
             self._attr_alarm_state == AlarmControlPanelState.TRIGGERED

--- a/homeassistant/components/satel_integra/strings.json
+++ b/homeassistant/components/satel_integra/strings.json
@@ -203,6 +203,9 @@
     "connection_initialization_failed": {
       "message": "[%key:component::satel_integra::config::error::connection_initialization_failed%]"
     },
+    "missing_alarm_access_code": {
+      "message": "Cannot disarm the alarm panel because no user code was provided."
+    },
     "missing_output_access_code": {
       "message": "Cannot control switchable outputs because no user code is configured for this Satel Integra entry. Configure a code in the integration options to enable output control."
     },

--- a/tests/components/satel_integra/test_alarm_control_panel.py
+++ b/tests/components/satel_integra/test_alarm_control_panel.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceRegistry
 from homeassistant.helpers.entity_registry import EntityRegistry
 
@@ -223,6 +224,28 @@ async def test_alarm_control_panel_disarming(
     mock_satel.disarm.assert_awaited_once_with(MOCK_CODE, [1])
 
     mock_satel.clear_alarm.assert_awaited_once_with(MOCK_CODE, [1])
+
+
+async def test_alarm_control_panel_disarming_requires_code(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_config_entry_with_subentries: MockConfigEntry,
+) -> None:
+    """Test disarming fails when the access code is missing."""
+    await setup_integration(hass, mock_config_entry_with_subentries)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            ALARM_DOMAIN,
+            SERVICE_ALARM_DISARM,
+            {ATTR_ENTITY_ID: "alarm_control_panel.home"},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "missing_alarm_access_code"
+    mock_satel.disarm.assert_not_awaited()
+    mock_satel.clear_alarm.assert_not_awaited()
 
 
 async def test_alarm_panel_last_reported(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Working on some of the silver quality scale items showed me that the service validation for the Alarm panel platform is not implemented.
Previously, if no code was given, no commands were send to the device, we just silently skipped the action. Now arming and disarming requires a code, failing with a ServiceValidationError if not provided. Arming actions use the build-in HA code validation.

Not sure if this classifies as a breaking change, previously nothing happened when no code was provided, now errors are raised. What is actually send to the device is not changed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
