### PR TITLE
Register Subaru unlock_specific_door action in async_setup

### DIFF
--- a/homeassistant/components/subaru/__init__.py
+++ b/homeassistant/components/subaru/__init__.py
@@ -13,8 +13,9 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     DOMAIN,
@@ -38,8 +39,17 @@ from .coordinator import (
     SubaruDataUpdateCoordinator,
     SubaruRuntimeData,
 )
+from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Subaru integration."""
+    async_setup_services(hass)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: SubaruConfigEntry) -> bool:

--- a/homeassistant/components/subaru/lock.py
+++ b/homeassistant/components/subaru/lock.py
@@ -3,17 +3,12 @@
 import logging
 from typing import Any, override
 
-import voluptuous as vol
-
 from homeassistant.components.lock import LockEntity
 from homeassistant.const import SERVICE_LOCK, SERVICE_UNLOCK
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import (
-    ATTR_DOOR,
-    SERVICE_UNLOCK_SPECIFIC_DOOR,
     UNLOCK_DOOR_ALL,
     UNLOCK_VALID_DOORS,
     VEHICLE_HAS_REMOTE_SERVICE,
@@ -39,14 +34,6 @@ async def async_setup_entry(
         SubaruLock(vehicle, controller, coordinator)
         for vehicle in vehicle_info.values()
         if vehicle[VEHICLE_HAS_REMOTE_SERVICE]
-    )
-
-    platform = entity_platform.async_get_current_platform()
-
-    platform.async_register_entity_service(
-        SERVICE_UNLOCK_SPECIFIC_DOOR,
-        {vol.Required(ATTR_DOOR): vol.In(UNLOCK_VALID_DOORS)},
-        "async_unlock_specific_door",
     )
 
 

--- a/homeassistant/components/subaru/services.py
+++ b/homeassistant/components/subaru/services.py
@@ -1,0 +1,22 @@
+"""Services for the Subaru integration."""
+
+import voluptuous as vol
+
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import service
+
+from .const import ATTR_DOOR, DOMAIN, SERVICE_UNLOCK_SPECIFIC_DOOR, UNLOCK_VALID_DOORS
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register the Subaru services."""
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_UNLOCK_SPECIFIC_DOOR,
+        entity_domain=LOCK_DOMAIN,
+        schema={vol.Required(ATTR_DOOR): vol.In(UNLOCK_VALID_DOORS)},
+        func="async_unlock_specific_door",
+    )

--- a/tests/components/subaru/test_init.py
+++ b/tests/components/subaru/test_init.py
@@ -8,7 +8,7 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HA_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
-from homeassistant.components.subaru.const import DOMAIN
+from homeassistant.components.subaru.const import DOMAIN, SERVICE_UNLOCK_SPECIFIC_DOOR
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
@@ -33,10 +33,10 @@ from .conftest import (
 
 
 async def test_setup_with_no_config(hass: HomeAssistant) -> None:
-    """Test DOMAIN is empty if there is no config."""
+    """Test the action is registered at integration setup, before any entry loads."""
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
-    assert DOMAIN not in hass.config_entries.async_domains()
+    assert hass.services.has_service(DOMAIN, SERVICE_UNLOCK_SPECIFIC_DOOR)
 
 
 async def test_setup_ev(hass: HomeAssistant, ev_entry) -> None:


### PR DESCRIPTION
## Proposed change

Register the `unlock_specific_door` entity action in `async_setup` via `service.async_register_platform_entity_service`, so it exists whether or not a config entry is loaded (quality-scale `action-setup`). Action behavior is unchanged. `test_setup_with_no_config` now asserts the action is registered with no entry loaded.

Prerequisite for #178638. Per-door unlock buttons (which would let the action be retired) will follow as a separate feature PR.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #178638
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
