### PR TITLE
Add Eufy RoboVac integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -532,6 +532,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/esphome/ @jesserockz @kbx81 @bdraco
 /homeassistant/components/essent/ @jaapp
 /tests/components/essent/ @jaapp
+/homeassistant/components/eufy_robovac/ @m17kea
+/tests/components/eufy_robovac/ @m17kea
 /homeassistant/components/eufylife_ble/ @bdr99
 /tests/components/eufylife_ble/ @bdr99
 /homeassistant/components/eurotronic_cometblue/ @rikroe

--- a/homeassistant/components/eufy_robovac/__init__.py
+++ b/homeassistant/components/eufy_robovac/__init__.py
@@ -1,0 +1,36 @@
+"""The Eufy RoboVac integration."""
+
+from eufy_robovac import RoboVac, RoboVacInfo
+
+from homeassistant.const import CONF_DEVICE_ID, CONF_HOST, CONF_MODEL, CONF_NAME
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_LOCAL_KEY, CONF_PROTOCOL_VERSION, PLATFORMS
+from .coordinator import EufyRoboVacConfigEntry, EufyRoboVacCoordinator
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: EufyRoboVacConfigEntry) -> bool:
+    """Set up Eufy RoboVac from a config entry."""
+    client = RoboVac(
+        RoboVacInfo(
+            device_id=entry.data[CONF_DEVICE_ID],
+            model=entry.data[CONF_MODEL],
+            name=entry.data[CONF_NAME],
+            local_key=entry.data[CONF_LOCAL_KEY],
+            host=entry.data[CONF_HOST],
+            protocol_version=entry.data[CONF_PROTOCOL_VERSION],
+        )
+    )
+    coordinator = EufyRoboVacCoordinator(hass, entry, client)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(
+    hass: HomeAssistant, entry: EufyRoboVacConfigEntry
+) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/eufy_robovac/config_flow.py
+++ b/homeassistant/components/eufy_robovac/config_flow.py
@@ -1,0 +1,167 @@
+"""Config flow for Eufy RoboVac."""
+
+from dataclasses import replace
+from typing import Any, override
+
+from eufy_robovac import (
+    AuthenticationError,
+    CloudClient,
+    RoboVac,
+    RoboVacConnectionError,
+    RoboVacInfo,
+)
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_HOST,
+    CONF_MODEL,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
+from homeassistant.helpers.selector import (
+    SelectOptionDict,
+    SelectSelector,
+    SelectSelectorConfig,
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
+
+from .const import CONF_LOCAL_KEY, CONF_PROTOCOL_VERSION, DOMAIN
+
+ACCOUNT_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.EMAIL, autocomplete="email")
+        ),
+        vol.Required(CONF_PASSWORD): TextSelector(
+            TextSelectorConfig(
+                type=TextSelectorType.PASSWORD,
+                autocomplete="current-password",
+            )
+        ),
+    }
+)
+
+
+class EufyRoboVacConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle an Eufy RoboVac config flow."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._devices: dict[str, RoboVacInfo] = {}
+        self._selected_device: RoboVacInfo | None = None
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Discover supported vacuums using Eufy account credentials."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                devices = await CloudClient(
+                    username=user_input[CONF_USERNAME],
+                    password=user_input[CONF_PASSWORD],
+                ).list_devices()
+            except AuthenticationError:
+                errors["base"] = "invalid_auth"
+            except RoboVacConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                if devices:
+                    self._devices = {device.device_id: device for device in devices}
+                    return await self.async_step_select_device()
+                errors["base"] = "no_devices"
+
+        return self.async_show_form(
+            step_id="user", data_schema=ACCOUNT_SCHEMA, errors=errors
+        )
+
+    async def async_step_select_device(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Select a discovered vacuum."""
+        if user_input is not None:
+            self._selected_device = self._devices[user_input[CONF_DEVICE_ID]]
+            await self.async_set_unique_id(self._selected_device.device_id)
+            self._abort_if_unique_id_configured()
+            return await self.async_step_device()
+
+        return self.async_show_form(
+            step_id="select_device",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_DEVICE_ID): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                SelectOptionDict(
+                                    value=device.device_id, label=device.name
+                                )
+                                for device in self._devices.values()
+                            ]
+                        )
+                    )
+                }
+            ),
+        )
+
+    async def async_step_device(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm local connection details and validate the vacuum."""
+        assert self._selected_device is not None
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            info = replace(
+                self._selected_device,
+                host=user_input[CONF_HOST],
+                protocol_version=user_input[CONF_PROTOCOL_VERSION],
+            )
+            try:
+                await RoboVac(info).update()
+            except RoboVacConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(
+                    title=info.name,
+                    data={
+                        CONF_NAME: info.name,
+                        CONF_MODEL: info.model,
+                        CONF_DEVICE_ID: info.device_id,
+                        CONF_LOCAL_KEY: info.local_key,
+                        CONF_HOST: info.host,
+                        CONF_PROTOCOL_VERSION: info.protocol_version,
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="device",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_HOST,
+                        default=(
+                            user_input[CONF_HOST]
+                            if user_input is not None
+                            else self._selected_device.host
+                        ),
+                    ): str,
+                    vol.Required(
+                        CONF_PROTOCOL_VERSION,
+                        default=(
+                            user_input[CONF_PROTOCOL_VERSION]
+                            if user_input is not None
+                            else self._selected_device.protocol_version
+                        ),
+                    ): str,
+                }
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/eufy_robovac/const.py
+++ b/homeassistant/components/eufy_robovac/const.py
@@ -1,0 +1,15 @@
+"""Constants for the Eufy RoboVac integration."""
+
+from datetime import timedelta
+import logging
+
+from homeassistant.const import Platform
+
+DOMAIN = "eufy_robovac"
+
+CONF_LOCAL_KEY = "local_key"
+CONF_PROTOCOL_VERSION = "protocol_version"
+
+LOGGER = logging.getLogger(__package__)
+PLATFORMS = [Platform.VACUUM]
+SCAN_INTERVAL = timedelta(seconds=30)

--- a/homeassistant/components/eufy_robovac/coordinator.py
+++ b/homeassistant/components/eufy_robovac/coordinator.py
@@ -1,0 +1,45 @@
+"""Data update coordinator for Eufy RoboVac."""
+
+from typing import override
+
+from eufy_robovac import RoboVac, RoboVacConnectionError, RoboVacState
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, LOGGER, SCAN_INTERVAL
+
+type EufyRoboVacConfigEntry = ConfigEntry[EufyRoboVacCoordinator]
+
+
+class EufyRoboVacCoordinator(DataUpdateCoordinator[RoboVacState]):
+    """Coordinate local polling of an Eufy RoboVac."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: EufyRoboVacConfigEntry,
+        client: RoboVac,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            config_entry=entry,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+        )
+        self.client = client
+
+    @override
+    async def _async_update_data(self) -> RoboVacState:
+        """Fetch the latest vacuum state."""
+        try:
+            return await self.client.update()
+        except RoboVacConnectionError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/homeassistant/components/eufy_robovac/manifest.json
+++ b/homeassistant/components/eufy_robovac/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "eufy_robovac",
+  "name": "Eufy RoboVac",
+  "codeowners": ["@m17kea"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/eufy_robovac",
+  "integration_type": "device",
+  "iot_class": "local_polling",
+  "quality_scale": "bronze",
+  "requirements": ["eufy-robovac-client==0.1.0"]
+}

--- a/homeassistant/components/eufy_robovac/quality_scale.yaml
+++ b/homeassistant/components/eufy_robovac/quality_scale.yaml
@@ -1,0 +1,88 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: This integration does not provide custom actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: This integration does not provide custom actions.
+  docs-conditions:
+    status: exempt
+    comment: This integration does not provide conditions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: This integration does not provide triggers.
+  entity-event-setup:
+    status: exempt
+    comment: This integration does not register entity events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: This integration does not provide an options flow.
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: Account credentials are used only during setup and are not stored.
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info: todo
+  discovery: todo
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
+  dynamic-devices:
+    status: exempt
+    comment: Each config entry represents one vacuum.
+  entity-category:
+    status: exempt
+    comment: The integration only provides a primary vacuum entity.
+  entity-device-class:
+    status: exempt
+    comment: The vacuum entity platform does not support device classes.
+  entity-disabled-by-default:
+    status: exempt
+    comment: The integration only provides a primary vacuum entity.
+  entity-translations:
+    status: exempt
+    comment: The primary entity uses the device name.
+  exception-translations: done
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices:
+    status: exempt
+    comment: Each config entry represents one vacuum.
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: todo

--- a/homeassistant/components/eufy_robovac/strings.json
+++ b/homeassistant/components/eufy_robovac/strings.json
@@ -1,0 +1,53 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "This Eufy RoboVac is already configured"
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "no_devices": "No supported Eufy RoboVac devices were found"
+    },
+    "step": {
+      "device": {
+        "data": {
+          "host": "Host",
+          "protocol_version": "Protocol version"
+        },
+        "data_description": {
+          "host": "IP address or hostname of the RoboVac",
+          "protocol_version": "Local Tuya protocol version used by the RoboVac"
+        },
+        "description": "Confirm the local connection details for your RoboVac."
+      },
+      "select_device": {
+        "data": {
+          "device_id": "RoboVac"
+        },
+        "data_description": {
+          "device_id": "RoboVac discovered from your Eufy account"
+        },
+        "description": "Select the RoboVac to add."
+      },
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Email"
+        },
+        "data_description": {
+          "password": "Password for your Eufy account",
+          "username": "Email address for your Eufy account"
+        },
+        "description": "Enter your Eufy account credentials to discover your RoboVac. Credentials are used only during setup and are not stored."
+      }
+    }
+  },
+  "exceptions": {
+    "command_failed": {
+      "message": "Failed to communicate with the Eufy RoboVac"
+    },
+    "update_failed": {
+      "message": "Failed to update the Eufy RoboVac: {error}"
+    }
+  }
+}

--- a/homeassistant/components/eufy_robovac/vacuum.py
+++ b/homeassistant/components/eufy_robovac/vacuum.py
@@ -1,0 +1,97 @@
+"""Vacuum platform for Eufy RoboVac."""
+
+from collections.abc import Awaitable, Callable
+from typing import Any, override
+
+from eufy_robovac import RoboVacActivity, RoboVacConnectionError
+
+from homeassistant.components.vacuum import (
+    StateVacuumEntity,
+    VacuumActivity,
+    VacuumEntityFeature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import EufyRoboVacConfigEntry, EufyRoboVacCoordinator
+
+ACTIVITY_MAP = {
+    RoboVacActivity.CLEANING: VacuumActivity.CLEANING,
+    RoboVacActivity.DOCKED: VacuumActivity.DOCKED,
+    RoboVacActivity.ERROR: VacuumActivity.ERROR,
+    RoboVacActivity.IDLE: VacuumActivity.IDLE,
+    RoboVacActivity.PAUSED: VacuumActivity.PAUSED,
+    RoboVacActivity.RETURNING: VacuumActivity.RETURNING,
+}
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: EufyRoboVacConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up an Eufy RoboVac vacuum entity."""
+    async_add_entities([EufyRoboVacVacuum(entry.runtime_data)])
+
+
+class EufyRoboVacVacuum(CoordinatorEntity[EufyRoboVacCoordinator], StateVacuumEntity):
+    """Representation of an Eufy RoboVac."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_supported_features = (
+        VacuumEntityFeature.PAUSE
+        | VacuumEntityFeature.RETURN_HOME
+        | VacuumEntityFeature.START
+        | VacuumEntityFeature.STATE
+    )
+
+    def __init__(self, coordinator: EufyRoboVacCoordinator) -> None:
+        """Initialize the vacuum entity."""
+        super().__init__(coordinator)
+        info = coordinator.client.info
+        self._attr_unique_id = info.device_id
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, info.device_id)},
+            manufacturer="Eufy",
+            model=info.model,
+            name=info.name,
+        )
+
+    @property
+    @override
+    def activity(self) -> VacuumActivity:
+        """Return the current vacuum activity."""
+        return ACTIVITY_MAP[self.coordinator.data.activity]
+
+    async def _async_command(self, command: Callable[[], Awaitable[None]]) -> None:
+        """Run a library command and refresh the state."""
+        try:
+            await command()
+        except RoboVacConnectionError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_failed",
+            ) from err
+        await self.coordinator.async_request_refresh()
+
+    @override
+    async def async_start(self, **kwargs: Any) -> None:
+        """Start cleaning."""
+        await self._async_command(self.coordinator.client.start)
+
+    @override
+    async def async_pause(self) -> None:
+        """Pause cleaning."""
+        await self._async_command(self.coordinator.client.pause)
+
+    @override
+    async def async_return_to_base(self, **kwargs: Any) -> None:
+        """Return the vacuum to its dock."""
+        await self._async_command(self.coordinator.client.return_home)

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -224,6 +224,7 @@ FLOWS = {
         "escea",
         "esphome",
         "essent",
+        "eufy_robovac",
         "eufylife_ble",
         "eurotronic_cometblue",
         "evil_genius_labs",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1988,6 +1988,12 @@
         }
       }
     },
+    "eufy_robovac": {
+      "name": "Eufy RoboVac",
+      "integration_type": "device",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "eurotronic_cometblue": {
       "name": "Eurotronic Comet Blue",
       "integration_type": "device",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -985,6 +985,9 @@ essent-dynamic-pricing==0.3.1
 # homeassistant.components.netgear_lte
 eternalegypt==0.0.18
 
+# homeassistant.components.eufy_robovac
+eufy-robovac-client==0.1.0
+
 # homeassistant.components.eufylife_ble
 eufylife-ble-client==0.1.10
 

--- a/tests/components/eufy_robovac/__init__.py
+++ b/tests/components/eufy_robovac/__init__.py
@@ -1,0 +1,23 @@
+"""Tests for the Eufy RoboVac integration."""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def init_integration(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    robovac: AsyncMock,
+) -> None:
+    """Set up the Eufy RoboVac integration."""
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.eufy_robovac.RoboVac",
+        return_value=robovac,
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()

--- a/tests/components/eufy_robovac/conftest.py
+++ b/tests/components/eufy_robovac/conftest.py
@@ -1,0 +1,62 @@
+"""Fixtures for the Eufy RoboVac integration tests."""
+
+from unittest.mock import AsyncMock
+
+from eufy_robovac import RoboVac, RoboVacActivity, RoboVacInfo, RoboVacState
+import pytest
+
+from homeassistant.components.eufy_robovac.const import (
+    CONF_LOCAL_KEY,
+    CONF_PROTOCOL_VERSION,
+    DOMAIN,
+)
+from homeassistant.const import CONF_DEVICE_ID, CONF_HOST, CONF_MODEL, CONF_NAME
+
+from tests.common import MockConfigEntry
+
+DEVICE_ID = "abc123"
+ENTITY_ID = "vacuum.hall_vacuum"
+MOCK_INFO = RoboVacInfo(
+    device_id=DEVICE_ID,
+    model="T2253",
+    name="Hall Vacuum",
+    local_key="abcdefghijklmnop",
+    host="192.168.1.50",
+    mac="AA:BB:CC:DD:EE:FF",
+    description="RoboVac",
+    protocol_version="3.3",
+)
+MOCK_STATE = RoboVacState(
+    activity=RoboVacActivity.IDLE,
+    error=None,
+    raw_status="standby",
+    raw_error="0",
+)
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock Eufy RoboVac config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=MOCK_INFO.name,
+        unique_id=MOCK_INFO.device_id,
+        data={
+            CONF_NAME: MOCK_INFO.name,
+            CONF_MODEL: MOCK_INFO.model,
+            CONF_DEVICE_ID: MOCK_INFO.device_id,
+            CONF_LOCAL_KEY: MOCK_INFO.local_key,
+            CONF_HOST: MOCK_INFO.host,
+            CONF_PROTOCOL_VERSION: MOCK_INFO.protocol_version,
+        },
+    )
+
+
+@pytest.fixture
+def mock_robovac() -> AsyncMock:
+    """Return a mocked communication-library client."""
+    robovac = AsyncMock(spec=RoboVac)
+    robovac.info = MOCK_INFO
+    robovac.state = MOCK_STATE
+    robovac.update.return_value = MOCK_STATE
+    return robovac

--- a/tests/components/eufy_robovac/test_config_flow.py
+++ b/tests/components/eufy_robovac/test_config_flow.py
@@ -1,0 +1,178 @@
+"""Tests for the Eufy RoboVac config flow."""
+
+from unittest.mock import AsyncMock, patch
+
+from eufy_robovac import AuthenticationError, RoboVacConnectionError
+
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import DEVICE_ID, MOCK_INFO, MOCK_STATE
+
+from tests.common import MockConfigEntry
+
+ACCOUNT_INPUT = {
+    CONF_USERNAME: "user@example.com",
+    CONF_PASSWORD: "supersecret",
+}
+
+
+async def _async_start_flow(hass: HomeAssistant) -> str:
+    result = await hass.config_entries.flow.async_init(
+        "eufy_robovac", context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    return result["flow_id"]
+
+
+async def test_cloud_discovery_and_local_validation(hass: HomeAssistant) -> None:
+    """Test credentials discover a vacuum but are not persisted."""
+    flow_id = await _async_start_flow(hass)
+
+    with patch(
+        "homeassistant.components.eufy_robovac.config_flow.CloudClient",
+        autospec=True,
+    ) as cloud_client:
+        cloud_client.return_value.list_devices = AsyncMock(return_value=[MOCK_INFO])
+        result = await hass.config_entries.flow.async_configure(flow_id, ACCOUNT_INPUT)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select_device"
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {"device_id": DEVICE_ID}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "device"
+
+    with (
+        patch(
+            "homeassistant.components.eufy_robovac.config_flow.RoboVac",
+            autospec=True,
+        ) as robovac,
+        patch(
+            "homeassistant.components.eufy_robovac.async_setup_entry",
+            return_value=True,
+        ),
+    ):
+        robovac.return_value.update = AsyncMock(return_value=MOCK_STATE)
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_HOST: "192.168.1.51", "protocol_version": "3.3"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == MOCK_INFO.name
+    assert result["data"] == {
+        "name": MOCK_INFO.name,
+        "model": MOCK_INFO.model,
+        "device_id": MOCK_INFO.device_id,
+        "local_key": MOCK_INFO.local_key,
+        "host": "192.168.1.51",
+        "protocol_version": "3.3",
+    }
+    assert CONF_USERNAME not in result["data"]
+    assert CONF_PASSWORD not in result["data"]
+
+
+async def test_invalid_auth(hass: HomeAssistant) -> None:
+    """Test invalid cloud credentials."""
+    flow_id = await _async_start_flow(hass)
+
+    with patch(
+        "homeassistant.components.eufy_robovac.config_flow.CloudClient",
+        autospec=True,
+    ) as cloud_client:
+        cloud_client.return_value.list_devices = AsyncMock(
+            side_effect=AuthenticationError
+        )
+        result = await hass.config_entries.flow.async_configure(flow_id, ACCOUNT_INPUT)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_cloud_cannot_connect(hass: HomeAssistant) -> None:
+    """Test cloud connection errors."""
+    flow_id = await _async_start_flow(hass)
+
+    with patch(
+        "homeassistant.components.eufy_robovac.config_flow.CloudClient",
+        autospec=True,
+    ) as cloud_client:
+        cloud_client.return_value.list_devices = AsyncMock(
+            side_effect=RoboVacConnectionError
+        )
+        result = await hass.config_entries.flow.async_configure(flow_id, ACCOUNT_INPUT)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_no_supported_devices(hass: HomeAssistant) -> None:
+    """Test accounts without a supported vacuum."""
+    flow_id = await _async_start_flow(hass)
+
+    with patch(
+        "homeassistant.components.eufy_robovac.config_flow.CloudClient",
+        autospec=True,
+    ) as cloud_client:
+        cloud_client.return_value.list_devices = AsyncMock(return_value=[])
+        result = await hass.config_entries.flow.async_configure(flow_id, ACCOUNT_INPUT)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "no_devices"}
+
+
+async def test_local_validation_failure(hass: HomeAssistant) -> None:
+    """Test local connectivity is checked before creating an entry."""
+    flow_id = await _async_start_flow(hass)
+
+    with patch(
+        "homeassistant.components.eufy_robovac.config_flow.CloudClient",
+        autospec=True,
+    ) as cloud_client:
+        cloud_client.return_value.list_devices = AsyncMock(return_value=[MOCK_INFO])
+        await hass.config_entries.flow.async_configure(flow_id, ACCOUNT_INPUT)
+
+    await hass.config_entries.flow.async_configure(flow_id, {"device_id": DEVICE_ID})
+    with patch(
+        "homeassistant.components.eufy_robovac.config_flow.RoboVac",
+        autospec=True,
+    ) as robovac:
+        robovac.return_value.update = AsyncMock(side_effect=RoboVacConnectionError)
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            {CONF_HOST: MOCK_INFO.host, "protocol_version": "3.3"},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "device"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_duplicate_device(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test a vacuum can only be configured once."""
+    mock_config_entry.add_to_hass(hass)
+    flow_id = await _async_start_flow(hass)
+
+    with patch(
+        "homeassistant.components.eufy_robovac.config_flow.CloudClient",
+        autospec=True,
+    ) as cloud_client:
+        cloud_client.return_value.list_devices = AsyncMock(return_value=[MOCK_INFO])
+        await hass.config_entries.flow.async_configure(flow_id, ACCOUNT_INPUT)
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {"device_id": DEVICE_ID}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/eufy_robovac/test_init.py
+++ b/tests/components/eufy_robovac/test_init.py
@@ -1,0 +1,47 @@
+"""Tests for Eufy RoboVac setup."""
+
+from unittest.mock import AsyncMock, patch
+
+from eufy_robovac import RoboVacConnectionError
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from . import init_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_and_unload(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_robovac: AsyncMock,
+) -> None:
+    """Test setup performs an initial update and can unload."""
+    await init_integration(hass, mock_config_entry, mock_robovac)
+
+    assert mock_config_entry.runtime_data.client is mock_robovac
+    mock_robovac.update.assert_awaited_once()
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_retries_when_vacuum_is_unreachable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_robovac: AsyncMock,
+) -> None:
+    """Test setup retries when the first local update fails."""
+    mock_robovac.update.side_effect = RoboVacConnectionError("unreachable")
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.eufy_robovac.RoboVac",
+        return_value=mock_robovac,
+    ):
+        assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/eufy_robovac/test_vacuum.py
+++ b/tests/components/eufy_robovac/test_vacuum.py
@@ -1,0 +1,153 @@
+"""Tests for the Eufy RoboVac vacuum entity."""
+
+from unittest.mock import AsyncMock
+
+from eufy_robovac import RoboVacActivity, RoboVacConnectionError, RoboVacState
+import pytest
+
+from homeassistant.components.vacuum import (
+    DOMAIN as VACUUM_DOMAIN,
+    SERVICE_PAUSE,
+    SERVICE_RETURN_TO_BASE,
+    SERVICE_START,
+    VacuumActivity,
+    VacuumEntityFeature,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from . import init_integration
+from .conftest import DEVICE_ID, ENTITY_ID
+
+from tests.common import MockConfigEntry
+
+EXPECTED_FEATURES = (
+    VacuumEntityFeature.PAUSE
+    | VacuumEntityFeature.RETURN_HOME
+    | VacuumEntityFeature.START
+    | VacuumEntityFeature.STATE
+)
+
+
+async def test_entity_state_naming_and_device_info(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_robovac: AsyncMock,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the primary entity follows naming and device conventions."""
+    await init_integration(hass, mock_config_entry, mock_robovac)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == VacuumActivity.IDLE
+    assert state.attributes["friendly_name"] == "Hall Vacuum"
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == EXPECTED_FEATURES
+
+    entity = entity_registry.async_get(ENTITY_ID)
+    assert entity is not None
+    assert entity.unique_id == DEVICE_ID
+    assert entity.original_name is None
+
+    device = device_registry.async_get_device_by_identifier(
+        ("eufy_robovac", DEVICE_ID), mock_config_entry.entry_id
+    )
+    assert device is not None
+    assert device.manufacturer == "Eufy"
+    assert device.model == "T2253"
+    assert device.name == "Hall Vacuum"
+
+
+@pytest.mark.parametrize(
+    ("service", "method"),
+    [
+        (SERVICE_START, "start"),
+        (SERVICE_PAUSE, "pause"),
+        (SERVICE_RETURN_TO_BASE, "return_home"),
+    ],
+)
+async def test_commands_refresh_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_robovac: AsyncMock,
+    service: str,
+    method: str,
+) -> None:
+    """Test supported commands are sent through the library."""
+    await init_integration(hass, mock_config_entry, mock_robovac)
+    initial_update_count = mock_robovac.update.await_count
+
+    await hass.services.async_call(
+        VACUUM_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+    getattr(mock_robovac, method).assert_awaited_once()
+    assert mock_robovac.update.await_count == initial_update_count + 1
+
+
+async def test_coordinator_state_update(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_robovac: AsyncMock,
+) -> None:
+    """Test coordinator updates are reflected by the vacuum entity."""
+    await init_integration(hass, mock_config_entry, mock_robovac)
+
+    mock_config_entry.runtime_data.async_set_updated_data(
+        RoboVacState(
+            activity=RoboVacActivity.RETURNING,
+            error=None,
+            raw_status="chargego",
+            raw_error="0",
+        )
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == VacuumActivity.RETURNING
+
+
+async def test_update_failure_marks_entity_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_robovac: AsyncMock,
+) -> None:
+    """Test local update failures mark the vacuum unavailable."""
+    await init_integration(hass, mock_config_entry, mock_robovac)
+    mock_robovac.update.side_effect = RoboVacConnectionError("unreachable")
+
+    await mock_config_entry.runtime_data.async_request_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_command_failure_raises_home_assistant_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_robovac: AsyncMock,
+) -> None:
+    """Test local command failures are exposed as Home Assistant errors."""
+    await init_integration(hass, mock_config_entry, mock_robovac)
+    mock_robovac.start.side_effect = RoboVacConnectionError("unreachable")
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            VACUUM_DOMAIN,
+            SERVICE_START,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This is not a breaking change.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add an `eufy_robovac` integration for the Eufy RoboVac G30 Hybrid (`T2253`). The initial integration provides one `vacuum` platform with activity reporting, start, pause, and return-to-base controls.

Eufy account credentials are used transiently during the config flow to discover the vacuum and obtain its local connection details. The credentials are not stored. Setup and runtime communication are local, with a 30-second polling interval and initial connectivity validation before entities are forwarded.

This replaces #164040 at the maintainer's request. It addresses the May review by:

- moving all Eufy-specific cloud, model, and device communication into the separate [`eufy-robovac-client`](https://github.com/m17kea/eufy-robovac-client) PyPI library;
- reducing the initial Core contribution to one platform and one live-validated model;
- keeping Core limited to Home Assistant config flow, coordinator, entity, and state mapping concerns.

### TinyTuya dependency

The T2253 exposes its local controls through the encrypted Tuya LAN protocol. `tinytuya` provides the low-level protocol framing, encryption, socket handling, and LAN discovery. The new Eufy-specific library uses TinyTuya as a transport dependency and owns the Eufy account discovery, local-key retrieval, supported-model profile, and normalized commands/state. Home Assistant Core only imports the high-level Eufy library API.

Library source and release notes: https://github.com/m17kea/eufy-robovac-client/releases/tag/v0.1.0

### Quality scale status

All Bronze requirements are covered for this scope, including config-flow tests, unique config entries and entities, runtime data, validation before configuration and setup, appropriate polling, entity naming, documentation, and Brands assets. The implementation also includes coordinator availability handling, translated action/update exceptions, config-entry unloading, typed code, and 100% focused test coverage.

### Validation

- `.venv/bin/pytest -q tests/components/eufy_robovac --cov=homeassistant.components.eufy_robovac --cov-report=term-missing --cov-fail-under=95` (`15 passed`, `100%`)
- `.venv/bin/uv run --no-sync prek run --from-ref origin/dev --to-ref HEAD`
- `.venv/bin/python -m script.hassfest` (`1515` integrations, `0` invalid)
- The T2253 protocol version and command payloads were previously validated on a live G30 Hybrid through the old PR's Home Assistant service path.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/164027
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47811
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Continues the closed pull request: https://github.com/home-assistant/core/pull/164040
- Link to Brands pull request: https://github.com/home-assistant/brands/pull/9873

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
