### PR TITLE
Handle unrecognized Cync color modes without invalid fallback

### DIFF
--- a/homeassistant/components/cync/light.py
+++ b/homeassistant/components/cync/light.py
@@ -58,6 +58,7 @@ class CyncLightEntity(CyncBaseEntity, LightEntity):
     """Representation of a Cync light."""
 
     _attr_color_mode = ColorMode.ONOFF
+    _attr_supported_color_modes: set[ColorMode]
     _attr_min_color_temp_kelvin = 2000
     _attr_max_color_temp_kelvin = 7000
     _attr_translation_key = "light"
@@ -129,10 +130,12 @@ class CyncLightEntity(CyncBaseEntity, LightEntity):
             and self._device.color_mode == 254
         ):
             return ColorMode.RGB
-        if self._device.supports_capability(CyncCapability.DIMMING):
+        if ColorMode.BRIGHTNESS in self._attr_supported_color_modes:
             return ColorMode.BRIGHTNESS
+        if ColorMode.ONOFF in self._attr_supported_color_modes:
+            return ColorMode.ONOFF
 
-        return ColorMode.ONOFF
+        return ColorMode.UNKNOWN
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/tests/components/cync/test_light.py
+++ b/tests/components/cync/test_light.py
@@ -1,10 +1,13 @@
 """Tests for the Cync integration light platform."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, PropertyMock, patch
 
+from pycync import CyncLight
+from pycync.devices.capabilities import CyncCapability
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.light import ColorMode
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -71,3 +74,80 @@ async def test_turn_on(
     test_device.set_combo.assert_called_once_with(
         True, expected_brightness, expected_color_temp, expected_rgb
     )
+
+
+@pytest.mark.parametrize(
+    ("capabilities", "expected_fallback"),
+    [
+        pytest.param(
+            {
+                CyncCapability.ON_OFF,
+                CyncCapability.DIMMING,
+                CyncCapability.CCT_COLOR,
+                CyncCapability.RGB_COLOR,
+            },
+            ColorMode.UNKNOWN,
+            id="full-color",
+        ),
+        pytest.param(
+            {CyncCapability.ON_OFF, CyncCapability.DIMMING, CyncCapability.CCT_COLOR},
+            ColorMode.UNKNOWN,
+            id="color-temperature",
+        ),
+        pytest.param(
+            {CyncCapability.ON_OFF, CyncCapability.DIMMING, CyncCapability.RGB_COLOR},
+            ColorMode.UNKNOWN,
+            id="rgb",
+        ),
+        pytest.param(
+            {CyncCapability.ON_OFF, CyncCapability.DIMMING},
+            ColorMode.BRIGHTNESS,
+            id="dimmer",
+        ),
+        pytest.param({CyncCapability.ON_OFF}, ColorMode.ONOFF, id="on-off"),
+    ],
+)
+@pytest.mark.parametrize("device_mode", [0, 101, 253, 255])
+async def test_unrecognized_color_mode(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    capabilities: set[CyncCapability],
+    expected_fallback: ColorMode,
+    device_mode: int,
+) -> None:
+    """Unrecognized device modes must not produce an invalid light state."""
+    with (
+        patch.object(
+            CyncLight, "supports_capability", side_effect=capabilities.__contains__
+        ),
+        patch.object(
+            CyncLight, "color_mode", new_callable=PropertyMock, return_value=device_mode
+        ),
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+        state = hass.states.get("light.bedroom_bedroom_lamp")
+        assert state.state == "on"
+        assert state.attributes["color_mode"] == expected_fallback
+        assert "white" not in state.attributes["supported_color_modes"]
+
+
+@pytest.mark.parametrize(
+    ("device_mode", "expected_mode"),
+    [(1, ColorMode.COLOR_TEMP), (100, ColorMode.COLOR_TEMP), (254, ColorMode.RGB)],
+)
+async def test_recognized_color_mode(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_mode: int,
+    expected_mode: ColorMode,
+) -> None:
+    """Recognized temperature and RGB modes retain their existing mapping."""
+    with patch.object(
+        CyncLight, "color_mode", new_callable=PropertyMock, return_value=device_mode
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+        state = hass.states.get("light.bedroom_bedroom_lamp")
+        assert state.state == "on"
+        assert state.attributes["color_mode"] == expected_mode


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a color-capable Cync light reports a mode outside the known color-temperature range (1-100) or RGB value (254), the integration falls back to BRIGHTNESS. Home Assistant removes BRIGHTNESS from the supported modes of color-capable lights, so state rendering raises an unsupported-color-mode error and can fail during entity registration.

Keep the existing temperature and RGB mappings. Only use BRIGHTNESS or ONOFF when that mode is actually supported; otherwise report UNKNOWN. This avoids inventing a white-mode capability or interpreting unrecognized effect/state bytes as a specific color. Supported capabilities remain unchanged.

Twenty-three new regression cases cover four unrecognized mode values across full-color, temperature-only, RGB-only, dimmer and on/off capabilities, plus the recognized temperature boundaries and RGB mapping. Twelve cases fail on unchanged upstream. All 42 Cync tests and all six existing snapshots pass with this fix. Changed-file Ruff, formatting, codespell, mypy, pylint and other applicable pre-commit checks pass.

Related reports describe the same unsupported-brightness fallback, but the exact raw values for all reported hardware are not confirmed. This PR does not claim to implement Cync effects or resolve every symptom in those reports.

Local environment limits: full script/setup failed on the unrelated dtlssocket build because autoconf is absent. Core/test/Cync and required shared typing dependencies were installed separately. The all-file pre-commit run stopped at the existing homeassistant.util.hass_dict .py/.pyi duplicate-module error. Neither full setup nor all-file lint is claimed as passed.

AI-assisted change, personally reviewed and approved by the contributor before submission.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #178379, #153611
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
