### PR TITLE
Discover Zooz ZSE43 vibration idle button

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -39,6 +39,7 @@ from homeassistant.helpers.issue_registry import (
     async_delete_issue,
 )
 from homeassistant.helpers.start import async_at_started
+from homeassistant.helpers.typing import UNDEFINED
 
 from .const import DOMAIN
 from .entity import NewZwaveDiscoveryInfo, ZWaveBaseEntity
@@ -684,10 +685,16 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         if description:
             self.entity_description = description
 
-        # Entity class attributes
-        self._attr_name = self.generate_name(
-            alternate_value_name=self.info.primary_value.metadata.states[self.state_key]
-        )
+        # Notification sensors are named after their notification state. A
+        # description may set its own name to override that.
+        if not hasattr(self, "entity_description") or (
+            self.entity_description.name is UNDEFINED
+        ):
+            self._attr_name = self.generate_name(
+                alternate_value_name=self.info.primary_value.metadata.states[
+                    self.state_key
+                ]
+            )
         self._attr_unique_id = f"{self._attr_unique_id}.{self.state_key}"
 
     @property
@@ -870,6 +877,33 @@ OPENING_STATE_NOTIFICATION_SCHEMA = ZWaveValueDiscoverySchema(
 
 
 DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
+    # Zooz ZSE43 Tilt/Shock Sensor. Its vibration sensor is reported
+    # through the Home Security "Cover status" notification, so expose
+    # that notification as a vibration sensor.
+    NewZWaveDiscoverySchema(
+        platform=Platform.BINARY_SENSOR,
+        manufacturer_id={0x027A},
+        product_id={0xE003},
+        product_type={0x7000},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Home Security"},
+            property_key={"Cover status"},
+            type={ValueType.NUMBER},
+            any_available_states_keys={3},
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.HOME_SECURITY)
+            },
+        ),
+        entity_description=NotificationZWaveJSEntityDescription(
+            # NotificationType 7: Home Security - State Id 3 (product cover removed)
+            key=NOTIFICATION_HOME_SECURITY,
+            name="Vibration",
+            states={3},
+            device_class=BinarySensorDeviceClass.VIBRATION,
+        ),
+        entity_class=ZWaveNotificationBinarySensor,
+    ),
     NewZWaveDiscoverySchema(
         platform=Platform.BINARY_SENSOR,
         primary_value=ZWaveValueDiscoverySchema(

--- a/homeassistant/components/zwave_js/button.py
+++ b/homeassistant/components/zwave_js/button.py
@@ -2,19 +2,33 @@
 
 from typing import override
 
+from zwave_js_server.const import CommandClass
+from zwave_js_server.const.command_class.notification import (
+    CC_SPECIFIC_NOTIFICATION_TYPE,
+    NotificationType,
+)
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node as ZwaveNode
 
-from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, ButtonEntity
-from homeassistant.const import EntityCategory
+from homeassistant.components.button import (
+    DOMAIN as BUTTON_DOMAIN,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
-from .discovery import ZwaveDiscoveryInfo
-from .entity import ZWaveBaseEntity, ZWaveNodeBaseEntity
-from .models import ZwaveJSConfigEntry
+from .entity import NewZwaveDiscoveryInfo, ZWaveBaseEntity, ZWaveNodeBaseEntity
+from .models import (
+    NewZWaveDiscoverySchema,
+    ValueType,
+    ZwaveDiscoveryInfo,
+    ZwaveJSConfigEntry,
+    ZWaveValueDiscoverySchema,
+)
 
 PARALLEL_UPDATES = 0
 
@@ -28,12 +42,14 @@ async def async_setup_entry(
     client = config_entry.runtime_data.client
 
     @callback
-    def async_add_button(info: ZwaveDiscoveryInfo) -> None:
+    def async_add_button(info: ZwaveDiscoveryInfo | NewZwaveDiscoveryInfo) -> None:
         """Add Z-Wave Button."""
         driver = client.driver
         assert driver is not None  # Driver is ready before platforms are loaded.
         entities: list[ZWaveBaseEntity] = []
-        if info.platform_hint == "notification idle":
+        if isinstance(info, NewZwaveDiscoveryInfo):
+            entities.append(info.entity_class(config_entry, driver, info))
+        elif info.platform_hint == "notification idle":
             entities.append(ZWaveNotificationIdleButton(config_entry, driver, info))
         else:
             entities.append(ZwaveBooleanNodeButton(config_entry, driver, info))
@@ -101,17 +117,25 @@ class ZWaveNotificationIdleButton(ZWaveBaseEntity, ButtonEntity):
     """Button to idle Notification CC values."""
 
     _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
 
     def __init__(
-        self, config_entry: ZwaveJSConfigEntry, driver: Driver, info: ZwaveDiscoveryInfo
+        self,
+        config_entry: ZwaveJSConfigEntry,
+        driver: Driver,
+        info: ZwaveDiscoveryInfo | NewZwaveDiscoveryInfo,
     ) -> None:
         """Initialize a ZWaveNotificationIdleButton entity."""
         super().__init__(config_entry, driver, info)
-        self._attr_name = self.generate_name(
-            alternate_value_name=self.info.primary_value.property_name,
-            additional_info=[self.info.primary_value.property_key_name],
-            name_prefix="Idle",
-        )
+        if isinstance(info, NewZwaveDiscoveryInfo):
+            # Name from the discovery schema, e.g. "Idle Vibration".
+            self._attr_name = self.generate_name(name_prefix="Idle")
+        else:
+            self._attr_name = self.generate_name(
+                alternate_value_name=self.info.primary_value.property_name,
+                additional_info=[self.info.primary_value.property_key_name],
+                name_prefix="Idle",
+            )
         self._attr_unique_id = f"{self._attr_unique_id}.notification_idle"
 
     @override
@@ -120,3 +144,31 @@ class ZWaveNotificationIdleButton(ZWaveBaseEntity, ButtonEntity):
         await self.info.node.async_manually_idle_notification_value(
             self.info.primary_value
         )
+
+
+DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
+    # Zooz ZSE43 Tilt/Shock Sensor. Its Home Security "Cover status" notification
+    # is exposed as a vibration binary sensor, so match that idle button here to
+    # name it after the sensor and keep it discovered.
+    NewZWaveDiscoverySchema(
+        platform=Platform.BUTTON,
+        manufacturer_id={0x027A},
+        product_id={0xE003},
+        product_type={0x7000},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.NOTIFICATION},
+            property={"Home Security"},
+            property_key={"Cover status"},
+            type={ValueType.NUMBER},
+            any_available_states={(0, "idle")},
+            any_available_cc_specific={
+                (CC_SPECIFIC_NOTIFICATION_TYPE, NotificationType.HOME_SECURITY)
+            },
+        ),
+        allow_multi=True,
+        entity_description=ButtonEntityDescription(
+            key="notification_idle", name="Vibration"
+        ),
+        entity_class=ZWaveNotificationIdleButton,
+    ),
+]

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -53,6 +53,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .binary_sensor import DISCOVERY_SCHEMAS as BINARY_SENSOR_SCHEMAS
+from .button import DISCOVERY_SCHEMAS as BUTTON_SCHEMAS
 from .const import COVER_POSITION_PROPERTY_KEYS, COVER_TILT_PROPERTY_KEYS, LOGGER
 from .discovery_data_template import (
     BaseDiscoverySchemaDataTemplate,
@@ -75,7 +76,10 @@ from .models import (
 )
 from .sensor import DISCOVERY_SCHEMAS as SENSOR_SCHEMAS
 
+# Button schemas are ordered before binary sensor schemas so a button can be
+# discovered from a value that a non-multi binary sensor schema then claims.
 NEW_DISCOVERY_SCHEMAS: dict[Platform, list[NewZWaveDiscoverySchema]] = {
+    Platform.BUTTON: BUTTON_SCHEMAS,
     Platform.BINARY_SENSOR: BINARY_SENSOR_SCHEMAS,
     Platform.EVENT: EVENT_SCHEMAS,
     Platform.SENSOR: SENSOR_SCHEMAS,

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -517,6 +517,12 @@ def switch_zooz_zen72_state_fixture() -> dict[str, Any]:
     return load_json_object_fixture("switch_zooz_zen72_state.json", DOMAIN)
 
 
+@pytest.fixture(name="zooz_zse43_state", scope="package")
+def zooz_zse43_state_fixture() -> dict[str, Any]:
+    """Load the Zooz ZSE43 tilt/shock sensor node state fixture data."""
+    return load_json_object_fixture("zooz_zse43_state.json", DOMAIN)
+
+
 @pytest.fixture(name="indicator_test_state", scope="package")
 def indicator_test_state_fixture() -> dict[str, Any]:
     """Load the indicator CC test node state fixture data."""
@@ -1431,6 +1437,14 @@ def lock_home_connect_620_fixture(client, lock_home_connect_620_state) -> Node:
 def switch_zooz_zen72_fixture(client, switch_zooz_zen72_state) -> Node:
     """Mock a Zooz Zen72 switch node."""
     node = Node(client, copy.deepcopy(switch_zooz_zen72_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="zooz_zse43")
+def zooz_zse43_fixture(client, zooz_zse43_state) -> Node:
+    """Mock a Zooz ZSE43 tilt/shock sensor node."""
+    node = Node(client, copy.deepcopy(zooz_zse43_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -1442,7 +1442,7 @@ def switch_zooz_zen72_fixture(client, switch_zooz_zen72_state) -> Node:
 
 
 @pytest.fixture(name="zooz_zse43")
-def zooz_zse43_fixture(client, zooz_zse43_state) -> Node:
+def zooz_zse43_fixture(client: MagicMock, zooz_zse43_state: NodeDataType) -> Node:
     """Mock a Zooz ZSE43 tilt/shock sensor node."""
     node = Node(client, copy.deepcopy(zooz_zse43_state))
     client.driver.controller.nodes[node.node_id] = node

--- a/tests/components/zwave_js/fixtures/zooz_zse43_state.json
+++ b/tests/components/zwave_js/fixtures/zooz_zse43_state.json
@@ -1,0 +1,1382 @@
+{
+  "nodeId": 13,
+  "index": 0,
+  "installerIcon": 3078,
+  "userIcon": 3072,
+  "status": 1,
+  "ready": true,
+  "isListening": false,
+  "isRouting": true,
+  "isSecure": true,
+  "manufacturerId": 634,
+  "productId": 57347,
+  "productType": 28672,
+  "firmwareVersion": "1.20.1",
+  "zwavePlusVersion": 2,
+  "deviceConfig": {
+    "filename": "/usr/src/app/store/.config-db/devices/0x027a/zse43.json",
+    "isEmbedded": true,
+    "manufacturer": "Zooz",
+    "manufacturerId": 634,
+    "label": "ZSE43",
+    "description": "Tilt Shock XS Sensor",
+    "devices": [
+      {
+        "productType": 28672,
+        "productId": 57347
+      }
+    ],
+    "firmwareVersion": {
+      "min": "0.0",
+      "max": "255.255"
+    },
+    "preferred": false,
+    "associations": {
+      "1": {
+        "groupId": 1,
+        "label": "Lifeline",
+        "maxNodes": 3,
+        "isLifeline": true,
+        "multiChannel": "auto"
+      },
+      "2": {
+        "groupId": 2,
+        "label": "Tilt On/Off",
+        "maxNodes": 5,
+        "isLifeline": false,
+        "multiChannel": "auto"
+      },
+      "3": {
+        "groupId": 3,
+        "label": "Shock On/Off",
+        "maxNodes": 5,
+        "isLifeline": false,
+        "multiChannel": "auto"
+      }
+    },
+    "paramInformation": {
+      "_map": {
+        "{\"parameter\":1}": {
+          "parameterNumber": 1,
+          "label": "LED Indicator",
+          "valueSize": 1,
+          "allowed": [
+            {
+              "from": 0,
+              "to": 3
+            }
+          ],
+          "minValue": 0,
+          "maxValue": 3,
+          "unsigned": false,
+          "defaultValue": 3,
+          "allowManualEntry": false,
+          "options": [
+            {
+              "value": 0,
+              "label": "Disable"
+            },
+            {
+              "value": 1,
+              "label": "LED on shock only"
+            },
+            {
+              "value": 2,
+              "label": "LED on tilt only"
+            },
+            {
+              "value": 3,
+              "label": "LED on shock and tilt"
+            }
+          ]
+        },
+        "{\"parameter\":2}": {
+          "parameterNumber": 2,
+          "label": "Battery Report Threshold",
+          "valueSize": 1,
+          "allowed": [
+            {
+              "from": 1,
+              "to": 50
+            }
+          ],
+          "minValue": 1,
+          "maxValue": 50,
+          "unsigned": true,
+          "defaultValue": 5,
+          "unit": "%",
+          "allowManualEntry": true,
+          "purpose": "reporting_threshold.battery",
+          "options": []
+        },
+        "{\"parameter\":3}": {
+          "parameterNumber": 3,
+          "label": "Low Battery Alarm Threshold",
+          "valueSize": 1,
+          "allowed": [
+            {
+              "from": 10,
+              "to": 50
+            }
+          ],
+          "minValue": 10,
+          "maxValue": 50,
+          "unsigned": true,
+          "defaultValue": 20,
+          "unit": "%",
+          "allowManualEntry": true,
+          "purpose": "reporting_threshold.low_battery",
+          "options": []
+        },
+        "{\"parameter\":4}": {
+          "parameterNumber": 4,
+          "label": "Shock Sensitivity",
+          "valueSize": 1,
+          "allowed": [
+            {
+              "from": 0,
+              "to": 2
+            }
+          ],
+          "minValue": 0,
+          "maxValue": 2,
+          "unsigned": false,
+          "defaultValue": 0,
+          "unit": "%",
+          "allowManualEntry": false,
+          "options": [
+            {
+              "value": 0,
+              "label": "High"
+            },
+            {
+              "value": 1,
+              "label": "Medium"
+            },
+            {
+              "value": 2,
+              "label": "Low"
+            }
+          ]
+        },
+        "{\"parameter\":5}": {
+          "parameterNumber": 5,
+          "label": "Group 2: On Delay",
+          "valueSize": 4,
+          "allowed": [
+            {
+              "from": 0,
+              "to": 3600
+            }
+          ],
+          "minValue": 0,
+          "maxValue": 3600,
+          "unsigned": true,
+          "defaultValue": 0,
+          "unit": "seconds",
+          "allowManualEntry": true,
+          "options": []
+        },
+        "{\"parameter\":6}": {
+          "parameterNumber": 6,
+          "label": "Group 2: Off Delay",
+          "valueSize": 4,
+          "allowed": [
+            {
+              "from": 0,
+              "to": 3600
+            }
+          ],
+          "minValue": 0,
+          "maxValue": 3600,
+          "unsigned": true,
+          "defaultValue": 0,
+          "unit": "seconds",
+          "allowManualEntry": true,
+          "options": []
+        },
+        "{\"parameter\":7}": {
+          "parameterNumber": 7,
+          "label": "Enable Sensors",
+          "valueSize": 1,
+          "allowed": [
+            {
+              "from": 0,
+              "to": 2
+            }
+          ],
+          "minValue": 0,
+          "maxValue": 2,
+          "unsigned": false,
+          "defaultValue": 2,
+          "allowManualEntry": false,
+          "options": [
+            {
+              "value": 0,
+              "label": "Only tilt sensor enabled"
+            },
+            {
+              "value": 1,
+              "label": "Only shock sensor enabled"
+            },
+            {
+              "value": 2,
+              "label": "Both sensors enabled"
+            }
+          ]
+        },
+        "{\"parameter\":8}": {
+          "parameterNumber": 8,
+          "label": "Group 2: Tilt Sensor Basic Reports",
+          "valueSize": 1,
+          "allowed": [
+            {
+              "from": 0,
+              "to": 3
+            }
+          ],
+          "minValue": 0,
+          "maxValue": 3,
+          "unsigned": false,
+          "defaultValue": 3,
+          "allowManualEntry": false,
+          "options": [
+            {
+              "value": 0,
+              "label": "Disable"
+            },
+            {
+              "value": 1,
+              "label": "0xff (On) when tilt detected"
+            },
+            {
+              "value": 2,
+              "label": "0x00 (Off) when tilt cleared"
+            },
+            {
+              "value": 3,
+              "label": "0xff (On) when tilt detected; 0x00 (Off) when tilt cleared"
+            }
+          ]
+        },
+        "{\"parameter\":9}": {
+          "parameterNumber": 9,
+          "label": "Group 3: Shock Sensor Basic Reports",
+          "valueSize": 1,
+          "allowed": [
+            {
+              "from": 0,
+              "to": 3
+            }
+          ],
+          "minValue": 0,
+          "maxValue": 3,
+          "unsigned": false,
+          "defaultValue": 3,
+          "allowManualEntry": false,
+          "options": [
+            {
+              "value": 0,
+              "label": "Disable"
+            },
+            {
+              "value": 1,
+              "label": "0xff (On) when shock detected"
+            },
+            {
+              "value": 2,
+              "label": "0x00 (Off) when shock cleared"
+            },
+            {
+              "value": 3,
+              "label": "0xff (On) when shock detected; 0x00 (Off) when shock cleared"
+            }
+          ]
+        }
+      }
+    },
+    "metadata": {
+      "wakeup": "Click the Z-Wave button 4 times quickly. The LED indicator will flash twice to confirm the device is awake.",
+      "inclusion": "Click the Z-Wave button 3 times as quickly as possible. The LED indicator will start flashing and turn off once inclusion is completed.",
+      "exclusion": "Click the Z-Wave button 3 times as quickly as possible. The LED indicator will start flashing and turn off when exclusion is complete.",
+      "reset": "1. Click the Z-Wave button twice and hold it the third time for 10 seconds\n2. The LED indicator will blink continuously\n3. Immediately click the Z-Wave button twice more to finalize the reset\n4. The LED indicator will flash 3 times to confirm a successful reset",
+      "manual": "https://cdn.shopify.com/s/files/1/0218/7704/files/zooz-700-series-tilt-shock-xs-sensor-zse43-manual.pdf"
+    }
+  },
+  "label": "ZSE43",
+  "interviewAttempts": 1,
+  "isFrequentListening": false,
+  "maxDataRate": 100000,
+  "supportedDataRates": [40000, 100000],
+  "protocolVersion": 3,
+  "supportsBeaming": true,
+  "supportsSecurity": false,
+  "nodeType": 1,
+  "zwavePlusNodeType": 0,
+  "zwavePlusRoleType": 6,
+  "deviceClass": {
+    "basic": {
+      "key": 4,
+      "label": "Routing End Node"
+    },
+    "generic": {
+      "key": 7,
+      "label": "Notification Sensor"
+    },
+    "specific": {
+      "key": 1,
+      "label": "Notification Sensor"
+    }
+  },
+  "interviewStage": "Complete",
+  "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x027a:0x7000:0xe003:1.20.1",
+  "statistics": {
+    "commandsTX": 122,
+    "commandsRX": 124,
+    "commandsDroppedRX": 0,
+    "commandsDroppedTX": 0,
+    "timeoutResponse": 3,
+    "rtt": 21.1,
+    "lastSeen": "2026-09-01T08:31:34.188Z",
+    "rssi": -62,
+    "lwr": {
+      "protocolDataRate": 2,
+      "repeaters": [],
+      "rssi": -62,
+      "repeaterRSSI": []
+    }
+  },
+  "highestSecurityClass": 1,
+  "isControllerNode": false,
+  "keepAwake": false,
+  "lastSeen": "2026-09-01T08:25:06.085Z",
+  "protocol": 0,
+  "sdkVersion": "7.13.10",
+  "canSleep": true,
+  "hardwareVersion": 1,
+  "hasSUCReturnRoute": true,
+  "manufacturer": "Zooz",
+  "dsk": "**REDACTED**",
+  "values": [
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 1,
+      "propertyName": "LED Indicator",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "LED Indicator",
+        "default": 3,
+        "min": 0,
+        "max": 3,
+        "states": {
+          "0": "Disable",
+          "1": "LED on shock only",
+          "2": "LED on tilt only",
+          "3": "LED on shock and tilt"
+        },
+        "valueSize": 1,
+        "format": 0,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "allowed": [
+          {
+            "from": 0,
+            "to": 3
+          }
+        ]
+      },
+      "value": 3
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 3,
+      "propertyName": "Low Battery Alarm Threshold",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Low Battery Alarm Threshold",
+        "default": 20,
+        "min": 10,
+        "max": 50,
+        "unit": "%",
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "allowed": [
+          {
+            "from": 10,
+            "to": 50
+          }
+        ],
+        "purpose": "reporting_threshold.low_battery"
+      },
+      "value": 20
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 4,
+      "propertyName": "Shock Sensitivity",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Shock Sensitivity",
+        "default": 0,
+        "min": 0,
+        "max": 2,
+        "states": {
+          "0": "High",
+          "1": "Medium",
+          "2": "Low"
+        },
+        "unit": "%",
+        "valueSize": 1,
+        "format": 0,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "allowed": [
+          {
+            "from": 0,
+            "to": 2
+          }
+        ]
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 5,
+      "propertyName": "Group 2: On Delay",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Group 2: On Delay",
+        "default": 0,
+        "min": 0,
+        "max": 3600,
+        "unit": "seconds",
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "allowed": [
+          {
+            "from": 0,
+            "to": 3600
+          }
+        ]
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 6,
+      "propertyName": "Group 2: Off Delay",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Group 2: Off Delay",
+        "default": 0,
+        "min": 0,
+        "max": 3600,
+        "unit": "seconds",
+        "valueSize": 4,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "allowed": [
+          {
+            "from": 0,
+            "to": 3600
+          }
+        ]
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 7,
+      "propertyName": "Enable Sensors",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Enable Sensors",
+        "default": 2,
+        "min": 0,
+        "max": 2,
+        "states": {
+          "0": "Only tilt sensor enabled",
+          "1": "Only shock sensor enabled",
+          "2": "Both sensors enabled"
+        },
+        "valueSize": 1,
+        "format": 0,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "allowed": [
+          {
+            "from": 0,
+            "to": 2
+          }
+        ]
+      },
+      "value": 2
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 8,
+      "propertyName": "Group 2: Tilt Sensor Basic Reports",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Group 2: Tilt Sensor Basic Reports",
+        "default": 3,
+        "min": 0,
+        "max": 3,
+        "states": {
+          "0": "Disable",
+          "1": "0xff (On) when tilt detected",
+          "2": "0x00 (Off) when tilt cleared",
+          "3": "0xff (On) when tilt detected; 0x00 (Off) when tilt cleared"
+        },
+        "valueSize": 1,
+        "format": 0,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "allowed": [
+          {
+            "from": 0,
+            "to": 3
+          }
+        ]
+      },
+      "value": 3
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 9,
+      "propertyName": "Group 3: Shock Sensor Basic Reports",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Group 3: Shock Sensor Basic Reports",
+        "default": 3,
+        "min": 0,
+        "max": 3,
+        "states": {
+          "0": "Disable",
+          "1": "0xff (On) when shock detected",
+          "2": "0x00 (Off) when shock cleared",
+          "3": "0xff (On) when shock detected; 0x00 (Off) when shock cleared"
+        },
+        "valueSize": 1,
+        "format": 0,
+        "allowManualEntry": false,
+        "isFromConfig": true,
+        "allowed": [
+          {
+            "from": 0,
+            "to": 3
+          }
+        ]
+      },
+      "value": 3
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 10,
+      "propertyName": "Report for contact",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Select report type(Notification or binary sensor) when contact sensor triggered",
+        "label": "Report for contact",
+        "default": 0,
+        "min": 0,
+        "max": 2,
+        "valueSize": 1,
+        "format": 1,
+        "isAdvanced": false,
+        "requiresReInclusion": false,
+        "allowManualEntry": true,
+        "isFromConfig": false
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 11,
+      "propertyName": "Report delay after tamper disarming",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Report will be issued after some seconds determined by this parameter",
+        "label": "Report delay after tamper disarming",
+        "default": 3,
+        "min": 0,
+        "max": 3600,
+        "valueSize": 2,
+        "format": 1,
+        "isAdvanced": false,
+        "requiresReInclusion": false,
+        "allowManualEntry": true,
+        "isFromConfig": false
+      },
+      "value": 3
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 2,
+      "propertyName": "Battery Report Threshold",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Battery Report Threshold",
+        "default": 5,
+        "min": 1,
+        "max": 50,
+        "unit": "%",
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true,
+        "allowed": [
+          {
+            "from": 1,
+            "to": 50
+          }
+        ],
+        "purpose": "reporting_threshold.battery"
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Access Control",
+      "propertyKey": "Door state",
+      "propertyName": "Access Control",
+      "propertyKeyName": "Door state",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Door state",
+        "ccSpecific": {
+          "notificationType": 6
+        },
+        "min": 0,
+        "max": 255,
+        "states": {
+          "22": "Window/door is open",
+          "23": "Window/door is closed",
+          "5632": "Window/door is open in regular position",
+          "5633": "Window/door is open in tilt position"
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": 22
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Home Security",
+      "propertyKey": "Cover status",
+      "propertyName": "Home Security",
+      "propertyKeyName": "Cover status",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Cover status",
+        "ccSpecific": {
+          "notificationType": 7
+        },
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "idle",
+          "3": "Tampering, product cover removed"
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "alarmType",
+      "propertyName": "alarmType",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Alarm Type",
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "alarmLevel",
+      "propertyName": "alarmLevel",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Alarm Level",
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Access Control",
+      "propertyKey": "Opening state",
+      "propertyName": "Access Control",
+      "propertyKeyName": "Opening state",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Opening state",
+        "ccSpecific": {
+          "notificationType": 6
+        },
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "Closed",
+          "1": "Open"
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": 1
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Access Control",
+      "propertyKey": "Door state (simple)",
+      "propertyName": "Access Control",
+      "propertyKeyName": "Door state (simple)",
+      "ccVersion": 8,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Door state (simple)",
+        "ccSpecific": {
+          "notificationType": 6
+        },
+        "min": 0,
+        "max": 255,
+        "states": {
+          "22": "Window/door is open",
+          "23": "Window/door is closed"
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": 22
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productId",
+      "propertyName": "productId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product ID",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 57347
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productType",
+      "propertyName": "productType",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product type",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 28672
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "manufacturerId",
+      "propertyName": "manufacturerId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Manufacturer ID",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 634
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 128,
+      "commandClassName": "Battery",
+      "property": "level",
+      "propertyName": "level",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Battery level",
+        "min": 0,
+        "max": 100,
+        "unit": "%",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 132,
+      "commandClassName": "Wake Up",
+      "property": "wakeUpInterval",
+      "propertyName": "wakeUpInterval",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "default": 21600,
+        "readable": false,
+        "writeable": true,
+        "min": 0,
+        "max": 86400,
+        "states": {
+          "0": "Disabled"
+        },
+        "stateful": true,
+        "secret": false,
+        "allowed": [
+          {
+            "value": 0
+          },
+          {
+            "from": 3600,
+            "to": 86400,
+            "step": 60
+          }
+        ]
+      },
+      "value": 21600
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 132,
+      "commandClassName": "Wake Up",
+      "property": "controllerNodeId",
+      "propertyName": "controllerNodeId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Node ID of the controller",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 1
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "hardwareVersion",
+      "propertyName": "hardwareVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip hardware version",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 1
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "firmwareVersions",
+      "propertyName": "firmwareVersions",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string[]",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip firmware versions",
+        "stateful": true,
+        "secret": false
+      },
+      "value": ["1.20"]
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "protocolVersion",
+      "propertyName": "protocolVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave protocol version",
+        "stateful": true,
+        "secret": false
+      },
+      "value": "7.13"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "libraryType",
+      "propertyName": "libraryType",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Library type",
+        "states": {
+          "0": "Unknown",
+          "1": "Static Controller",
+          "2": "Controller",
+          "3": "Enhanced Slave",
+          "4": "Slave",
+          "5": "Installer",
+          "6": "Routing Slave",
+          "7": "Bridge Controller",
+          "8": "Device under Test",
+          "9": "N/A",
+          "10": "AV Remote",
+          "11": "AV Device"
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": 3
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "applicationBuildNumber",
+      "propertyName": "applicationBuildNumber",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Application build number",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 43707
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "applicationVersion",
+      "propertyName": "applicationVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Application version",
+        "stateful": true,
+        "secret": false
+      },
+      "value": "1.20.1"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "zWaveProtocolBuildNumber",
+      "propertyName": "zWaveProtocolBuildNumber",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave protocol build number",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 423
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "zWaveProtocolVersion",
+      "propertyName": "zWaveProtocolVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave protocol version",
+        "stateful": true,
+        "secret": false
+      },
+      "value": "7.13.10"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "hostInterfaceBuildNumber",
+      "propertyName": "hostInterfaceBuildNumber",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Serial API build number",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "hostInterfaceVersion",
+      "propertyName": "hostInterfaceVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Serial API version",
+        "stateful": true,
+        "secret": false
+      },
+      "value": "unused"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "applicationFrameworkBuildNumber",
+      "propertyName": "applicationFrameworkBuildNumber",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave application framework API build number",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 423
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "applicationFrameworkAPIVersion",
+      "propertyName": "applicationFrameworkAPIVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave application framework API version",
+        "stateful": true,
+        "secret": false
+      },
+      "value": "10.13.10"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "sdkVersion",
+      "propertyName": "sdkVersion",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "SDK version",
+        "stateful": true,
+        "secret": false
+      },
+      "value": "7.13.10"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 135,
+      "commandClassName": "Indicator",
+      "property": "value",
+      "propertyName": "value",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Indicator value",
+        "ccSpecific": {
+          "indicatorId": 0
+        },
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 135,
+      "commandClassName": "Indicator",
+      "property": "identify",
+      "propertyName": "identify",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "boolean",
+        "readable": false,
+        "writeable": true,
+        "label": "Identify",
+        "states": {
+          "true": "Identify"
+        },
+        "stateful": true,
+        "secret": false
+      }
+    }
+  ],
+  "endpoints": [
+    {
+      "nodeId": 13,
+      "index": 0,
+      "installerIcon": 3078,
+      "userIcon": 3072,
+      "deviceClass": {
+        "basic": {
+          "key": 4,
+          "label": "Routing End Node"
+        },
+        "generic": {
+          "key": 7,
+          "label": "Notification Sensor"
+        },
+        "specific": {
+          "key": 1,
+          "label": "Notification Sensor"
+        }
+      },
+      "commandClasses": [
+        {
+          "id": 94,
+          "name": "Z-Wave Plus Info",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 133,
+          "name": "Association",
+          "version": 2,
+          "isSecure": true
+        },
+        {
+          "id": 142,
+          "name": "Multi Channel Association",
+          "version": 3,
+          "isSecure": true
+        },
+        {
+          "id": 89,
+          "name": "Association Group Information",
+          "version": 3,
+          "isSecure": true
+        },
+        {
+          "id": 85,
+          "name": "Transport Service",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 3,
+          "isSecure": true
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 2,
+          "isSecure": true
+        },
+        {
+          "id": 90,
+          "name": "Device Reset Locally",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 115,
+          "name": "Powerlevel",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 128,
+          "name": "Battery",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 159,
+          "name": "Security 2",
+          "version": 1,
+          "isSecure": true
+        },
+        {
+          "id": 113,
+          "name": "Notification",
+          "version": 8,
+          "isSecure": true
+        },
+        {
+          "id": 135,
+          "name": "Indicator",
+          "version": 3,
+          "isSecure": true
+        },
+        {
+          "id": 48,
+          "name": "Binary Sensor",
+          "version": 2,
+          "isSecure": true
+        },
+        {
+          "id": 112,
+          "name": "Configuration",
+          "version": 4,
+          "isSecure": true
+        },
+        {
+          "id": 132,
+          "name": "Wake Up",
+          "version": 2,
+          "isSecure": true
+        },
+        {
+          "id": 108,
+          "name": "Supervision",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 122,
+          "name": "Firmware Update Meta Data",
+          "version": 5,
+          "isSecure": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.components.zwave_js.const import DOMAIN
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
+    ATTR_FRIENDLY_NAME,
     STATE_OFF,
     STATE_ON,
     STATE_UNKNOWN,
@@ -1706,3 +1707,23 @@ async def test_legacy_door_open_state_stale_repair_issue_cleaned_up(
         )
         is None
     )
+
+
+ZSE43_VIBRATION_SENSOR = "binary_sensor.tilt_shock_xs_sensor_vibration"
+
+
+@pytest.mark.usefixtures("zooz_zse43", "integration")
+async def test_zooz_zse43_vibration_sensor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the ZSE43 cover-removed notification is exposed as a vibration sensor."""
+    state = hass.states.get(ZSE43_VIBRATION_SENSOR)
+    assert state
+    assert state.attributes[ATTR_DEVICE_CLASS] == BinarySensorDeviceClass.VIBRATION
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "Tilt Shock XS Sensor Vibration"
+
+    entity_entry = entity_registry.async_get(ZSE43_VIBRATION_SENSOR)
+    assert entity_entry
+    assert entity_entry.original_name == "Vibration"
+    assert entity_entry.entity_category is None

--- a/tests/components/zwave_js/test_button.py
+++ b/tests/components/zwave_js/test_button.py
@@ -150,3 +150,53 @@ async def test_power_management_notification_idle_button(
     assert entity_entry
     assert entity_entry.entity_category is EntityCategory.CONFIG
     assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+async def test_zooz_zse43_idle_vibration_button(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    client: MagicMock,
+    zooz_zse43: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test the ZSE43 idle button is named after its vibration sensor.
+
+    The vibration binary sensor is derived from the same Cover status value, so
+    this also guards against the idle button being dropped in discovery.
+    """
+    node = zooz_zse43
+    entity_id = "button.tilt_shock_xs_sensor_idle_vibration"
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry
+    assert entity_entry.entity_category is EntityCategory.CONFIG
+    assert entity_entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert hass.states.get(entity_id) is None  # disabled by default
+
+    entity_registry.async_update_entity(entity_id, disabled_by=None)
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["friendly_name"] == "Tilt Shock XS Sensor Idle Vibration"
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    assert client.async_send_command_no_wait.call_count == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
+    assert args["command"] == "node.manually_idle_notification_value"
+    assert args["nodeId"] == node.node_id
+    assert args["valueId"] == {
+        "commandClass": 113,
+        "endpoint": 0,
+        "property": "Home Security",
+        "propertyKey": "Cover status",
+    }


### PR DESCRIPTION
## Proposed change

> [!NOTE]
> Draft — depends on and is stacked on top of home-assistant/core#181003.
> Until that PR merges, the diff here also contains its changes. Merge #181003
> first, then this can be rebased onto `dev`.

home-assistant/core#181003 moves the Zooz ZSE43 Home Security "Cover status" notification onto a device-specific binary sensor discovery schema (`allow_multi=False`), which claims the value and drops the "Idle Cover status" button that the generic notification-idle discovery used to create.

This PR restores that button and names it after the sensor:

- Extends the button platform into the new discovery schemas (mirroring the sensor platform), so `async_add_button` instantiates `info.entity_class` for `NewZwaveDiscoveryInfo`.
- Adds a device-specific button schema for the ZSE43 cover-status value and teaches `ZWaveNotificationIdleButton` to name itself from the schema, giving "Idle Vibration".
- Registers `Platform.BUTTON` before `Platform.BINARY_SENSOR` in `NEW_DISCOVERY_SCHEMAS` so the `allow_multi=True` button schema is discovered before the vibration schema claims the value.

The button stays disabled by default and behaves like the other notification idle buttons (CONFIG category, press calls `manually_idle_notification_value`).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
