### PR TITLE
Complete Subaru config flow error tests to CREATE_ENTRY

### DIFF
--- a/tests/components/subaru/test_config_flow.py
+++ b/tests/components/subaru/test_config_flow.py
@@ -41,15 +41,6 @@ MOCK_2FA_CONTACTS = {
 }
 
 
-async def test_user_form_init(user_form) -> None:
-    """Test the initial user form for first step of the config flow."""
-    assert user_form["description_placeholders"] is None
-    assert user_form["errors"] is None
-    assert user_form["handler"] == DOMAIN
-    assert user_form["step_id"] == "user"
-    assert user_form["type"] is FlowResultType.FORM
-
-
 async def test_user_form_repeat_identifier(hass: HomeAssistant, user_form) -> None:
     """Test we handle repeat identifiers."""
     entry = MockConfigEntry(
@@ -86,7 +77,7 @@ async def test_user_form_cannot_connect(hass: HomeAssistant, user_form) -> None:
 
 
 async def test_user_form_invalid_auth(hass: HomeAssistant, user_form) -> None:
-    """Test we handle invalid auth."""
+    """Test we handle invalid auth, and that the flow can still be completed afterward."""
     with patch(
         MOCK_API_CONNECT,
         side_effect=InvalidCredentials("invalidAccount"),
@@ -98,6 +89,18 @@ async def test_user_form_invalid_auth(hass: HomeAssistant, user_form) -> None:
     assert len(mock_connect.mock_calls) == 1
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
+
+    with (
+        patch(MOCK_API_CONNECT, return_value=True),
+        patch(MOCK_API_DEVICE_REGISTERED, new_callable=PropertyMock, return_value=True),
+        patch(MOCK_API_IS_PIN_REQUIRED, return_value=False),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            TEST_CREDS,
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_user_form_pin_not_required(
@@ -154,9 +157,21 @@ async def test_registered_pin_required(hass: HomeAssistant, user_form) -> None:
         patch(MOCK_API_IS_PIN_REQUIRED, return_value=True),
     ):
         mock_device_registered.return_value = True
-        await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             user_form["flow_id"], user_input=TEST_CREDS
         )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pin"
+
+    with (
+        patch(MOCK_API_TEST_PIN, return_value=True),
+        patch(MOCK_API_UPDATE_SAVED_PIN, return_value=True),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PIN: TEST_PIN}
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_registered_no_pin_required(hass: HomeAssistant, user_form) -> None:
@@ -167,11 +182,13 @@ async def test_registered_no_pin_required(hass: HomeAssistant, user_form) -> Non
             MOCK_API_DEVICE_REGISTERED, new_callable=PropertyMock
         ) as mock_device_registered,
         patch(MOCK_API_IS_PIN_REQUIRED, return_value=False),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
     ):
         mock_device_registered.return_value = True
-        await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             user_form["flow_id"], user_input=TEST_CREDS
         )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_two_factor_request_success(
@@ -186,11 +203,24 @@ async def test_two_factor_request_success(
         patch(MOCK_API_2FA_CONTACTS, new_callable=PropertyMock) as mock_contacts,
     ):
         mock_contacts.return_value = MOCK_2FA_CONTACTS
-        await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             two_factor_start_form["flow_id"],
             user_input={config_flow.CONF_CONTACT_METHOD: "email@addr.com"},
         )
     assert len(mock_two_factor_request.mock_calls) == 1
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "two_factor_validate"
+
+    with (
+        patch(MOCK_API_2FA_VERIFY, return_value=True),
+        patch(MOCK_API_IS_PIN_REQUIRED, return_value=False),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_two_factor_request_fail(
@@ -225,18 +255,30 @@ async def test_two_factor_verify_success(
         ) as mock_two_factor_verify,
         patch(MOCK_API_IS_PIN_REQUIRED, return_value=True) as mock_is_in_required,
     ):
-        await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             two_factor_verify_form["flow_id"],
             user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
         )
     assert len(mock_two_factor_verify.mock_calls) == 1
     assert len(mock_is_in_required.mock_calls) == 1
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pin"
+
+    with (
+        patch(MOCK_API_TEST_PIN, return_value=True),
+        patch(MOCK_API_UPDATE_SAVED_PIN, return_value=True),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PIN: TEST_PIN}
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_two_factor_verify_bad_format(
     hass: HomeAssistant, two_factor_verify_form
 ) -> None:
