### PR TITLE
Start Imou reauthentication when an entity action rejects the credentials

### DIFF
--- a/homeassistant/components/imou/button.py
+++ b/homeassistant/components/imou/button.py
@@ -3,7 +3,6 @@
 from typing import override
 
 from pyimouapi.const import PARAM_RESTART_DEVICE
-from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import ImouHaDevice
 
 from homeassistant.components.button import (
@@ -12,12 +11,11 @@ from homeassistant.components.button import (
     ButtonEntityDescription,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, PTZ_MOVE_DURATION_MS, imou_device_identifier
+from .const import PTZ_MOVE_DURATION_MS, imou_device_identifier
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
-from .entity import ImouEntity
+from .entity import ImouEntity, async_wrap_imou_command
 
 PARALLEL_UPDATES = 1
 # Button types not yet exported by pyimouapi (keep module-local).
@@ -100,18 +98,12 @@ class ImouButton(ImouEntity, ButtonEntity):
     entity_description: ButtonEntityDescription
 
     @override
+    @async_wrap_imou_command("press_button_failed")
     async def async_press(self) -> None:
         """Handle button press."""
         duration = PTZ_MOVE_DURATION_MS if self._entity_type in PTZ_BUTTON_TYPES else 0
-        try:
-            await self.coordinator.device_manager.async_press_button(
-                self.device,
-                self._entity_type,
-                duration,
-            )
-        except ImouException as e:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="press_button_failed",
-                translation_placeholders={"error": e.message},
-            ) from e
+        await self.coordinator.device_manager.async_press_button(
+            self.device,
+            self._entity_type,
+            duration,
+        )

--- a/homeassistant/components/imou/button.py
+++ b/homeassistant/components/imou/button.py
@@ -15,7 +15,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import PTZ_MOVE_DURATION_MS, imou_device_identifier
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
-from .entity import ImouEntity, async_wrap_imou_command
+from .entity import ImouEntity
+from .helpers import async_wrap_imou_command
 
 PARALLEL_UPDATES = 1
 # Button types not yet exported by pyimouapi (keep module-local).

--- a/homeassistant/components/imou/camera.py
+++ b/homeassistant/components/imou/camera.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import override
 
 from pyimouapi.const import PARAM_HD, PARAM_MOTION_DETECT, PARAM_STATE
-from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import ImouHaDevice
 
 from homeassistant.components.camera import (
@@ -13,12 +12,11 @@ from homeassistant.components.camera import (
     CameraEntityFeature,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, PARAM_HEADER_DETECT, imou_device_identifier
+from .const import PARAM_HEADER_DETECT, imou_device_identifier
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
-from .entity import ImouEntity
+from .entity import ImouEntity, async_wrap_imou_command
 
 PARALLEL_UPDATES = 0
 
@@ -89,37 +87,25 @@ class ImouCamera(ImouEntity, Camera):
         super().__init__(coordinator, description, device)
 
     @override
+    @async_wrap_imou_command("get_stream_failed")
     async def stream_source(self) -> str | None:
         """Return the live stream URL from the Imou cloud."""
-        try:
-            return await self.coordinator.device_manager.async_get_device_stream(
-                self.device,
-                self.entity_description.resolution,
-                PYIMOUAPI_LIVE_PROTOCOL,
-            )
-        except ImouException as err:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="get_stream_failed",
-                translation_placeholders={"error": err.message},
-            ) from err
+        return await self.coordinator.device_manager.async_get_device_stream(
+            self.device,
+            self.entity_description.resolution,
+            PYIMOUAPI_LIVE_PROTOCOL,
+        )
 
     @override
+    @async_wrap_imou_command("get_image_failed")
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return bytes of camera image."""
-        try:
-            return await self.coordinator.device_manager.async_get_device_image(
-                self.device,
-                PYIMOUAPI_SNAPSHOT_WAIT_SECONDS,
-            )
-        except ImouException as err:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="get_image_failed",
-                translation_placeholders={"error": err.message},
-            ) from err
+        return await self.coordinator.device_manager.async_get_device_image(
+            self.device,
+            PYIMOUAPI_SNAPSHOT_WAIT_SECONDS,
+        )
 
     @property
     @override

--- a/homeassistant/components/imou/camera.py
+++ b/homeassistant/components/imou/camera.py
@@ -16,7 +16,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import PARAM_HEADER_DETECT, imou_device_identifier
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
-from .entity import ImouEntity, async_wrap_imou_command
+from .entity import ImouEntity
+from .helpers import async_wrap_imou_command
 
 PARALLEL_UPDATES = 0
 

--- a/homeassistant/components/imou/entity.py
+++ b/homeassistant/components/imou/entity.py
@@ -1,14 +1,10 @@
 """An abstract class common to all Imou entities."""
 
-from collections.abc import Awaitable, Callable, Coroutine
-from functools import wraps
-from typing import Any, Concatenate, override
+from typing import override
 
 from pyimouapi.const import PARAM_STATE, PARAM_STATUS
-from pyimouapi.exceptions import ImouException, InvalidAppIdOrSecretException
 from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -68,36 +64,3 @@ class ImouEntity(CoordinatorEntity[ImouDataUpdateCoordinator]):
         return (
             self.device.sensors[PARAM_STATUS][PARAM_STATE] != DeviceStatus.OFFLINE.value
         )
-
-
-def async_wrap_imou_command[_T: ImouEntity, **_P, _R](
-    error_key: str,
-) -> Callable[
-    [Callable[Concatenate[_T, _P], Awaitable[_R]]],
-    Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]],
-]:
-    """Wrap an Imou command and start reauthentication when credentials are rejected."""
-
-    def decorator(
-        func: Callable[Concatenate[_T, _P], Awaitable[_R]],
-    ) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]]:
-        @wraps(func)
-        async def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R:
-            try:
-                return await func(self, *args, **kwargs)
-            except InvalidAppIdOrSecretException as err:
-                self.coordinator.config_entry.async_start_reauth(self.hass)
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key="invalid_auth",
-                ) from err
-            except ImouException as err:
-                raise HomeAssistantError(
-                    translation_domain=DOMAIN,
-                    translation_key=error_key,
-                    translation_placeholders={"error": err.message},
-                ) from err
-
-        return wrapper
-
-    return decorator

--- a/homeassistant/components/imou/entity.py
+++ b/homeassistant/components/imou/entity.py
@@ -1,10 +1,14 @@
 """An abstract class common to all Imou entities."""
 
-from typing import override
+from collections.abc import Awaitable, Callable, Coroutine
+from functools import wraps
+from typing import Any, Concatenate, override
 
 from pyimouapi.const import PARAM_STATE, PARAM_STATUS
+from pyimouapi.exceptions import ImouException, InvalidAppIdOrSecretException
 from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -64,3 +68,36 @@ class ImouEntity(CoordinatorEntity[ImouDataUpdateCoordinator]):
         return (
             self.device.sensors[PARAM_STATUS][PARAM_STATE] != DeviceStatus.OFFLINE.value
         )
+
+
+def async_wrap_imou_command[_T: ImouEntity, **_P, _R](
+    error_key: str,
+) -> Callable[
+    [Callable[Concatenate[_T, _P], Awaitable[_R]]],
+    Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]],
+]:
+    """Wrap an Imou command and start reauthentication when credentials are rejected."""
+
+    def decorator(
+        func: Callable[Concatenate[_T, _P], Awaitable[_R]],
+    ) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]]:
+        @wraps(func)
+        async def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+            try:
+                return await func(self, *args, **kwargs)
+            except InvalidAppIdOrSecretException as err:
+                self.coordinator.config_entry.async_start_reauth(self.hass)
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_auth",
+                ) from err
+            except ImouException as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key=error_key,
+                    translation_placeholders={"error": err.message},
+                ) from err
+
+        return wrapper
+
+    return decorator

--- a/homeassistant/components/imou/helpers.py
+++ b/homeassistant/components/imou/helpers.py
@@ -18,7 +18,7 @@ def async_wrap_imou_command[_T: ImouEntity, **_P, _R](
     [Callable[Concatenate[_T, _P], Awaitable[_R]]],
     Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]],
 ]:
-    """Wrap an Imou command and reload the entry when credentials are rejected."""
+    """Wrap an Imou command and start reauthentication when credentials are rejected."""
 
     def decorator(
         func: Callable[Concatenate[_T, _P], Awaitable[_R]],
@@ -28,9 +28,7 @@ def async_wrap_imou_command[_T: ImouEntity, **_P, _R](
             try:
                 return await func(self, *args, **kwargs)
             except InvalidAppIdOrSecretException as err:
-                self.hass.config_entries.async_schedule_reload(
-                    self.coordinator.config_entry.entry_id
-                )
+                self.coordinator.config_entry.async_start_reauth(self.hass)
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="invalid_auth",
@@ -39,7 +37,6 @@ def async_wrap_imou_command[_T: ImouEntity, **_P, _R](
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key=error_key,
-                    translation_placeholders={"error": err.message},
                 ) from err
 
         return wrapper

--- a/homeassistant/components/imou/helpers.py
+++ b/homeassistant/components/imou/helpers.py
@@ -1,0 +1,47 @@
+"""Helpers for Imou."""
+
+from collections.abc import Awaitable, Callable, Coroutine
+from functools import wraps
+from typing import Any, Concatenate
+
+from pyimouapi.exceptions import ImouException, InvalidAppIdOrSecretException
+
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN
+from .entity import ImouEntity
+
+
+def async_wrap_imou_command[_T: ImouEntity, **_P, _R](
+    error_key: str,
+) -> Callable[
+    [Callable[Concatenate[_T, _P], Awaitable[_R]]],
+    Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]],
+]:
+    """Wrap an Imou command and reload the entry when credentials are rejected."""
+
+    def decorator(
+        func: Callable[Concatenate[_T, _P], Awaitable[_R]],
+    ) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]]:
+        @wraps(func)
+        async def wrapper(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+            try:
+                return await func(self, *args, **kwargs)
+            except InvalidAppIdOrSecretException as err:
+                self.hass.config_entries.async_schedule_reload(
+                    self.coordinator.config_entry.entry_id
+                )
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_auth",
+                ) from err
+            except ImouException as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key=error_key,
+                    translation_placeholders={"error": err.message},
+                ) from err
+
+        return wrapper
+
+    return decorator

--- a/homeassistant/components/imou/select.py
+++ b/homeassistant/components/imou/select.py
@@ -17,7 +17,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import imou_device_identifier
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
-from .entity import ImouEntity, async_wrap_imou_command
+from .entity import ImouEntity
+from .helpers import async_wrap_imou_command
 
 PARALLEL_UPDATES = 0
 

--- a/homeassistant/components/imou/select.py
+++ b/homeassistant/components/imou/select.py
@@ -8,18 +8,16 @@ from pyimouapi.const import (
     PARAM_NIGHT_VISION_MODE,
     PARAM_OPTIONS,
 )
-from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import ImouHaDevice
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, imou_device_identifier
+from .const import imou_device_identifier
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
-from .entity import ImouEntity
+from .entity import ImouEntity, async_wrap_imou_command
 
 PARALLEL_UPDATES = 0
 
@@ -87,18 +85,12 @@ class ImouSelect(ImouEntity, SelectEntity):
         return self.device.selects[self._entity_type][PARAM_CURRENT_OPTION]
 
     @override
+    @async_wrap_imou_command("select_option_failed")
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        try:
-            await self.coordinator.device_manager.async_select_option(
-                self.device,
-                self._entity_type,
-                option,
-            )
-        except ImouException as e:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="select_option_failed",
-                translation_placeholders={"error": e.message},
-            ) from e
+        await self.coordinator.device_manager.async_select_option(
+            self.device,
+            self._entity_type,
+            option,
+        )
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/imou/strings.json
+++ b/homeassistant/components/imou/strings.json
@@ -138,22 +138,22 @@
   },
   "exceptions": {
     "get_image_failed": {
-      "message": "Could not get a snapshot from Imou: {error}"
+      "message": "Could not get a snapshot from Imou"
     },
     "get_stream_failed": {
-      "message": "Could not get the live stream URL from Imou: {error}"
+      "message": "Could not get the live stream URL from Imou"
     },
     "invalid_auth": {
       "message": "Imou rejected the App ID and App secret"
     },
     "press_button_failed": {
-      "message": "Imou rejected the button press: {error}"
+      "message": "Imou rejected the button press"
     },
     "select_option_failed": {
-      "message": "Imou rejected the new option: {error}"
+      "message": "Imou rejected the new option"
     },
     "switch_operation_failed": {
-      "message": "Imou rejected the switch change: {error}"
+      "message": "Imou rejected the switch change"
     }
   },
   "selector": {

--- a/homeassistant/components/imou/switch.py
+++ b/homeassistant/components/imou/switch.py
@@ -24,7 +24,8 @@ from .const import (
     imou_device_identifier,
 )
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
-from .entity import ImouEntity, async_wrap_imou_command
+from .entity import ImouEntity
+from .helpers import async_wrap_imou_command
 
 PARALLEL_UPDATES = 0
 

--- a/homeassistant/components/imou/switch.py
+++ b/homeassistant/components/imou/switch.py
@@ -3,7 +3,6 @@
 from typing import Any, override
 
 from pyimouapi.const import PARAM_MOTION_DETECT, PARAM_STATE
-from pyimouapi.exceptions import ImouException
 from pyimouapi.ha_device import ImouHaDevice
 
 from homeassistant.components.switch import (
@@ -12,11 +11,9 @@ from homeassistant.components.switch import (
     SwitchEntityDescription,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
-    DOMAIN,
     PARAM_AB_ALARM_SOUND,
     PARAM_AUDIO_ENCODE_CONTROL,
     PARAM_CLOSE_CAMERA,
@@ -27,7 +24,7 @@ from .const import (
     imou_device_identifier,
 )
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
-from .entity import ImouEntity
+from .entity import ImouEntity, async_wrap_imou_command
 
 PARALLEL_UPDATES = 0
 
@@ -122,18 +119,12 @@ class ImouSwitch(ImouEntity, SwitchEntity):
         """Turn the switch off."""
         await self._async_switch_operation(False)
 
+    @async_wrap_imou_command("switch_operation_failed")
     async def _async_switch_operation(self, enable: bool) -> None:
         """Call the vendor library to change switch state."""
-        try:
-            await self.coordinator.device_manager.async_switch_operation(
-                self.device,
-                self._entity_type,
-                enable,
-            )
-        except ImouException as e:
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="switch_operation_failed",
-                translation_placeholders={"error": e.message},
-            ) from e
+        await self.coordinator.device_manager.async_switch_operation(
+            self.device,
+            self._entity_type,
+            enable,
+        )
         await self.coordinator.async_request_refresh()

--- a/tests/components/imou/test_button.py
+++ b/tests/components/imou/test_button.py
@@ -13,7 +13,7 @@ from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRE
 from homeassistant.components.imou.button import PARAM_MUTE, PARAM_PTZ_UP
 from homeassistant.components.imou.const import PTZ_MOVE_DURATION_MS
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -131,9 +131,7 @@ async def test_press_button_service_propagates_api_error(
 
     entity_id = hass.states.async_all("button")[0].entity_id
 
-    with pytest.raises(
-        HomeAssistantError, match="Imou rejected the button press: cloud failure"
-    ):
+    with pytest.raises(HomeAssistantError, match="Imou rejected the button press"):
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,
@@ -143,16 +141,13 @@ async def test_press_button_service_propagates_api_error(
 
 
 @pytest.mark.usefixtures("init_integration")
-async def test_press_button_invalid_auth_reloads_entry(
+async def test_press_button_invalid_auth_starts_reauth(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_imou_ha_device_manager: MagicMock,
 ) -> None:
-    """Rejected credentials while pressing a button reload the entry into setup error."""
+    """Rejected credentials while pressing a button start reauthentication."""
     mock_imou_ha_device_manager.async_press_button.side_effect = (
-        InvalidAppIdOrSecretException("fail")
-    )
-    mock_imou_ha_device_manager.async_get_devices.side_effect = (
         InvalidAppIdOrSecretException("fail")
     )
 
@@ -169,7 +164,8 @@ async def test_press_button_invalid_auth_reloads_entry(
         )
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
 
 
 @pytest.mark.parametrize(

--- a/tests/components/imou/test_button.py
+++ b/tests/components/imou/test_button.py
@@ -13,7 +13,7 @@ from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRE
 from homeassistant.components.imou.button import PARAM_MUTE, PARAM_PTZ_UP
 from homeassistant.components.imou.const import PTZ_MOVE_DURATION_MS
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -119,36 +119,48 @@ async def test_press_ptz_button_passes_move_duration(
     assert call.args[2] == PTZ_MOVE_DURATION_MS
 
 
-@pytest.mark.parametrize(
-    ("exception", "message", "reauth_expected"),
-    [
-        (
-            ImouException("cloud failure"),
-            "Imou rejected the button press: cloud failure",
-            False,
-        ),
-        (
-            InvalidAppIdOrSecretException("fail"),
-            "Imou rejected the App ID and App secret",
-            True,
-        ),
-    ],
-)
 @pytest.mark.usefixtures("init_integration")
 async def test_press_button_service_propagates_api_error(
     hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
     mock_imou_ha_device_manager: MagicMock,
-    exception: Exception,
-    message: str,
-    reauth_expected: bool,
 ) -> None:
     """Imou API errors from async_press_button surface to the service call."""
-    mock_imou_ha_device_manager.async_press_button.side_effect = exception
+    mock_imou_ha_device_manager.async_press_button.side_effect = ImouException(
+        "cloud failure"
+    )
 
     entity_id = hass.states.async_all("button")[0].entity_id
 
-    with pytest.raises(HomeAssistantError, match=message):
+    with pytest.raises(
+        HomeAssistantError, match="Imou rejected the button press: cloud failure"
+    ):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_press_button_invalid_auth_reloads_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_imou_ha_device_manager: MagicMock,
+) -> None:
+    """Rejected credentials while pressing a button reload the entry into setup error."""
+    mock_imou_ha_device_manager.async_press_button.side_effect = (
+        InvalidAppIdOrSecretException("fail")
+    )
+    mock_imou_ha_device_manager.async_get_devices.side_effect = (
+        InvalidAppIdOrSecretException("fail")
+    )
+
+    entity_id = hass.states.async_all("button")[0].entity_id
+
+    with pytest.raises(
+        HomeAssistantError, match="Imou rejected the App ID and App secret"
+    ):
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,
@@ -157,11 +169,7 @@ async def test_press_button_service_propagates_api_error(
         )
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert (
-        any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
-        is reauth_expected
-    )
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 @pytest.mark.parametrize(

--- a/tests/components/imou/test_button.py
+++ b/tests/components/imou/test_button.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 from pyimouapi.const import PARAM_STATE, PARAM_STATUS
-from pyimouapi.exceptions import ImouException
+from pyimouapi.exceptions import ImouException, InvalidAppIdOrSecretException
 from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -13,6 +13,7 @@ from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRE
 from homeassistant.components.imou.button import PARAM_MUTE, PARAM_PTZ_UP
 from homeassistant.components.imou.const import PTZ_MOVE_DURATION_MS
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -118,27 +119,49 @@ async def test_press_ptz_button_passes_move_duration(
     assert call.args[2] == PTZ_MOVE_DURATION_MS
 
 
+@pytest.mark.parametrize(
+    ("exception", "message", "reauth_expected"),
+    [
+        (
+            ImouException("cloud failure"),
+            "Imou rejected the button press: cloud failure",
+            False,
+        ),
+        (
+            InvalidAppIdOrSecretException("fail"),
+            "Imou rejected the App ID and App secret",
+            True,
+        ),
+    ],
+)
 @pytest.mark.usefixtures("init_integration")
 async def test_press_button_service_propagates_api_error(
     hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
     mock_imou_ha_device_manager: MagicMock,
+    exception: Exception,
+    message: str,
+    reauth_expected: bool,
 ) -> None:
     """Imou API errors from async_press_button surface to the service call."""
-    mock_imou_ha_device_manager.async_press_button.side_effect = ImouException(
-        "cloud failure"
-    )
+    mock_imou_ha_device_manager.async_press_button.side_effect = exception
 
     entity_id = hass.states.async_all("button")[0].entity_id
 
-    with pytest.raises(
-        HomeAssistantError, match="Imou rejected the button press: cloud failure"
-    ):
+    with pytest.raises(HomeAssistantError, match=message):
         await hass.services.async_call(
             BUTTON_DOMAIN,
             SERVICE_PRESS,
             {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert (
+        any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
+        is reauth_expected
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/imou/test_camera.py
+++ b/tests/components/imou/test_camera.py
@@ -16,7 +16,7 @@ from homeassistant.components.imou.camera import (
 )
 from homeassistant.components.imou.const import PARAM_HEADER_DETECT
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -285,44 +285,24 @@ async def test_camera_state(
     ],
     indirect=True,
 )
-@pytest.mark.parametrize(
-    ("exception", "message", "reauth_expected"),
-    [
-        (
-            ImouException("stream failure"),
-            "Could not get the live stream URL from Imou: stream failure",
-            False,
-        ),
-        (
-            InvalidAppIdOrSecretException("fail"),
-            "Imou rejected the App ID and App secret",
-            True,
-        ),
-    ],
-)
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
 async def test_camera_stream_source_propagates_api_error(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_imou_ha_device_manager: MagicMock,
     mock_config_entry: MockConfigEntry,
-    exception: Exception,
-    message: str,
-    reauth_expected: bool,
 ) -> None:
     """Imou API errors from stream fetch surface to the caller."""
-    mock_imou_ha_device_manager.async_get_device_stream.side_effect = exception
+    mock_imou_ha_device_manager.async_get_device_stream.side_effect = ImouException(
+        "stream failure"
+    )
 
     entity_id = _camera_entity_id(entity_registry, mock_config_entry)
-    with pytest.raises(HomeAssistantError, match=message):
+    with pytest.raises(
+        HomeAssistantError,
+        match="Could not get the live stream URL from Imou: stream failure",
+    ):
         await async_get_stream_source(hass, entity_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert (
-        any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
-        is reauth_expected
-    )
 
 
 @pytest.mark.parametrize(
@@ -339,20 +319,44 @@ async def test_camera_stream_source_propagates_api_error(
     ],
     indirect=True,
 )
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_camera_stream_source_invalid_auth_reloads_entry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_imou_ha_device_manager: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Rejected credentials while fetching a stream reload the entry into setup error."""
+    mock_imou_ha_device_manager.async_get_device_stream.side_effect = (
+        InvalidAppIdOrSecretException("fail")
+    )
+    mock_imou_ha_device_manager.async_get_devices.side_effect = (
+        InvalidAppIdOrSecretException("fail")
+    )
+
+    entity_id = _camera_entity_id(entity_registry, mock_config_entry)
+    with pytest.raises(
+        HomeAssistantError, match="Imou rejected the App ID and App secret"
+    ):
+        await async_get_stream_source(hass, entity_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
 @pytest.mark.parametrize(
-    ("exception", "message", "reauth_expected"),
+    "imou_mock_devices",
     [
-        (
-            ImouException("image failure"),
-            "Could not get a snapshot from Imou: image failure",
-            False,
-        ),
-        (
-            InvalidAppIdOrSecretException("fail"),
-            "Imou rejected the App ID and App secret",
-            True,
-        ),
+        [
+            create_online_device(
+                "d1",
+                "Device 1",
+                channel_id="1",
+                button_keys=(),
+            )
+        ]
     ],
+    indirect=True,
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
 async def test_camera_image_propagates_api_error(
@@ -360,23 +364,57 @@ async def test_camera_image_propagates_api_error(
     entity_registry: er.EntityRegistry,
     mock_imou_ha_device_manager: MagicMock,
     mock_config_entry: MockConfigEntry,
-    exception: Exception,
-    message: str,
-    reauth_expected: bool,
 ) -> None:
     """Imou API errors from snapshot fetch surface to the caller."""
-    mock_imou_ha_device_manager.async_get_device_image.side_effect = exception
+    mock_imou_ha_device_manager.async_get_device_image.side_effect = ImouException(
+        "image failure"
+    )
 
     entity_id = _camera_entity_id(entity_registry, mock_config_entry)
-    with pytest.raises(HomeAssistantError, match=message):
+    with pytest.raises(
+        HomeAssistantError,
+        match="Could not get a snapshot from Imou: image failure",
+    ):
+        await async_get_image(hass, entity_id)
+
+
+@pytest.mark.parametrize(
+    "imou_mock_devices",
+    [
+        [
+            create_online_device(
+                "d1",
+                "Device 1",
+                channel_id="1",
+                button_keys=(),
+            )
+        ]
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_camera_image_invalid_auth_reloads_entry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_imou_ha_device_manager: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Rejected credentials while fetching a snapshot reload the entry into setup error."""
+    mock_imou_ha_device_manager.async_get_device_image.side_effect = (
+        InvalidAppIdOrSecretException("fail")
+    )
+    mock_imou_ha_device_manager.async_get_devices.side_effect = (
+        InvalidAppIdOrSecretException("fail")
+    )
+
+    entity_id = _camera_entity_id(entity_registry, mock_config_entry)
+    with pytest.raises(
+        HomeAssistantError, match="Imou rejected the App ID and App secret"
+    ):
         await async_get_image(hass, entity_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert (
-        any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
-        is reauth_expected
-    )
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 @pytest.mark.parametrize(

--- a/tests/components/imou/test_camera.py
+++ b/tests/components/imou/test_camera.py
@@ -16,7 +16,7 @@ from homeassistant.components.imou.camera import (
 )
 from homeassistant.components.imou.const import PARAM_HEADER_DETECT
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -300,7 +300,7 @@ async def test_camera_stream_source_propagates_api_error(
     entity_id = _camera_entity_id(entity_registry, mock_config_entry)
     with pytest.raises(
         HomeAssistantError,
-        match="Could not get the live stream URL from Imou: stream failure",
+        match="Could not get the live stream URL from Imou",
     ):
         await async_get_stream_source(hass, entity_id)
 
@@ -320,17 +320,14 @@ async def test_camera_stream_source_propagates_api_error(
     indirect=True,
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
-async def test_camera_stream_source_invalid_auth_reloads_entry(
+async def test_camera_stream_source_invalid_auth_starts_reauth(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_imou_ha_device_manager: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Rejected credentials while fetching a stream reload the entry into setup error."""
+    """Rejected credentials while fetching a stream start reauthentication."""
     mock_imou_ha_device_manager.async_get_device_stream.side_effect = (
-        InvalidAppIdOrSecretException("fail")
-    )
-    mock_imou_ha_device_manager.async_get_devices.side_effect = (
         InvalidAppIdOrSecretException("fail")
     )
 
@@ -341,7 +338,8 @@ async def test_camera_stream_source_invalid_auth_reloads_entry(
         await async_get_stream_source(hass, entity_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
 
 
 @pytest.mark.parametrize(
@@ -373,7 +371,7 @@ async def test_camera_image_propagates_api_error(
     entity_id = _camera_entity_id(entity_registry, mock_config_entry)
     with pytest.raises(
         HomeAssistantError,
-        match="Could not get a snapshot from Imou: image failure",
+        match="Could not get a snapshot from Imou",
     ):
         await async_get_image(hass, entity_id)
 
@@ -393,17 +391,14 @@ async def test_camera_image_propagates_api_error(
     indirect=True,
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
-async def test_camera_image_invalid_auth_reloads_entry(
+async def test_camera_image_invalid_auth_starts_reauth(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_imou_ha_device_manager: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Rejected credentials while fetching a snapshot reload the entry into setup error."""
+    """Rejected credentials while fetching a snapshot start reauthentication."""
     mock_imou_ha_device_manager.async_get_device_image.side_effect = (
-        InvalidAppIdOrSecretException("fail")
-    )
-    mock_imou_ha_device_manager.async_get_devices.side_effect = (
         InvalidAppIdOrSecretException("fail")
     )
 
@@ -414,7 +409,8 @@ async def test_camera_image_invalid_auth_reloads_entry(
         await async_get_image(hass, entity_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
 
 
 @pytest.mark.parametrize(

--- a/tests/components/imou/test_camera.py
+++ b/tests/components/imou/test_camera.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 from pyimouapi.const import PARAM_HD, PARAM_MOTION_DETECT, PARAM_STATE
-from pyimouapi.exceptions import ImouException
+from pyimouapi.exceptions import ImouException, InvalidAppIdOrSecretException
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -16,6 +16,7 @@ from homeassistant.components.imou.camera import (
 )
 from homeassistant.components.imou.const import PARAM_HEADER_DETECT
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -284,24 +285,44 @@ async def test_camera_state(
     ],
     indirect=True,
 )
+@pytest.mark.parametrize(
+    ("exception", "message", "reauth_expected"),
+    [
+        (
+            ImouException("stream failure"),
+            "Could not get the live stream URL from Imou: stream failure",
+            False,
+        ),
+        (
+            InvalidAppIdOrSecretException("fail"),
+            "Imou rejected the App ID and App secret",
+            True,
+        ),
+    ],
+)
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
 async def test_camera_stream_source_propagates_api_error(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_imou_ha_device_manager: MagicMock,
     mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    message: str,
+    reauth_expected: bool,
 ) -> None:
     """Imou API errors from stream fetch surface to the caller."""
-    mock_imou_ha_device_manager.async_get_device_stream.side_effect = ImouException(
-        "stream failure"
-    )
+    mock_imou_ha_device_manager.async_get_device_stream.side_effect = exception
 
     entity_id = _camera_entity_id(entity_registry, mock_config_entry)
-    with pytest.raises(
-        HomeAssistantError,
-        match="Could not get the live stream URL from Imou: stream failure",
-    ):
+    with pytest.raises(HomeAssistantError, match=message):
         await async_get_stream_source(hass, entity_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert (
+        any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
+        is reauth_expected
+    )
 
 
 @pytest.mark.parametrize(
@@ -318,24 +339,44 @@ async def test_camera_stream_source_propagates_api_error(
     ],
     indirect=True,
 )
+@pytest.mark.parametrize(
+    ("exception", "message", "reauth_expected"),
+    [
+        (
+            ImouException("image failure"),
+            "Could not get a snapshot from Imou: image failure",
+            False,
+        ),
+        (
+            InvalidAppIdOrSecretException("fail"),
+            "Imou rejected the App ID and App secret",
+            True,
+        ),
+    ],
+)
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
 async def test_camera_image_propagates_api_error(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_imou_ha_device_manager: MagicMock,
     mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    message: str,
+    reauth_expected: bool,
 ) -> None:
     """Imou API errors from snapshot fetch surface to the caller."""
-    mock_imou_ha_device_manager.async_get_device_image.side_effect = ImouException(
-        "image failure"
-    )
+    mock_imou_ha_device_manager.async_get_device_image.side_effect = exception
 
     entity_id = _camera_entity_id(entity_registry, mock_config_entry)
-    with pytest.raises(
-        HomeAssistantError,
-        match="Could not get a snapshot from Imou: image failure",
-    ):
+    with pytest.raises(HomeAssistantError, match=message):
         await async_get_image(hass, entity_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert (
+        any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
+        is reauth_expected
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/imou/test_select.py
+++ b/tests/components/imou/test_select.py
@@ -11,13 +11,14 @@ from pyimouapi.const import (
     PARAM_STATE,
     PARAM_STATUS,
 )
-from pyimouapi.exceptions import ImouException
+from pyimouapi.exceptions import ImouException, InvalidAppIdOrSecretException
 from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_OPTION,
@@ -123,6 +124,21 @@ async def test_select_option_via_domain_service(
     assert hass.states.get(volume_entry.entity_id).state == "high"
 
 
+@pytest.mark.parametrize(
+    ("exception", "message", "reauth_expected"),
+    [
+        (
+            ImouException("cloud failure"),
+            "Imou rejected the new option: cloud failure",
+            False,
+        ),
+        (
+            InvalidAppIdOrSecretException("fail"),
+            "Imou rejected the App ID and App secret",
+            True,
+        ),
+    ],
+)
 @pytest.mark.parametrize("platforms", [[Platform.SELECT]], indirect=True)
 @pytest.mark.parametrize("imou_mock_devices", [select_mock_devices], indirect=True)
 @pytest.mark.usefixtures("init_integration")
@@ -131,11 +147,12 @@ async def test_select_option_propagates_api_error(
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_imou_ha_device_manager: MagicMock,
+    exception: Exception,
+    message: str,
+    reauth_expected: bool,
 ) -> None:
     """Imou API errors from async_select_option surface to the service call."""
-    mock_imou_ha_device_manager.async_select_option.side_effect = ImouException(
-        "cloud failure"
-    )
+    mock_imou_ha_device_manager.async_select_option.side_effect = exception
 
     volume_entry = next(
         entry
@@ -145,15 +162,20 @@ async def test_select_option_propagates_api_error(
         if entry.unique_id == "d1$device_volume"
     )
 
-    with pytest.raises(
-        HomeAssistantError, match="Imou rejected the new option: cloud failure"
-    ):
+    with pytest.raises(HomeAssistantError, match=message):
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
             {ATTR_ENTITY_ID: volume_entry.entity_id, ATTR_OPTION: "high"},
             blocking=True,
         )
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert (
+        any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
+        is reauth_expected
+    )
 
 
 @pytest.mark.parametrize("platforms", [[Platform.SELECT]], indirect=True)

--- a/tests/components/imou/test_select.py
+++ b/tests/components/imou/test_select.py
@@ -18,7 +18,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_OPTION,
@@ -146,9 +146,7 @@ async def test_select_option_propagates_api_error(
         if entry.unique_id == "d1$device_volume"
     )
 
-    with pytest.raises(
-        HomeAssistantError, match="Imou rejected the new option: cloud failure"
-    ):
+    with pytest.raises(HomeAssistantError, match="Imou rejected the new option"):
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
@@ -160,17 +158,14 @@ async def test_select_option_propagates_api_error(
 @pytest.mark.parametrize("platforms", [[Platform.SELECT]], indirect=True)
 @pytest.mark.parametrize("imou_mock_devices", [select_mock_devices], indirect=True)
 @pytest.mark.usefixtures("init_integration")
-async def test_select_option_invalid_auth_reloads_entry(
+async def test_select_option_invalid_auth_starts_reauth(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_imou_ha_device_manager: MagicMock,
 ) -> None:
-    """Rejected credentials while changing a select reload the entry into setup error."""
+    """Rejected credentials while changing a select start reauthentication."""
     mock_imou_ha_device_manager.async_select_option.side_effect = (
-        InvalidAppIdOrSecretException("fail")
-    )
-    mock_imou_ha_device_manager.async_get_devices.side_effect = (
         InvalidAppIdOrSecretException("fail")
     )
 
@@ -193,7 +188,8 @@ async def test_select_option_invalid_auth_reloads_entry(
         )
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
 
 
 @pytest.mark.parametrize("platforms", [[Platform.SELECT]], indirect=True)

--- a/tests/components/imou/test_select.py
+++ b/tests/components/imou/test_select.py
@@ -18,7 +18,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_OPTION,
@@ -124,21 +124,6 @@ async def test_select_option_via_domain_service(
     assert hass.states.get(volume_entry.entity_id).state == "high"
 
 
-@pytest.mark.parametrize(
-    ("exception", "message", "reauth_expected"),
-    [
-        (
-            ImouException("cloud failure"),
-            "Imou rejected the new option: cloud failure",
-            False,
-        ),
-        (
-            InvalidAppIdOrSecretException("fail"),
-            "Imou rejected the App ID and App secret",
-            True,
-        ),
-    ],
-)
 @pytest.mark.parametrize("platforms", [[Platform.SELECT]], indirect=True)
 @pytest.mark.parametrize("imou_mock_devices", [select_mock_devices], indirect=True)
 @pytest.mark.usefixtures("init_integration")
@@ -147,12 +132,11 @@ async def test_select_option_propagates_api_error(
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
     mock_imou_ha_device_manager: MagicMock,
-    exception: Exception,
-    message: str,
-    reauth_expected: bool,
 ) -> None:
     """Imou API errors from async_select_option surface to the service call."""
-    mock_imou_ha_device_manager.async_select_option.side_effect = exception
+    mock_imou_ha_device_manager.async_select_option.side_effect = ImouException(
+        "cloud failure"
+    )
 
     volume_entry = next(
         entry
@@ -162,7 +146,45 @@ async def test_select_option_propagates_api_error(
         if entry.unique_id == "d1$device_volume"
     )
 
-    with pytest.raises(HomeAssistantError, match=message):
+    with pytest.raises(
+        HomeAssistantError, match="Imou rejected the new option: cloud failure"
+    ):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {ATTR_ENTITY_ID: volume_entry.entity_id, ATTR_OPTION: "high"},
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize("platforms", [[Platform.SELECT]], indirect=True)
+@pytest.mark.parametrize("imou_mock_devices", [select_mock_devices], indirect=True)
+@pytest.mark.usefixtures("init_integration")
+async def test_select_option_invalid_auth_reloads_entry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_imou_ha_device_manager: MagicMock,
+) -> None:
+    """Rejected credentials while changing a select reload the entry into setup error."""
+    mock_imou_ha_device_manager.async_select_option.side_effect = (
+        InvalidAppIdOrSecretException("fail")
+    )
+    mock_imou_ha_device_manager.async_get_devices.side_effect = (
+        InvalidAppIdOrSecretException("fail")
+    )
+
+    volume_entry = next(
+        entry
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        if entry.unique_id == "d1$device_volume"
+    )
+
+    with pytest.raises(
+        HomeAssistantError, match="Imou rejected the App ID and App secret"
+    ):
         await hass.services.async_call(
             SELECT_DOMAIN,
             SERVICE_SELECT_OPTION,
@@ -171,11 +193,7 @@ async def test_select_option_propagates_api_error(
         )
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert (
-        any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
-        is reauth_expected
-    )
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 @pytest.mark.parametrize("platforms", [[Platform.SELECT]], indirect=True)

--- a/tests/components/imou/test_switch.py
+++ b/tests/components/imou/test_switch.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 from pyimouapi.const import PARAM_MOTION_DETECT, PARAM_STATE, PARAM_STATUS
-from pyimouapi.exceptions import ImouException
+from pyimouapi.exceptions import ImouException, InvalidAppIdOrSecretException
 from pyimouapi.ha_device import DeviceStatus, ImouHaDevice
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -12,6 +12,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.imou.const import PARAM_HEADER_DETECT
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
@@ -160,28 +161,50 @@ async def test_turn_off_via_service(
     assert hass.states.get(header_entry.entity_id).state == "off"
 
 
+@pytest.mark.parametrize(
+    ("exception", "message", "reauth_expected"),
+    [
+        (
+            ImouException("cloud failure"),
+            "Imou rejected the switch change: cloud failure",
+            False,
+        ),
+        (
+            InvalidAppIdOrSecretException("fail"),
+            "Imou rejected the App ID and App secret",
+            True,
+        ),
+    ],
+)
 @pytest.mark.parametrize("imou_mock_devices", [SWITCH_MOCK_DEVICES], indirect=True)
 @pytest.mark.usefixtures("init_integration")
 async def test_turn_on_service_propagates_api_error(
     hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
     mock_imou_ha_device_manager: MagicMock,
+    exception: Exception,
+    message: str,
+    reauth_expected: bool,
 ) -> None:
     """Imou API errors from async_switch_operation surface to the service call."""
-    mock_imou_ha_device_manager.async_switch_operation.side_effect = ImouException(
-        "cloud failure"
-    )
+    mock_imou_ha_device_manager.async_switch_operation.side_effect = exception
 
     entity_id = hass.states.async_all("switch")[0].entity_id
 
-    with pytest.raises(
-        HomeAssistantError, match="Imou rejected the switch change: cloud failure"
-    ):
+    with pytest.raises(HomeAssistantError, match=message):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
             {ATTR_ENTITY_ID: entity_id},
             blocking=True,
         )
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert (
+        any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
+        is reauth_expected
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/imou/test_switch.py
+++ b/tests/components/imou/test_switch.py
@@ -12,7 +12,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.imou.const import PARAM_HEADER_DETECT
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
@@ -174,9 +174,7 @@ async def test_turn_on_service_propagates_api_error(
 
     entity_id = hass.states.async_all("switch")[0].entity_id
 
-    with pytest.raises(
-        HomeAssistantError, match="Imou rejected the switch change: cloud failure"
-    ):
+    with pytest.raises(HomeAssistantError, match="Imou rejected the switch change"):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
@@ -187,16 +185,13 @@ async def test_turn_on_service_propagates_api_error(
 
 @pytest.mark.parametrize("imou_mock_devices", [SWITCH_MOCK_DEVICES], indirect=True)
 @pytest.mark.usefixtures("init_integration")
-async def test_turn_on_invalid_auth_reloads_entry(
+async def test_turn_on_invalid_auth_starts_reauth(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_imou_ha_device_manager: MagicMock,
 ) -> None:
-    """Rejected credentials while toggling a switch reload the entry into setup error."""
+    """Rejected credentials while toggling a switch start reauthentication."""
     mock_imou_ha_device_manager.async_switch_operation.side_effect = (
-        InvalidAppIdOrSecretException("fail")
-    )
-    mock_imou_ha_device_manager.async_get_devices.side_effect = (
         InvalidAppIdOrSecretException("fail")
     )
 
@@ -213,7 +208,8 @@ async def test_turn_on_invalid_auth_reloads_entry(
         )
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
 
 
 @pytest.mark.parametrize(

--- a/tests/components/imou/test_switch.py
+++ b/tests/components/imou/test_switch.py
@@ -12,7 +12,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.imou.const import PARAM_HEADER_DETECT
 from homeassistant.components.imou.coordinator import SCAN_INTERVAL
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
@@ -161,37 +161,50 @@ async def test_turn_off_via_service(
     assert hass.states.get(header_entry.entity_id).state == "off"
 
 
-@pytest.mark.parametrize(
-    ("exception", "message", "reauth_expected"),
-    [
-        (
-            ImouException("cloud failure"),
-            "Imou rejected the switch change: cloud failure",
-            False,
-        ),
-        (
-            InvalidAppIdOrSecretException("fail"),
-            "Imou rejected the App ID and App secret",
-            True,
-        ),
-    ],
-)
 @pytest.mark.parametrize("imou_mock_devices", [SWITCH_MOCK_DEVICES], indirect=True)
 @pytest.mark.usefixtures("init_integration")
 async def test_turn_on_service_propagates_api_error(
     hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
     mock_imou_ha_device_manager: MagicMock,
-    exception: Exception,
-    message: str,
-    reauth_expected: bool,
 ) -> None:
     """Imou API errors from async_switch_operation surface to the service call."""
-    mock_imou_ha_device_manager.async_switch_operation.side_effect = exception
+    mock_imou_ha_device_manager.async_switch_operation.side_effect = ImouException(
+        "cloud failure"
+    )
 
     entity_id = hass.states.async_all("switch")[0].entity_id
 
-    with pytest.raises(HomeAssistantError, match=message):
+    with pytest.raises(
+        HomeAssistantError, match="Imou rejected the switch change: cloud failure"
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize("imou_mock_devices", [SWITCH_MOCK_DEVICES], indirect=True)
+@pytest.mark.usefixtures("init_integration")
+async def test_turn_on_invalid_auth_reloads_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_imou_ha_device_manager: MagicMock,
+) -> None:
+    """Rejected credentials while toggling a switch reload the entry into setup error."""
+    mock_imou_ha_device_manager.async_switch_operation.side_effect = (
+        InvalidAppIdOrSecretException("fail")
+    )
+    mock_imou_ha_device_manager.async_get_devices.side_effect = (
+        InvalidAppIdOrSecretException("fail")
+    )
+
+    entity_id = hass.states.async_all("switch")[0].entity_id
+
+    with pytest.raises(
+        HomeAssistantError, match="Imou rejected the App ID and App secret"
+    ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
@@ -200,11 +213,7 @@ async def test_turn_on_service_propagates_api_error(
         )
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert (
-        any(mock_config_entry.async_get_active_flows(hass, {SOURCE_REAUTH}))
-        is reauth_expected
-    )
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

<!-- N/A -->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #180989. Polling already starts reauthentication when Imou rejects the App ID and App secret. Pressing a button, toggling a switch, changing a select option, or opening a live view still treated that rejection as a generic command failure, so a rotated secret never prompted the user.

`async_wrap_imou_command` (same shape as the TP-Link `async_refresh_after` wrapper) now wraps those command methods. `InvalidAppIdOrSecretException` starts reauthentication and raises the existing `invalid_auth` message. Other `ImouException` errors keep the platform-specific messages. The config entry stays loaded.

The reauthentication flow itself is already documented; this only starts it from entity actions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #180975, #180989
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
