### PR TITLE
Allow users to reconfigure weatherkit config entries

### DIFF
--- a/homeassistant/components/weatherkit/__init__.py
+++ b/homeassistant/components/weatherkit/__init__.py
@@ -6,12 +6,20 @@ from apple_weatherkit.client import (
     WeatherKitApiClientError,
 )
 
-from homeassistant.const import Platform
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_KEY_ID, CONF_KEY_PEM, CONF_SERVICE_ID, CONF_TEAM_ID, LOGGER
+from .const import (
+    CONF_KEY_ID,
+    CONF_KEY_PEM,
+    CONF_SERVICE_ID,
+    CONF_TEAM_ID,
+    DOMAIN,
+    LOGGER,
+)
 from .coordinator import WeatherKitConfigEntry, WeatherKitDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.WEATHER]
@@ -49,3 +57,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: WeatherKitConfigEntry) -
 async def async_unload_entry(hass: HomeAssistant, entry: WeatherKitConfigEntry) -> bool:
     """Handle removal of an entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant, entry: WeatherKitConfigEntry
+) -> bool:
+    """Migrate old entry."""
+    if entry.version == 1:
+        # Move entity/device identity off the (mutable) location and onto the
+        # entry_id so that reconfiguring the location doesn't orphan them.
+        old_unique_id = f"{entry.data[CONF_LATITUDE]}-{entry.data[CONF_LONGITUDE]}"
+
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, old_unique_id), entry.entry_id
+        )
+        if device is not None:
+            device_registry.async_update_device(
+                device.id, new_identifiers={(DOMAIN, entry.entry_id)}
+            )
+
+        entity_registry = er.async_get(hass)
+        for entity_entry in er.async_entries_for_config_entry(
+            entity_registry, entry.entry_id
+        ):
+            if entity_entry.unique_id == old_unique_id:
+                new_unique_id = entry.entry_id
+            elif entity_entry.unique_id.startswith(f"{old_unique_id}_"):
+                suffix = entity_entry.unique_id.removeprefix(old_unique_id)
+                new_unique_id = f"{entry.entry_id}{suffix}"
+            else:
+                continue
+
+            entity_registry.async_update_entity(
+                entity_entry.entity_id, new_unique_id=new_unique_id
+            )
+
+        hass.config_entries.async_update_entry(entry, version=2)
+
+    return True

--- a/homeassistant/components/weatherkit/config_flow.py
+++ b/homeassistant/components/weatherkit/config_flow.py
@@ -30,22 +30,38 @@ from .const import (
     LOGGER,
 )
 
-DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_LOCATION): LocationSelector(
-            LocationSelectorConfig(radius=False, icon="")
-        ),
-        # Auth
-        vol.Required(CONF_KEY_ID): str,
-        vol.Required(CONF_SERVICE_ID): str,
-        vol.Required(CONF_TEAM_ID): str,
-        vol.Required(CONF_KEY_PEM): TextSelector(
-            TextSelectorConfig(
-                multiline=True,
-            )
-        ),
-    }
-)
+
+def _build_data_schema(*, key_pem_required: bool) -> vol.Schema:
+    """Build the config flow data schema.
+
+    The private key is optional during reconfigure so the user can leave it
+    blank to keep the currently configured key.
+    """
+    key_pem_marker = (
+        vol.Required(CONF_KEY_PEM)
+        if key_pem_required
+        else vol.Optional(CONF_KEY_PEM, default="")
+    )
+    return vol.Schema(
+        {
+            vol.Required(CONF_LOCATION): LocationSelector(
+                LocationSelectorConfig(radius=False, icon="")
+            ),
+            # Auth
+            vol.Required(CONF_KEY_ID): str,
+            vol.Required(CONF_SERVICE_ID): str,
+            vol.Required(CONF_TEAM_ID): str,
+            key_pem_marker: TextSelector(
+                TextSelectorConfig(
+                    multiline=True,
+                )
+            ),
+        }
+    )
+
+
+DATA_SCHEMA = _build_data_schema(key_pem_required=True)
+RECONFIGURE_DATA_SCHEMA = _build_data_schema(key_pem_required=False)
 
 
 class WeatherKitUnsupportedLocationError(Exception):
@@ -55,7 +71,7 @@ class WeatherKitUnsupportedLocationError(Exception):
 class WeatherKitFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for WeatherKit."""
 