-    """Test two factor verification bad format."""
+    """Test two factor verification bad format, and that the flow can still be completed afterward."""
     with (
         patch(
             MOCK_API_2FA_VERIFY,
@@ -252,11 +294,22 @@ async def test_two_factor_verify_bad_format(
     assert len(mock_is_pin_required.mock_calls) == 0
     assert result["errors"] == {"base": "bad_validation_code_format"}
 
+    with (
+        patch(MOCK_API_2FA_VERIFY, return_value=True),
+        patch(MOCK_API_IS_PIN_REQUIRED, return_value=False),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
 
 async def test_two_factor_verify_fail(
     hass: HomeAssistant, two_factor_verify_form
 ) -> None:
-    """Test two factor verification failure."""
+    """Test two factor verification failure, and that the flow can still be completed afterward."""
     with (
         patch(
             MOCK_API_2FA_VERIFY,
@@ -272,25 +325,20 @@ async def test_two_factor_verify_fail(
     assert len(mock_is_pin_required.mock_calls) == 0
     assert result["errors"] == {"base": "incorrect_validation_code"}
 
-
-async def test_pin_form_init(pin_form) -> None:
-    """Test the pin entry form for second step of the config flow."""
-    expected = {
-        "data_schema": config_flow.PIN_SCHEMA,
-        "description_placeholders": None,
-        "errors": None,
-        "flow_id": mock.ANY,
-        "handler": DOMAIN,
-        "step_id": "pin",
-        "type": "form",
-        "last_step": None,
-        "preview": None,
-    }
-    assert pin_form == expected
+    with (
+        patch(MOCK_API_2FA_VERIFY, return_value=True),
+        patch(MOCK_API_IS_PIN_REQUIRED, return_value=False),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_pin_form_bad_pin_format(hass: HomeAssistant, pin_form) -> None:
-    """Test we handle invalid pin."""
+    """Test we handle invalid pin, and that the flow can still be completed afterward."""
     with (
         patch(
             MOCK_API_TEST_PIN,
@@ -307,6 +355,16 @@ async def test_pin_form_bad_pin_format(hass: HomeAssistant, pin_form) -> None:
     assert len(mock_update_saved_pin.mock_calls) == 1
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "bad_pin_format"}
+
+    with (
+        patch(MOCK_API_TEST_PIN, return_value=True),
+        patch(MOCK_API_UPDATE_SAVED_PIN, return_value=True),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PIN: TEST_PIN}
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_pin_form_success(hass: HomeAssistant, pin_form) -> None:
@@ -379,16 +437,11 @@ async def test_pin_form_incorrect_pin(hass: HomeAssistant, pin_form) -> None:
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-async def test_option_flow_form(options_form) -> None:
-    """Test config flow options form."""
-    assert options_form["description_placeholders"] is None
-    assert options_form["errors"] is None
-    assert options_form["step_id"] == "init"
-    assert options_form["type"] is FlowResultType.FORM
-
-
 async def test_option_flow(hass: HomeAssistant, options_form) -> None:
     """Test config flow options."""
+    assert options_form["type"] is FlowResultType.FORM
+    assert options_form["step_id"] == "init"
+
     result = await hass.config_entries.options.async_configure(
         options_form["flow_id"],
         user_input={
@@ -404,9 +457,13 @@ async def test_option_flow(hass: HomeAssistant, options_form) -> None:
 @pytest.fixture
 async def user_form(hass: HomeAssistant) -> ConfigFlowResult:
     """Return initial form for Subaru config flow."""
-    return await hass.config_entries.flow.async_init(
+    result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] is None
+    return result
 
 
 @pytest.fixture
@@ -455,10 +512,13 @@ async def pin_form(
         ),
         patch(MOCK_API_IS_PIN_REQUIRED, return_value=True),
     ):
-        return await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             two_factor_verify_form["flow_id"],
             user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
         )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pin"
+    return result
 
 
 @pytest.fixture


### PR DESCRIPTION
## Proposed change

Make every Subaru config flow test end in `CREATE_ENTRY` or `ABORT` (quality-scale `config-flow-test-coverage`): each error-path test now recovers and completes the flow, intermediate-step tests continue to a terminal result, and the three form-init-only tests are folded into the fixtures/success tests they duplicated.

Answers review feedback on #178638.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #178638
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
