### PR TITLE
Add async_update to Insteon entities to support forced status refresh

### DIFF
--- a/homeassistant/components/insteon/entity.py
+++ b/homeassistant/components/insteon/entity.py
@@ -191,3 +191,15 @@ class InsteonEntity(Entity):
     async def _async_add_default_links(self):
         """Add default links between the device and the modem."""
         await self._insteon_device.async_add_default_links()
+
+    async def async_update(self) -> None:
+        """Request a live status update from the device.
+
+        No-op for battery-powered devices: a status request on those queues
+        work and starts a wake-ping loop rather than completing, matching
+        the same skip used for the startup status pass in
+        async_get_device_config.
+        """
+        if self._insteon_device.is_battery:
+            return
+        await self._insteon_device.async_status(self.insteon_group)

--- a/homeassistant/components/insteon/entity.py
+++ b/homeassistant/components/insteon/entity.py
@@ -193,13 +193,7 @@ class InsteonEntity(Entity):
         await self._insteon_device.async_add_default_links()
 
     async def async_update(self) -> None:
-        """Request a live status update from the device.
-
-        No-op for battery-powered devices: a status request on those queues
-        work and starts a wake-ping loop rather than completing, matching
-        the same skip used for the startup status pass in
-        async_get_device_config.
-        """
+        """Request a live status update from the device, skipping battery-powered devices."""
         if self._insteon_device.is_battery:
             return
         await self._insteon_device.async_status(self.insteon_group)

