### PR TITLE
Fire a Lutron single press when the button reports only a release

### DIFF
--- a/homeassistant/components/lutron/event.py
+++ b/homeassistant/components/lutron/event.py
@@ -94,7 +94,12 @@ class LutronEventEntity(LutronKeypad, EventEntity):
                 action = LutronEventType.PRESS
             else:
                 action = LutronEventType.RELEASE
-        elif event == Button.Event.PRESSED:
+        elif event in (Button.Event.PRESSED, Button.Event.RELEASED):
+            # A button whose programming carries a hold or multi-tap action
+            # reports on release rather than press: at press time the system
+            # cannot yet tell a tap from a hold, so it waits for the release to
+            # decide. Such a button never sends a press, and treating only
+            # presses as a tap makes it silent.
             action = LutronEventType.SINGLE_PRESS
 
         if action:

--- a/homeassistant/components/lutron/event.py
+++ b/homeassistant/components/lutron/event.py
@@ -95,11 +95,7 @@ class LutronEventEntity(LutronKeypad, EventEntity):
             else:
                 action = LutronEventType.RELEASE
         elif event in (Button.Event.PRESSED, Button.Event.RELEASED):
-            # A button whose programming carries a hold or multi-tap action
-            # reports on release rather than press: at press time the system
-            # cannot yet tell a tap from a hold, so it waits for the release to
-            # decide. Such a button never sends a press, and treating only
-            # presses as a tap makes it silent.
+            # Buttons carrying a hold action report only a release, never a press.
             action = LutronEventType.SINGLE_PRESS
 
         if action:

--- a/tests/components/lutron/test_event.py
+++ b/tests/components/lutron/test_event.py
@@ -98,14 +98,7 @@ async def test_event_press_release(
 async def test_event_release_only_button(
     hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
 ) -> None:
-    """A button that only ever reports a release still fires a single press.
-
-    When a button's programming carries a hold or multi-tap action, the system
-    reports on release rather than on press: at press time it cannot yet tell a
-    tap from a hold, so it waits for the release to decide. Such a button never
-    sends a press, and its button type is an ordinary one -- not a raise/lower --
-    so it cannot be recognised from the type alone.
-    """
+    """A button that only ever reports a release still fires a single press."""
     mock_config_entry.add_to_hass(hass)
 
     button = mock_lutron.areas[0].keypads[0].buttons[0]

--- a/tests/components/lutron/test_event.py
+++ b/tests/components/lutron/test_event.py
@@ -93,3 +93,31 @@ async def test_event_press_release(
 
     assert len(events) == 2
     assert events[1].data["action"] == "released"
+
+
+async def test_event_release_only_button(
+    hass: HomeAssistant, mock_lutron: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """A button that only ever reports a release still fires a single press.
+
+    When a button's programming carries a hold or multi-tap action, the system
+    reports on release rather than on press: at press time it cannot yet tell a
+    tap from a hold, so it waits for the release to decide. Such a button never
+    sends a press, and its button type is an ordinary one -- not a raise/lower --
+    so it cannot be recognised from the type alone.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    button = mock_lutron.areas[0].keypads[0].buttons[0]
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    events = async_capture_events(hass, "lutron_event")
+
+    for call in button.subscribe.call_args_list:
+        callback = call[0][0]
+        callback(button, None, Button.Event.RELEASED, None)
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].data["action"] == "single"


### PR DESCRIPTION
## Proposed change

A keypad button whose programming carries a hold or multi-tap action reports on
**release** rather than on press: at press time the system cannot yet tell a tap
from a hold, so it waits for the release to decide. Such a button never sends a
press at all.

`_has_release_event` is derived from the button type containing `"RaiseLower"`,
and these buttons are ordinary types, so they take the single-press branch —
which only reacts to `Button.Event.PRESSED`. The release is dropped and the
button is **silent**: no event entity update, no `lutron_event` on the bus, and
nothing for an automation to trigger on.

On the HomeWorks QS project I looked at, **41 of 152 programmed buttons report
only a release**, and the button type cannot tell them apart:

```
ButtonType                reports release   count
SingleAction              no                 91
SingleAction              yes                41     <- same type, opposite behaviour
SingleSceneRaiseLower     yes                 4     <- the only one recognised today
AdvancedToggle            no                  9
AdvancedConditional       no                  7
```

Cross-checking against the XML database, the rule is exact with no exceptions
across all 152 buttons: every button carrying a `Hold` or `MultiTap` action
reports only a release, and every button without one reports a press. Scene
buttons such as "away" and curtain buttons are commonly programmed with a hold,
so this is not an exotic configuration — on that system the affected buttons
included the main "away" scene and both curtain buttons.

Captured from the integration port, on one keypad:

```
~DEVICE,138,4,4    button 4  "away"    release only, never a press
~DEVICE,138,1,3    button 1  "daily"   press
```

Only the second produced anything in Home Assistant.

The fix treats a release as a single press for buttons that are not
raise/lower. The two are mutually exclusive there — such a button either reports
presses or reports releases, never both — so it cannot double-fire. Raise/lower
buttons keep their existing separate press and release events.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

A more precise fix would read the button's programmed actions from the XML
database, which does record whether a hold is configured — but pylutron does not
parse that today, so it would need a library change first. Treating a release as
a tap needs no new data and covers every case I could construct.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---

`tests/components/lutron/test_event.py` gains one test. It fails on `dev` with
`assert 0 == 1` and passes with the change; the file's four tests pass and ruff
is clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