-    VERSION = 1
+    VERSION = 2
 
     @override
     async def async_step_user(
@@ -65,23 +81,10 @@ class WeatherKitFlowHandler(ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by the user."""
         errors = {}
         if user_input is not None:
-            try:
-                user_input[CONF_KEY_PEM] = self._fix_key_input(user_input[CONF_KEY_PEM])
-                await self._test_config(user_input)
-            except WeatherKitUnsupportedLocationError as exception:
-                LOGGER.error(exception)
-                errors["base"] = "unsupported_location"
-            except WeatherKitApiClientAuthenticationError as exception:
-                LOGGER.warning(exception)
-                errors["base"] = "invalid_auth"
-            except WeatherKitApiClientCommunicationError as exception:
-                LOGGER.error(exception)
-                errors["base"] = "cannot_connect"
-            except WeatherKitApiClientError as exception:
-                LOGGER.exception(exception)
-                errors["base"] = "unknown"
+            error = await self._validate_input(user_input)
+            if error:
+                errors["base"] = error
             else:
-                # Flatten location
                 location = user_input.pop(CONF_LOCATION)
                 user_input[CONF_LATITUDE] = location[CONF_LATITUDE]
                 user_input[CONF_LONGITUDE] = location[CONF_LONGITUDE]
@@ -104,6 +107,68 @@ class WeatherKitFlowHandler(ConfigFlow, domain=DOMAIN):
             data_schema=data_schema,
             errors=errors,
         )
+
+    async def async_step_reconfigure(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of an existing entry."""
+        errors = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+        if user_input is not None:
+            if not user_input[CONF_KEY_PEM]:
+                user_input[CONF_KEY_PEM] = reconfigure_entry.data[CONF_KEY_PEM]
+
+            error = await self._validate_input(user_input)
+            if error:
+                errors["base"] = error
+            else:
+                location = user_input.pop(CONF_LOCATION)
+                user_input[CONF_LATITUDE] = location[CONF_LATITUDE]
+                user_input[CONF_LONGITUDE] = location[CONF_LONGITUDE]
+
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    title=f"{user_input[CONF_LATITUDE]}, {user_input[CONF_LONGITUDE]}",
+                    data=user_input,
+                )
+
+        suggested_values = {
+            CONF_KEY_ID: reconfigure_entry.data[CONF_KEY_ID],
+            CONF_SERVICE_ID: reconfigure_entry.data[CONF_SERVICE_ID],
+            CONF_TEAM_ID: reconfigure_entry.data[CONF_TEAM_ID],
+            CONF_LOCATION: {
+                CONF_LATITUDE: reconfigure_entry.data[CONF_LATITUDE],
+                CONF_LONGITUDE: reconfigure_entry.data[CONF_LONGITUDE],
+            },
+        }
+        data_schema = self.add_suggested_values_to_schema(
+            RECONFIGURE_DATA_SCHEMA, suggested_values
+        )
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=data_schema,
+            errors=errors,
+        )
+
+    async def _validate_input(self, user_input: dict[str, Any]) -> str | None:
+        """Fix up and validate user input, returning an error key on failure."""
+        try:
+            user_input[CONF_KEY_PEM] = self._fix_key_input(user_input[CONF_KEY_PEM])
+            await self._test_config(user_input)
+        except WeatherKitUnsupportedLocationError as exception:
+            LOGGER.error(exception)
+            return "unsupported_location"
+        except WeatherKitApiClientAuthenticationError as exception:
+            LOGGER.warning(exception)
+            return "invalid_auth"
+        except WeatherKitApiClientCommunicationError as exception:
+            LOGGER.error(exception)
+            return "cannot_connect"
+        except WeatherKitApiClientError as exception:
+            LOGGER.exception(exception)
+            return "unknown"
+        return None
 
     def _fix_key_input(self, key_input: str) -> str:
         """Fix common user errors with the key input."""

