### PR TITLE
Add multi-probe support to Probe Plus

### DIFF
--- a/homeassistant/components/probe_plus/__init__.py
+++ b/homeassistant/components/probe_plus/__init__.py
@@ -44,7 +44,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ProbePlusConfigEntry) 
     if entry.version > 1:
         return False
 
-    if entry.version == 1 and entry.minor_version == 0:
+    if entry.version == 1 and entry.minor_version == 1:
         mac = entry.unique_id
         if mac is None:
             return True
@@ -68,7 +68,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ProbePlusConfigEntry) 
             return {"new_unique_id": f"{mac}_{key}_0"}
 
         await er.async_migrate_entries(hass, entry.entry_id, migrate_entity)
-        hass.config_entries.async_update_entry(entry, minor_version=1)
+        hass.config_entries.async_update_entry(entry, minor_version=2)
 
     _LOGGER.debug(
         "Migration to version %s.%s successful",

--- a/homeassistant/components/probe_plus/__init__.py
+++ b/homeassistant/components/probe_plus/__init__.py
@@ -44,10 +44,14 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ProbePlusConfigEntry) 
     if entry.version > 1:
         return False
 
-    if entry.version == 1 and entry.minor_version == 1:
+    if entry.version == 1 and entry.minor_version < 2:
         mac = entry.unique_id
         if mac is None:
-            return True
+            _LOGGER.warning(
+                "Cannot migrate config entry %s because unique_id is None",
+                entry.entry_id,
+            )
+            return False
 
         legacy_keys = (
             "probe_temperature",

--- a/homeassistant/components/probe_plus/__init__.py
+++ b/homeassistant/components/probe_plus/__init__.py
@@ -1,10 +1,15 @@
 """The Probe Plus integration."""
 
+import logging
+
 from homeassistant.const import CONF_MODEL, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_registry import RegistryEntry
 
 from .coordinator import ProbePlusConfigEntry, ProbePlusDataUpdateCoordinator
 
+_LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 
@@ -26,3 +31,48 @@ async def async_setup_entry(hass: HomeAssistant, entry: ProbePlusConfigEntry) ->
 async def async_unload_entry(hass: HomeAssistant, entry: ProbePlusConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ProbePlusConfigEntry) -> bool:
+    """Migrate a config entry."""
+    _LOGGER.debug(
+        "Migrating config entry from version %s.%s",
+        entry.version,
+        entry.minor_version,
+    )
+
+    if entry.version > 1:
+        return False
+
+    if entry.version == 1 and entry.minor_version == 0:
+        mac = entry.unique_id
+        if mac is None:
+            return True
+
+        legacy_keys = (
+            "probe_temperature",
+            "probe_battery",
+            "probe_voltage",
+            "probe_rssi",
+        )
+
+        @callback
+        def migrate_entity(entity: RegistryEntry) -> dict[str, str] | None:
+            """Migrate an entity's unique ID to include the slot number."""
+            prefix = f"{mac}_"
+            if not entity.unique_id.startswith(prefix):
+                return None
+            key = entity.unique_id.removeprefix(prefix)
+            if key not in legacy_keys:
+                return None
+            return {"new_unique_id": f"{mac}_{key}_0"}
+
+        await er.async_migrate_entries(hass, entry.entry_id, migrate_entity)
+        hass.config_entries.async_update_entry(entry, minor_version=1)
+
+    _LOGGER.debug(
+        "Migration to version %s.%s successful",
+        entry.version,
+        entry.minor_version,
+    )
+    return True

--- a/homeassistant/components/probe_plus/config_flow.py
+++ b/homeassistant/components/probe_plus/config_flow.py
@@ -40,6 +40,8 @@ def title(discovery_info: BluetoothServiceInfo) -> str:
 class ProbeConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for BT Probe."""
 
+    MINOR_VERSION = 1
+
     def __init__(self) -> None:
         """Initialize the config flow."""
         self._discovered_devices: dict[str, Discovery] = {}

--- a/homeassistant/components/probe_plus/config_flow.py
+++ b/homeassistant/components/probe_plus/config_flow.py
@@ -40,7 +40,7 @@ def title(discovery_info: BluetoothServiceInfo) -> str:
 class ProbeConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for BT Probe."""
 
-    MINOR_VERSION = 1
+    MINOR_VERSION = 2
 
     def __init__(self) -> None:
         """Initialize the config flow."""

--- a/homeassistant/components/probe_plus/coordinator.py
+++ b/homeassistant/components/probe_plus/coordinator.py
@@ -1,5 +1,6 @@
 """Coordinator for the probe_plus integration."""
 
+from collections.abc import Callable, Iterable
 from datetime import timedelta
 import logging
 from typing import override
@@ -10,8 +11,10 @@ from pyprobeplus.exceptions import ProbePlusDeviceNotFound, ProbePlusError
 from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ADDRESS
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN
@@ -79,3 +82,24 @@ class ProbePlusDataUpdateCoordinator(DataUpdateCoordinator[None]):
             )
             self.device.device_disconnected_handler(notify=False)
             return
