### PR TITLE
Add Steinway Lyngdorf SSDP manufacturer to lyngdorf discovery

### DIFF
--- a/homeassistant/components/lyngdorf/manifest.json
+++ b/homeassistant/components/lyngdorf/manifest.json
@@ -14,6 +14,10 @@
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",
       "manufacturer": "Lyngdorf"
+    },
+    {
+      "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",
+      "manufacturer": "Steinway Lyngdorf"
     }
   ]
 }

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -221,6 +221,10 @@ SSDP = {
             "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",
             "manufacturer": "Lyngdorf",
         },
+        {
+            "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",
+            "manufacturer": "Steinway Lyngdorf",
+        },
     ],
     "nanoleaf": [
         {


### PR DESCRIPTION
## Proposed change

SSDP discovery for the `lyngdorf` integration never fires for Steinway-branded units
(Steinway & Sons Model P100/P200/P300 surround processors): their UPnP device description
reports `<manufacturer>Steinway Lyngdorf</manufacturer>`, while the manifest matcher only lists
`Lyngdorf`. The SSDP scanner matches manifest values by exact string equality
(`homeassistant/components/ssdp/scanner.py`, value-keyed matcher lookup), so these devices are
never discovered even though the integration and the `lyngdorf` library fully support them
(`lookup_model("P200")` resolves, the unique id comes from the UPnP `serialNumber`, and the
manual user flow works against the same device).

This adds a second SSDP matcher for `Steinway Lyngdorf` (plus the hassfest-regenerated
`generated/ssdp.py`).

Device description XML from a live P200 (firmware p20.5.4.1):

```xml
<deviceType>urn:schemas-upnp-org:device:MediaRenderer:2</deviceType>
<friendlyName>lyd</friendlyName>
<manufacturer>Steinway Lyngdorf</manufacturer>
<manufacturerURL>http://steinwaylyngdorf.com/</manufacturerURL>
<modelName>P200</modelName>
<serialNumber>0050c2xxxxxx</serialNumber>
```

Verified live on HA 2026.8.3 by loading the integration with exactly this manifest change on
the network with that P200: the scanner then matches
(`x_homeassistant_matching_domains={'lyngdorf'}`) and logs

```
[homeassistant.components.ssdp.scanner] Discovered lyngdorf at http://192.168.x.x:39799/<uuid>.xml
```

and the SSDP discovery flow is created without errors (model detected as `P200`, unique id
`0050c2xxxxxx`).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
