### PR TITLE
Improve entity cleanup when adding the entity fails

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -547,6 +547,10 @@ class Entity(
     # If entity is added to an entity platform
     _platform_state = EntityPlatformState.NOT_ADDED
 
+    # Whether async_added_to_hass has started for the current add attempt. Read by
+    # EntityPlatform to run async_will_remove_from_hass if adding the entity fails.
+    _added_to_hass_started = False
+
     # Attributes to exclude from recording, only set by base components, e.g. light
     _entity_component_unrecorded_attributes: frozenset[str] = frozenset()
     # Additional integration specific attributes to exclude from recording, set by
@@ -1419,6 +1423,7 @@ class Entity(
         self.platform_data = platform.platform_data
         self.parallel_updates = parallel_updates
         self._platform_state = EntityPlatformState.ADDING
+        self._added_to_hass_started = False
 
     def _call_on_remove_callbacks(self) -> None:
         """Call callbacks registered by async_on_remove."""
@@ -1441,6 +1446,7 @@ class Entity(
     async def add_to_platform_finish(self) -> None:
         """Finish adding an entity to a platform."""
         await self.async_internal_added_to_hass()
+        self._added_to_hass_started = True
         await self.async_added_to_hass()
         self._platform_state = EntityPlatformState.ADDED
         self.async_write_ha_state()

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -910,13 +910,24 @@ class EntityPlatform:
             # `async_internal_added_to_hass` may have populated entity_sources.
             # Roll that back before aborting so neither leaks.
             try:
-                await entity.async_internal_will_remove_from_hass()
-            except Exception:
-                self.logger.exception(
-                    "%s: Error cleaning up entity %s after it failed to be added",
-                    self.platform_name,
-                    entity_id,
-                )
+                try:
+                    await entity.async_internal_will_remove_from_hass()
+                except Exception:
+                    self.logger.exception(
+                        "%s: Error cleaning up entity %s after it failed to be added",
+                        self.platform_name,
+                        entity_id,
+                    )
+                if entity._added_to_hass_started:  # noqa: SLF001
+                    try:
+                        await entity.async_will_remove_from_hass()
+                    except Exception:
+                        self.logger.exception(
+                            "%s: Error cleaning up entity %s after it failed to be"
+                            " added",
+                            self.platform_name,
+                            entity_id,
+                        )
             finally:
                 if not restored:
                     self.hass.states.async_remove(entity_id)

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -3107,6 +3107,75 @@ async def test_platform_state_fail_to_add_rollback_raises(
     assert "Failed to add entity" in caplog.text
 
 
+async def test_platform_state_fail_to_add_runs_will_remove(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test the integration removal hook runs when a partial add is rolled back.
+
+    Resources set up by async_added_to_hass that are not registered via
+    async_on_remove (e.g. MQTT topic subscriptions) must be torn down by
+    async_will_remove_from_hass when adding the entity fails.
+    """
+    entry = entity_registry.async_get_or_create(
+        "test", "test_platform", "5678", suggested_object_id="test"
+    )
+    assert entry.entity_id == "test.test"
+
+    class MockEntity(entity.Entity):
+        _attr_unique_id = "5678"
+        will_remove_called = False
+
+        async def async_added_to_hass(self) -> None:
+            # A resource set up here would not be registered via async_on_remove.
+            raise ValueError("Failed to add entity")
+
+        async def async_will_remove_from_hass(self) -> None:
+            self.will_remove_called = True
+
+    platform = MockEntityPlatform(hass, domain="test")
+    ent = MockEntity()
+    await platform.async_add_entities([ent])
+
+    assert ent.will_remove_called
+    assert ent._platform_state is entity.EntityPlatformState.REMOVED
+    assert ent.hass is None
+    assert ent.platform is None
+    assert "test.test" not in platform.entities
+    assert hass.states.async_available("test.test")
+    assert "test.test" not in entity.entity_sources(hass)
+
+
+async def test_platform_state_fail_to_add_skips_will_remove_if_not_started(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test the integration removal hook is skipped when the add hook never ran.
+
+    If async_internal_added_to_hass fails, async_added_to_hass never starts, so
+    async_will_remove_from_hass must not be called.
+    """
+    entity_registry.async_get_or_create(
+        "test", "test_platform", "5678", suggested_object_id="test"
+    )
+
+    class MockEntity(entity.Entity):
+        _attr_unique_id = "5678"
+        will_remove_called = False
+
+        async def async_internal_added_to_hass(self) -> None:
+            raise ValueError("Failed internal add")
+
+        async def async_will_remove_from_hass(self) -> None:
+            self.will_remove_called = True
+
+    platform = MockEntityPlatform(hass, domain="test")
+    ent = MockEntity()
+    await platform.async_add_entities([ent])
+
+    assert not ent.will_remove_called
+    assert ent._platform_state is entity.EntityPlatformState.REMOVED
+    assert ent.hass is None
+
+
 async def test_platform_state_write_from_init(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve entity cleanup when adding the entity fails

This is a follow-up to https://github.com/home-assistant/core/pull/179509 as requested in https://github.com/home-assistant/core/pull/179509#discussion_r3869815249

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
