### PR TITLE
Type the lookin UDP manager with a HassKey

### DIFF
--- a/homeassistant/components/lookin/__init__.py
+++ b/homeassistant/components/lookin/__init__.py
@@ -1,5 +1,4 @@
 """The lookin integration."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import asyncio
 from collections.abc import Callable, Coroutine
@@ -23,6 +22,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.hass_dict import HassKey
 
 from .const import (
     DOMAIN,
@@ -36,8 +36,6 @@ from .entity import _lookin_device_to_device_info
 from .models import LookinConfigEntry, LookinData
 
 LOGGER = logging.getLogger(__name__)
-
-UDP_MANAGER = "udp_manager"
 
 
 def _async_climate_updater(
@@ -90,9 +88,13 @@ class LookinUDPManager:
             self._subscriptions = None
 
 
+# One UDP listener serves every lookin device, so the manager is shared between
+# config entries rather than owned by any one of them.
+UDP_MANAGER: HassKey[LookinUDPManager] = HassKey(f"{DOMAIN}_udp_manager")
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: LookinConfigEntry) -> bool:
     """Set up lookin from a config entry."""
-    domain_data = hass.data.setdefault(DOMAIN, {})
     host = entry.data[CONF_HOST]
     lookin_protocol = LookInHttpProtocol(
         api_uri=f"http://{host}", session=async_get_clientsession(hass)
@@ -159,10 +161,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: LookinConfigEntry) -> bo
         meteo.update_from_value(event.value)
         meteo_coordinator.async_set_updated_data(meteo)
 
-    if UDP_MANAGER not in domain_data:
-        manager = domain_data[UDP_MANAGER] = LookinUDPManager()
-    else:
-        manager = domain_data[UDP_MANAGER]
+    if (manager := hass.data.get(UDP_MANAGER)) is None:
+        manager = hass.data[UDP_MANAGER] = LookinUDPManager()
 
     lookin_udp_subs = await manager.async_get_subscriptions()
 
@@ -200,7 +200,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: LookinConfigEntry) -> b
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if not hass.config_entries.async_loaded_entries(DOMAIN):
-        manager: LookinUDPManager = hass.data[DOMAIN][UDP_MANAGER]
+        manager = hass.data[UDP_MANAGER]
         await manager.async_stop()
     return unload_ok
 

--- a/homeassistant/components/lookin/__init__.py
+++ b/homeassistant/components/lookin/__init__.py
@@ -90,7 +90,7 @@ class LookinUDPManager:
 
 # One UDP listener serves every lookin device, so the manager is shared between
 # config entries rather than owned by any one of them.
-UDP_MANAGER: HassKey[LookinUDPManager] = HassKey(f"{DOMAIN}_udp_manager")
+UDP_MANAGER: HassKey[LookinUDPManager] = HassKey(DOMAIN)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: LookinConfigEntry) -> bool:

--- a/tests/components/lookin/test_init.py
+++ b/tests/components/lookin/test_init.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.components.lookin import UDP_MANAGER
 from homeassistant.components.lookin.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST
@@ -81,3 +82,37 @@ async def test_controlled_device_links_to_lookin_device(
     )
     assert controlled_device is not None
     assert controlled_device.via_device_id == lookin_device.id
+
+
+async def test_udp_manager_outlives_the_config_entry(hass: HomeAssistant) -> None:
+    """Test the shared UDP manager is reused rather than rebuilt per entry."""
+    device = _mocked_device()
+    remote = _mocked_remote()
+    protocol = _mocked_protocol(device, remote)
+
+    subscriptions = MagicMock()
+    subscriptions.subscribe_event = MagicMock(return_value=MagicMock())
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=DEVICE_ID
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(f"{MODULE}.LookInHttpProtocol", return_value=protocol),
+        patch(f"{MODULE}.LookinUDPSubscriptions", return_value=subscriptions),
+        patch(f"{MODULE}.start_lookin_udp", AsyncMock(return_value=MagicMock())),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        manager = hass.data[UDP_MANAGER]
+        assert manager is not None
+
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    # The manager is keyed globally, not on the entry, so a reload reuses it
+    # instead of leaving a second listener behind.
+    assert hass.data[UDP_MANAGER] is manager


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

One UDP listener serves every lookin device, so `LookinUDPManager` is shared between config entries rather than owned by any one of them. That is why it lives in `hass.data`, and why the module carried a `# pylint: disable=home-assistant-use-runtime-data` suppression — moving it to `entry.runtime_data` would give each entry its own manager and start a second listener.

This gives it a typed `HassKey` instead and drops the suppression rather than carrying it. Storing the manager directly under its own key also removes the single-entry `hass.data[DOMAIN]` dict and the untyped `"udp_manager"` string that indexed it:

```python
UDP_MANAGER: HassKey[LookinUDPManager] = HassKey(f"{DOMAIN}_udp_manager")
...
if (manager := hass.data.get(UDP_MANAGER)) is None:
    manager = hass.data[UDP_MANAGER] = LookinUDPManager()
```

Behaviour is unchanged: the manager is still created once and reused, and `async_unload_entry` still stops it when the last entry unloads.

I verified `W7405` still fires on the current code with the suppression removed, and does not fire after this change.

Added a test asserting a reload reuses the same manager instead of rebuilding it, which is the behaviour the shared key exists to guarantee. It fails against a per-setup manager and passes here.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The manifest file has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  Thank you for contributing <3
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
