### PR TITLE
Fix duplicate first day of month statistics in Suez Water

### DIFF
--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -72,8 +72,10 @@ from .store import BackupStore
 from .util import (
     DecryptedBackupStreamer,
     EncryptedBackupStreamer,
+    iter_upload_chunks,
     make_backup_dir,
     read_backup,
+    receive_file,
     validate_password,
     validate_password_stream,
 )
@@ -1004,7 +1006,6 @@ class BackupManager:
         contents: aiohttp.BodyPartReader,
     ) -> str:
         """Receive and store a backup file from upload."""
-        contents.chunk_size = BUF_SIZE
         suggested_filename = contents.filename or "backup.tar"
         safe_filename = PureWindowsPath(suggested_filename).name
         if (
@@ -1022,7 +1023,7 @@ class BackupManager:
         )
         written_backup = await self._reader_writer.async_receive_backup(
             agent_ids=agent_ids,
-            stream=contents,
+            stream=iter_upload_chunks(contents),
             suggested_filename=suggested_filename,
         )
         self.async_on_backup_event(
@@ -1958,6 +1959,47 @@ class CoreBackupReaderWriter(BackupReaderWriter):
             ) from err
         return (tar_file_path, stat_result.st_size)
 
+    async def _receive_and_move_backup(
+        self,
+        *,
+        agent_ids: list[str],
+        stream: AsyncIterator[bytes],
+        temp_file: Path,
+    ) -> tuple[AgentBackup, Path]:
+        """Receive the upload into temp_file, validate it, and move it into place.
+
+        Remove temp_file on any failure, including cancellation from a client
+        disconnect, so a partial or unparsable upload does not orphan a
+        potentially large temp file.
+        """
+        async_add_executor_job = self._hass.async_add_executor_job
+        try:
+            await receive_file(self._hass, stream, temp_file)
+            try:
+                backup = await async_add_executor_job(read_backup, temp_file)
+            except (
+                OSError,
+                tarfile.TarError,
+                json.JSONDecodeError,
+                KeyError,
+                InvalidBackupFilename,
+            ) as err:
+                LOGGER.warning("Unable to parse backup %s: %s", temp_file, err)
+                raise
+
+            manager = self._hass.data[DATA_MANAGER]
+            if self._local_agent_id in agent_ids:
+                local_agent = manager.local_backup_agents[self._local_agent_id]
+                tar_file_path = local_agent.get_new_backup_path(backup)
+                await async_add_executor_job(make_backup_dir, tar_file_path.parent)
+                await async_add_executor_job(shutil.move, temp_file, tar_file_path)
+            else:
+                tar_file_path = temp_file
+        except Exception, asyncio.CancelledError:
+            await async_add_executor_job(temp_file.unlink, True)
+            raise
+        return backup, tar_file_path
+
     @override
     async def async_receive_backup(
         self,
@@ -1971,33 +2013,9 @@ class CoreBackupReaderWriter(BackupReaderWriter):
 
         async_add_executor_job = self._hass.async_add_executor_job
         await async_add_executor_job(make_backup_dir, self.temp_backup_dir)
-        f = await async_add_executor_job(temp_file.open, "wb")
-        try:
-            async for chunk in stream:
-                await async_add_executor_job(f.write, chunk)
-        finally:
-            await async_add_executor_job(f.close)
-
-        try:
-            backup = await async_add_executor_job(read_backup, temp_file)
-        except (
-            OSError,
-            tarfile.TarError,
-            json.JSONDecodeError,
-            KeyError,
-            InvalidBackupFilename,
-        ) as err:
-            LOGGER.warning("Unable to parse backup %s: %s", temp_file, err)
-            raise
-
-        manager = self._hass.data[DATA_MANAGER]
-        if self._local_agent_id in agent_ids:
-            local_agent = manager.local_backup_agents[self._local_agent_id]
-            tar_file_path = local_agent.get_new_backup_path(backup)
-            await async_add_executor_job(make_backup_dir, tar_file_path.parent)
-            await async_add_executor_job(shutil.move, temp_file, tar_file_path)
-        else:
-            tar_file_path = temp_file
+        backup, tar_file_path = await self._receive_and_move_backup(
+            agent_ids=agent_ids, stream=stream, temp_file=temp_file
+        )
 
         async def send_backup() -> AsyncIterator[bytes]:
             f = await async_add_executor_job(tar_file_path.open, "rb")

--- a/homeassistant/components/backup/util.py
+++ b/homeassistant/components/backup/util.py
@@ -12,7 +12,6 @@ import tarfile
 import threading
 from typing import IO, Any, cast
 
-import aiohttp
 from securetar import (
     InvalidPasswordError,
     SecureTarArchive,
@@ -508,7 +507,7 @@ class EncryptedBackupStreamer(_CipherBackupStreamer):
 
 
 async def receive_file(
-    hass: HomeAssistant, contents: aiohttp.BodyPartReader, path: Path
+    hass: HomeAssistant, stream: AsyncIterator[bytes], path: Path
 ) -> None:
     """Receive a file from a stream and write it to a file."""
     queue: SimpleQueue[tuple[bytes, asyncio.Future[None] | None] | None] = SimpleQueue()
@@ -526,10 +525,10 @@ async def receive_file(
     fut: asyncio.Future[None] | None = None
     try:
         fut = hass.async_add_executor_job(_sync_queue_consumer)
-        megabytes_sending = 0
-        while chunk := await contents.read_chunk(BUF_SIZE):
-            megabytes_sending += 1
-            if megabytes_sending % 5 != 0:
+        chunks_sent = 0
+        async for chunk in stream:
+            chunks_sent += 1
+            if chunks_sent % 5 != 0:
                 queue.put_nowait((chunk, None))
                 continue
 
@@ -542,8 +541,9 @@ async def receive_file(
             if fut.done():
                 # The executor job failed
                 break
-
-        queue.put_nowait(None)  # terminate queue consumer
     finally:
+        # Always terminate the queue consumer, also if the stream raised or the
+        # task was cancelled.
+        queue.put_nowait(None)
         if fut is not None:
             await fut

--- a/homeassistant/components/backup/util.py
+++ b/homeassistant/components/backup/util.py
@@ -12,6 +12,7 @@ import tarfile
 import threading
 from typing import IO, Any, cast
 
+import aiohttp
 from securetar import (
     InvalidPasswordError,
     SecureTarArchive,
@@ -504,6 +505,16 @@ class EncryptedBackupStreamer(_CipherBackupStreamer):
     def backup(self) -> AgentBackup:
         """Return the encrypted backup."""
         return replace(self._backup, protected=True, size=self.size())
+
+
+async def iter_upload_chunks(contents: aiohttp.BodyPartReader) -> AsyncIterator[bytes]:
+    """Yield chunks of an uploaded file.
+
+    Iterating a BodyPartReader reads the whole part into memory and enforces the
+    request's client_max_size limit; reading it in chunks does neither.
+    """
+    while chunk := await contents.read_chunk(BUF_SIZE):
+        yield chunk
 
 
 async def receive_file(

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.deprecation import deprecated_function
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType
@@ -91,6 +92,9 @@ __all__ = [
 ]
 
 
+@deprecated_function(
+    "hass.states.is_state(entity_id, 'closed')", breaks_in_ha_version="2027.10"
+)
 def is_closed(hass: HomeAssistant, entity_id: str) -> bool:
     """Return if the cover is closed based on the statemachine."""
     return hass.states.is_state(entity_id, CoverState.CLOSED)

--- a/homeassistant/components/suez_water/coordinator.py
+++ b/homeassistant/components/suez_water/coordinator.py
@@ -177,14 +177,25 @@ class SuezWaterCoordinator(DataUpdateCoordinator[SuezWaterData]):
         """Build statistics data from fetched data."""
         consumption_statistics = []
         cost_statistics = []
+        seen_dates: dict[date, float] = {}
 
         for data in usage:
-            if (
-                (last_stats is not None and data.date <= last_stats)
-                or not data.index
-                or data.volume is None
-            ):
+            if last_stats is not None and data.date <= last_stats:
                 continue
+            if not data.index or data.volume is None:
+                continue
+            if data.date in seen_dates:
+                if seen_dates[data.date] != data.volume:
+                    _LOGGER.warning(
+                        "Duplicate date %s with different volume: %.2f L vs %.2f L - keeping first value",
+                        data.date,
+                        seen_dates[data.date],
+                        data.volume,
+                    )
+                else:
+                    _LOGGER.debug("Skipping duplicate date: %s", data.date)
+                continue
+            seen_dates[data.date] = data.volume
             consumption_date = dt_util.start_of_local_day(data.date)
 
             consumption_sum += data.volume

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Callable, Generator
 from dataclasses import replace
 from datetime import timedelta
-from io import StringIO
+from io import BytesIO, StringIO
 import json
 from pathlib import Path
 import re
@@ -34,7 +34,7 @@ from homeassistant.components.backup import (
     LocalBackupAgent,
 )
 from homeassistant.components.backup.agent import BackupAgentError
-from homeassistant.components.backup.const import DATA_MANAGER
+from homeassistant.components.backup.const import BUF_SIZE, DATA_MANAGER
 from homeassistant.components.backup.manager import (
     AddonErrorData,
     AddonInfo,
@@ -50,6 +50,7 @@ from homeassistant.components.backup.manager import (
     UploadBackupEvent,
     WrittenBackup,
 )
+from homeassistant.components.http.server import MAX_CLIENT_SIZE
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -2015,6 +2016,141 @@ async def test_receive_backup(
             backup_data += chunk
         assert backup_data == expected_backup_data
     assert unlink_mock.call_count == temp_file_unlink_call_count
+
+
+@pytest.mark.parametrize(
+    ("upload_size", "min_chunk_count"),
+    [
+        pytest.param(1024, 1, id="small"),
+        pytest.param(MAX_CLIENT_SIZE + 1024, 2, id="above_max_client_size"),
+    ],
+)
+async def test_receive_large_backup(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    upload_size: int,
+    min_chunk_count: int,
+) -> None:
+    """Test receiving a backup larger than the max request body size."""
+    await setup_backup_integration(hass)
+    # Make sure we wait for Platform.EVENT and Platform.SENSOR to be fully processed,
+    # to avoid interference with the Path.open patching below which is used to verify
+    # that the file is written to the expected location.
+    await hass.async_block_till_done(True)
+    client = await hass_client()
+    open_mock = mock_open()
+
+    with (
+        patch("pathlib.Path.open", open_mock),
+        patch("homeassistant.components.backup.manager.make_backup_dir"),
+        patch("shutil.move"),
+        patch(
+            "homeassistant.components.backup.manager.read_backup",
+            return_value=TEST_BACKUP_ABC123,
+        ),
+    ):
+        data = FormData(quote_fields=False)
+        data.add_field(
+            "file",
+            BytesIO(b"\0" * upload_size),
+            filename="backup.tar",
+            content_type="application/octet-stream",
+        )
+        resp = await client.post("/api/backup/upload?agent_id=backup.local", data=data)
+        await hass.async_block_till_done()
+
+    assert resp.status == 201
+    assert await resp.json() == {"backup_id": TEST_BACKUP_ABC123.backup_id}
+    written_chunks = [
+        call.args[0] for call in open_mock.return_value.write.call_args_list
+    ]
+    assert sum(len(chunk) for chunk in written_chunks) == upload_size
+    # The file must be written in bounded chunks, not buffered into memory whole
+    assert len(written_chunks) >= min_chunk_count
+    assert max(len(chunk) for chunk in written_chunks) <= BUF_SIZE
+
+
+class _DisconnectingBodyPartReader:
+    """Minimal BodyPartReader whose read_chunk raises after the first chunk.
+
+    Models a client disconnect mid-upload: aiohttp sets a ConnectionResetError on
+    the request payload and cancels the handler when the connection is lost.
+    """
+
+    filename = "backup.tar"
+
+    def __init__(self, chunk: bytes, error: Exception) -> None:
+        """Initialize the reader."""
+        self._chunk = chunk
+        self._error = error
+        self._sent = False
+
+    async def read_chunk(self, size: int) -> bytes:
+        """Return one chunk, then raise on the next read."""
+        if self._sent:
+            raise self._error
+        self._sent = True
+        return self._chunk
+
+
+async def test_receive_backup_stream_error_resets_state(hass: HomeAssistant) -> None:
+    """Test the backup manager returns to IDLE when the upload stream fails.
+
+    A client disconnect (or other stream error) mid-upload must not wedge the
+    manager in a busy state; this drives the manager with a stream that raises
+    rather than a real socket disconnect, which the test client can't produce.
+    """
+    await setup_backup_integration(hass)
+    await hass.async_block_till_done(True)
+    manager = hass.data[DATA_MANAGER]
+    contents = _DisconnectingBodyPartReader(
+        b"\0" * 1024, ConnectionResetError("Connection lost")
+    )
+
+    with (
+        patch("pathlib.Path.open", mock_open()),
+        patch("homeassistant.components.backup.manager.make_backup_dir"),
+        patch("pathlib.Path.unlink") as unlink_mock,
+    ):
+        # Bound the await so a reintroduced deadlock fails fast instead of hanging.
+        async with asyncio.timeout(10):
+            with pytest.raises(ConnectionResetError):
+                await manager.async_receive_backup(
+                    agent_ids=["backup.local"], contents=contents
+                )
+
+    assert manager.state is BackupManagerState.IDLE
+    # The partially written temp file is removed on the failed upload.
+    assert unlink_mock.call_count == 1
+
+
+async def test_receive_backup_unparsable_file_removed(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test the temp file is removed when the uploaded backup can't be parsed."""
+    await setup_backup_integration(hass)
+    await hass.async_block_till_done(True)
+    client = await hass_client()
+
+    with (
+        patch("pathlib.Path.open", mock_open(read_data=b"test")),
+        patch("homeassistant.components.backup.manager.make_backup_dir"),
+        patch(
+            "homeassistant.components.backup.manager.read_backup",
+            side_effect=OSError("Boom"),
+        ),
+        patch("pathlib.Path.unlink") as unlink_mock,
+    ):
+        resp = await client.post(
+            "/api/backup/upload?agent_id=backup.local",
+            data={"file": StringIO("test")},
+        )
+        await hass.async_block_till_done()
+
+    assert resp.status == 500
+    # The unparsable temp file is removed exactly once.
+    assert unlink_mock.call_count == 1
 
 
 async def test_receive_backup_valid_filename(

--- a/tests/components/backup/test_util.py
+++ b/tests/components/backup/test_util.py
@@ -19,6 +19,7 @@ from homeassistant.components.backup.util import (
     DecryptedBackupStreamer,
     EncryptedBackupStreamer,
     read_backup,
+    receive_file,
     suggested_filename,
     validate_password,
 )
@@ -784,3 +785,87 @@ def test_suggested_filename(name: str, resulting_filename: str) -> None:
         size=1234,
     )
     assert suggested_filename(backup) == resulting_filename
+
+
+# Bound receive_file awaits so a reintroduced deadlock fails fast instead of
+# hanging the test run.
+_RECEIVE_FILE_TIMEOUT = 10
+
+
+async def _stream_chunks(
+    chunks: list[bytes], error: Exception | None = None
+) -> AsyncIterator[bytes]:
+    """Yield chunks, then optionally raise to simulate a broken upload stream."""
+    for chunk in chunks:
+        yield chunk
+    if error is not None:
+        raise error
+
+
+@pytest.mark.parametrize(
+    "chunks",
+    [
+        pytest.param([], id="empty"),
+        pytest.param([b"single"], id="single_chunk"),
+        pytest.param([b"chunk1", b"chunk2", b"chunk3"], id="multi_chunk"),
+        # >5 chunks crosses the backpressure checkpoint (every 5th chunk).
+        pytest.param([f"chunk{i}".encode() for i in range(12)], id="many_chunks"),
+    ],
+)
+async def test_receive_file(
+    hass: HomeAssistant, tmp_path: Path, chunks: list[bytes]
+) -> None:
+    """Test receiving a stream and writing it to a file."""
+    path = tmp_path / "received.bin"
+    async with asyncio.timeout(_RECEIVE_FILE_TIMEOUT):
+        await receive_file(hass, _stream_chunks(chunks), path)
+    assert path.read_bytes() == b"".join(chunks)
+
+
+async def test_receive_file_writer_error(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Test an OSError from the file writer propagates without deadlocking."""
+    # The parent directory does not exist, so opening the file for writing fails.
+    path = tmp_path / "missing" / "received.bin"
+    async with asyncio.timeout(_RECEIVE_FILE_TIMEOUT):
+        with pytest.raises(FileNotFoundError):
+            await receive_file(hass, _stream_chunks([b"data"] * 10), path)
+
+
+async def test_receive_file_stream_error(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Test a stream error propagates and the consumer still terminates."""
+    path = tmp_path / "received.bin"
+    stream = _stream_chunks(
+        [b"chunk1", b"chunk2"], ConnectionResetError("Connection lost")
+    )
+    async with asyncio.timeout(_RECEIVE_FILE_TIMEOUT):
+        with pytest.raises(ConnectionResetError):
+            await receive_file(hass, stream, path)
+    # The consumer drained the queued chunks and closed the file before the error
+    # surfaced, proving it terminated rather than deadlocked.
+    assert path.read_bytes() == b"chunk1chunk2"
+
+
+async def test_receive_file_cancelled(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Test cancelling mid-transfer propagates CancelledError without deadlocking."""
+    path = tmp_path / "received.bin"
+    first_chunk_sent = asyncio.Event()
+    blocked = asyncio.Event()  # never set, so the stream blocks until cancelled
+
+    async def _blocking_stream() -> AsyncIterator[bytes]:
+        yield b"chunk1"
+        first_chunk_sent.set()
+        await blocked.wait()
+
+    task = asyncio.create_task(receive_file(hass, _blocking_stream(), path))
+    await first_chunk_sent.wait()
+    task.cancel()
+
+    # asyncio.wait does not cancel on timeout, so a deadlocked task stays pending
+    # and the assertion fails fast instead of the run hanging.
+    _done, pending = await asyncio.wait({task}, timeout=_RECEIVE_FILE_TIMEOUT)
+    assert not pending
+    with pytest.raises(asyncio.CancelledError):
+        task.result()
+    # The first chunk was flushed and the file closed before cancellation
+    # completed, proving the consumer terminated rather than deadlocked.
+    assert path.read_bytes() == b"chunk1"

--- a/tests/components/cover/test_init.py
+++ b/tests/components/cover/test_init.py
@@ -320,3 +320,19 @@ async def test_services_with_speed(
         blocking=True,
     )
     assert ent2.last_kwargs == {"position": 49}
+
+
+async def test_deprecated_is_closed(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test the deprecated is_closed helper."""
+    hass.states.async_set("cover.test", CoverState.CLOSED)
+    assert cover.is_closed(hass, "cover.test") is True
+
+    hass.states.async_set("cover.test", CoverState.OPEN)
+    assert cover.is_closed(hass, "cover.test") is False
+
+    assert (
+        "The deprecated function is_closed was called. It will be removed in HA Core "
+        "2027.10. Use hass.states.is_state(entity_id, 'closed') instead"
+    ) in caplog.text

--- a/tests/components/subaru/test_config_flow.py
+++ b/tests/components/subaru/test_config_flow.py
@@ -41,15 +41,6 @@ MOCK_2FA_CONTACTS = {
 }
 
 
-async def test_user_form_init(user_form) -> None:
-    """Test the initial user form for first step of the config flow."""
-    assert user_form["description_placeholders"] is None
-    assert user_form["errors"] is None
-    assert user_form["handler"] == DOMAIN
-    assert user_form["step_id"] == "user"
-    assert user_form["type"] is FlowResultType.FORM
-
-
 async def test_user_form_repeat_identifier(hass: HomeAssistant, user_form) -> None:
     """Test we handle repeat identifiers."""
     entry = MockConfigEntry(
@@ -86,7 +77,7 @@ async def test_user_form_cannot_connect(hass: HomeAssistant, user_form) -> None:
 
 
 async def test_user_form_invalid_auth(hass: HomeAssistant, user_form) -> None:
-    """Test we handle invalid auth."""
+    """Test we handle invalid auth, and that the flow can still be completed afterward."""
     with patch(
         MOCK_API_CONNECT,
         side_effect=InvalidCredentials("invalidAccount"),
@@ -98,6 +89,18 @@ async def test_user_form_invalid_auth(hass: HomeAssistant, user_form) -> None:
     assert len(mock_connect.mock_calls) == 1
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_auth"}
+
+    with (
+        patch(MOCK_API_CONNECT, return_value=True),
+        patch(MOCK_API_DEVICE_REGISTERED, new_callable=PropertyMock, return_value=True),
+        patch(MOCK_API_IS_PIN_REQUIRED, return_value=False),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            TEST_CREDS,
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_user_form_pin_not_required(
@@ -154,9 +157,21 @@ async def test_registered_pin_required(hass: HomeAssistant, user_form) -> None:
         patch(MOCK_API_IS_PIN_REQUIRED, return_value=True),
     ):
         mock_device_registered.return_value = True
-        await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             user_form["flow_id"], user_input=TEST_CREDS
         )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pin"
+
+    with (
+        patch(MOCK_API_TEST_PIN, return_value=True),
+        patch(MOCK_API_UPDATE_SAVED_PIN, return_value=True),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PIN: TEST_PIN}
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_registered_no_pin_required(hass: HomeAssistant, user_form) -> None:
@@ -167,11 +182,13 @@ async def test_registered_no_pin_required(hass: HomeAssistant, user_form) -> Non
             MOCK_API_DEVICE_REGISTERED, new_callable=PropertyMock
         ) as mock_device_registered,
         patch(MOCK_API_IS_PIN_REQUIRED, return_value=False),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
     ):
         mock_device_registered.return_value = True
-        await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             user_form["flow_id"], user_input=TEST_CREDS
         )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_two_factor_request_success(
@@ -186,11 +203,24 @@ async def test_two_factor_request_success(
         patch(MOCK_API_2FA_CONTACTS, new_callable=PropertyMock) as mock_contacts,
     ):
         mock_contacts.return_value = MOCK_2FA_CONTACTS
-        await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             two_factor_start_form["flow_id"],
             user_input={config_flow.CONF_CONTACT_METHOD: "email@addr.com"},
         )
     assert len(mock_two_factor_request.mock_calls) == 1
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "two_factor_validate"
+
+    with (
+        patch(MOCK_API_2FA_VERIFY, return_value=True),
+        patch(MOCK_API_IS_PIN_REQUIRED, return_value=False),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_two_factor_request_fail(
@@ -225,18 +255,30 @@ async def test_two_factor_verify_success(
         ) as mock_two_factor_verify,
         patch(MOCK_API_IS_PIN_REQUIRED, return_value=True) as mock_is_in_required,
     ):
-        await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             two_factor_verify_form["flow_id"],
             user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
         )
     assert len(mock_two_factor_verify.mock_calls) == 1
     assert len(mock_is_in_required.mock_calls) == 1
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pin"
+
+    with (
+        patch(MOCK_API_TEST_PIN, return_value=True),
+        patch(MOCK_API_UPDATE_SAVED_PIN, return_value=True),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PIN: TEST_PIN}
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_two_factor_verify_bad_format(
     hass: HomeAssistant, two_factor_verify_form
 ) -> None:
-    """Test two factor verification bad format."""
+    """Test two factor verification bad format, and that the flow can still be completed afterward."""
     with (
         patch(
             MOCK_API_2FA_VERIFY,
@@ -252,11 +294,22 @@ async def test_two_factor_verify_bad_format(
     assert len(mock_is_pin_required.mock_calls) == 0
     assert result["errors"] == {"base": "bad_validation_code_format"}
 
+    with (
+        patch(MOCK_API_2FA_VERIFY, return_value=True),
+        patch(MOCK_API_IS_PIN_REQUIRED, return_value=False),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
 
 async def test_two_factor_verify_fail(
     hass: HomeAssistant, two_factor_verify_form
 ) -> None:
-    """Test two factor verification failure."""
+    """Test two factor verification failure, and that the flow can still be completed afterward."""
     with (
         patch(
             MOCK_API_2FA_VERIFY,
@@ -272,25 +325,20 @@ async def test_two_factor_verify_fail(
     assert len(mock_is_pin_required.mock_calls) == 0
     assert result["errors"] == {"base": "incorrect_validation_code"}
 
-
-async def test_pin_form_init(pin_form) -> None:
-    """Test the pin entry form for second step of the config flow."""
-    expected = {
-        "data_schema": config_flow.PIN_SCHEMA,
-        "description_placeholders": None,
-        "errors": None,
-        "flow_id": mock.ANY,
-        "handler": DOMAIN,
-        "step_id": "pin",
-        "type": "form",
-        "last_step": None,
-        "preview": None,
-    }
-    assert pin_form == expected
+    with (
+        patch(MOCK_API_2FA_VERIFY, return_value=True),
+        patch(MOCK_API_IS_PIN_REQUIRED, return_value=False),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_pin_form_bad_pin_format(hass: HomeAssistant, pin_form) -> None:
-    """Test we handle invalid pin."""
+    """Test we handle invalid pin, and that the flow can still be completed afterward."""
     with (
         patch(
             MOCK_API_TEST_PIN,
@@ -307,6 +355,16 @@ async def test_pin_form_bad_pin_format(hass: HomeAssistant, pin_form) -> None:
     assert len(mock_update_saved_pin.mock_calls) == 1
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "bad_pin_format"}
+
+    with (
+        patch(MOCK_API_TEST_PIN, return_value=True),
+        patch(MOCK_API_UPDATE_SAVED_PIN, return_value=True),
+        patch(ASYNC_SETUP_ENTRY, return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_PIN: TEST_PIN}
+        )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_pin_form_success(hass: HomeAssistant, pin_form) -> None:
@@ -379,16 +437,11 @@ async def test_pin_form_incorrect_pin(hass: HomeAssistant, pin_form) -> None:
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-async def test_option_flow_form(options_form) -> None:
-    """Test config flow options form."""
-    assert options_form["description_placeholders"] is None
-    assert options_form["errors"] is None
-    assert options_form["step_id"] == "init"
-    assert options_form["type"] is FlowResultType.FORM
-
-
 async def test_option_flow(hass: HomeAssistant, options_form) -> None:
     """Test config flow options."""
+    assert options_form["type"] is FlowResultType.FORM
+    assert options_form["step_id"] == "init"
+
     result = await hass.config_entries.options.async_configure(
         options_form["flow_id"],
         user_input={
@@ -404,9 +457,13 @@ async def test_option_flow(hass: HomeAssistant, options_form) -> None:
 @pytest.fixture
 async def user_form(hass: HomeAssistant) -> ConfigFlowResult:
     """Return initial form for Subaru config flow."""
-    return await hass.config_entries.flow.async_init(
+    result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] is None
+    return result
 
 
 @pytest.fixture
@@ -455,10 +512,13 @@ async def pin_form(
         ),
         patch(MOCK_API_IS_PIN_REQUIRED, return_value=True),
     ):
-        return await hass.config_entries.flow.async_configure(
+        result = await hass.config_entries.flow.async_configure(
             two_factor_verify_form["flow_id"],
             user_input={config_flow.CONF_VALIDATION_CODE: "123456"},
         )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pin"
+    return result
 
 
 @pytest.fixture

--- a/tests/components/suez_water/test_init.py
+++ b/tests/components/suez_water/test_init.py
@@ -299,3 +299,93 @@ async def test_migration_version_1_to_2(
     assert past_entry.unique_id == MOCK_DATA[CONF_COUNTER_ID]
     assert past_entry.title == MOCK_DATA[CONF_USERNAME]
     assert past_entry.version == 2
+
+
+@pytest.mark.usefixtures("recorder_mock")
+@pytest.mark.parametrize(
+    ("duplicate_volume", "expected_log_level"),
+    [
+        (100.0, "debug"),
+        (999.0, "warning"),
+    ],
+)
+async def test_statistics_with_duplicate_dates(
+    hass: HomeAssistant,
+    suez_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+    duplicate_volume: float,
+    expected_log_level: str,
+) -> None:
+    """Test that duplicate dates in data are handled correctly."""
+    start = datetime.fromisoformat("2024-12-04T02:00:00.0")
+    freezer.move_to(start)
+
+    origin = dt_util.start_of_local_day(start.date()) - timedelta(days=3)
+
+    result = [
+        TelemetryMeasure(
+            date=origin.date().strftime("%Y-%m-%d %H:%M:%S"),
+            volume=0.1,
+            index=0.1,
+        ),
+        TelemetryMeasure(
+            date=(origin + timedelta(days=1)).date().strftime("%Y-%m-%d %H:%M:%S"),
+            volume=0.15,
+            index=0.25,
+        ),
+        TelemetryMeasure(
+            date=(origin + timedelta(days=2)).date().strftime("%Y-%m-%d %H:%M:%S"),
+            volume=0.2,
+            index=0.45,
+        ),
+        # Duplicate of the first day with same or different volume
+        TelemetryMeasure(
+            date=origin.date().strftime("%Y-%m-%d %H:%M:%S"),
+            volume=duplicate_volume / 1000,  # Convert L to m³
+            index=0.1,
+        ),
+    ]
+    suez_client.fetch_all_daily_data.return_value = result
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    await hass.async_block_till_done(True)
+    await async_wait_recording_done(hass)
+
+    statistic_id = f"{DOMAIN}:{mock_config_entry.data[CONF_COUNTER_ID]}_water_consumption_statistics"
+    stats = await hass.async_add_executor_job(
+        statistics_during_period,
+        hass,
+        origin - timedelta(days=1),
+        None,
+        [statistic_id],
+        "hour",
+        None,
+        {"start", "state", "sum"},
+    )
+
+    # Verify that we only have 3 entries (not 4), and the duplicate was ignored
+    assert statistic_id in stats
+    assert len(stats[statistic_id]) == 3
+
+    # Verify the cumulative sum is correct (100 + 150 + 200 = 450, not 550)
+    assert stats[statistic_id][0]["sum"] == 100.0
+    assert stats[statistic_id][1]["sum"] == 250.0
+    assert stats[statistic_id][2]["sum"] == 450.0
+
+    # Verify appropriate log message based on whether values differ
+    if expected_log_level == "warning":
+        assert any(
+            "Duplicate date" in record.message and "different volume" in record.message
+            for record in caplog.records
+            if record.levelname == "WARNING"
+        )
+    else:
+        assert any(
+            "Skipping duplicate date" in record.message
+            for record in caplog.records
+            if record.levelname == "DEBUG"
+        )

--- a/tests/components/suez_water/test_init.py
+++ b/tests/components/suez_water/test_init.py
@@ -303,10 +303,10 @@ async def test_migration_version_1_to_2(
 
 @pytest.mark.usefixtures("recorder_mock")
 @pytest.mark.parametrize(
-    ("duplicate_volume", "expected_log_level"),
+    ("duplicate_volume", "expected_log_level", "expected_log_message"),
     [
-        (100.0, "debug"),
-        (999.0, "warning"),
+        (100.0, "DEBUG", "Skipping duplicate date"),
+        (999.0, "WARNING", "different volume"),
     ],
 )
 async def test_statistics_with_duplicate_dates(
@@ -317,6 +317,7 @@ async def test_statistics_with_duplicate_dates(
     caplog: pytest.LogCaptureFixture,
     duplicate_volume: float,
     expected_log_level: str,
+    expected_log_message: str,
 ) -> None:
     """Test that duplicate dates in data are handled correctly."""
     start = datetime.fromisoformat("2024-12-04T02:00:00.0")
@@ -340,10 +341,9 @@ async def test_statistics_with_duplicate_dates(
             volume=0.2,
             index=0.45,
         ),
-        # Duplicate of the first day with same or different volume
         TelemetryMeasure(
             date=origin.date().strftime("%Y-%m-%d %H:%M:%S"),
-            volume=duplicate_volume / 1000,  # Convert L to m³
+            volume=duplicate_volume / 1000,
             index=0.1,
         ),
     ]
@@ -367,25 +367,15 @@ async def test_statistics_with_duplicate_dates(
         {"start", "state", "sum"},
     )
 
-    # Verify that we only have 3 entries (not 4), and the duplicate was ignored
     assert statistic_id in stats
     assert len(stats[statistic_id]) == 3
 
-    # Verify the cumulative sum is correct (100 + 150 + 200 = 450, not 550)
     assert stats[statistic_id][0]["sum"] == 100.0
     assert stats[statistic_id][1]["sum"] == 250.0
     assert stats[statistic_id][2]["sum"] == 450.0
 
-    # Verify appropriate log message based on whether values differ
-    if expected_log_level == "warning":
-        assert any(
-            "Duplicate date" in record.message and "different volume" in record.message
-            for record in caplog.records
-            if record.levelname == "WARNING"
-        )
-    else:
-        assert any(
-            "Skipping duplicate date" in record.message
-            for record in caplog.records
-            if record.levelname == "DEBUG"
-        )
+    assert any(
+        expected_log_message in record.message
+        for record in caplog.records
+        if record.levelname == expected_log_level
+    )


### PR DESCRIPTION
## Breaking change

N/A

## Proposed change

This PR adds defensive deduplication in the Suez Water integration's statistics building process to prevent cumulative sum corruption when duplicate dates appear in the data source.

The issue (#161012) manifests as doubled water consumption statistics on the 1st day of each month. While the root cause is in the upstream pySuez library (pending fix in jb101010-2/pySuez#20), this change adds a defensive layer in Home Assistant to:

1. **Protect against duplicate dates** from any external statistics source
2. **Detect data inconsistencies** by logging a warning when duplicate dates have different volumes
3. **Maintain correct cumulative sums** by processing each date only once (first occurrence wins)

The fix uses a `dict[date, float]` to track processed dates and their volumes, ensuring O(1) lookup performance with minimal memory overhead.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #161012
- This PR is related to issue: 
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

**Note for affected users**: The incorrect cumulative values are already frozen in the statistics database. After upgrading, users should delete the `suez_water:{counter_id}_water_consumption_statistics` statistic via Developer Tools → Statistics to trigger a clean re-import.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