--- a/homeassistant/components/weatherkit/config_flow.py
+++ b/homeassistant/components/weatherkit/config_flow.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
 )
 
+from . import async_migrate_entry
 from .const import (
     CONF_KEY_ID,
     CONF_KEY_PEM,
@@ -123,6 +124,12 @@ class WeatherKitFlowHandler(ConfigFlow, domain=DOMAIN):
             if error:
                 errors["base"] = error
             else:
+                # A disabled or not-yet-set-up entry may still be on the old
+                # lat/lon-based unique id scheme, since migration only runs
+                # during setup. Migrate it now, before its location changes,
+                # so the migration can still find the old registry records.
+                await async_migrate_entry(self.hass, reconfigure_entry)
+
                 location = user_input.pop(CONF_LOCATION)
                 user_input[CONF_LATITUDE] = location[CONF_LATITUDE]
                 user_input[CONF_LONGITUDE] = location[CONF_LONGITUDE]

--- a/homeassistant/components/weatherkit/config_flow.py
+++ b/homeassistant/components/weatherkit/config_flow.py
@@ -21,7 +21,6 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
 )
 
-from . import async_migrate_entry
 from .const import (
     CONF_KEY_ID,
     CONF_KEY_PEM,
@@ -124,12 +123,6 @@ class WeatherKitFlowHandler(ConfigFlow, domain=DOMAIN):
             if error:
                 errors["base"] = error
             else:
-                # A disabled or not-yet-set-up entry may still be on the old
-                # lat/lon-based unique id scheme, since migration only runs
-                # during setup. Migrate it now, before its location changes,
-                # so the migration can still find the old registry records.
-                await async_migrate_entry(self.hass, reconfigure_entry)
-
                 location = user_input.pop(CONF_LOCATION)
                 user_input[CONF_LATITUDE] = location[CONF_LATITUDE]
                 user_input[CONF_LONGITUDE] = location[CONF_LONGITUDE]

--- a/homeassistant/components/weatherkit/config_flow.py
+++ b/homeassistant/components/weatherkit/config_flow.py
@@ -49,9 +49,9 @@ def _build_data_schema(*, key_pem_required: bool) -> vol.Schema:
                 LocationSelectorConfig(radius=False, icon="")
             ),
             # Auth
-            vol.Required(CONF_KEY_ID): str,
-            vol.Required(CONF_SERVICE_ID): str,
-            vol.Required(CONF_TEAM_ID): str,
+            vol.Required(CONF_KEY_ID): TextSelector(),
+            vol.Required(CONF_SERVICE_ID): TextSelector(),
+            vol.Required(CONF_TEAM_ID): TextSelector(),
             key_pem_marker: TextSelector(
                 TextSelectorConfig(
                     multiline=True,

--- a/homeassistant/components/weatherkit/entity.py
+++ b/homeassistant/components/weatherkit/entity.py
@@ -1,6 +1,5 @@
 """Base entity for weatherkit."""
 
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import Entity
 
@@ -17,17 +16,14 @@ class WeatherKitEntity(Entity):
         self, coordinator: WeatherKitDataUpdateCoordinator, unique_id_suffix: str | None
     ) -> None:
         """Initialize the entity with device info and unique ID."""
-        config_data = coordinator.config_entry.data
+        entry_id = coordinator.config_entry.entry_id
 
-        config_entry_unique_id = (
-            f"{config_data[CONF_LATITUDE]}-{config_data[CONF_LONGITUDE]}"
-        )
-        self._attr_unique_id = config_entry_unique_id
+        self._attr_unique_id = entry_id
         if unique_id_suffix is not None:
             self._attr_unique_id += f"_{unique_id_suffix}"
 
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, config_entry_unique_id)},
+            identifiers={(DOMAIN, entry_id)},
             manufacturer=MANUFACTURER,
         )

