### PR TITLE
Improve error handling in file_upload

### DIFF
--- a/homeassistant/components/file_upload/__init__.py
+++ b/homeassistant/components/file_upload/__init__.py
@@ -176,27 +176,37 @@ class FileUploadView(HomeAssistantView):
 
         fut: asyncio.Future[None] | None = None
         try:
-            fut = hass.async_add_executor_job(_sync_queue_consumer)
-            megabytes_sending = 0
-            while chunk := await file_field_reader.read_chunk(ONE_MEGABYTE):
-                megabytes_sending += 1
-                if megabytes_sending % 5 != 0:
-                    queue.put_nowait((chunk, None))
-                    continue
+            try:
+                fut = hass.async_add_executor_job(_sync_queue_consumer)
+                chunks_sent = 0
+                while chunk := await file_field_reader.read_chunk(ONE_MEGABYTE):
+                    chunks_sent += 1
+                    if chunks_sent % 5 != 0:
+                        queue.put_nowait((chunk, None))
+                        continue
 
-                chunk_future = hass.loop.create_future()
-                queue.put_nowait((chunk, chunk_future))
-                await asyncio.wait(
-                    (fut, chunk_future), return_when=asyncio.FIRST_COMPLETED
-                )
-                if fut.done():
-                    # The executor job failed
-                    break
-
-            queue.put_nowait(None)  # terminate queue consumer
-        finally:
-            if fut is not None:
-                await fut
+                    chunk_future = hass.loop.create_future()
+                    queue.put_nowait((chunk, chunk_future))
+                    await asyncio.wait(
+                        (fut, chunk_future), return_when=asyncio.FIRST_COMPLETED
+                    )
+                    if fut.done():
+                        # The executor job failed
+                        break
+            finally:
+                # Always terminate the queue consumer, also if the stream raised or
+                # the task was cancelled.
+                queue.put_nowait(None)
+                if fut is not None:
+                    await fut
+        except Exception, asyncio.CancelledError:
+            # Upload failed: the consumer has finished and closed the file (inner
+            # finally above), so removing the directory now cannot race the writer.
+            # ignore_errors covers a failure that happened before the dir was created.
+            await hass.async_add_executor_job(
+                lambda: shutil.rmtree(file_dir, ignore_errors=True)
+            )
+            raise
 
         file_upload_data.files[file_id] = filename
 

--- a/tests/components/file_upload/test_init.py
+++ b/tests/components/file_upload/test_init.py
@@ -1,15 +1,19 @@
 """Test the File Upload integration."""
 
+import asyncio
 from contextlib import contextmanager
+from io import StringIO
 from pathlib import Path
 from random import getrandbits
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+from aiohttp import BodyPartReader
 import pytest
 
 from homeassistant.components import file_upload
-from homeassistant.components.file_upload import DOMAIN
+from homeassistant.components.file_upload import DOMAIN, FileUploadView
+from homeassistant.components.http import KEY_HASS
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -170,3 +174,111 @@ async def test_upload_large_file_fails(
     response = await res.content.read()
 
     assert b"Boom" in response
+
+
+async def test_upload_stream_error_releases_lock(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    large_file_io: StringIO,
+) -> None:
+    """Test a mid-upload stream error propagates and releases the upload lock.
+
+    Models a client disconnect: aiohttp raises from read_chunk when the
+    connection is lost mid-transfer. If the queue consumer's terminating sentinel
+    is skipped on the error path, awaiting the consumer deadlocks while holding
+    the upload lock, wedging every later upload; this guards that regression.
+    """
+    assert await async_setup_component(hass, DOMAIN, {})
+    client = await hass_client()
+
+    with (
+        patch(
+            # Patch temp dir name to avoid tests fail running in parallel
+            "homeassistant.components.file_upload.TEMP_DIR_NAME",
+            file_upload.TEMP_DIR_NAME + f"-{getrandbits(10):03x}",
+        ),
+        patch.object(
+            BodyPartReader,
+            "read_chunk",
+            AsyncMock(
+                side_effect=[b"partial", ConnectionResetError("Connection lost")]
+            ),
+        ),
+    ):
+        # Bound the request so a reintroduced deadlock fails fast instead of hanging
+        async with asyncio.timeout(10):
+            res = await client.post("/api/file_upload", data={"file": large_file_io})
+
+    assert res.status == 500
+
+    # The failed upload must not leave a partially written file orphaned on disk
+    file_upload_data = hass.data[file_upload.DOMAIN]
+    assert list(file_upload_data.temp_dir.iterdir()) == []
+
+    # The upload lock must have been released: a subsequent normal upload succeeds
+    large_file_io.seek(0)
+    with patch(
+        "homeassistant.components.file_upload.TEMP_DIR_NAME",
+        file_upload.TEMP_DIR_NAME + f"-{getrandbits(10):03x}",
+    ):
+        async with asyncio.timeout(10):
+            res = await client.post("/api/file_upload", data={"file": large_file_io})
+
+    assert res.status == 200
+
+
+async def test_upload_cancelled_releases_consumer(hass: HomeAssistant) -> None:
+    """Test cancelling an upload mid-transfer does not deadlock the consumer.
+
+    Driven at the view level because the test HTTP client cannot produce a true
+    task cancellation mid-request. Without delivering the queue sentinel on the
+    cancellation path, awaiting the consumer future would hang forever.
+    """
+    assert await async_setup_component(hass, DOMAIN, {})
+    view = FileUploadView()
+
+    first_chunk_sent = asyncio.Event()
+    blocked = asyncio.Event()  # never set, so the stream blocks until cancelled
+
+    class _BlockingPart:
+        """Fake BodyPartReader that blocks after yielding one chunk."""
+
+        name = "file"
+        filename = "blocking.bin"
+
+        async def read_chunk(self, size: int) -> bytes:
+            if first_chunk_sent.is_set():
+                await blocked.wait()
+                return b""
+            first_chunk_sent.set()
+            return b"chunk"
+
+    part = _BlockingPart()
+
+    class _Reader:
+        async def next(self) -> _BlockingPart:
+            return part
+
+    class _Request:
+        app = {KEY_HASS: hass}
+
+        async def multipart(self) -> _Reader:
+            return _Reader()
+
+    with (
+        patch(
+            "homeassistant.components.file_upload.TEMP_DIR_NAME",
+            file_upload.TEMP_DIR_NAME + f"-{getrandbits(10):03x}",
+        ),
+        patch("homeassistant.components.file_upload.BodyPartReader", _BlockingPart),
+    ):
+        task = asyncio.create_task(view._upload_file(_Request()))
+        await first_chunk_sent.wait()
+        task.cancel()
+        # asyncio.wait does not cancel on timeout, so a deadlocked task stays
+        # pending and the assertion fails fast instead of the run hanging.
+        _done, pending = await asyncio.wait({task}, timeout=10)
+
+    assert not pending
+    with pytest.raises(asyncio.CancelledError):
+        task.result()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve error handling in file_upload, it had the same issues as the issues found in the corresponding backup util in https://github.com/home-assistant/core/pull/181012

Also improve variable naming

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
