### PR TITLE
Use async_config_entry_first_refresh in Subaru setup

### DIFF
--- a/homeassistant/components/subaru/__init__.py
+++ b/homeassistant/components/subaru/__init__.py
@@ -75,7 +75,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SubaruConfigEntry) -> bo
         hass, entry, controller=controller, vehicle_info=vehicle_info
     )
 
-    await coordinator.async_refresh()
+    await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = SubaruRuntimeData(
         controller=controller,

--- a/tests/components/subaru/test_button.py
+++ b/tests/components/subaru/test_button.py
@@ -26,6 +26,7 @@ from .conftest import (
     MOCK_API,
     MOCK_API_FETCH,
     MOCK_API_GET_DATA,
+    advance_time_to_next_fetch,
     setup_subaru_config_entry,
 )
 
@@ -302,12 +303,12 @@ async def test_no_buttons_without_remote_start(
 
 
 async def test_button_unavailable_on_fetch_failure(
-    hass: HomeAssistant, subaru_config_entry: MockConfigEntry
+    hass: HomeAssistant, ev_entry: MockConfigEntry
 ) -> None:
-    """Test button goes unavailable when the coordinator fails to fetch data."""
-    await setup_subaru_config_entry(
-        hass, subaru_config_entry, fetch_effect=SubaruException("403 Error")
-    )
+    """Test button goes unavailable when a fetch fails after setup."""
+    with patch(MOCK_API_FETCH, side_effect=SubaruException("403 Error")):
+        advance_time_to_next_fetch(hass)
+        await hass.async_block_till_done()
 
     state = hass.states.get(VEHICLE_BUTTONS[TEST_VIN_2_EV]["remote_start"])
     assert state.state == STATE_UNAVAILABLE

--- a/tests/components/subaru/test_init.py
+++ b/tests/components/subaru/test_init.py
@@ -172,7 +172,7 @@ async def test_update_disabled(hass: HomeAssistant, ev_entry) -> None:
 
 
 async def test_fetch_failed(hass: HomeAssistant, subaru_config_entry) -> None:
-    """Tests when fetch fails."""
+    """Test setup retries when the first fetch fails."""
     await setup_subaru_config_entry(
         hass,
         subaru_config_entry,
@@ -182,8 +182,7 @@ async def test_fetch_failed(hass: HomeAssistant, subaru_config_entry) -> None:
         fetch_effect=SubaruException("403 Error"),
     )
 
-    test_entity = hass.states.get(TEST_ENTITY_ID)
-    assert test_entity.state == "unavailable"
+    assert subaru_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_unload_entry(hass: HomeAssistant, ev_entry) -> None:

--- a/tests/components/subaru/test_lock.py
+++ b/tests/components/subaru/test_lock.py
@@ -23,7 +23,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import MOCK_API, setup_subaru_config_entry
+from .conftest import MOCK_API, MOCK_API_FETCH, advance_time_to_next_fetch
 
 from tests.common import MockConfigEntry
 
@@ -98,12 +98,12 @@ async def test_unlock_specific_door_invalid(hass: HomeAssistant, ev_entry) -> No
 
 
 async def test_lock_unavailable_on_fetch_failure(
-    hass: HomeAssistant, subaru_config_entry: MockConfigEntry
+    hass: HomeAssistant, ev_entry: MockConfigEntry
 ) -> None:
-    """Test lock goes unavailable when the coordinator fails to fetch data."""
-    await setup_subaru_config_entry(
-        hass, subaru_config_entry, fetch_effect=SubaruException("403 Error")
-    )
+    """Test lock goes unavailable when a fetch fails after setup."""
+    with patch(MOCK_API_FETCH, side_effect=SubaruException("403 Error")):
+        advance_time_to_next_fetch(hass)
+        await hass.async_block_till_done()
 
     state = hass.states.get(DEVICE_ID)
     assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change

Use `async_config_entry_first_refresh` for the initial coordinator refresh so a failed first fetch defers setup with `ConfigEntryNotReady` instead of loading the entry with all entities unavailable. Tests adjusted: first-fetch failure now asserts `SETUP_RETRY`; entity-unavailable tests fail a subsequent poll instead.

Answers review feedback on #178638.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #178638
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
