### PR TITLE
Fix stuck installing state in Teslemetry streaming update entity

### DIFF
--- a/homeassistant/components/teslemetry/update.py
+++ b/homeassistant/components/teslemetry/update.py
@@ -1,5 +1,7 @@
 """Update platform for Teslemetry integration."""
 
+from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import Any, override
 
 from tesla_fleet_api import firmware_at_least
@@ -11,9 +13,11 @@ from homeassistant.components.update import (
     UpdateEntityFeature,
     UpdateEntityStateAttribute,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.event import async_track_point_in_utc_time
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
+from homeassistant.util import dt as dt_util
 
 from . import TeslemetryConfigEntry
 from .entity import (
@@ -31,6 +35,36 @@ WIFI_WAIT = "downloading_wifi_wait"
 SCHEDULED = "scheduled"
 
 PARALLEL_UPDATES = 0
+
+ATTR_SCHEDULED_AT = "scheduled_at"
+
+# A scheduled install normally begins within hours. A schedule this old was
+# never followed by the clearing push it should have received, so treat it
+# as abandoned rather than keep the entity latched on "installing" forever.
+SCHEDULED_STALE_AFTER = timedelta(days=2)
+
+
+@dataclass
+class TeslemetryUpdateExtraStoredData(ExtraStoredData):
+    """Extra stored data for the streaming update entity."""
+
+    scheduled_at: datetime | None = None
+
+    @override
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dict representation of the extra data."""
+        return {
+            ATTR_SCHEDULED_AT: self.scheduled_at.isoformat()
+            if self.scheduled_at is not None
+            else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TeslemetryUpdateExtraStoredData:
+        """Initialize the extra data from a dict."""
+        if (scheduled_at := data[ATTR_SCHEDULED_AT]) is None:
+            return cls()
+        return cls(dt_util.parse_datetime(scheduled_at))
 
 
 async def async_setup_entry(
@@ -140,6 +174,8 @@ class TeslemetryStreamingUpdateEntity(
     _download_percentage: int = 0
     _install_percentage: int = 0
     _scheduled: bool = False
+    _scheduled_at: datetime | None = None
+    _cancel_scheduled_expiry: CALLBACK_TYPE | None = None
 
     def __init__(
         self,
@@ -157,6 +193,10 @@ class TeslemetryStreamingUpdateEntity(
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
         await super().async_added_to_hass()
+        if (extra_data := await self.async_get_last_extra_data()) is not None:
+            self._scheduled_at = TeslemetryUpdateExtraStoredData.from_dict(
+                extra_data.as_dict()
+            ).scheduled_at
         if (state := await self.async_get_last_state()) is not None:
             self._attr_installed_version = state.attributes.get(
                 UpdateEntityStateAttribute.INSTALLED_VERSION
@@ -179,8 +219,18 @@ class TeslemetryStreamingUpdateEntity(
                     UpdateEntityStateAttribute.UPDATE_PERCENTAGE
                 )
                 self._scheduled = self._attr_in_progress
+                # A restored in-progress flag caused only by the scheduled latch
+                # (no real download/install percentage) is unverifiable once its
+                # schedule has gone stale; a genuine one re-arms its own expiry.
+                if self._scheduled and self._attr_update_percentage is None:
+                    if self._scheduled_stale:
+                        self._attr_in_progress = False
+                        self._scheduled = False
+                    else:
+                        self._async_arm_scheduled_expiry()
             self.async_write_ha_state()
 
+        self.async_on_remove(self._async_cancel_scheduled_expiry)
         self.async_on_remove(
             self.vehicle.stream_vehicle.listen_SoftwareUpdateDownloadPercentComplete(
                 self._async_handle_software_update_download_percent_complete
@@ -235,6 +285,35 @@ class TeslemetryStreamingUpdateEntity(
         """Handle software update scheduled start time."""
 
         self._scheduled = value is not None
+        self._scheduled_at = dt_util.utcnow() if value is not None else None
+        self._async_arm_scheduled_expiry()
+        self._async_update_progress()
+        self.async_write_ha_state()
+
+    @callback
+    def _async_cancel_scheduled_expiry(self) -> None:
+        """Cancel any pending scheduled-expiry timer."""
+        if self._cancel_scheduled_expiry is not None:
+            self._cancel_scheduled_expiry()
+            self._cancel_scheduled_expiry = None
+
+    @callback
+    def _async_arm_scheduled_expiry(self) -> None:
+        """(Re)start the timer that clears the scheduled flag once it is stale."""
+        self._async_cancel_scheduled_expiry()
+        if self._scheduled_at is not None and not self._scheduled_stale:
+            self._cancel_scheduled_expiry = async_track_point_in_utc_time(
+                self.hass,
+                self._async_handle_scheduled_expiry,
+                self._scheduled_at + SCHEDULED_STALE_AFTER,
+            )
+
+    @callback
+    def _async_handle_scheduled_expiry(self, _now: datetime) -> None:
+        """Clear an expired scheduled flag and refresh progress."""
+        self._cancel_scheduled_expiry = None
+        self._scheduled = False
+        self._scheduled_at = None
         self._async_update_progress()
         self.async_write_ha_state()
 
@@ -264,6 +343,20 @@ class TeslemetryStreamingUpdateEntity(
             and self._attr_installed_version == self._attr_latest_version
         )
 
+    @property
+    def _scheduled_stale(self) -> bool:
+        """Return True when the scheduled flag has outlived its staleness bound."""
+        return (
+            self._scheduled_at is None
+            or dt_util.utcnow() - self._scheduled_at > SCHEDULED_STALE_AFTER
+        )
+
+    @property
+    @override
+    def extra_restore_state_data(self) -> TeslemetryUpdateExtraStoredData:
+        """Return entity specific state data to be restored."""
+        return TeslemetryUpdateExtraStoredData(self._scheduled_at)
+
     def _async_update_progress(self) -> None:
         """Update the progress of the update."""
 
@@ -273,7 +366,7 @@ class TeslemetryStreamingUpdateEntity(
         elif 10 < self._install_percentage < 100:
             self._attr_in_progress = True
             self._attr_update_percentage = self._install_percentage
-        elif self._scheduled and not self._up_to_date:
+        elif self._scheduled and not self._up_to_date and not self._scheduled_stale:
             self._attr_in_progress = True
             self._attr_update_percentage = None
         else:

--- a/homeassistant/components/teslemetry/update.py
+++ b/homeassistant/components/teslemetry/update.py
@@ -37,6 +37,8 @@ SCHEDULED = "scheduled"
 PARALLEL_UPDATES = 0
 
 ATTR_SCHEDULED_AT = "scheduled_at"
+ATTR_DOWNLOAD_PERCENTAGE = "download_percentage"
+ATTR_INSTALL_PERCENTAGE = "install_percentage"
 
 # A scheduled install normally begins within hours. A schedule this old was
 # never followed by the clearing push it should have received, so treat it
@@ -49,6 +51,8 @@ class TeslemetryUpdateExtraStoredData(ExtraStoredData):
     """Extra stored data for the streaming update entity."""
 
     scheduled_at: datetime | None = None
+    download_percentage: int = 0
+    install_percentage: int = 0
 
     @override
     def as_dict(self) -> dict[str, Any]:
@@ -57,14 +61,19 @@ class TeslemetryUpdateExtraStoredData(ExtraStoredData):
             ATTR_SCHEDULED_AT: self.scheduled_at.isoformat()
             if self.scheduled_at is not None
             else None,
+            ATTR_DOWNLOAD_PERCENTAGE: self.download_percentage,
+            ATTR_INSTALL_PERCENTAGE: self.install_percentage,
         }
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TeslemetryUpdateExtraStoredData:
         """Initialize the extra data from a dict."""
-        if (scheduled_at := data[ATTR_SCHEDULED_AT]) is None:
-            return cls()
-        return cls(dt_util.parse_datetime(scheduled_at))
+        scheduled_at = data[ATTR_SCHEDULED_AT]
+        return cls(
+            dt_util.parse_datetime(scheduled_at) if scheduled_at is not None else None,
+            data.get(ATTR_DOWNLOAD_PERCENTAGE, 0),
+            data.get(ATTR_INSTALL_PERCENTAGE, 0),
+        )
 
 
 async def async_setup_entry(
@@ -194,9 +203,10 @@ class TeslemetryStreamingUpdateEntity(
         """Handle entity which will be added."""
         await super().async_added_to_hass()
         if (extra_data := await self.async_get_last_extra_data()) is not None:
-            self._scheduled_at = TeslemetryUpdateExtraStoredData.from_dict(
-                extra_data.as_dict()
-            ).scheduled_at
+            extra = TeslemetryUpdateExtraStoredData.from_dict(extra_data.as_dict())
+            self._scheduled_at = extra.scheduled_at
+            self._download_percentage = extra.download_percentage
+            self._install_percentage = extra.install_percentage
         if (state := await self.async_get_last_state()) is not None:
             self._attr_installed_version = state.attributes.get(
                 UpdateEntityStateAttribute.INSTALLED_VERSION
@@ -355,7 +365,9 @@ class TeslemetryStreamingUpdateEntity(
     @override
     def extra_restore_state_data(self) -> TeslemetryUpdateExtraStoredData:
         """Return entity specific state data to be restored."""
-        return TeslemetryUpdateExtraStoredData(self._scheduled_at)
+        return TeslemetryUpdateExtraStoredData(
+            self._scheduled_at, self._download_percentage, self._install_percentage
+        )
 
     def _async_update_progress(self) -> None:
         """Update the progress of the update."""

--- a/tests/components/teslemetry/test_update.py
+++ b/tests/components/teslemetry/test_update.py
@@ -1,6 +1,7 @@
 """Test the Teslemetry update platform."""
 
 import copy
+from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -9,16 +10,21 @@ from syrupy.assertion import SnapshotAssertion
 from teslemetry_stream import Signal
 
 from homeassistant.components.teslemetry.coordinator import VEHICLE_INTERVAL
-from homeassistant.components.teslemetry.update import INSTALLING
+from homeassistant.components.teslemetry.update import INSTALLING, SCHEDULED_STALE_AFTER
 from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN, SERVICE_INSTALL
 from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, Platform
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from . import assert_entities, reload_platform, setup_platform
 from .const import COMMAND_OK, VEHICLE_DATA, VEHICLE_DATA_ALT
 
-from tests.common import async_fire_time_changed, mock_restore_cache
+from tests.common import (
+    async_fire_time_changed,
+    mock_restore_cache,
+    mock_restore_cache_with_extra_data,
+)
 
 
 async def test_update(
@@ -250,6 +256,74 @@ async def test_update_streaming_scheduled_not_clobbered(
     assert state == snapshot(name="downloading_after_schedule_cleared")
 
 
+async def test_update_streaming_scheduled_expires(
+    hass: HomeAssistant,
+    mock_vehicle_data: AsyncMock,
+    mock_add_listener: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a scheduled install self-clears once stale, with no clearing push."""
+
+    mock_vehicle_data.return_value = VEHICLE_DATA_ALT
+    await setup_platform(hass, [Platform.UPDATE])
+
+    mock_add_listener.send(
+        {
+            "vin": VEHICLE_DATA_ALT["response"]["vin"],
+            "data": {
+                Signal.SOFTWARE_UPDATE_DOWNLOAD_PERCENT_COMPLETE: None,
+                Signal.SOFTWARE_UPDATE_INSTALLATION_PERCENT_COMPLETE: None,
+                Signal.SOFTWARE_UPDATE_SCHEDULED_START_TIME: 1735689600,
+            },
+            "createdAt": "2024-10-04T10:45:17.537Z",
+        }
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("update.test_update")
+    assert state.attributes["in_progress"] is True
+
+    freezer.tick(SCHEDULED_STALE_AFTER + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("update.test_update")
+    assert state.attributes["in_progress"] is False
+    assert state.attributes["update_percentage"] is None
+
+
+async def test_update_streaming_scheduled_not_yet_stale(
+    hass: HomeAssistant,
+    mock_vehicle_data: AsyncMock,
+    mock_add_listener: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a genuinely current schedule still reports in progress."""
+
+    mock_vehicle_data.return_value = VEHICLE_DATA_ALT
+    await setup_platform(hass, [Platform.UPDATE])
+
+    mock_add_listener.send(
+        {
+            "vin": VEHICLE_DATA_ALT["response"]["vin"],
+            "data": {
+                Signal.SOFTWARE_UPDATE_DOWNLOAD_PERCENT_COMPLETE: None,
+                Signal.SOFTWARE_UPDATE_INSTALLATION_PERCENT_COMPLETE: None,
+                Signal.SOFTWARE_UPDATE_SCHEDULED_START_TIME: 1735689600,
+            },
+            "createdAt": "2024-10-04T10:45:17.537Z",
+        }
+    )
+    await hass.async_block_till_done()
+
+    freezer.tick(SCHEDULED_STALE_AFTER - timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("update.test_update")
+    assert state.attributes["in_progress"] is True
+    assert state.attributes["update_percentage"] is None
+
+
 async def test_update_streaming_restore(
     hass: HomeAssistant,
     mock_vehicle_data: AsyncMock,
@@ -305,6 +379,80 @@ async def test_update_streaming_restore_completed_not_in_progress(
                     "update_percentage": None,
                     "installed_version": "2026.26.1",
                     "latest_version": "2026.26.1",
+                },
+            ),
+        ),
+    )
+
+    await setup_platform(hass, [Platform.UPDATE])
+
+    state = hass.states.get(entity_id)
+    assert state.attributes["in_progress"] is False
+    assert state.attributes["update_percentage"] is None
+
+
+async def test_update_streaming_restore_scheduled_expired(
+    hass: HomeAssistant,
+    mock_vehicle_data: AsyncMock,
+) -> None:
+    """Test a persisted latched state with an expired schedule restores NOT in progress."""
+
+    mock_vehicle_data.return_value = VEHICLE_DATA_ALT
+    entity_id = "update.test_update"
+    mock_restore_cache_with_extra_data(
+        hass,
+        (
+            (
+                State(
+                    entity_id,
+                    STATE_ON,
+                    attributes={
+                        "in_progress": True,
+                        "update_percentage": None,
+                        "installed_version": "2025.1.1",
+                        "latest_version": "",
+                    },
+                ),
+                {
+                    "scheduled_at": (
+                        dt_util.utcnow() - SCHEDULED_STALE_AFTER - timedelta(hours=1)
+                    ).isoformat()
+                },
+            ),
+        ),
+    )
+
+    await setup_platform(hass, [Platform.UPDATE])
+
+    state = hass.states.get(entity_id)
+    assert state.attributes["in_progress"] is False
+    assert state.attributes["update_percentage"] is None
+
+
+async def test_update_streaming_restore_scheduled_never_recorded(
+    hass: HomeAssistant,
+    mock_vehicle_data: AsyncMock,
+) -> None:
+    """Test a persisted latched state with no scheduled timestamp on record self-heals.
+
+    Reproduces the live stuck-vehicle case: entities latched before this guard
+    existed have no persisted scheduled_at, so there is no evidence the schedule
+    is still current.
+    """
+
+    mock_vehicle_data.return_value = VEHICLE_DATA_ALT
+    entity_id = "update.test_update"
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                entity_id,
+                STATE_ON,
+                attributes={
+                    "in_progress": True,
+                    "update_percentage": None,
+                    "installed_version": "2025.1.1",
+                    "latest_version": "",
                 },
             ),
         ),

--- a/tests/components/teslemetry/test_update.py
+++ b/tests/components/teslemetry/test_update.py
@@ -391,6 +391,68 @@ async def test_update_streaming_restore_completed_not_in_progress(
     assert state.attributes["update_percentage"] is None
 
 
+async def test_update_streaming_restore_real_progress_survives_stream_event(
+    hass: HomeAssistant,
+    mock_vehicle_data: AsyncMock,
+    mock_add_listener: AsyncMock,
+) -> None:
+    """Test a restored genuine in-progress download is not cleared by the next stream event.
+
+    Reproduces a restart during a real download: only update_percentage is part
+    of the restored entity state, so without persisting download/install
+    percentage too, the next stream event recomputed progress from zeroed
+    percentages and wrongly cleared in_progress.
+    """
+
+    mock_vehicle_data.return_value = VEHICLE_DATA_ALT
+    entity_id = "update.test_update"
+    mock_restore_cache_with_extra_data(
+        hass,
+        (
+            (
+                State(
+                    entity_id,
+                    STATE_ON,
+                    attributes={
+                        "in_progress": True,
+                        "update_percentage": 42,
+                        "installed_version": "2025.1.1",
+                        "latest_version": "2025.2.1",
+                    },
+                ),
+                {
+                    "scheduled_at": None,
+                    "download_percentage": 42,
+                    "install_percentage": 0,
+                },
+            ),
+        ),
+    )
+
+    await setup_platform(hass, [Platform.UPDATE])
+
+    state = hass.states.get(entity_id)
+    assert state.attributes["in_progress"] is True
+    assert state.attributes["update_percentage"] == 42
+
+    # An unrelated stream event (no download/install signal) still triggers a
+    # progress recompute, which must be based on the restored percentages.
+    mock_add_listener.send(
+        {
+            "vin": VEHICLE_DATA_ALT["response"]["vin"],
+            "data": {
+                Signal.VERSION: "2025.1.1",
+            },
+            "createdAt": "2024-10-04T10:45:17.537Z",
+        }
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.attributes["in_progress"] is True
+    assert state.attributes["update_percentage"] == 42
+
+
 async def test_update_streaming_restore_scheduled_expired(
     hass: HomeAssistant,
     mock_vehicle_data: AsyncMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change

`TeslemetryStreamingUpdateEntity._scheduled` is a one-way latch: it is set
whenever a `SoftwareUpdateScheduledStartTime` push arrives, and it is only
ever cleared by an explicit `null` push for that same field. If that clearing
push is missed, the entity is stuck reporting `installing` indefinitely, and
`RestoreEntity` re-latches the same stuck value on every restart. Users see
the update entity permanently show "Installing" with no real update running.

The upstream API is being fixed to reliably emit that clearing `null`, but
the fix isn't retroactive: entities already latched keep re-restoring `True`
until a real future update triggers a fresh clearing push for that vehicle,
which may never happen for some.

There's already a guard in `async_added_to_hass` that refuses to restore the
latch when `installed_version == latest_version`. It doesn't cover this case:
affected vehicles report `SoftwareUpdateVersion` as an empty string, so
`latest_version` never matches `installed_version` and the up-to-date check
never fires.

This adds a second, time-based guard: `_scheduled` now expires on its own
after `SCHEDULED_STALE_AFTER` (2 days — a scheduled install normally begins
within hours) instead of latching forever.

- Chose an age-based bound (when the last `SoftwareUpdateScheduledStartTime`
  push arrived) over a value-based one (the schedule's own timestamp). The
  value-based approach reads more naturally from the field's own semantics,
  but the age-based one self-heals the *existing* stuck entities immediately
  on their next restart, since it needs no new push at all — it only needs
  the persisted arrival time (or the absence of one) to judge staleness.
- The arrival time is persisted via `extra_restore_state_data` /
  `async_get_last_extra_data`, since it isn't part of the entity's regular
  restored state attributes. An entity restoring with no persisted timestamp
  (every currently-stuck vehicle, since this field didn't exist before) is
  treated as stale rather than trusted, mirroring the existing
  `installed_version == latest_version` guard's philosophy of not restoring
  a latch it can't verify.
- A restored in-progress flag that also carries a real download/install
  `update_percentage` is left untouched — that's a genuinely active update,
  not the scheduled-only latch this guards against.
- While the entity stays loaded, an `async_track_point_in_utc_time` timer
  (armed on each scheduled push, and on restore if not yet stale) clears the
  flag at the exact expiry moment, rather than waiting for the next
  unrelated event to happen to re-evaluate it.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