--- a/homeassistant/components/weatherkit/entity.py
+++ b/homeassistant/components/weatherkit/entity.py
@@ -16,12 +16,14 @@ class WeatherKitEntity(Entity):
         self, coordinator: WeatherKitDataUpdateCoordinator, unique_id_suffix: str | None
     ) -> None:
         """Initialize the entity with device info and unique ID."""
-        self._attr_unique_id = coordinator.config_entry.entry_id
+        entry_id = coordinator.config_entry.entry_id
+
+        self._attr_unique_id = entry_id
         if unique_id_suffix is not None:
             self._attr_unique_id += f"_{unique_id_suffix}"
 
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, self._attr_unique_id)},
+            identifiers={(DOMAIN, entry_id)},
             manufacturer=MANUFACTURER,
         )

--- a/homeassistant/components/weatherkit/entity.py
+++ b/homeassistant/components/weatherkit/entity.py
@@ -16,14 +16,12 @@ class WeatherKitEntity(Entity):
         self, coordinator: WeatherKitDataUpdateCoordinator, unique_id_suffix: str | None
     ) -> None:
         """Initialize the entity with device info and unique ID."""
-        entry_id = coordinator.config_entry.entry_id
-
-        self._attr_unique_id = entry_id
+        self._attr_unique_id = coordinator.config_entry.entry_id
         if unique_id_suffix is not None:
             self._attr_unique_id += f"_{unique_id_suffix}"
 
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, entry_id)},
+            identifiers={(DOMAIN, self._attr_unique_id)},
             manufacturer=MANUFACTURER,
         )

