### PR TITLE
Fix backup upload of files larger than 16 MiB

### DIFF
--- a/homeassistant/components/backup/const.py
+++ b/homeassistant/components/backup/const.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from .manager import BackupManager
 
 BUF_SIZE = 2**20 * 4  # 4MB
+MAX_UPLOAD_SIZE = 2**30 * 4  # 4GB
 DOMAIN = "backup"
 DATA_MANAGER: HassKey[BackupManager] = HassKey(DOMAIN)
 LOGGER = getLogger(__package__)

--- a/homeassistant/components/backup/http.py
+++ b/homeassistant/components/backup/http.py
@@ -19,11 +19,9 @@ from homeassistant.util.async_iterator import AsyncIteratorReader, AsyncIterator
 
 from . import util
 from .agent import BackupAgent
-from .const import DATA_MANAGER
+from .const import DATA_MANAGER, MAX_UPLOAD_SIZE
 from .manager import BackupManager
 from .models import AgentBackup, BackupNotFound, InvalidBackupFilename
-
-MAX_UPLOAD_SIZE = 1024**3 * 4  # 4 GiB
 
 
 @callback

--- a/homeassistant/components/backup/http.py
+++ b/homeassistant/components/backup/http.py
@@ -23,6 +23,8 @@ from .const import DATA_MANAGER
 from .manager import BackupManager
 from .models import AgentBackup, BackupNotFound, InvalidBackupFilename
 
+MAX_UPLOAD_SIZE = 1024**3 * 4  # 4 GiB
+
 
 @callback
 def async_register_http_views(hass: HomeAssistant) -> None:
@@ -186,6 +188,8 @@ class UploadBackupView(HomeAssistantView):
         except KeyError:
             return Response(status=HTTPStatus.BAD_REQUEST)
         manager = request.app[KEY_HASS].data[DATA_MANAGER]
+        # Increase max payload; backups can be large
+        request._client_max_size = MAX_UPLOAD_SIZE  # noqa: SLF001
         reader = await request.multipart()
         contents = cast(BodyPartReader, await reader.next())
 

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -353,6 +353,14 @@ class BackupManagerExceptionGroup(BackupManagerError, ExceptionGroup):
     error_code = "multiple_errors"
 
 
+async def _iter_body_part_chunks(
+    contents: aiohttp.BodyPartReader,
+) -> AsyncIterator[bytes]:
+    """Read a body part in chunks to avoid buffering it in memory."""
+    while chunk := await contents.read_chunk(BUF_SIZE):
+        yield chunk
+
+
 class BackupManager:
     """Define the format that backup managers can have."""
 
@@ -1004,7 +1012,6 @@ class BackupManager:
         contents: aiohttp.BodyPartReader,
     ) -> str:
         """Receive and store a backup file from upload."""
