### PR TITLE
Drop the DC claim from the Fronius MPPT energy sensor

### DIFF
--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -269,7 +269,7 @@ class FroniusModbusInverterUpdateCoordinator(FroniusModbusCoordinatorBase):
             values[f"mppt_{number}_current_dc"] = module.current
             values[f"mppt_{number}_voltage_dc"] = module.voltage
             values[f"mppt_{number}_power_dc"] = module.power
-            values[f"mppt_{number}_energy_dc"] = module.energy
+            values[f"mppt_{number}_energy"] = module.energy
         return self._as_device_data(values)
 
 

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -324,12 +324,12 @@ def _modbus_mppt_descriptions(
             translation_placeholders={"mppt_no": str(mppt_no)},
         ),
         FroniusSensorEntityDescription(
-            key=f"mppt_{mppt_no}_energy_dc",
+            key=f"mppt_{mppt_no}_energy",
             native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
             invalid_when_falsy=True,
-            translation_key="modbus_mppt_energy_dc",
+            translation_key="modbus_mppt_energy",
             translation_placeholders={"mppt_no": str(mppt_no)},
         ),
     ]

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -264,8 +264,8 @@
       "modbus_mppt_current_dc": {
         "name": "MPPT {mppt_no} DC current"
       },
-      "modbus_mppt_energy_dc": {
-        "name": "MPPT {mppt_no} DC energy"
+      "modbus_mppt_energy": {
+        "name": "MPPT {mppt_no} energy"
       },
       "modbus_mppt_power_dc": {
         "name": "MPPT {mppt_no} DC power"

--- a/tests/components/fronius/snapshots/test_diagnostics.ambr
+++ b/tests/components/fronius/snapshots/test_diagnostics.ambr
@@ -741,7 +741,7 @@
               'mppt_1_current_dc': dict({
                 'value': 8.2,
               }),
-              'mppt_1_energy_dc': dict({
+              'mppt_1_energy': dict({
                 'value': 1000000,
               }),
               'mppt_1_power_dc': dict({

--- a/tests/components/fronius/test_modbus.py
+++ b/tests/components/fronius/test_modbus.py
@@ -74,7 +74,7 @@ async def test_gen24_storage_mppt(
     assert_state(hass, "sensor.gen24_storage_mppt_1_dc_current", 8.2)
     assert_state(hass, "sensor.gen24_storage_mppt_1_dc_voltage", 402.1)
     assert_state(hass, "sensor.gen24_storage_mppt_1_dc_power", 3300)
-    assert_state(hass, "sensor.gen24_storage_mppt_1_dc_energy", 1000000)
+    assert_state(hass, "sensor.gen24_storage_mppt_1_energy", 1000000)
     assert_state(hass, "sensor.gen24_storage_mppt_2_dc_power", 1650)
     assert_state(hass, "sensor.gen24_storage_mppt_3_dc_power", 0)
     assert_state(hass, "sensor.gen24_storage_mppt_4_dc_power", 480)
@@ -301,7 +301,7 @@ async def test_not_implemented_values(
 
     assert_state(hass, "sensor.inverter_name_mppt_1_dc_power", 3300)
     assert hass.states.get("sensor.inverter_name_mppt_2_dc_power") is None
-    assert hass.states.get("sensor.inverter_name_mppt_2_dc_energy") is None
+    assert hass.states.get("sensor.inverter_name_mppt_2_energy") is None
     # PV total unknown when a PV module doesn't report energy
     assert hass.states.get("sensor.inverter_name_pv_energy_total") is None
 
@@ -312,7 +312,7 @@ async def test_not_implemented_values(
     freezer.tick(FroniusModbusInverterUpdateCoordinator.default_interval)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert_state(hass, "sensor.inverter_name_mppt_1_dc_energy", "unknown")
+    assert_state(hass, "sensor.inverter_name_mppt_1_energy", "unknown")
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Renames `MPPT <n> DC energy` to `MPPT <n> energy`. Only some devices report per-string DC energy there, so the name promised something the value does not always deliver.

Measured on three inverters, comparing the tracker's lifetime energy against `Total energy`, the AC counter:

| device | result |
|---|---|
| Gen24 10.0 Plus | sum is **5.7 % higher** — a real DC counter |
| Symo 5.0-3-M | identical to within 4 Wh, which is the float32 step at 48 MWh |
| Galvo 1.5-1 | **identical** |

So a SnapINverter puts the AC total energy into `DCWH` rather than a per-string DC measurement. The *power* register is unaffected: on the Galvo, `MPPT 1 DC power` reads 211 W against `1.19 A × 178 V = 211.8 V·A` and an AC power of 187 W, so that one is genuinely DC everywhere and keeps its name.

Fronius's own register map draws the same line. In the Multiple MPPT model it names the registers:

| register | Fronius calls it |
|---|---|
| `1_DCA` | DC Current |
| `1_DCV` | DC Voltage |
| `1_DCW` | DC Power |
| `1_DCWH` | **Lifetime Energy** |

Only the energy register is left without a side, and it is additionally flagged as *"Not supported for Fronius Hybrid inverters"* — so a device-dependent value there is expected rather than a fault.

Nothing else changes: `PV energy total` keeps its name, and the derivation is unchanged.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

The `unique_id` changes from `…-modbus-mppt_<n>_energy_dc` to `…-modbus-mppt_<n>_energy`. The Modbus support is merged but **not yet released**, so no entity registry migration is needed — only installations running `dev` are affected.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47793
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
