### PR TITLE
Ignore static add-on devices when attributing serial ports

### DIFF
--- a/homeassistant/components/usb/consumers.py
+++ b/homeassistant/components/usb/consumers.py
@@ -1,6 +1,6 @@
 """Attribution of serial ports to the integrations and apps using them."""
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 import os
 import re
 from typing import Any
@@ -156,14 +156,29 @@ async def _async_get_config_entry_consumers(
     return consumers
 
 
+def _iter_option_device_paths(value: Any) -> Iterator[str]:
+    """Yield device paths configured anywhere in the options of an app."""
+    if isinstance(value, str):
+        if value.startswith("/dev/"):
+            yield value
+    elif isinstance(value, Mapping):
+        for item in value.values():
+            yield from _iter_option_device_paths(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _iter_option_device_paths(item)
+
+
 @callback
 def _async_get_app_consumers(
     hass: HomeAssistant,
 ) -> dict[str, list[SerialPortConsumer]]:
-    """Return devices mapped into apps, either statically or through options.
+    """Return devices configured in the options of apps.
 
-    Supervisor resolves `device(subsystem=tty)` options into real devices, so device
-    paths that no longer exist are missing and non-serial devices are included.
+    The `devices` field of an app also lists the static devices of its manifest,
+    which are mapped into the container whether the app uses them or not, so only
+    options are evidence of a device being used. Options can refer to devices
+    that no longer exist or are not serial ports.
     """
     if not is_hassio(hass):
         return {}
@@ -179,7 +194,7 @@ def _async_get_app_consumers(
         if info is None:
             continue
 
-        for device in info["devices"]:
+        for device in _iter_option_device_paths(info["options"]):
             consumers.setdefault(device, []).append(
                 SerialPortConsumer(
                     kind="app",
@@ -224,7 +239,7 @@ async def async_get_serial_port_consumers(
         consumers.setdefault(device, []).extend(path_consumers)
 
     for path, path_consumers in app_consumers.items():
-        # Apps also map non-serial devices, only scanned ports are of interest
+        # Options can name non-serial devices, only scanned ports are of interest
         resolved_path = resolved[path]
 
         if resolved_path not in aliases:

--- a/tests/components/usb/test_consumers.py
+++ b/tests/components/usb/test_consumers.py
@@ -439,17 +439,26 @@ async def test_app_consumers(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test detecting serial ports mapped into apps."""
+    """Test detecting serial ports configured in the options of apps."""
     apps_info = {
         "core_zwave_js": {
             "name": "Z-Wave JS",
             "state": "started",
-            "devices": [TTY_USB0_BY_ID, "/dev/dri/card0"],
+            "devices": [TTY_USB0],
+            "options": {"device": TTY_USB0_BY_ID, "gpu": "/dev/dri/card0"},
         },
         "some_app": {
             "name": "Some App",
             "state": "stopped",
             "devices": [TTY_USB1],
+            "options": {"serial": [{"port": TTY_USB0}]},
+        },
+        # Static devices of the manifest are mapped regardless of being used
+        "wmbusmeters": {
+            "name": "Wmbusmeters",
+            "state": "started",
+            "devices": [TTY_USB0, TTY_USB1],
+            "options": {"reset_config": False},
         },
         "uninstalled_app": None,
     }
@@ -478,7 +487,15 @@ async def test_app_consumers(
                     "domain": None,
                     "config_entry_id": None,
                     "slug": "core_zwave_js",
-                }
+                },
+                {
+                    "kind": "app",
+                    "title": "Some App",
+                    "active": False,
+                    "domain": None,
+                    "config_entry_id": None,
+                    "slug": "some_app",
+                },
             ],
         ),
         (ESPHOME_PORT, []),
@@ -531,7 +548,12 @@ async def test_multiple_consumers(
     entry.add_to_hass(hass)
 
     apps_info = {
-        "some_app": {"name": "Some App", "state": "started", "devices": [TTY_USB0]}
+        "some_app": {
+            "name": "Some App",
+            "state": "started",
+            "devices": [TTY_USB0],
+            "options": {"device": TTY_USB0},
+        }
     }
 
     with (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Supervisor's add-on `devices` field merges the devices a user selected in a `device(subsystem=tty)` option with the static `devices:` list of the add-on manifest. The static list maps device nodes into the container whether the add-on uses them or not, so it is no evidence of usage. Add-ons like Wmbusmeters and Mealie statically declare `/dev/ttyUSB0` and `/dev/ttyACM0`, which made the serial port panel show them as consumers of the SkyConnect and ZBT-2 ports.

Serial ports are now attributed to add-ons from the device paths in their options only. Options are walked recursively, since add-on schemas allow nested lists and dicts. As before, only scanned ports are kept, so non-serial or stale option values are dropped. Add-ons that only map a port through a static manifest list lose their attribution; no add-on should statically map a serial port.

### Not a Supervisor bug

The `devices` field of the Supervisor API lists every device node mapped into the add-on container, which is the union of the static manifest list and the option-selected devices. That is the right answer to "what can this container access", but not to "what does this add-on use", which is how the serial port panel read it. Two related limitations remain outside this PR:

- **No provenance in the API.** Supervisor computes option-derived device paths separately, but only uses them internally for cgroup allowlisting. Exposing static and option devices as separate fields would let core tell them apart without walking the options itself. This PR reads the option values directly, so it does not depend on such a change.
- **Blanket serial access.** Add-ons with `uart: true` or `usb: true` get access to the whole device class and may read their port from their own config file, as Wmbusmeters does. Neither Supervisor nor core can attribute those ports, so add-on attribution stays best-effort.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #180552
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
