### PR TITLE
Bump rapt-ble to 2.0.0

### DIFF
--- a/homeassistant/components/rapt_ble/manifest.json
+++ b/homeassistant/components/rapt_ble/manifest.json
@@ -17,5 +17,5 @@
   "documentation": "https://www.home-assistant.io/integrations/rapt_ble",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["rapt-ble==0.1.2"]
+  "requirements": ["rapt-ble==2.0.0"]
 }

--- a/homeassistant/components/rapt_ble/sensor.py
+++ b/homeassistant/components/rapt_ble/sensor.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.sensor import sensor_device_info_to_hass_device_info
 
 from . import RAPTBLEConfigEntry
 
-SENSOR_DESCRIPTIONS = {
+SENSOR_DESCRIPTIONS: dict[tuple[str | None, str | None], SensorEntityDescription] = {
     (DeviceClass.TEMPERATURE, Units.TEMP_CELSIUS): SensorEntityDescription(
         key=f"{DeviceClass.TEMPERATURE}_{Units.TEMP_CELSIUS}",
         device_class=SensorDeviceClass.TEMPERATURE,
@@ -81,7 +81,8 @@ def sensor_update_to_bluetooth_data_update(
                 (description.device_class, description.native_unit_of_measurement)
             ]
             for device_key, description in sensor_update.entity_descriptions.items()
-            if description.device_class and description.native_unit_of_measurement
+            if (description.device_class, description.native_unit_of_measurement)
+            in SENSOR_DESCRIPTIONS
         },
         entity_data={
             _device_key_to_bluetooth_entity_key(device_key): sensor_values.native_value

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2944,7 +2944,7 @@ radiotherm==2.1.0
 raincloudy==0.0.7
 
 # homeassistant.components.rapt_ble
-rapt-ble==0.1.2
+rapt-ble==2.0.0
 
 # homeassistant.components.raspyrfm
 raspyrfm-client==1.2.9

--- a/tests/components/rapt_ble/__init__.py
+++ b/tests/components/rapt_ble/__init__.py
@@ -26,3 +26,29 @@ COMPLETE_SERVICE_INFO = BluetoothServiceInfo(
     service_uuids=[],
     source="local",
 )
+
+V2_SERVICE_INFO = BluetoothServiceInfo(
+    name="",
+    address=RAPT_MAC,
+    rssi=-70,
+    manufacturer_data={
+        16722: b"PT\x02\x00\x01\xc1m&\x14\x92kD\x7fR\xc91\xc9\x02-)\x97?F",
+        17739: b"G20220612_050156_81c6d14",
+    },
+    service_data={},
+    service_uuids=[],
+    source="local",
+)
+
+V2_NO_VELOCITY_SERVICE_INFO = BluetoothServiceInfo(
+    name="",
+    address=RAPT_MAC,
+    rssi=-70,
+    manufacturer_data={
+        16722: b"PT\x02\x00\x00\x00\x00\x00\x00\x94\x8bD|\xb9\xf64E\x02b&w*\xac",
+        17739: b"G20220612_050156_81c6d14",
+    },
+    service_data={},
+    service_uuids=[],
+    source="local",
+)

--- a/tests/components/rapt_ble/test_sensor.py
+++ b/tests/components/rapt_ble/test_sensor.py
@@ -1,5 +1,7 @@
 """Test the RAPT Pill BLE sensors."""
 
+import pytest
+
 from homeassistant.components.rapt_ble.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
 from homeassistant.const import (
@@ -9,8 +11,14 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
-from . import COMPLETE_SERVICE_INFO, RAPT_MAC
+from . import (
+    COMPLETE_SERVICE_INFO,
+    RAPT_MAC,
+    V2_NO_VELOCITY_SERVICE_INFO,
+    V2_SERVICE_INFO,
+)
 
 from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
@@ -59,6 +67,35 @@ async def test_sensors(hass: HomeAssistant) -> None:
         temp_sensor_attributes[ATTR_FRIENDLY_NAME] == "RAPT Pill 0666 Specific Gravity"
     )
     assert temp_sensor_attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize(
+    "service_info",
+    [
+        pytest.param(V2_SERVICE_INFO, id="valid_velocity"),
+        pytest.param(V2_NO_VELOCITY_SERVICE_INFO, id="invalid_velocity"),
+    ],
+)
+async def test_sensors_v2_payload(
+    hass: HomeAssistant, service_info: BluetoothServiceInfo
+) -> None:
+    """Test a version 2 advertisement sets up the known sensors."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=RAPT_MAC,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    inject_bluetooth_service_info(hass, service_info)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 3
+    assert hass.states.get("sensor.rapt_pill_0666_specific_gravity") is not None
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

rapt-ble 2.0.0 exports its own DeviceClass and Units enums and adds a specific gravity velocity sensor to every version 2 advertisement. Type the description map with plain string keys and skip pairs the integration does not map, so version 2 advertisements keep updating the existing sensors. The new velocity sensor is not exposed yet.

Release notes:
* https://github.com/sairon/rapt-ble/releases/tag/v1.0.0
* https://github.com/sairon/rapt-ble/releases/tag/v2.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
