### PR TITLE
Fix offline devices being removed in Xbox integration

### DIFF
--- a/homeassistant/components/xbox/__init__.py
+++ b/homeassistant/components/xbox/__init__.py
@@ -88,6 +88,27 @@ async def async_unload_entry(hass: HomeAssistant, entry: XboxConfigEntry) -> boo
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    config_entry: XboxConfigEntry,
+    device_entry: dr.AnyDeviceEntry,
+) -> bool:
+    """Remove a stale device from a config entry."""
+
+    return not any(
+        identifier
+        for identifier in device_entry.identifiers
+        if identifier[0] == DOMAIN
+        and (
+            (
+                isinstance(device_entry, dr.DeviceEntry)
+                and device_entry.entry_type == dr.DeviceEntryType.SERVICE
+            )
+            or identifier[1] in config_entry.runtime_data.consoles.data
+        )
+    )
+
+
 async def async_migrate_entry(hass: HomeAssistant, entry: XboxConfigEntry) -> bool:
     """Migrate config entry."""
 

--- a/homeassistant/components/xbox/coordinator.py
+++ b/homeassistant/components/xbox/coordinator.py
@@ -20,8 +20,6 @@ from pythonxbox.api.provider.titlehub.models import Title
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
@@ -116,18 +114,6 @@ class XboxConsolesCoordinator(XboxBaseCoordinator[dict[str, SmartglassConsole]])
         _LOGGER.debug(
             "Found %d consoles: %s", len(consoles.result), consoles.model_dump()
         )
-
-        device_reg = dr.async_get(self.hass)
-        identifiers = {(DOMAIN, console.id) for console in consoles.result}
-        for device in dr.async_entries_for_config_entry(
-            device_reg, self.config_entry.entry_id
-        ):
-            if (
-                device.entry_type is not DeviceEntryType.SERVICE
-                and not set(device.identifiers) & identifiers
-            ):
-                _LOGGER.debug("Removing stale device %s", device.name)
-                device_reg.async_remove_device(device.id)
 
         return {console.id: console for console in consoles.result}
 

--- a/tests/components/xbox/test_init.py
+++ b/tests/components/xbox/test_init.py
@@ -23,12 +23,14 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
 )
+from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
     async_load_json_object_fixture,
 )
+from tests.typing import WebSocketGenerator
 
 
 @pytest.mark.usefixtures("xbox_live_client")
@@ -204,9 +206,11 @@ async def test_dynamic_devices(
     xbox_live_client: AsyncMock,
     device_registry: dr.DeviceRegistry,
     freezer: FrozenDateTimeFactory,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test adding of new and removal of stale devices at runtime."""
-
+    assert await async_setup_component(hass, "config", {})
+    client = await hass_ws_client(hass)
     xbox_live_client.smartglass.get_console_list.return_value = SmartglassConsoleList(
         **await async_load_json_object_fixture(
             hass, "smartglass_console_list_empty.json", DOMAIN
@@ -225,12 +229,6 @@ async def test_dynamic_devices(
         )
         is None
     )
-    assert (
-        device_registry.async_get_device_by_identifier(
-            (DOMAIN, "HIJKLMN"), config_entry.entry_id
-        )
-        is None
-    )
 
     xbox_live_client.smartglass.get_console_list.return_value = SmartglassConsoleList(
         **await async_load_json_object_fixture(
@@ -242,12 +240,14 @@ async def test_dynamic_devices(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device_by_identifier(
-        (DOMAIN, "ABCDEFG"), config_entry.entry_id
+    assert (
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, "ABCDEFG"), config_entry.entry_id
+        )
     )
-    assert device_registry.async_get_device_by_identifier(
-        (DOMAIN, "HIJKLMN"), config_entry.entry_id
-    )
+
+    response = await client.remove_device(device.id)
+    assert not response["success"]
 
     xbox_live_client.smartglass.get_console_list.return_value = SmartglassConsoleList(
         **await async_load_json_object_fixture(
@@ -259,15 +259,21 @@ async def test_dynamic_devices(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
+    response = await client.remove_device(device.id)
+    assert response["success"]
+
     assert (
         device_registry.async_get_device_by_identifier(
             (DOMAIN, "ABCDEFG"), config_entry.entry_id
         )
         is None
     )
+
+    # Test that service devices cannot be removed
     assert (
-        device_registry.async_get_device_by_identifier(
-            (DOMAIN, "HIJKLMN"), config_entry.entry_id
+        account := device_registry.async_get_device_by_identifier(
+            (DOMAIN, "271958441785640"), config_entry.entry_id
         )
-        is None
     )
+    response = await client.remove_device(account.id)
+    assert not response["success"]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I mistakenly assumed that the API endpoint to retrieve consoles returned all devices the user has registered with their Xbox account. Instead, it returns all devices that are currently connected to the Xbox Network. Devices that are offline are not listed anymore after being offline for some time. Therefore the automatic cleanup of stale devices is changed to manual. As soon as the device is no longer in the console list it can be removed, otherwise removal is blocked.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180397
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