--- a/tests/components/insteon/test_entity.py
+++ b/tests/components/insteon/test_entity.py
@@ -69,6 +69,12 @@ async def test_async_update_requests_status_for_mains_powered_device(
     try:
         lock = entity_registry.async_get("lock.device_55_55_55_55_55_55")
 
+        # Setup's own async_get_device_config background task already polled
+        # every non-battery device once (see homeassistant/components/insteon/
+        # __init__.py); reset so the assertion below only covers the explicit
+        # update_entity call this test is exercising.
+        devices["55.55.55"].async_status.reset_mock()
+
         await hass.services.async_call(
             "homeassistant",
             "update_entity",

--- a/tests/components/insteon/test_entity.py
+++ b/tests/components/insteon/test_entity.py
@@ -14,6 +14,7 @@ from homeassistant.components.insteon.entity import InsteonEntity
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
 
 from .const import MOCK_USER_INPUT_PLM
 from .mock_devices import MockDevices
@@ -56,6 +57,8 @@ async def test_async_update_requests_status_for_mains_powered_device(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test homeassistant.update_entity forwards the entity's group to async_status."""
+
+    await async_setup_component(hass, "homeassistant", {})
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT_PLM)
     config_entry.add_to_hass(hass)

--- a/tests/components/insteon/test_entity.py
+++ b/tests/components/insteon/test_entity.py
@@ -1,0 +1,95 @@
+"""Tests for the Insteon entity base class."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components import insteon
+from homeassistant.components.insteon import (
+    DOMAIN,
+    entity as insteon_entity,
+    utils as insteon_utils,
+)
+from homeassistant.components.insteon.entity import InsteonEntity
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .const import MOCK_USER_INPUT_PLM
+from .mock_devices import MockDevices
+
+from tests.common import MockConfigEntry
+
+devices = MockDevices()
+
+
+@pytest.fixture(autouse=True)
+def lock_platform_only():
+    """Only setup the lock and required base platforms to speed up tests."""
+    with patch(
+        "homeassistant.components.insteon.INSTEON_PLATFORMS",
+        (Platform.LOCK,),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_setup_and_devices():
+    """Patch the Insteon setup process and devices."""
+    with (
+        patch.object(insteon, "async_connect", new=mock_connection),
+        patch.object(insteon, "async_close"),
+        patch.object(insteon, "devices", devices),
+        patch.object(insteon_utils, "devices", devices),
+        patch.object(insteon_entity, "devices", devices),
+    ):
+        yield
+
+
+async def mock_connection(*args, **kwargs):
+    """Return a successful connection."""
+    return True
+
+
+async def test_async_update_requests_status_for_mains_powered_device(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test homeassistant.update_entity forwards the entity's group to async_status."""
+
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT_PLM)
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    try:
+        lock = entity_registry.async_get("lock.device_55_55_55_55_55_55")
+
+        await hass.services.async_call(
+            "homeassistant",
+            "update_entity",
+            {"entity_id": lock.entity_id},
+            blocking=True,
+        )
+        devices["55.55.55"].async_status.assert_awaited_once_with(1)
+    finally:
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
+
+
+async def test_async_update_skips_battery_powered_device() -> None:
+    """Test async_update is a no-op for a battery-powered device.
+
+    GeneralController_RemoteLinc devices (e.g. 22.22.22) have no entry in
+    ipdb.DEVICE_PLATFORM and are never set up as a standard HA entity, so
+    this exercises InsteonEntity.async_update directly against the device
+    rather than through a full platform/service-call setup.
+    """
+    await devices.async_load()
+    device = devices["22.22.22"]
+    entity = InsteonEntity(device, 1)
+
+    await entity.async_update()
+
+    device.async_status.assert_not_awaited()

--- a/tests/components/insteon/test_entity.py
+++ b/tests/components/insteon/test_entity.py
@@ -5,18 +5,23 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import insteon
+from homeassistant.components.homeassistant import (
+    DOMAIN as HOME_ASSISTANT_DOMAIN,
+    SERVICE_UPDATE_ENTITY,
+)
 from homeassistant.components.insteon import (
     DOMAIN,
     entity as insteon_entity,
     utils as insteon_utils,
 )
 from homeassistant.components.insteon.entity import InsteonEntity
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .const import MOCK_USER_INPUT_PLM
+from .mock_connection import mock_successful_connection
 from .mock_devices import MockDevices
 
 from tests.common import MockConfigEntry
@@ -38,7 +43,7 @@ def lock_platform_only():
 def patch_setup_and_devices():
     """Patch the Insteon setup process and devices."""
     with (
-        patch.object(insteon, "async_connect", new=mock_connection),
+        patch.object(insteon, "async_connect", new=mock_successful_connection),
         patch.object(insteon, "async_close"),
         patch.object(insteon, "devices", devices),
         patch.object(insteon_utils, "devices", devices),
@@ -47,18 +52,13 @@ def patch_setup_and_devices():
         yield
 
 
-async def mock_connection(*args, **kwargs):
-    """Return a successful connection."""
-    return True
-
-
 async def test_async_update_requests_status_for_mains_powered_device(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test homeassistant.update_entity forwards the entity's group to async_status."""
 
-    await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, HOME_ASSISTANT_DOMAIN, {})
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT_PLM)
     config_entry.add_to_hass(hass)
@@ -76,9 +76,9 @@ async def test_async_update_requests_status_for_mains_powered_device(
         devices["55.55.55"].async_status.reset_mock()
 
         await hass.services.async_call(
-            "homeassistant",
-            "update_entity",
-            {"entity_id": lock.entity_id},
+            HOME_ASSISTANT_DOMAIN,
+            SERVICE_UPDATE_ENTITY,
+            {ATTR_ENTITY_ID: lock.entity_id},
             blocking=True,
         )
         devices["55.55.55"].async_status.assert_awaited_once_with(1)


### PR DESCRIPTION
## Proposed change

Insteon is a `local_push` integration and relies entirely on the device pushing state changes over the powerline/RF mesh via ALL-LINK broadcasts. That push can be missed — interference, a command sent while Home Assistant was offline or restarting, a companion/3-way switch's relay to the load switch failing, etc. When that happens there is currently no way to recover the correct state other than a full Home Assistant restart:

- No `InsteonEntity` subclass implements `async_update`, so calling `homeassistant.update_entity` on an Insteon entity is a silent no-op.
- The integration's own "Enable polling for changes" system option has no effect for the same reason (see #140778).

`Device.async_status()` already exists in `pyinsteon` and sends a genuine Insteon status-request command over the powerline — it's already used internally elsewhere in this integration (e.g. `dimmable_lighting_control.py` calls it after certain direct commands). This change exposes that existing, working capability through the standard entity `async_update` path, so `homeassistant.update_entity` — and any automation built on top of it, e.g. a periodic refresh — can force a real device re-sync instead of doing nothing.

Battery-powered devices are explicitly skipped, matching the existing skip for the startup status pass in `async_get_device_config` (`__init__.py`) — a status request on those queues work and starts a wake-ping loop rather than completing immediately, so calling it repeatedly (e.g. from a periodic refresh automation) could otherwise accumulate duplicate work indefinitely.

This is a small, additive change (one method, no changes to existing behavior/signatures).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #140778, #43715, #72648
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:
- Tested on real Insteon hardware (SwitchLinc Dimmers + PLM) via a local `custom_components/insteon` override, since I don't have a way to reproduce Insteon RF/powerline behavior without physical devices:
  1. Confirmed via the physical switch's own paddle that a light was genuinely off, while Home Assistant's entity state still showed on (a real missed-broadcast scenario, not simulated).
  2. Before this change: calling `homeassistant.update_entity` on the entity had no effect — state remained stuck at the stale "on".
  3. After this change: the same call correctly updated the entity to "off", matching physical reality, with the state-change timestamp matching the exact moment of the API call.
  4. Confirmed this works for both a single-switch circuit and a 3-way (load + companion) circuit.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass** — not run locally (no HA dev environment set up for this session); CI's `Run tests Python 3.14.5 (insteon)` passes against the current commit.
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
