### PR TITLE
Preserve Cync light settings on a bare turn-on

### DIFF
--- a/homeassistant/components/cync/light.py
+++ b/homeassistant/components/cync/light.py
@@ -137,6 +137,10 @@ class CyncLightEntity(CyncBaseEntity, LightEntity):
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Process an action on the light."""
+        if not kwargs:
+            await self._device.turn_on()
+            return
+
         converted_brightness: int | None = None
         converted_color_temp: int | None = None
         rgb: tuple[int, int, int] | None = None

--- a/tests/components/cync/test_light.py
+++ b/tests/components/cync/test_light.py
@@ -1,6 +1,6 @@
 """Tests for the Cync integration light platform."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -38,6 +38,7 @@ async def test_entities(
         ),
         ({"color_temp_kelvin": 2500}, 90, 10, None),
         ({"rgb_color": (50, 100, 150)}, 90, None, (50, 100, 150)),
+        ({"brightness_pct": 50}, 50, None, [120, 145, 180]),
     ],
 )
 async def test_turn_on(
@@ -46,7 +47,7 @@ async def test_turn_on(
     input_parameters: dict,
     expected_brightness: int | None,
     expected_color_temp: int | None,
-    expected_rgb: tuple[int, int, int] | None,
+    expected_rgb: tuple[int, int, int] | list[int] | None,
 ) -> None:
     """Test that turning on the light changes all necessary attributes."""
 
@@ -59,6 +60,7 @@ async def test_turn_on(
 
     test_device = mock_config_entry.runtime_data.data.get(1111)
     test_device.set_combo = AsyncMock(name="set_combo")
+    test_device.turn_on = AsyncMock(name="turn_on")
 
     # now call the HA turn_on service
     await hass.services.async_call(
@@ -68,6 +70,36 @@ async def test_turn_on(
         blocking=True,
     )
 
-    test_device.set_combo.assert_called_once_with(
+    test_device.set_combo.assert_awaited_once_with(
         True, expected_brightness, expected_color_temp, expected_rgb
     )
+
+    test_device.turn_on.assert_not_called()
+
+
+@pytest.mark.parametrize("device_mode", [0, 20, 254, 255])
+@pytest.mark.parametrize("brightness", [0, 90])
+async def test_turn_on_without_parameters(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_mode: int,
+    brightness: int,
+) -> None:
+    """A bare turn-on must not overwrite retained settings with cached values."""
+    await setup_integration(hass, mock_config_entry)
+
+    device = mock_config_entry.runtime_data.data[1111]
+    device.update_state(False, brightness=brightness, color_temp=device_mode)
+    with (
+        patch.object(device, "turn_on") as turn_on,
+        patch.object(device, "set_combo") as set_combo,
+    ):
+        await hass.services.async_call(
+            "light",
+            "turn_on",
+            {"entity_id": "light.office_lamp_bulb_1"},
+            blocking=True,
+        )
+
+    turn_on.assert_awaited_once_with()
+    set_combo.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A bare light.turn_on currently sends set_combo with cached brightness and, when recognized, cached color. For unrecognized modes no color is passed, and pycync encodes the combined command with its fallback color-mode byte. Replaying these settings can replace the device's retained app-selected mode rather than simply restoring power.

When the integration receives no light attributes, await CyncLight.turn_on(), which sends only the power command. Preserve set_combo for requests carrying explicit brightness or color attributes, including attributes supplied by Home Assistant light profiles.

Eight new service-level cases cover cached brightness 0/90 and modes 0/20/254/255, asserting that power-only turn_on is awaited and set_combo is not called. All eight fail on unchanged upstream. An additional brightness-only case and the existing color/combo cases confirm explicit attributes still use the combined command. All 28 Cync tests and all six snapshots pass. Changed-file Ruff, formatting, codespell, mypy, pylint and other applicable pre-commit checks pass.

This preserves the multi-attribute behavior introduced in #159574. Validation uses mocked devices; this candidate has not been deployed or physically tested.

Local environment limits: full script/setup failed on the unrelated dtlssocket build because autoconf is absent. Core/test/Cync and required shared typing dependencies were installed separately. The all-file pre-commit run stopped at the existing homeassistant.util.hass_dict .py/.pyi duplicate-module error. Neither full setup nor all-file lint is claimed as passed.

AI-assisted change, personally reviewed and approved by the contributor before submission.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #159574
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
