### PR TITLE
Type the dlna_dms domain data with a HassKey

### DIFF
--- a/homeassistant/components/dlna_dms/const.py
+++ b/homeassistant/components/dlna_dms/const.py
@@ -2,14 +2,22 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 from homeassistant.components.media_player import MediaClass
+from homeassistant.util.hass_dict import HassKey
+
+if TYPE_CHECKING:
+    from .dms import DlnaDmsData
 
 LOGGER = logging.getLogger(__package__)
 
 DOMAIN: Final = "dlna_dms"
 DEFAULT_NAME: Final = "DLNA Media Server"
+
+# One DlnaDmsData holds the device and source registries for every config
+# entry, so it is shared rather than owned by any one entry.
+DOMAIN_DATA: HassKey[DlnaDmsData] = HassKey(DOMAIN)
 
 CONF_SOURCE_ID: Final = "source_id"
 CONFIG_VERSION: Final = 1

--- a/homeassistant/components/dlna_dms/dms.py
+++ b/homeassistant/components/dlna_dms/dms.py
@@ -1,12 +1,11 @@
 """Wrapper for media_source around async_upnp_client's DmsDevice ."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import asyncio
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from enum import StrEnum
 import functools
-from typing import Any, cast
+from typing import Any
 
 from async_upnp_client.aiohttp import AiohttpSessionRequester
 from async_upnp_client.client import UpnpRequester
@@ -37,6 +36,7 @@ from .const import (
     DLNA_RESOLVE_FILTER,
     DLNA_SORT_CRITERIA,
     DOMAIN,
+    DOMAIN_DATA,
     LOGGER,
     MEDIA_CLASS_MAP,
     PATH_OBJECT_ID_FLAG,
@@ -92,11 +92,10 @@ class DlnaDmsData:
 @callback
 def get_domain_data(hass: HomeAssistant) -> DlnaDmsData:
     """Obtain this integration's domain data, creating it if needed."""
-    if DOMAIN in hass.data:
-        return cast(DlnaDmsData, hass.data[DOMAIN])
+    if (data := hass.data.get(DOMAIN_DATA)) is not None:
+        return data
 
-    data = DlnaDmsData(hass)
-    hass.data[DOMAIN] = data
+    data = hass.data[DOMAIN_DATA] = DlnaDmsData(hass)
     return data
 
 

--- a/homeassistant/components/dlna_dms/dms.py
+++ b/homeassistant/components/dlna_dms/dms.py
@@ -91,7 +91,13 @@ class DlnaDmsData:
 
 @callback
 def get_domain_data(hass: HomeAssistant) -> DlnaDmsData:
-    """Obtain this integration's domain data, creating it if needed."""
+    """Obtain this integration's domain data, creating it if needed.
+
+    Creation is deferred to the first caller rather than done at setup, to
+    avoid building DlnaDmsData and its dependencies until a device is
+    actually connected to. This module is imported to run the config flow
+    for any DMS device discovered on the network, including ignored ones.
+    """
     if (data := hass.data.get(DOMAIN_DATA)) is not None:
         return data
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

`DlnaDmsData` holds the device and source registries for every config entry, so it is shared rather than owned by any one entry. That is why it lives in `hass.data`, and why the module carried a `home-assistant-use-runtime-data` suppression — `entry.runtime_data` would give each entry its own registry.

This gives it a typed `HassKey` and drops the suppression rather than carrying it. The typed key also removes the `cast(DlnaDmsData, hass.data[DOMAIN])` the untyped lookup required:

```python
DOMAIN_DATA: HassKey[DlnaDmsData] = HassKey(DOMAIN)
...
if (data := hass.data.get(DOMAIN_DATA)) is not None:
    return data
```

Behaviour is unchanged; the key uses the same `DOMAIN` string, so existing data is found at the same place. I verified `W7405` still fires on the current code with the suppression removed, and does not fire after this change.

No test is added: this is a typing change with identical runtime behaviour. `tests/components/dlna_dms/` gives an identical result before and after (52 passed, with the same pre-existing failures on `dev`).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The manifest file has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  Thank you for contributing <3
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