+
+    @callback
+    def setup_dynamic_discovery(
+        self,
+        entry: ProbePlusConfigEntry,
+        async_add_entities: AddConfigEntryEntitiesCallback,
+        entity_fn: Callable[[int], Iterable[Entity]],
+    ) -> None:
+        """Set up dynamic discovery of entities for the probe device."""
+        known_slots: set[int] = set()
+
+        @callback
+        def _maybe_add_entities() -> None:
+            """Check/add entities when a new probe is detected."""
+            for slot, _ in enumerate(self.device.device_state.probes):
+                if slot not in known_slots:
+                    known_slots.add(slot)
+                    async_add_entities(entity_fn(slot))
+
+        entry.async_on_unload(self.async_add_listener(_maybe_add_entities))
+        _maybe_add_entities()

--- a/homeassistant/components/probe_plus/entity.py
+++ b/homeassistant/components/probe_plus/entity.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from pyprobeplus import ProbePlusDevice
+from pyprobeplus.parsers.base import ProbeReading
 
 from homeassistant.const import CONF_MODEL
 from homeassistant.helpers.device_registry import (
@@ -56,3 +57,35 @@ class ProbePlusEntity(CoordinatorEntity[ProbePlusDataUpdateCoordinator]):
     def device(self) -> ProbePlusDevice:
         """Return the device associated with this entity."""
         return self.coordinator.device
+
+
+class ProbePlusProbeEntity(ProbePlusEntity):
+    """Base class for Probe Plus probe entities."""
+
+    def __init__(
+        self,
+        coordinator: ProbePlusDataUpdateCoordinator,
+        entity_description: EntityDescription,
+        slot: int,
+    ) -> None:
+        """Initialize the probe entity."""
+        super().__init__(coordinator, entity_description)
+        self.slot = slot
+        self._attr_unique_id = f"{self._attr_unique_id}_{slot}"
+        self._attr_translation_placeholders = {
+            **(entity_description.translation_placeholders or {}),
+            "slot": str(slot + 1),
+        }
+
+    @property
+    def probe(self) -> ProbeReading | None:
+        """Return the probe associated with this entity."""
+        if len(self.device.device_state.probes) <= self.slot:
+            return None
+        return self.device.device_state.probes[self.slot]
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return True if the entity is available."""
+        return super().available and self.probe is not None and self.probe.online

--- a/homeassistant/components/probe_plus/sensor.py
+++ b/homeassistant/components/probe_plus/sensor.py
@@ -2,7 +2,10 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import override
+
+from pyprobeplus.parsers.base import ProbeReading
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -21,52 +24,49 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import ProbePlusConfigEntry, ProbePlusDevice
-from .entity import ProbePlusEntity
+from .entity import ProbePlusEntity, ProbePlusProbeEntity
 
 # Coordinator is used to centralize the data updates
 PARALLEL_UPDATES = 0
 
 
+class ProbePlusSensor(StrEnum):
+    """Store keys for Probe Plus sensors."""
+
+    RELAY_BATTERY = "relay_battery"
+    RELAY_VOLTAGE = "relay_voltage"
+    PROBE_TEMPERATURE = "probe_temperature"
+    PROBE_BATTERY = "probe_battery"
+    PROBE_RSSI = "probe_rssi"
+    PROBE_VOLTAGE = "probe_voltage"
+
+
 @dataclass(kw_only=True, frozen=True)
-class ProbePlusSensorEntityDescription(SensorEntityDescription):
-    """Description for Probe Plus sensor entities."""
+class ProbePlusRelaySensorEntityDescription(SensorEntityDescription):
+    """Description for Probe Plus relay sensor entities."""
 
     value_fn: Callable[[ProbePlusDevice], int | float | None]
 
 
-SENSOR_DESCRIPTIONS: tuple[ProbePlusSensorEntityDescription, ...] = (
-    ProbePlusSensorEntityDescription(
-        key="probe_temperature",
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        value_fn=lambda device: device.device_state.probe.temperature,
-        device_class=SensorDeviceClass.TEMPERATURE,
-    ),
-    ProbePlusSensorEntityDescription(
-        key="probe_battery",
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=PERCENTAGE,
-        value_fn=lambda device: device.device_state.probe.battery,
-        device_class=SensorDeviceClass.BATTERY,
-    ),
-    ProbePlusSensorEntityDescription(
-        key="relay_battery",
+@dataclass(kw_only=True, frozen=True)
+class ProbePlusProbeSensorEntityDescription(SensorEntityDescription):
+    """Description for Probe Plus probe sensor entities."""
+
+    value_fn: Callable[[ProbeReading], int | float | None]
+
+
+RELAY_SENSOR_DESCRIPTIONS: tuple[ProbePlusRelaySensorEntityDescription, ...] = (
+    ProbePlusRelaySensorEntityDescription(
+        key=ProbePlusSensor.RELAY_BATTERY,
+        translation_key=ProbePlusSensor.RELAY_BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
         value_fn=lambda device: device.device_state.relay_battery,
         device_class=SensorDeviceClass.BATTERY,
     ),
-    ProbePlusSensorEntityDescription(
-        key="probe_rssi",
-        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda device: device.device_state.probe.rssi,
-        entity_registry_enabled_default=False,
-    ),
-    ProbePlusSensorEntityDescription(
-        key="relay_voltage",
+    ProbePlusRelaySensorEntityDescription(
+        key=ProbePlusSensor.RELAY_VOLTAGE,
+        translation_key=ProbePlusSensor.RELAY_VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -74,13 +74,42 @@ SENSOR_DESCRIPTIONS: tuple[ProbePlusSensorEntityDescription, ...] = (
         value_fn=lambda device: device.device_state.relay_voltage,
         entity_registry_enabled_default=False,
     ),
-    ProbePlusSensorEntityDescription(
-        key="probe_voltage",
+)
+PROBE_SENSOR_DESCRIPTIONS: tuple[ProbePlusProbeSensorEntityDescription, ...] = (
+    ProbePlusProbeSensorEntityDescription(
+        key=ProbePlusSensor.PROBE_TEMPERATURE,
+        translation_key=ProbePlusSensor.PROBE_TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        value_fn=lambda probe: probe.temperature,
+        device_class=SensorDeviceClass.TEMPERATURE,
+    ),
+    ProbePlusProbeSensorEntityDescription(
+        key=ProbePlusSensor.PROBE_BATTERY,
+        translation_key=ProbePlusSensor.PROBE_BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        value_fn=lambda probe: probe.battery,
+        device_class=SensorDeviceClass.BATTERY,
+    ),
+    ProbePlusProbeSensorEntityDescription(
+        key=ProbePlusSensor.PROBE_RSSI,
+        translation_key=ProbePlusSensor.PROBE_RSSI,
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda probe: probe.rssi,
+        entity_registry_enabled_default=False,
+    ),
+    ProbePlusProbeSensorEntityDescription(
+        key=ProbePlusSensor.PROBE_VOLTAGE,
+        translation_key=ProbePlusSensor.PROBE_VOLTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.VOLTAGE,
-        value_fn=lambda device: device.device_state.probe.voltage,
+        value_fn=lambda probe: probe.voltage,
         entity_registry_enabled_default=False,
     ),
 )
@@ -93,16 +122,40 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Probe Plus sensors."""
     coordinator = entry.runtime_data
-    async_add_entities(ProbeSensor(coordinator, desc) for desc in SENSOR_DESCRIPTIONS)
+    async_add_entities(
+        RelaySensor(coordinator, desc) for desc in RELAY_SENSOR_DESCRIPTIONS
+    )
+
+    coordinator.setup_dynamic_discovery(
+        entry,
+        async_add_entities,
+        lambda slot: [
+            ProbeSensor(coordinator, desc, slot) for desc in PROBE_SENSOR_DESCRIPTIONS
+        ],
+    )
 
 
-class ProbeSensor(ProbePlusEntity, RestoreSensor):
+class RelaySensor(ProbePlusEntity, RestoreSensor):
     """Representation of a Probe Plus sensor."""
 
-    entity_description: ProbePlusSensorEntityDescription
+    entity_description: ProbePlusRelaySensorEntityDescription
 
     @property
     @override
     def native_value(self) -> int | float | None:
         """Return the state of the sensor."""
         return self.entity_description.value_fn(self.device)
+
+
+class ProbeSensor(ProbePlusProbeEntity, RestoreSensor):
+    """Representation of a Probe Plus probe sensor."""
+
+    entity_description: ProbePlusProbeSensorEntityDescription
+
+    @property
+    @override
+    def native_value(self) -> int | float | None:
+        """Return the state of the sensor."""
+        if not self.probe:
+            return None
+        return self.entity_description.value_fn(self.probe)

--- a/homeassistant/components/probe_plus/sensor.py
+++ b/homeassistant/components/probe_plus/sensor.py
@@ -8,8 +8,8 @@ from typing import override
 from pyprobeplus.parsers.base import ProbeReading
 
 from homeassistant.components.sensor import (
-    RestoreSensor,
     SensorDeviceClass,
+    SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
 )
@@ -135,7 +135,7 @@ async def async_setup_entry(
     )
 
 
-class RelaySensor(ProbePlusEntity, RestoreSensor):
+class RelaySensor(ProbePlusEntity, SensorEntity):
     """Representation of a Probe Plus sensor."""
 
     entity_description: ProbePlusRelaySensorEntityDescription
@@ -147,7 +147,7 @@ class RelaySensor(ProbePlusEntity, RestoreSensor):
         return self.entity_description.value_fn(self.device)
 
 
-class ProbeSensor(ProbePlusProbeEntity, RestoreSensor):
+class ProbeSensor(ProbePlusProbeEntity, SensorEntity):
     """Representation of a Probe Plus probe sensor."""
 
     entity_description: ProbePlusProbeSensorEntityDescription

--- a/homeassistant/components/probe_plus/strings.json
+++ b/homeassistant/components/probe_plus/strings.json
@@ -27,16 +27,16 @@
   "entity": {
     "sensor": {
       "probe_battery": {
-        "name": "Probe battery"
+        "name": "Probe {slot} battery"
       },
       "probe_rssi": {
-        "name": "Probe RSSI"
+        "name": "Probe {slot} RSSI"
       },
       "probe_temperature": {
-        "name": "Probe temperature"
+        "name": "Probe {slot} temperature"
       },
       "probe_voltage": {
-        "name": "Probe voltage"
+        "name": "Probe {slot} voltage"
       },
       "relay_battery": {
         "name": "Relay battery"

--- a/tests/components/probe_plus/conftest.py
+++ b/tests/components/probe_plus/conftest.py
@@ -1,13 +1,13 @@
 """Common fixtures for the Probe Plus tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
-from pyprobeplus.parser import ParserBase, ProbePlusData
+from pyprobeplus.parsers.base import ProbePlusData, ProbeReading
 import pytest
 
 from homeassistant.components.probe_plus.const import DOMAIN
-from homeassistant.const import CONF_ADDRESS
+from homeassistant.const import CONF_ADDRESS, CONF_MODEL
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -31,30 +31,58 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
         version=1,
         data={
             CONF_ADDRESS: "aa:bb:cc:dd:ee:ff",
+            CONF_MODEL: "FM210",
         },
         unique_id="aa:bb:cc:dd:ee:ff",
     )
 
 
 @pytest.fixture
-def mock_probe_plus() -> MagicMock:
-    """Mock the Probe Plus device."""
+def mock_probe_reading() -> MagicMock:
+    """Return a mock probe reading."""
+    probe = create_autospec(ProbeReading, instance=True)
+    probe.temperature = 25.0
+    probe.rssi = -60
+    probe.voltage = 3.7
+    probe.online = True
+    return probe
+
+
+@pytest.fixture
+def mock_probe_plus() -> Generator[MagicMock]:
+    """Mock the Probe Plus device with multiple probes."""
     with patch(
         "homeassistant.components.probe_plus.coordinator.ProbePlusDevice",
         autospec=True,
     ) as mock_device:
         device = mock_device.return_value
         device.connected = True
-        device.name = "FM210 aa:bb:cc:dd:ee:ff"
-        mock_state = ParserBase()
-        mock_state.state = ProbePlusData(
-            relay_battery=50,
-            probe_battery=50,
-            probe_temperature=25.0,
-            probe_rssi=200,
-            probe_voltage=3.7,
-            relay_status=1,
-            relay_voltage=9.0,
-        )
-        device._device_state = mock_state
+        device.mac = "aa:bb:cc:dd:ee:ff"
+        device.name = "FM210"
+        device.connect = AsyncMock()
+        device.device_disconnected_handler = MagicMock()
+
+        probe_1 = create_autospec(ProbeReading, instance=True)
+        probe_1.temperature = 25.0
+        probe_1.rssi = -60
+        probe_1.voltage = 3.7
+        probe_1.online = True
+        probe_1.battery = 75
+
+        probe_2 = create_autospec(ProbeReading, instance=True)
+        probe_2.temperature = 22.0
+        probe_2.rssi = -70
+        probe_2.voltage = 3.8
+        probe_2.online = True
+        probe_2.battery = 80
+
+        device_state = create_autospec(ProbePlusData, instance=True)
+        device_state.relay_voltage = 10.5
+        device_state.relay_status = 1
+        device_state.relay_battery = 100
+        device_state.alarm_temperatures = None
+        device_state.cook_targets = [None, None]
+        device_state.probes = [probe_1, probe_2]
+
+        device.device_state = device_state
         yield device

--- a/tests/components/probe_plus/conftest.py
+++ b/tests/components/probe_plus/conftest.py
@@ -38,17 +38,6 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
 
 
 @pytest.fixture
-def mock_probe_reading() -> MagicMock:
-    """Return a mock probe reading."""
-    probe = create_autospec(ProbeReading, instance=True)
-    probe.temperature = 25.0
-    probe.rssi = -60
-    probe.voltage = 3.7
-    probe.online = True
-    return probe
-
-
-@pytest.fixture
 def mock_probe_plus() -> Generator[MagicMock]:
     """Mock the Probe Plus device with multiple probes."""
     with patch(

--- a/tests/components/probe_plus/snapshots/test_sensor.ambr
+++ b/tests/components/probe_plus/snapshots/test_sensor.ambr
@@ -1,0 +1,566 @@
+# serializer version: 1
+# name: test_sensor[sensor.kitchen_fm210_probe_1_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kitchen_fm210_probe_1_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Probe 1 battery',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Probe 1 battery',
+    'platform': 'probe_plus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <ProbePlusSensor.PROBE_BATTERY: 'probe_battery'>,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_probe_battery_0',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_1_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'FM210 Probe 1 battery',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_fm210_probe_1_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '75',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_1_rssi-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_fm210_probe_1_rssi',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Probe 1 RSSI',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_icon': None,
+    'original_name': 'Probe 1 RSSI',
+    'platform': 'probe_plus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <ProbePlusSensor.PROBE_RSSI: 'probe_rssi'>,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_probe_rssi_0',
+    'unit_of_measurement': 'dBm',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_1_rssi-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'signal_strength',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'FM210 Probe 1 RSSI',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'dBm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_fm210_probe_1_rssi',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-60',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_1_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kitchen_fm210_probe_1_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Probe 1 temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Probe 1 temperature',
+    'platform': 'probe_plus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <ProbePlusSensor.PROBE_TEMPERATURE: 'probe_temperature'>,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_probe_temperature_0',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_1_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'FM210 Probe 1 temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_fm210_probe_1_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.0',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_1_voltage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_fm210_probe_1_voltage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Probe 1 voltage',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Probe 1 voltage',
+    'platform': 'probe_plus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <ProbePlusSensor.PROBE_VOLTAGE: 'probe_voltage'>,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_probe_voltage_0',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_1_voltage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'FM210 Probe 1 voltage',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_fm210_probe_1_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.7',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_2_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kitchen_fm210_probe_2_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Probe 2 battery',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Probe 2 battery',
+    'platform': 'probe_plus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <ProbePlusSensor.PROBE_BATTERY: 'probe_battery'>,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_probe_battery_1',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_2_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'FM210 Probe 2 battery',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_fm210_probe_2_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_2_rssi-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_fm210_probe_2_rssi',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Probe 2 RSSI',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_icon': None,
+    'original_name': 'Probe 2 RSSI',
+    'platform': 'probe_plus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <ProbePlusSensor.PROBE_RSSI: 'probe_rssi'>,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_probe_rssi_1',
+    'unit_of_measurement': 'dBm',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_2_rssi-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'signal_strength',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'FM210 Probe 2 RSSI',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'dBm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_fm210_probe_2_rssi',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-70',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_2_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kitchen_fm210_probe_2_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Probe 2 temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Probe 2 temperature',
+    'platform': 'probe_plus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <ProbePlusSensor.PROBE_TEMPERATURE: 'probe_temperature'>,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_probe_temperature_1',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_2_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'FM210 Probe 2 temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_fm210_probe_2_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '22.0',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_2_voltage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_fm210_probe_2_voltage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Probe 2 voltage',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Probe 2 voltage',
+    'platform': 'probe_plus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <ProbePlusSensor.PROBE_VOLTAGE: 'probe_voltage'>,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_probe_voltage_1',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_probe_2_voltage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'FM210 Probe 2 voltage',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_fm210_probe_2_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3.8',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_relay_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.kitchen_fm210_relay_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Relay battery',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Relay battery',
+    'platform': 'probe_plus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <ProbePlusSensor.RELAY_BATTERY: 'relay_battery'>,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_relay_battery',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_relay_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'FM210 Relay battery',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_fm210_relay_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_relay_voltage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.kitchen_fm210_relay_voltage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Relay voltage',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Relay voltage',
+    'platform': 'probe_plus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': <ProbePlusSensor.RELAY_VOLTAGE: 'relay_voltage'>,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_relay_voltage',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensor[sensor.kitchen_fm210_relay_voltage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'FM210 Relay voltage',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.kitchen_fm210_relay_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10.5',
+  })
+# ---

--- a/tests/components/probe_plus/test_init.py
+++ b/tests/components/probe_plus/test_init.py
@@ -1,0 +1,145 @@
+"""Tests for the Probe Plus init."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.probe_plus.const import DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_probe_plus")
+async def test_load_unload_config_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test loading and unloading the config entry."""
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.bluetooth.async_scanner_count",
+            return_value=1,
+        ),
+        patch("homeassistant.components.bluetooth.async_get_scanner"),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.parametrize(
+    ("legacy_unique_id", "expected_unique_id"),
+    [
+        pytest.param(
+            "aa:bb:cc:dd:ee:ff_probe_temperature",
+            "aa:bb:cc:dd:ee:ff_probe_temperature_0",
+            id="probe_temperature",
+        ),
+        pytest.param(
+            "aa:bb:cc:dd:ee:ff_probe_battery",
+            "aa:bb:cc:dd:ee:ff_probe_battery_0",
+            id="probe_battery",
+        ),
+        pytest.param(
+            "aa:bb:cc:dd:ee:ff_probe_voltage",
+            "aa:bb:cc:dd:ee:ff_probe_voltage_0",
+            id="probe_voltage",
+        ),
+        pytest.param(
+            "aa:bb:cc:dd:ee:ff_probe_rssi",
+            "aa:bb:cc:dd:ee:ff_probe_rssi_0",
+            id="probe_rssi",
+        ),
+        pytest.param(
+            "aa:bb:cc:dd:ee:ff_relay_battery",
+            "aa:bb:cc:dd:ee:ff_relay_battery",
+            id="relay_battery_unchanged",
+        ),
+        pytest.param(
+            "unrelated_unique_id",
+            "unrelated_unique_id",
+            id="unrelated_unchanged",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_migrate_entity_unique_id(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    legacy_unique_id: str,
+    expected_unique_id: str,
+) -> None:
+    """Test migrating entity unique IDs."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        minor_version=0,
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    entry.add_to_hass(hass)
+
+    entity = entity_registry.async_get_or_create(
+        domain=SENSOR_DOMAIN,
+        platform=DOMAIN,
+        unique_id=legacy_unique_id,
+        config_entry=entry,
+    )
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.version == 1
+    assert entry.minor_version == 1
+
+    migrated_entity = entity_registry.async_get(entity.entity_id)
+    assert migrated_entity is not None
+    assert migrated_entity.unique_id == expected_unique_id
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_migrate_entry_no_unique_id(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration when unique_id is None."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        minor_version=0,
+        unique_id=None,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.version == 1
+    assert entry.minor_version == 0
+
+
+async def test_migrate_entry_future_version(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration fails for future major version."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        minor_version=0,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR

--- a/tests/components/probe_plus/test_init.py
+++ b/tests/components/probe_plus/test_init.py
@@ -125,7 +125,7 @@ async def test_migrate_entry_no_unique_id(
     await hass.async_block_till_done()
 
     assert entry.version == 1
-    assert entry.minor_version == 1
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR
 
 
 async def test_migrate_entry_future_version(

--- a/tests/components/probe_plus/test_init.py
+++ b/tests/components/probe_plus/test_init.py
@@ -85,7 +85,7 @@ async def test_migrate_entity_unique_id(
     entry = MockConfigEntry(
         domain=DOMAIN,
         version=1,
-        minor_version=0,
+        minor_version=1,
         unique_id="aa:bb:cc:dd:ee:ff",
     )
     entry.add_to_hass(hass)
@@ -101,7 +101,7 @@ async def test_migrate_entity_unique_id(
     await hass.async_block_till_done()
 
     assert entry.version == 1
-    assert entry.minor_version == 1
+    assert entry.minor_version == 2
 
     migrated_entity = entity_registry.async_get(entity.entity_id)
     assert migrated_entity is not None
@@ -116,7 +116,7 @@ async def test_migrate_entry_no_unique_id(
     entry = MockConfigEntry(
         domain=DOMAIN,
         version=1,
-        minor_version=0,
+        minor_version=1,
         unique_id=None,
     )
     entry.add_to_hass(hass)
@@ -125,7 +125,7 @@ async def test_migrate_entry_no_unique_id(
     await hass.async_block_till_done()
 
     assert entry.version == 1
-    assert entry.minor_version == 0
+    assert entry.minor_version == 1
 
 
 async def test_migrate_entry_future_version(
@@ -135,7 +135,7 @@ async def test_migrate_entry_future_version(
     entry = MockConfigEntry(
         domain=DOMAIN,
         version=2,
-        minor_version=0,
+        minor_version=1,
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/probe_plus/test_sensor.py
+++ b/tests/components/probe_plus/test_sensor.py
@@ -1,0 +1,76 @@
+"""Tests for the Probe Plus sensor platform."""
+
+from unittest.mock import MagicMock, create_autospec, patch
+
+from pyprobeplus.parsers.base import ProbeReading
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_probe_plus")
+async def test_sensor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test sensor platform."""
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.bluetooth.async_scanner_count",
+            return_value=1,
+        ),
+        patch("homeassistant.components.bluetooth.async_get_scanner"),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_dynamic_probe_discovery(
+    hass: HomeAssistant,
+    mock_probe_plus: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test dynamic discovery of probe entities."""
+    mock_probe_plus.device_state.probes = [mock_probe_plus.device_state.probes[0]]
+    mock_config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.bluetooth.async_scanner_count",
+            return_value=1,
+        ),
+        patch("homeassistant.components.bluetooth.async_get_scanner"),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.kitchen_fm210_probe_1_temperature") is not None
+    assert hass.states.get("sensor.kitchen_fm210_probe_2_temperature") is None
+    assert hass.states.get("sensor.kitchen_fm210_probe_2_battery") is None
+
+    probe_2 = create_autospec(ProbeReading, instance=True)
+    probe_2.temperature = 22.0
+    probe_2.battery = 80
+    probe_2.online = True
+    mock_probe_plus.device_state.probes.append(probe_2)
+    mock_config_entry.runtime_data.async_update_listeners()
+    await hass.async_block_till_done()
+
+    assert (
+        state := hass.states.get("sensor.kitchen_fm210_probe_2_temperature")
+    ) is not None
+    assert state.state == "22.0"
+    assert (
+        state := hass.states.get("sensor.kitchen_fm210_probe_2_battery")
+    ) is not None
+    assert state.state == "80"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This finalises the previous bump to 2.x.x of pyprobeplus and introduces support for multiple probes.

A standardised function within the coordinator is used to centralise the creation of probe entities as they are discovered (a further PR will add the number platform to support setting target temperatures). As the unique ID of probe related sensors has changed to included the "slot", a migration has been added to ensure that all existing customisations to entities are carried over.

The migration fails if the user attempts to either downgrade or the unique ID of the config entry is None. This is defensive behaviour more than anything as the config flow itself always sets the unique ID to the mac address.

A test suite is added to cover the changes made (as a bonus it also includes snapshot tests for the sensors themselves which were not present previously). The only "issue" is that I do not have a physical device with multiple probes to fully test this with, therefore I have only tested with a single probe variant. The library is tested for devices with multiple probes with sample packet data provided in a PR / issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
