### PR TITLE
Update Lutron light state without waiting for the controller

### DIFF
--- a/homeassistant/components/lutron/light.py
+++ b/homeassistant/components/lutron/light.py
@@ -96,6 +96,8 @@ class LutronLight(LutronDevice, LightEntity):
             if ATTR_TRANSITION in kwargs:
                 args["fade_time_seconds"] = kwargs[ATTR_TRANSITION]
             self._lutron_device.set_level(**args)
+            # Publish now rather than waiting for the controller to report back.
+            self._publish_level()
 
     @override
     def turn_off(self, **kwargs: Any) -> None:
@@ -104,6 +106,18 @@ class LutronLight(LutronDevice, LightEntity):
         if ATTR_TRANSITION in kwargs:
             args["fade_time_seconds"] = kwargs[ATTR_TRANSITION]
         self._lutron_device.set_level(**args)
+        self._publish_level()
+
+    def _publish_level(self) -> None:
+        """Publish the device's current level without waiting for a report.
+
+        Reads `last_level()` like `_update_callback` does, so a report that
+        lands around the same time cannot be overwritten by a separately held
+        assumed value -- whichever reached the library last is what gets
+        published.
+        """
+        self._update_attrs()
+        self.schedule_update_ha_state()
 
     @property
     @override

--- a/tests/components/lutron/conftest.py
+++ b/tests/components/lutron/conftest.py
@@ -48,6 +48,13 @@ def mock_lutron() -> Generator[MagicMock]:
         light.is_dimmable = True
         light.type = "LIGHT"
         light.last_level.return_value = 0
+
+        # pylutron's Output.set_level() stores the new level, which last_level()
+        # then returns. Mirror that so the mock behaves like the library.
+        def _set_level(new_level, fade_time_seconds=None):
+            light.last_level.return_value = new_level
+
+        light.set_level.side_effect = _set_level
         area.outputs.append(light)
 
         # Mock a switch

--- a/tests/components/lutron/test_light.py
+++ b/tests/components/lutron/test_light.py
@@ -226,3 +226,79 @@ async def test_light_brightness_restore(
     )
     # HA level 127 -> Lutron level ~49.8
     light.set_level.assert_called_with(new_level=pytest.approx(50.0, abs=0.5))
+
+
+async def test_light_state_published_without_waiting_for_a_report(
+    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """State follows the command without waiting for the controller to report.
+
+    The subscription still delivers the authoritative value later, but it can
+    be slow, and on a HomeWorks QS system driven by keypad scenes it never
+    arrives for zone levels at all.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    light = mock_lutron.areas[0].outputs[0]
+    light.last_level.return_value = 0
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = "light.test_area_test_light"
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    # No callback is fired here: nothing reports the change back.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 128},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+
+async def test_a_later_report_wins_over_the_commanded_value(
+    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """The controller remains authoritative when it does report."""
+    mock_config_entry.add_to_hass(hass)
+
+    light = mock_lutron.areas[0].outputs[0]
+    light.last_level.return_value = 0
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = "light.test_area_test_light"
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 128},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).attributes[ATTR_BRIGHTNESS] == 128
+
+    # The controller says the zone actually landed on 100%.
+    light.last_level.return_value = 100
+    callback = light.subscribe.call_args[0][0]
+    callback(light, None, None, None)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).attributes[ATTR_BRIGHTNESS] == 255


### PR DESCRIPTION
## Proposed change

`turn_on` and `turn_off` send the command and then leave the entity state
alone, relying entirely on the controller echoing the change back through the
pylutron subscription. The entity does not poll (`_attr_should_poll = False`),
so until that echo arrives the UI keeps showing the old value.

That echo is usually fast. But it is not guaranteed, and on HomeWorks QS it is
absent for the changes users actually make: the processor reports button, LED
and occupancy monitoring, but not zone levels for scene-driven changes. In a
keypad-programmed installation — the normal shape for HomeWorks QS, where wall
buttons recall scenes rather than set levels — light states stay at whatever
they were when Home Assistant started, and moving a brightness slider snaps
straight back.

This publishes right after the command. The value is read from `last_level()`,
the same source `_update_callback` uses, so a report landing around the same
time cannot be lost to a separately held assumed value: whichever reached the
library last is what gets published. Nothing changes on systems where the echo
works — it only closes the window where the UI is knowingly stale.

The flash branch is left alone; flashing does not set a level.
`schedule_update_ha_state()` rather than `async_write_ha_state()` because
`turn_on`/`turn_off` are sync methods running in the executor, matching
`LutronBaseEntity._update_callback`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Related upstream library work, not required by this PR:
[thecynic/pylutron#134](https://github.com/thecynic/pylutron/pull/134) —
`Output.set_level()` returns early when its cached level matches the request,
so with a stale cache the *second* identical command is dropped. Combined with
the state not being published, an affected user sees the control work once and
then stop.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  Thank you for contributing <3
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---

**Test run on `tests/components/lutron/`, before and after:**

```
dev:          2 failed, 42 passed, 34 errors
this branch:  2 failed, 44 passed, 36 errors
```

Same two failures either way (`test_binary_sensor.py::test_binary_sensor_setup`
and `::test_binary_sensor_update`), as are the teardown errors, which are a
local environment artifact (`Translation not found for light:
services.turn_off.name`). The change adds exactly the two new passing tests.

`conftest.py` now gives the light mock a `set_level` side effect that updates
`last_level()`, matching what `pylutron.Output.set_level()` does. No existing
test changes behaviour as a result.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