--- a/homeassistant/components/weatherkit/strings.json
+++ b/homeassistant/components/weatherkit/strings.json
@@ -1,5 +1,8 @@
 {
   "config": {
+    "abort": {
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+    },
     "error": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_location%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -8,6 +11,20 @@
       "unsupported_location": "Apple WeatherKit does not provide data for this location."
     },
     "step": {
+      "reconfigure": {
+        "data": {
+          "key_id": "[%key:component::weatherkit::config::step::user::data::key_id%]",
+          "key_pem": "[%key:component::weatherkit::config::step::user::data::key_pem%]",
+          "location": "[%key:common::config_flow::data::location%]",
+          "service_id": "[%key:component::weatherkit::config::step::user::data::service_id%]",
+          "team_id": "[%key:component::weatherkit::config::step::user::data::team_id%]"
+        },
+        "data_description": {
+          "key_pem": "Leave blank to keep the currently configured private key."
+        },
+        "description": "[%key:component::weatherkit::config::step::user::description%]",
+        "title": "[%key:component::weatherkit::config::step::user::title%]"
+      },
       "user": {
         "data": {
           "key_id": "Key ID",

--- a/tests/components/weatherkit/test_config_flow.py
+++ b/tests/components/weatherkit/test_config_flow.py
@@ -9,6 +9,7 @@ from apple_weatherkit.client import (
     WeatherKitApiClientError,
 )
 import pytest
+import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components.weatherkit.config_flow import (
@@ -26,6 +27,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import EXAMPLE_CONFIG_DATA
+
+from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
@@ -178,3 +181,140 @@ async def test_auto_fix_key_input(
 
     assert result["data"][CONF_KEY_PEM] == EXAMPLE_CONFIG_DATA[CONF_KEY_PEM]
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_reconfigure_flow(hass: HomeAssistant) -> None:
+    """Test that reconfigure updates the entry's location and credentials."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Home", data=EXAMPLE_CONFIG_DATA)
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    new_user_input = {
+        CONF_LOCATION: {
+            CONF_LATITUDE: 40.7127753,
+            CONF_LONGITUDE: -74.0059728,
+        },
+        CONF_KEY_ID: "NEWKEY123456",
+        CONF_SERVICE_ID: "io.home-assistant.testing",
+        CONF_TEAM_ID: "ABCD123456",
+        CONF_KEY_PEM: "-----BEGIN PRIVATE KEY-----\nanewkey\n-----END PRIVATE KEY-----",
+    }
+
+    with patch(
+        "homeassistant.components.weatherkit.WeatherKitApiClient.get_availability",
+        return_value=[DataSetType.CURRENT_WEATHER],
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], new_user_input
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    location = new_user_input[CONF_LOCATION]
+    assert entry.data[CONF_LATITUDE] == location[CONF_LATITUDE]
+    assert entry.data[CONF_LONGITUDE] == location[CONF_LONGITUDE]
+    assert entry.data[CONF_KEY_ID] == new_user_input[CONF_KEY_ID]
+    assert entry.data[CONF_KEY_PEM] == new_user_input[CONF_KEY_PEM]
+
+
+async def test_reconfigure_flow_blank_key_pem_keeps_existing_key(
+    hass: HomeAssistant,
+) -> None:
+    """Test that leaving the private key blank during reconfigure keeps the existing key."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Home", data=EXAMPLE_CONFIG_DATA)
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    new_user_input = {
+        CONF_LOCATION: {
+            CONF_LATITUDE: 40.7127753,
+            CONF_LONGITUDE: -74.0059728,
+        },
+        CONF_KEY_ID: EXAMPLE_CONFIG_DATA[CONF_KEY_ID],
+        CONF_SERVICE_ID: EXAMPLE_CONFIG_DATA[CONF_SERVICE_ID],
+        CONF_TEAM_ID: EXAMPLE_CONFIG_DATA[CONF_TEAM_ID],
+        CONF_KEY_PEM: "",
+    }
+
+    with patch(
+        "homeassistant.components.weatherkit.WeatherKitApiClient.get_availability",
+        return_value=[DataSetType.CURRENT_WEATHER],
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], new_user_input
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    location = new_user_input[CONF_LOCATION]
+    assert entry.data[CONF_LATITUDE] == location[CONF_LATITUDE]
+    assert entry.data[CONF_LONGITUDE] == location[CONF_LONGITUDE]
+    assert entry.data[CONF_KEY_PEM] == EXAMPLE_CONFIG_DATA[CONF_KEY_PEM]
+
+
+async def test_reconfigure_flow_prefills_current_values(hass: HomeAssistant) -> None:
+    """Test that the reconfigure form is prefilled with the entry's current values."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Home", data=EXAMPLE_CONFIG_DATA)
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    schema = result["data_schema"].schema
+    suggested_location = next(
+        key.description["suggested_value"] for key in schema if key == CONF_LOCATION
+    )
+    assert suggested_location == {
+        CONF_LATITUDE: EXAMPLE_CONFIG_DATA[CONF_LATITUDE],
+        CONF_LONGITUDE: EXAMPLE_CONFIG_DATA[CONF_LONGITUDE],
+    }
+
+    suggested_key_id = next(
+        key.description["suggested_value"] for key in schema if key == CONF_KEY_ID
+    )
+    assert suggested_key_id == EXAMPLE_CONFIG_DATA[CONF_KEY_ID]
+
+    key_pem_key = next(key for key in schema if key == CONF_KEY_PEM)
+    assert isinstance(key_pem_key, vol.Optional)
+    assert key_pem_key.description is None
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_error"),
+    [
+        (WeatherKitApiClientAuthenticationError, "invalid_auth"),
+        (WeatherKitApiClientCommunicationError, "cannot_connect"),
+        (WeatherKitUnsupportedLocationError, "unsupported_location"),
+        (WeatherKitApiClientError, "unknown"),
+    ],
+)
+async def test_reconfigure_flow_error_handling(
+    hass: HomeAssistant, exception: Exception, expected_error: str
+) -> None:
+    """Test that reconfigure handles various exceptions and generates appropriate errors."""
+    entry = MockConfigEntry(domain=DOMAIN, title="Home", data=EXAMPLE_CONFIG_DATA)
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+
+    with patch(
+        "homeassistant.components.weatherkit.WeatherKitApiClient.get_availability",
+        side_effect=exception,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            EXAMPLE_USER_INPUT,
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": expected_error}
+
+    assert entry.data == EXAMPLE_CONFIG_DATA

--- a/tests/components/weatherkit/test_config_flow.py
+++ b/tests/components/weatherkit/test_config_flow.py
@@ -22,9 +22,10 @@ from homeassistant.components.weatherkit.const import (
     CONF_TEAM_ID,
     DOMAIN,
 )
-from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE
+from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import EXAMPLE_CONFIG_DATA
 
@@ -181,6 +182,82 @@ async def test_auto_fix_key_input(
 
     assert result["data"][CONF_KEY_PEM] == EXAMPLE_CONFIG_DATA[CONF_KEY_PEM]
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_reconfigure_of_disabled_v1_entry_migrates_old_entities(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that reconfiguring a disabled, not-yet-migrated entry doesn't orphan its entities.
+
+    A disabled config entry is never set up, so `async_migrate_entry` (which
+    only runs as part of setup) never gets a chance to move its entities off
+    their lat/lon-based unique ids before reconfigure changes the location.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        data=EXAMPLE_CONFIG_DATA,
+        version=1,
+        disabled_by=config_entries.ConfigEntryDisabler.USER,
+    )
+    entry.add_to_hass(hass)
+
+    old_unique_id = (
+        f"{EXAMPLE_CONFIG_DATA[CONF_LATITUDE]}-{EXAMPLE_CONFIG_DATA[CONF_LONGITUDE]}"
+    )
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, old_unique_id)},
+    )
+    weather_entity = entity_registry.async_get_or_create(
+        Platform.WEATHER,
+        DOMAIN,
+        old_unique_id,
+        config_entry=entry,
+        device_id=device.id,
+    )
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+
+    new_user_input = {
+        CONF_LOCATION: {
+            CONF_LATITUDE: 40.7127753,
+            CONF_LONGITUDE: -74.0059728,
+        },
+        CONF_KEY_ID: EXAMPLE_CONFIG_DATA[CONF_KEY_ID],
+        CONF_SERVICE_ID: EXAMPLE_CONFIG_DATA[CONF_SERVICE_ID],
+        CONF_TEAM_ID: EXAMPLE_CONFIG_DATA[CONF_TEAM_ID],
+        CONF_KEY_PEM: "",
+    }
+
+    with patch(
+        "homeassistant.components.weatherkit.WeatherKitApiClient.get_availability",
+        return_value=[DataSetType.CURRENT_WEATHER],
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], new_user_input
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    # Simulate the user later re-enabling the entry, which reloads (and thus
+    # migrates) it the way it normally would be if it were never disabled.
+    await hass.config_entries.async_set_disabled_by(entry.entry_id, None)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get(device.id)
+    assert device is not None
+    assert device.identifiers == {(DOMAIN, entry.entry_id)}
+
+    assert (
+        entity_registry.async_get(weather_entity.entity_id).unique_id == entry.entry_id
+    )
 
 
 async def test_reconfigure_flow(hass: HomeAssistant) -> None:

--- a/tests/components/weatherkit/test_config_flow.py
+++ b/tests/components/weatherkit/test_config_flow.py
@@ -22,10 +22,9 @@ from homeassistant.components.weatherkit.const import (
     CONF_TEAM_ID,
     DOMAIN,
 )
-from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE, Platform
+from homeassistant.const import CONF_LATITUDE, CONF_LOCATION, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import EXAMPLE_CONFIG_DATA
 
@@ -182,82 +181,6 @@ async def test_auto_fix_key_input(
 
     assert result["data"][CONF_KEY_PEM] == EXAMPLE_CONFIG_DATA[CONF_KEY_PEM]
     assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_reconfigure_of_disabled_v1_entry_migrates_old_entities(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Test that reconfiguring a disabled, not-yet-migrated entry doesn't orphan its entities.
-
-    A disabled config entry is never set up, so `async_migrate_entry` (which
-    only runs as part of setup) never gets a chance to move its entities off
-    their lat/lon-based unique ids before reconfigure changes the location.
-    """
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title="Home",
-        data=EXAMPLE_CONFIG_DATA,
-        version=1,
-        disabled_by=config_entries.ConfigEntryDisabler.USER,
-    )
-    entry.add_to_hass(hass)
-
-    old_unique_id = (
-        f"{EXAMPLE_CONFIG_DATA[CONF_LATITUDE]}-{EXAMPLE_CONFIG_DATA[CONF_LONGITUDE]}"
-    )
-
-    device = device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, old_unique_id)},
-    )
-    weather_entity = entity_registry.async_get_or_create(
-        Platform.WEATHER,
-        DOMAIN,
-        old_unique_id,
-        config_entry=entry,
-        device_id=device.id,
-    )
-
-    result = await entry.start_reconfigure_flow(hass)
-    assert result["type"] is FlowResultType.FORM
-
-    new_user_input = {
-        CONF_LOCATION: {
-            CONF_LATITUDE: 40.7127753,
-            CONF_LONGITUDE: -74.0059728,
-        },
-        CONF_KEY_ID: EXAMPLE_CONFIG_DATA[CONF_KEY_ID],
-        CONF_SERVICE_ID: EXAMPLE_CONFIG_DATA[CONF_SERVICE_ID],
-        CONF_TEAM_ID: EXAMPLE_CONFIG_DATA[CONF_TEAM_ID],
-        CONF_KEY_PEM: "",
-    }
-
-    with patch(
-        "homeassistant.components.weatherkit.WeatherKitApiClient.get_availability",
-        return_value=[DataSetType.CURRENT_WEATHER],
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], new_user_input
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reconfigure_successful"
-
-    # Simulate the user later re-enabling the entry, which reloads (and thus
-    # migrates) it the way it normally would be if it were never disabled.
-    await hass.config_entries.async_set_disabled_by(entry.entry_id, None)
-    await hass.async_block_till_done()
-
-    device = device_registry.async_get(device.id)
-    assert device is not None
-    assert device.identifiers == {(DOMAIN, entry.entry_id)}
-
-    assert (
-        entity_registry.async_get(weather_entity.entity_id).unique_id == entry.entry_id
-    )
 
 
 async def test_reconfigure_flow(hass: HomeAssistant) -> None:

--- a/tests/components/weatherkit/test_setup.py
+++ b/tests/components/weatherkit/test_setup.py
@@ -9,9 +9,11 @@ from apple_weatherkit.client import (
 
 from homeassistant.components.weatherkit.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from . import EXAMPLE_CONFIG_DATA
+from . import EXAMPLE_CONFIG_DATA, mock_weather_response
 
 from tests.common import MockConfigEntry
 
@@ -66,3 +68,60 @@ async def test_client_error_handling(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_migration_from_version_1(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that entities and the device are migrated off their lat/lon-based unique ids."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        data=EXAMPLE_CONFIG_DATA,
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    old_unique_id = (
+        f"{EXAMPLE_CONFIG_DATA[CONF_LATITUDE]}-{EXAMPLE_CONFIG_DATA[CONF_LONGITUDE]}"
+    )
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, old_unique_id)},
+    )
+    weather_entity = entity_registry.async_get_or_create(
+        Platform.WEATHER,
+        DOMAIN,
+        old_unique_id,
+        config_entry=entry,
+        device_id=device.id,
+    )
+    sensor_entity = entity_registry.async_get_or_create(
+        Platform.SENSOR,
+        DOMAIN,
+        f"{old_unique_id}_pressureTrend",
+        config_entry=entry,
+        device_id=device.id,
+    )
+
+    with mock_weather_response():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 2
+
+    device = device_registry.async_get(device.id)
+    assert device is not None
+    assert device.identifiers == {(DOMAIN, entry.entry_id)}
+
+    assert (
+        entity_registry.async_get(weather_entity.entity_id).unique_id == entry.entry_id
+    )
+    assert (
+        entity_registry.async_get(sensor_entity.entity_id).unique_id
+        == f"{entry.entry_id}_pressureTrend"
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Adds the ability to reconfigure a WeatherKit integration after it's added so the user can change their Apple Developer details and weather location after the fact.

`WeatherKitEntity`'s `_attr_unique_id` and `_attr_device_info` identifiers previously keyed on the config entry's lat/lon since it was immutable, but since this is no longer case they now key on the config entry's ID which remains stable even if location is changed. Entities using the old unique ID format are automatically migrated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #159673
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