-        contents.chunk_size = BUF_SIZE
         suggested_filename = contents.filename or "backup.tar"
         safe_filename = PureWindowsPath(suggested_filename).name
         if (
@@ -1022,7 +1029,7 @@ class BackupManager:
         )
         written_backup = await self._reader_writer.async_receive_backup(
             agent_ids=agent_ids,
-            stream=contents,
+            stream=_iter_body_part_chunks(contents),
             suggested_filename=suggested_filename,
         )
         self.async_on_backup_event(

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -18,6 +18,7 @@ import time
 from typing import IO, TYPE_CHECKING, Any, Protocol, TypedDict, cast, override
 
 import aiohttp
+from aiohttp.web import HTTPRequestEntityTooLarge
 from securetar import SecureTarArchive, atomic_contents_add
 
 from homeassistant.backup_restore import RESTORE_BACKUP_FILE, RESTORE_BACKUP_RESULT_FILE
@@ -55,6 +56,7 @@ from .const import (
     EXCLUDE_DATABASE_FROM_BACKUP,
     EXCLUDE_FROM_BACKUP,
     LOGGER,
+    MAX_UPLOAD_SIZE,
     SECURETAR_CREATE_VERSION,
 )
 from .models import (
@@ -357,7 +359,14 @@ async def _iter_body_part_chunks(
     contents: aiohttp.BodyPartReader,
 ) -> AsyncIterator[bytes]:
     """Read a body part in chunks to avoid buffering it in memory."""
+    # BodyPartReader.read_chunk does not check client_max_size, enforce it here
+    bytes_read = 0
     while chunk := await contents.read_chunk(BUF_SIZE):
+        bytes_read += len(chunk)
+        if bytes_read > MAX_UPLOAD_SIZE:
+            raise HTTPRequestEntityTooLarge(
+                max_size=MAX_UPLOAD_SIZE, actual_size=bytes_read
+            )
         yield chunk
 
 
@@ -1978,12 +1987,17 @@ class CoreBackupReaderWriter(BackupReaderWriter):
 
         async_add_executor_job = self._hass.async_add_executor_job
         await async_add_executor_job(make_backup_dir, self.temp_backup_dir)
-        f = await async_add_executor_job(temp_file.open, "wb")
         try:
-            async for chunk in stream:
-                await async_add_executor_job(f.write, chunk)
-        finally:
-            await async_add_executor_job(f.close)
+            f = await async_add_executor_job(temp_file.open, "wb")
+            try:
+                async for chunk in stream:
+                    await async_add_executor_job(f.write, chunk)
+            finally:
+                await async_add_executor_job(f.close)
+        except Exception, asyncio.CancelledError:
+            # Don't leave a partially written file behind
+            await async_add_executor_job(temp_file.unlink, True)
+            raise
 
         try:
             backup = await async_add_executor_job(read_backup, temp_file)

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -1994,31 +1994,31 @@ class CoreBackupReaderWriter(BackupReaderWriter):
                     await async_add_executor_job(f.write, chunk)
             finally:
                 await async_add_executor_job(f.close)
+
+            try:
+                backup = await async_add_executor_job(read_backup, temp_file)
+            except (
+                OSError,
+                tarfile.TarError,
+                json.JSONDecodeError,
+                KeyError,
+                InvalidBackupFilename,
+            ) as err:
+                LOGGER.warning("Unable to parse backup %s: %s", temp_file, err)
+                raise
+
+            manager = self._hass.data[DATA_MANAGER]
+            if self._local_agent_id in agent_ids:
+                local_agent = manager.local_backup_agents[self._local_agent_id]
+                tar_file_path = local_agent.get_new_backup_path(backup)
+                await async_add_executor_job(make_backup_dir, tar_file_path.parent)
+                await async_add_executor_job(shutil.move, temp_file, tar_file_path)
+            else:
+                tar_file_path = temp_file
         except Exception, asyncio.CancelledError:
-            # Don't leave a partially written file behind
+            # Don't leave a partially written or unusable file behind
             await async_add_executor_job(temp_file.unlink, True)
             raise
-
-        try:
-            backup = await async_add_executor_job(read_backup, temp_file)
-        except (
-            OSError,
-            tarfile.TarError,
-            json.JSONDecodeError,
-            KeyError,
-            InvalidBackupFilename,
-        ) as err:
-            LOGGER.warning("Unable to parse backup %s: %s", temp_file, err)
-            raise
-
-        manager = self._hass.data[DATA_MANAGER]
-        if self._local_agent_id in agent_ids:
-            local_agent = manager.local_backup_agents[self._local_agent_id]
-            tar_file_path = local_agent.get_new_backup_path(backup)
-            await async_add_executor_job(make_backup_dir, tar_file_path.parent)
-            await async_add_executor_job(shutil.move, temp_file, tar_file_path)
-        else:
-            tar_file_path = temp_file
 
         async def send_backup() -> AsyncIterator[bytes]:
             f = await async_add_executor_job(tar_file_path.open, "rb")

--- a/tests/components/backup/test_http.py
+++ b/tests/components/backup/test_http.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import re
 import tarfile
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import mock_open, patch
 
 from aiohttp import BodyPartReader, web
 from aiohttp.hdrs import CONTENT_DISPOSITION, CONTENT_TYPE
@@ -316,6 +316,31 @@ async def test_uploading_a_large_backup_file(
         assert resp.status == 201
         assert await resp.json() == {"backup_id": TEST_BACKUP_ABC123.backup_id}
         assert async_receive_backup_mock.called
+
+
+async def test_uploading_a_backup_file_exceeding_max_size(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test uploading a backup file larger than the maximum upload size."""
+    await setup_backup_integration(hass)
+
+    client = await hass_client()
+
+    with (
+        patch("pathlib.Path.open", mock_open()),
+        patch("pathlib.Path.unlink") as unlink_mock,
+        patch("homeassistant.components.backup.manager.make_backup_dir"),
+        patch("homeassistant.components.backup.manager.MAX_UPLOAD_SIZE", 1024),
+    ):
+        resp = await client.post(
+            "/api/backup/upload?agent_id=backup.local",
+            data={"file": BytesIO(b"0" * 2048)},
+        )
+        await hass.async_block_till_done()
+
+    assert resp.status == 413
+    unlink_mock.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/components/backup/test_http.py
+++ b/tests/components/backup/test_http.py
@@ -10,7 +10,7 @@ import tarfile
 from typing import Any
 from unittest.mock import patch
 
-from aiohttp import web
+from aiohttp import BodyPartReader, web
 from aiohttp.hdrs import CONTENT_DISPOSITION, CONTENT_TYPE
 import pytest
 
@@ -283,6 +283,35 @@ async def test_uploading_a_backup_file(
         resp = await client.post(
             "/api/backup/upload?agent_id=backup.local",
             data={"file": StringIO("test")},
+        )
+        assert resp.status == 201
+        assert await resp.json() == {"backup_id": TEST_BACKUP_ABC123.backup_id}
+        assert async_receive_backup_mock.called
+
+
+async def test_uploading_a_large_backup_file(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test uploading a backup file larger than the default request size limit."""
+    await setup_backup_integration(hass)
+
+    client = await hass_client()
+
+    async def mock_receive_backup(
+        *, agent_ids: list[str], contents: BodyPartReader
+    ) -> str:
+        async for _chunk in contents:
+            pass
+        return TEST_BACKUP_ABC123.backup_id
+
+    with patch(
+        "homeassistant.components.backup.manager.BackupManager.async_receive_backup",
+        side_effect=mock_receive_backup,
+    ) as async_receive_backup_mock:
+        resp = await client.post(
+            "/api/backup/upload?agent_id=backup.local",
+            data={"file": BytesIO(b"0" * (17 * 1024 * 1024))},
         )
         assert resp.status == 201
         assert await resp.json() == {"backup_id": TEST_BACKUP_ABC123.backup_id}

--- a/tests/components/backup/test_http.py
+++ b/tests/components/backup/test_http.py
@@ -328,9 +328,10 @@ async def test_uploading_a_backup_file_exceeding_max_size(
     client = await hass_client()
 
     with (
-        patch("pathlib.Path.open", mock_open()),
+        patch("pathlib.Path.open", mock_open()) as open_mock,
         patch("pathlib.Path.unlink") as unlink_mock,
         patch("homeassistant.components.backup.manager.make_backup_dir"),
+        patch("homeassistant.components.backup.manager.BUF_SIZE", 1024),
         patch("homeassistant.components.backup.manager.MAX_UPLOAD_SIZE", 1024),
     ):
         resp = await client.post(
@@ -340,6 +341,8 @@ async def test_uploading_a_backup_file_exceeding_max_size(
         await hass.async_block_till_done()
 
     assert resp.status == 413
+    # At least one chunk was written before the limit was exceeded
+    assert open_mock.return_value.write.called
     unlink_mock.assert_called_once()
 
 

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -2017,6 +2017,33 @@ async def test_receive_backup(
     assert unlink_mock.call_count == temp_file_unlink_call_count
 
 
+async def test_receive_backup_unparsable_file_removed(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test the temp file is removed when the uploaded backup can't be parsed."""
+    await setup_backup_integration(hass)
+    client = await hass_client()
+
+    with (
+        patch("pathlib.Path.open", mock_open()),
+        patch("pathlib.Path.unlink") as unlink_mock,
+        patch("homeassistant.components.backup.manager.make_backup_dir"),
+        patch(
+            "homeassistant.components.backup.manager.read_backup",
+            side_effect=OSError("Boom!"),
+        ),
+    ):
+        resp = await client.post(
+            "/api/backup/upload?agent_id=backup.local",
+            data={"file": StringIO("test")},
+        )
+        await hass.async_block_till_done()
+
+    assert resp.status == 500
+    unlink_mock.assert_called_once()
+
+
 async def test_receive_backup_valid_filename(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Uploading or restoring a backup larger than 16 MiB via `/api/backup/upload` (or the onboarding equivalent) fails with HTTP 413 `Maximum request body size 16777216 exceeded`, because the request is subject to aiohttp's default `client_max_size`. Real-world backups that include the recorder database are regularly far larger than 16 MiB, which breaks the documented migrate-via-backup-restore workflow on a fresh install.

Two changes:

- `UploadBackupView._post` now raises the per-request size limit before reading the multipart body, following the exact pattern already used by the `file_upload`, `image_upload` and `media_source` upload views. The onboarding upload view inherits `_post`, so both endpoints are covered.
- The backup manager now consumes the uploaded body part with `BodyPartReader.read_chunk()` instead of `async for`. In current aiohttp, iterating a `BodyPartReader` reads the *entire* part into memory in one call (which is also where the 16 MiB limit was being enforced). The existing `contents.chunk_size = BUF_SIZE` assignment had no effect on that path, so large uploads were buffered fully in RAM instead of being streamed to disk as intended. With this change the upload is written to disk in 4 MiB chunks again, which matters on low-memory hosts like a Raspberry Pi.

Added a regression test that uploads a 17 MiB file (just over the old limit) and consumes the stream the same way production code does; it fails with 413 before this change and passes after.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178574
- This PR is related to issue: #180502
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backup uploads can now support files up to 4 GB.
  * Uploads exceeding the maximum size are rejected with an appropriate error.

* **Bug Fixes**
  * Failed or unparseable backup uploads now clean up temporary files automatically.
  * Improved handling of large upload streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->