### PR TITLE
Fix AdGuard Home device identifiers

### DIFF
--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -17,9 +17,9 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
     Platform,
 )
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
@@ -120,6 +120,22 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
+@callback
+def _async_migrate_device_identifiers(
+    hass: HomeAssistant, entry: AdGuardConfigEntry
+) -> None:
+    """Migrate devices identified by host, port and base path to the entry ID.
+
+    Those identifiers had four parts, while the device registry only supports two.
+    """
+    device_registry = dr.async_get(hass)
+    identifiers = {(DOMAIN, entry.entry_id)}
+
+    for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
+        if device.identifiers != identifiers:
+            device_registry.async_update_device(device.id, new_identifiers=identifiers)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: AdGuardConfigEntry) -> bool:
     """Set up AdGuard Home from a config entry."""
     session = async_get_clientsession(hass, entry.data[CONF_VERIFY_SSL])
@@ -139,6 +155,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdGuardConfigEntry) -> b
         raise ConfigEntryNotReady from exception
 
     entry.runtime_data = AdGuardData(adguard, version)
+
+    _async_migrate_device_identifiers(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -130,10 +130,21 @@ def _async_migrate_device_identifiers(
     """
     device_registry = dr.async_get(hass)
     identifiers = {(DOMAIN, entry.entry_id)}
+    migrated = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
 
     for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
-        if device.identifiers != identifiers:
-            device_registry.async_update_device(device.id, new_identifiers=identifiers)
+        if device.identifiers == identifiers:
+            continue
+
+        # Downgrading recreates the old device, leaving a duplicate behind. Its
+        # entities move back to the migrated device when the platforms set up.
+        if migrated is not None:
+            device_registry.async_remove_device(device.id)
+            continue
+
+        device_registry.async_update_device(device.id, new_identifiers=identifiers)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AdGuardConfigEntry) -> bool:

--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -138,6 +138,8 @@ def _async_migrate_device_identifiers(
 
 async def async_setup_entry(hass: HomeAssistant, entry: AdGuardConfigEntry) -> bool:
     """Set up AdGuard Home from a config entry."""
+    _async_migrate_device_identifiers(hass, entry)
+
     session = async_get_clientsession(hass, entry.data[CONF_VERIFY_SSL])
     adguard = AdGuardHome(
         entry.data[CONF_HOST],
@@ -155,8 +157,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdGuardConfigEntry) -> b
         raise ConfigEntryNotReady from exception
 
     entry.runtime_data = AdGuardData(adguard, version)
-
-    _async_migrate_device_identifiers(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/adguard/entity.py
+++ b/homeassistant/components/adguard/entity.py
@@ -61,14 +61,7 @@ class AdGuardHomeEntity(Entity):
 
         return DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
-            identifiers={
-                (  # type: ignore[arg-type]
-                    DOMAIN,
-                    self.adguard.host,
-                    self.adguard.port,
-                    self.adguard.base_path,
-                )
-            },
+            identifiers={(DOMAIN, self._entry.entry_id)},
             manufacturer="AdGuard Team",
             name="AdGuard Home",
             sw_version=self.data.version,

--- a/tests/components/adguard/test_init.py
+++ b/tests/components/adguard/test_init.py
@@ -83,3 +83,29 @@ async def test_device_identifiers_migration(
     migrated = device_registry.async_get(device.id)
     assert migrated is not None
     assert migrated.identifiers == {(DOMAIN, mock_config_entry.entry_id)}
+
+
+async def test_device_identifiers_migration_when_unavailable(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_adguard: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the device is migrated even when the instance cannot be reached."""
+    mock_adguard.version.side_effect = AdGuardHomeConnectionError("Connection error")
+
+    mock_config_entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "127.0.0.1", 3000, "/control")},  # type: ignore[arg-type]
+        name="AdGuard Home",
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+    migrated = device_registry.async_get(device.id)
+    assert migrated is not None
+    assert migrated.identifiers == {(DOMAIN, mock_config_entry.entry_id)}

--- a/tests/components/adguard/test_init.py
+++ b/tests/components/adguard/test_init.py
@@ -1,13 +1,15 @@
 """Tests for the AdGuard Home."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from adguardhome import AdGuardHomeConnectionError
 import pytest
 
+from homeassistant.components.adguard.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
@@ -39,3 +41,45 @@ async def test_setup_failed(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_device_identifiers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_adguard: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the device is identified by a two part identifier."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.adguard.PLATFORMS", [Platform.SENSOR]):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    )
+    assert device is not None
+    assert device.identifiers == {(DOMAIN, mock_config_entry.entry_id)}
+
+
+async def test_device_identifiers_migration(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_adguard: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the device created by an older version is migrated."""
+    mock_config_entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "127.0.0.1", 3000, "/control")},  # type: ignore[arg-type]
+        name="AdGuard Home",
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    migrated = device_registry.async_get(device.id)
+    assert migrated is not None
+    assert migrated.identifiers == {(DOMAIN, mock_config_entry.entry_id)}

--- a/tests/components/adguard/test_init.py
+++ b/tests/components/adguard/test_init.py
@@ -109,3 +109,30 @@ async def test_device_identifiers_migration_when_unavailable(
     migrated = device_registry.async_get(device.id)
     assert migrated is not None
     assert migrated.identifiers == {(DOMAIN, mock_config_entry.entry_id)}
+
+
+async def test_device_identifiers_migration_with_duplicate(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_adguard: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a device left behind by a downgrade is cleaned up."""
+    mock_config_entry.add_to_hass(hass)
+    current = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, mock_config_entry.entry_id)},
+        name="AdGuard Home",
+    )
+    duplicate = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "127.0.0.1", 3000, "/control")},  # type: ignore[arg-type]
+        name="AdGuard Home",
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert device_registry.async_get(duplicate.id) is None
+    assert device_registry.async_get(current.id) is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The AdGuard Home integration registered its device with a four part identifier: `(DOMAIN, host, port, base_path)`. The device registry contract is a two part `(domain, identifier)` tuple, which the code acknowledged with a `# type: ignore[arg-type]`. On top of that, the port is an integer.

The result reached users through the iOS companion app: fetching the device registry failed with `HAKit.HADataError error 1` for the whole installation. In the reported case, 3 out of 423 devices had a malformed identifier, and all three were AdGuard Home.

The device is now identified by its config entry ID. Existing devices are migrated on setup, so they keep their entity links, area, name and any automations pointing at them, instead of being replaced by a duplicate.

Tests cover both a fresh install and the migration of an existing four part device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180697
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
