### PR TITLE
Expose optional raw Bond power toggle for untrusted bridge state

### DIFF
--- a/homeassistant/components/bond/button.py
+++ b/homeassistant/components/bond/button.py
@@ -285,9 +285,16 @@ async def async_setup_entry(
             and (
                 description.mutually_exclusive is None
                 or not device.has_action(description.mutually_exclusive)
+                or (
+                    description.key == Action.TOGGLE_POWER
+                    and data.hub.is_bridge
+                    and not device.trust_state
+                )
             )
         ]
-        if device_entities and device.has_action(STOP_BUTTON.key):
+        if device.has_action(STOP_BUTTON.key) and any(
+            entity.entity_registry_enabled_default for entity in device_entities
+        ):
             # Most devices have the stop action available, but
             # we only add the stop action button if we add actions
             # since its not so useful if there are no actions to stop
@@ -313,6 +320,9 @@ class BondButtonEntity(BondEntity, ButtonEntity):
         """Init Bond button."""
         self.entity_description = description
         super().__init__(data, device, description.name, description.key.lower())
+        if description.key == Action.TOGGLE_POWER and device.has_action(Action.TURN_ON):
+            # Raw toggling is opt-in when absolute power controls also exist.
+            self._attr_entity_registry_enabled_default = False
 
     @override
     async def async_press(self) -> None:

--- a/tests/components/bond/test_button.py
+++ b/tests/components/bond/test_button.py
@@ -1,6 +1,7 @@
 """Tests for the Bond button device."""
 
 from bond_async import Action, DeviceType
+import pytest
 
 from homeassistant.components.bond.button import STEP_SIZE
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
@@ -274,3 +275,132 @@ async def test_preset_does_not_trigger_stop_button(hass: HomeAssistant) -> None:
 
     assert hass.states.get("button.name_1_preset")
     assert not hass.states.get("button.name_1_stop_actions")
+
+
+@pytest.mark.parametrize(
+    ("props", "actions", "disabled_by"),
+    [
+        pytest.param(
+            {"trust_state": False},
+            [Action.TOGGLE_POWER, Action.TURN_ON, Action.TURN_OFF],
+            er.RegistryEntryDisabler.INTEGRATION,
+            id="untrusted-absolute-power",
+        ),
+        pytest.param(
+            {},
+            [Action.TOGGLE_POWER, Action.TURN_ON, Action.TURN_OFF],
+            er.RegistryEntryDisabler.INTEGRATION,
+            id="default-untrusted-absolute-power",
+        ),
+        pytest.param(
+            {"trust_state": False},
+            [Action.TOGGLE_POWER],
+            None,
+            id="untrusted-toggle-only",
+        ),
+        pytest.param(
+            {"trust_state": True}, [Action.TOGGLE_POWER], None, id="trusted-toggle-only"
+        ),
+    ],
+)
+async def test_toggle_power_registration(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    props: dict[str, bool],
+    actions: list[str],
+    disabled_by: er.RegistryEntryDisabler | None,
+) -> None:
+    """Raw toggle keeps its identity and is opt-in alongside absolute controls."""
+    await setup_platform(
+        hass,
+        BUTTON_DOMAIN,
+        {
+            "name": "Test fan",
+            "type": DeviceType.CEILING_FAN,
+            "actions": [*actions, Action.STOP],
+        },
+        bond_device_id="test-device-id",
+        props=props,
+    )
+
+    entity = entity_registry.entities["button.test_fan_toggle_power"]
+    assert entity.unique_id == "ZXXX12345_test-device-id_togglepower"
+    assert (entity_registry.async_get("button.test_fan_stop_actions") is None) == (
+        disabled_by is not None
+    )
+    assert entity.disabled_by is disabled_by
+    assert (hass.states.get(entity.entity_id) is None) == (disabled_by is not None)
+
+
+@pytest.mark.parametrize(
+    ("props", "actions", "bond_id"),
+    [
+        pytest.param(
+            {"trust_state": True},
+            [Action.TOGGLE_POWER, Action.TURN_ON, Action.TURN_OFF],
+            "ZXXX12345",
+            id="trusted-absolute-power",
+        ),
+        pytest.param(
+            {"trust_state": False},
+            [Action.TURN_ON, Action.TURN_OFF],
+            "ZXXX12345",
+            id="raw-toggle-unsupported",
+        ),
+        pytest.param(
+            {},
+            [Action.TOGGLE_POWER, Action.TURN_ON, Action.TURN_OFF],
+            "KXXX12345",
+            id="smart-by-bond",
+        ),
+    ],
+)
+async def test_toggle_power_not_registered(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    props: dict[str, bool],
+    actions: list[str],
+    bond_id: str,
+) -> None:
+    """Trusted absolute controls and unsupported raw actions remain excluded."""
+    await setup_platform(
+        hass,
+        BUTTON_DOMAIN,
+        {"name": "Test fan", "type": DeviceType.CEILING_FAN, "actions": actions},
+        props=props,
+        bond_version={"bondid": bond_id},
+    )
+
+    assert entity_registry.async_get("button.test_fan_toggle_power") is None
+    assert not hass.states.async_all(BUTTON_DOMAIN)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize("power", [0, 1])
+async def test_toggle_power_ignores_assumed_state(
+    hass: HomeAssistant, power: int
+) -> None:
+    """An enabled raw toggle sends TogglePower regardless of the cached power."""
+    await setup_platform(
+        hass,
+        BUTTON_DOMAIN,
+        {
+            "name": "Test fan",
+            "type": DeviceType.CEILING_FAN,
+            "actions": [Action.TOGGLE_POWER, Action.TURN_ON, Action.TURN_OFF],
+        },
+        bond_device_id="test-device-id",
+        props={"trust_state": False},
+        state={"power": power},
+    )
+
+    with patch_bond_action() as mock_action, patch_bond_device_state():
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            {ATTR_ENTITY_ID: "button.test_fan_toggle_power"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    mock_action.assert_called_once_with("test-device-id", Action(Action.TOGGLE_POWER))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


A Bond Bridge can expose both `TogglePower` and `TurnOn` while its state is untrusted. A handheld remote can then change physical power without updating HA's assumed state. The button platform suppresses the raw toggle because `TurnOn` exists, leaving no state-independent button action.

Allow the existing `TogglePower` button for bridge devices with untrusted state. When absolute power control also exists, register it disabled by default so users can opt in. Preserve the existing unique ID, trusted-device behavior, Smart by Bond behavior and enabled-by-default toggle-only buttons. A newly disabled raw toggle alone does not expose an additional Stop Actions button.

Nine regression cases cover selection, default enablement, identity, Stop button behavior and the exact raw action for both cached power values. All 154 Bond tests pass. Four new cases fail against the original implementation. Scoped Ruff, formatting, mypy, pylint and other applicable pre-commit checks pass.

The behavior is motivated by a household Bond fan using an equivalent device-scoped raw-toggle workaround. That workaround has physical-use evidence; this generalized candidate has been tested with mocked devices and has not been deployed to hardware. No household device identifiers are included.

Local environment caveat: full `script/setup` hit an unrelated `dtlssocket` build failure (missing autoconf). Core/test/Bond dependencies and generated translations were then installed separately. The all-file pre-commit run hit the existing `homeassistant.util.hass_dict` .py/.pyi duplicate-module error; it was stopped during the subsequent unrelated pylint scan. The final changed-file pre-commit run passed in full.

AI-assisted implementation and description, reviewed and approved by the contributor before submission.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
