### PR TITLE
Fix swallowed exceptions in roomba action handlers

### DIFF
--- a/homeassistant/components/roomba/strings.json
+++ b/homeassistant/components/roomba/strings.json
@@ -89,6 +89,23 @@
       }
     }
   },
+  "exceptions": {
+    "invalid_fan_speed": {
+      "message": "Invalid fan speed {fan_speed}. Expected one of: {fan_speeds}."
+    },
+    "invalid_fan_speed_format": {
+      "message": "Invalid fan speed {fan_speed}. Expected the format behavior-spray_amount, for example Standard-1."
+    },
+    "invalid_mop_behavior": {
+      "message": "Invalid mop behavior {behavior}. Expected one of: {behaviors}."
+    },
+    "invalid_spray_amount": {
+      "message": "Invalid spray amount {spray_amount}. Expected one of: {spray_amounts}."
+    },
+    "spray_amount_not_a_number": {
+      "message": "Invalid spray amount {spray_amount}. Expected a whole number."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/homeassistant/components/roomba/vacuum.py
+++ b/homeassistant/components/roomba/vacuum.py
@@ -11,11 +11,13 @@ from homeassistant.components.vacuum import (
     VacuumEntityFeature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from . import roomba_reported_state
+from .const import DOMAIN
 from .entity import IRobotEntity
 from .models import RoombaConfigEntry
 
@@ -317,8 +319,14 @@ class RoombaVacuumCarpetBoost(RoombaVacuum):
             high_perf = True
             carpet_boost = False
         else:
-            _LOGGER.error("No such fan speed available: %s", fan_speed)
-            return
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_fan_speed",
+                translation_placeholders={
+                    "fan_speed": fan_speed,
+                    "fan_speeds": ", ".join(FAN_SPEEDS),
+                },
+            )
 
         # The set_preference method does only accept string values
         def _set_fan_speed_preferences() -> None:
@@ -371,30 +379,36 @@ class BraavaJet(IRobotVacuum):
             spray = int(split[1])
             if behavior.capitalize() in BRAAVA_MOP_BEHAVIORS:
                 behavior = behavior.capitalize()
-        # pylint: disable-next=home-assistant-action-swallowed-exception
-        except IndexError:
-            _LOGGER.error(
-                "Fan speed error: expected {behavior}-{spray_amount}, got '%s'",
-                fan_speed,
-            )
-            return
-        except ValueError:
-            _LOGGER.error("Spray amount error: expected integer, got '%s'", split[1])
-            return
+        except IndexError as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_fan_speed_format",
+                translation_placeholders={"fan_speed": fan_speed},
+            ) from err
+        except ValueError as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="spray_amount_not_a_number",
+                translation_placeholders={"spray_amount": split[1]},
+            ) from err
         if behavior not in BRAAVA_MOP_BEHAVIORS:
-            _LOGGER.error(
-                "Mop behavior error: expected one of %s, got '%s'",
-                str(BRAAVA_MOP_BEHAVIORS),
-                behavior,
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_mop_behavior",
+                translation_placeholders={
+                    "behavior": behavior,
+                    "behaviors": ", ".join(BRAAVA_MOP_BEHAVIORS),
+                },
             )
-            return
         if spray not in BRAAVA_SPRAY_AMOUNT:
-            _LOGGER.error(
-                "Spray amount error: expected one of %s, got '%d'",
-                str(BRAAVA_SPRAY_AMOUNT),
-                spray,
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_spray_amount",
+                translation_placeholders={
+                    "spray_amount": str(spray),
+                    "spray_amounts": ", ".join(str(s) for s in BRAAVA_SPRAY_AMOUNT),
+                },
             )
-            return
 
         overlap = 0
         if behavior == MOP_STANDARD:

--- a/tests/components/roomba/test_vacuum.py
+++ b/tests/components/roomba/test_vacuum.py
@@ -4,13 +4,27 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from homeassistant.components.vacuum import VacuumActivity
-from homeassistant.const import Platform
+from homeassistant.components.vacuum import (
+    ATTR_FAN_SPEED,
+    DOMAIN as VACUUM_DOMAIN,
+    SERVICE_SET_FAN_SPEED,
+    VacuumActivity,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 
 from tests.common import MockConfigEntry
 
 ENTITY_ID = "vacuum.test_roomba"
+
+
+async def _setup(hass: HomeAssistant, mock_config_entry: MockConfigEntry) -> None:
+    """Set up the vacuum platform only."""
+    with patch("homeassistant.components.roomba.PLATFORMS", [Platform.VACUUM]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
 
 
 @pytest.mark.parametrize(
@@ -52,3 +66,83 @@ async def test_vacuum_activity(
     state = hass.states.get(ENTITY_ID)
     assert state is not None
     assert state.state == expected
+
+
+@pytest.mark.parametrize(
+    ("fan_speed", "translation_key"),
+    [
+        # Missing the "-<spray amount>" half entirely.
+        ("Standard", "invalid_fan_speed_format"),
+        # Spray amount present but not a number.
+        ("Standard-x", "spray_amount_not_a_number"),
+        # Well-formed, but the behavior is not one we support.
+        ("Bogus-1", "invalid_mop_behavior"),
+        # Well-formed, but the spray amount is out of range.
+        ("Standard-9", "invalid_spray_amount"),
+    ],
+)
+async def test_braava_set_fan_speed_invalid(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_roomba: AsyncMock,
+    fan_speed: str,
+    translation_key: str,
+) -> None:
+    """Test that invalid Braava fan speeds raise instead of being swallowed."""
+    mock_roomba.master_state["state"]["reported"]["detectedPad"] = "reusableWet"
+
+    await _setup(hass, mock_config_entry)
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            VACUUM_DOMAIN,
+            SERVICE_SET_FAN_SPEED,
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_FAN_SPEED: fan_speed},
+            blocking=True,
+        )
+
+    assert err.value.translation_domain == "roomba"
+    assert err.value.translation_key == translation_key
+
+
+async def test_carpet_boost_set_fan_speed_invalid(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_roomba: AsyncMock,
+) -> None:
+    """Test that an unknown carpet-boost fan speed raises instead of being swallowed."""
+    mock_roomba.master_state["state"]["reported"]["cap"]["carpetBoost"] = 1
+
+    await _setup(hass, mock_config_entry)
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            VACUUM_DOMAIN,
+            SERVICE_SET_FAN_SPEED,
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_FAN_SPEED: "Turbo"},
+            blocking=True,
+        )
+
+    assert err.value.translation_domain == "roomba"
+    assert err.value.translation_key == "invalid_fan_speed"
+
+
+async def test_carpet_boost_set_fan_speed_valid(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_roomba: AsyncMock,
+) -> None:
+    """Test that a valid fan speed still sets the preferences."""
+    mock_roomba.master_state["state"]["reported"]["cap"]["carpetBoost"] = 1
+
+    await _setup(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        VACUUM_DOMAIN,
+        SERVICE_SET_FAN_SPEED,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_FAN_SPEED: "eco"},
+        blocking=True,
+    )
+
+    mock_roomba.set_preference.assert_any_call("carpetBoost", "False")
+    mock_roomba.set_preference.assert_any_call("vacHigh", "False")


### PR DESCRIPTION
## Proposed change

The roomba `set_fan_speed` action handlers logged invalid input and returned, so the user got no feedback in the UI and automations continued as if the action had succeeded.

`set_fan_speed` is registered with `{vol.Required(ATTR_FAN_SPEED): cv.string}` and is **not** validated against `fan_speed_list`, so any string reaches the handler from a YAML automation even though the UI picker only offers valid values. Every path below is reachable.

**`BraavaJet.async_set_fan_speed`**

| Was | Now raises |
|---|---|
| `except IndexError` -> log + `return` | `invalid_fan_speed_format` |
| `except ValueError` -> log + `return` | `spray_amount_not_a_number` |
| `if behavior not in BRAAVA_MOP_BEHAVIORS` -> log + `return` | `invalid_mop_behavior` |
| `if spray not in BRAAVA_SPRAY_AMOUNT` -> log + `return` | `invalid_spray_amount` |

**`RoombaVacuumCarpetBoost.async_set_fan_speed`**

| Was | Now raises |
|---|---|
| trailing `else:` -> log + `return` | `invalid_fan_speed` |

The `# pylint: disable-next=home-assistant-action-swallowed-exception` suppression is no longer needed and is removed.

### Two notes for the reviewer

**Scope.** The checker only inspects `except` handlers, so strictly it only requires the first two. I included the three `if`/`else` validation branches because they produce the identical user-visible failure the issue describes, and because #177416 set the precedent for widening past `except` blocks in this epic. **Happy to split those three into a follow-up if you would rather keep this minimal.**

**Exception type.** I used `ServiceValidationError` rather than `HomeAssistantError`. All five cases are bad user input rather than a device failure, so this keeps the traceback out of the log. It is a `HomeAssistantError` subclass, so the swallowed-exception and translation checkers are both satisfied. #177416 uses the same. One-word change if you prefer the base class.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #170636
- This PR is related to issue: part of home-assistant/epics#64
- Link to documentation pull request: not needed, no user-facing configuration change
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

---

Verified locally against `dev` before opening:

- `pytest tests/components/roomba/` -> 44 passed (6 new)
- `ruff check` and `ruff format --check` -> clean
- `python -m script.hassfest --integration-path homeassistant/components/roomba` -> 0 invalid
- Pylint control, to confirm the suppression is genuinely no longer needed: original with the disable comment -> clean; original with the comment removed -> `E7405` fires at line 374; this branch -> clean with zero suppression comments remaining.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
