### PR TITLE
Type the dlna_dmr domain data with a HassKey

### DIFF
--- a/homeassistant/components/dlna_dmr/const.py
+++ b/homeassistant/components/dlna_dmr/const.py
@@ -2,15 +2,23 @@
 
 from collections.abc import Mapping
 import logging
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 from async_upnp_client.profiles.dlna import PlayMode as _PlayMode
 
 from homeassistant.components.media_player import MediaType, RepeatMode
+from homeassistant.util.hass_dict import HassKey
+
+if TYPE_CHECKING:
+    from .data import DlnaDmrData
 
 LOGGER = logging.getLogger(__package__)
 
 DOMAIN: Final = "dlna_dmr"
+
+# One DlnaDmrData owns the shared UPnP requester and event notifiers used by
+# every config entry, so it is not per-entry state.
+DOMAIN_DATA: HassKey[DlnaDmrData] = HassKey(DOMAIN)
 
 CONF_LISTEN_PORT: Final = "listen_port"
 CONF_CALLBACK_URL_OVERRIDE: Final = "callback_url_override"

--- a/homeassistant/components/dlna_dmr/data.py
+++ b/homeassistant/components/dlna_dmr/data.py
@@ -1,9 +1,8 @@
 """Data used by this integration."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import asyncio
 from collections import defaultdict
-from typing import NamedTuple, cast
+from typing import NamedTuple
 
 from async_upnp_client.aiohttp import AiohttpNotifyServer, AiohttpSessionRequester
 from async_upnp_client.client import UpnpRequester
@@ -14,7 +13,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
 from homeassistant.helpers import aiohttp_client
 
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN_DATA, LOGGER
 
 
 class EventListenAddr(NamedTuple):
@@ -118,9 +117,8 @@ class DlnaDmrData:
 
 def get_domain_data(hass: HomeAssistant) -> DlnaDmrData:
     """Obtain this integration's domain data, creating it if needed."""
-    if DOMAIN in hass.data:
-        return cast(DlnaDmrData, hass.data[DOMAIN])
+    if (data := hass.data.get(DOMAIN_DATA)) is not None:
+        return data
 
-    data = DlnaDmrData(hass)
-    hass.data[DOMAIN] = data
+    data = hass.data[DOMAIN_DATA] = DlnaDmrData(hass)
     return data

--- a/homeassistant/components/dlna_dmr/data.py
+++ b/homeassistant/components/dlna_dmr/data.py
@@ -116,7 +116,13 @@ class DlnaDmrData:
 
 
 def get_domain_data(hass: HomeAssistant) -> DlnaDmrData:
-    """Obtain this integration's domain data, creating it if needed."""
+    """Obtain this integration's domain data, creating it if needed.
+
+    Creation is deferred to the first caller rather than done at setup, to
+    avoid building DlnaDmrData and its dependencies until a device is
+    actually connected to. This module is imported to run the config flow
+    for any DMR device discovered on the network, including ignored ones.
+    """
     if (data := hass.data.get(DOMAIN_DATA)) is not None:
         return data
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

`DlnaDmrData` owns the shared UPnP requester and the event notifiers used by every config entry, so it is not per-entry state. That is why it lives in `hass.data`, and why the module carried a `home-assistant-use-runtime-data` suppression — `entry.runtime_data` would give each entry its own requester.

This gives it a typed `HassKey` and drops the suppression rather than carrying it. The typed key also removes the `cast(DlnaDmrData, hass.data[DOMAIN])` the untyped lookup required:

```python
DOMAIN_DATA: HassKey[DlnaDmrData] = HassKey(DOMAIN)
...
if (data := hass.data.get(DOMAIN_DATA)) is not None:
    return data
```

Behaviour is unchanged; the key uses the same `DOMAIN` string, so existing data is found at the same place. I verified `W7405` still fires on the current code with the suppression removed, and does not fire after this change.

No test is added: this is a typing change with identical runtime behaviour, and `tests/components/dlna_dmr/` gives an identical result before and after.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The manifest file has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  Thank you for contributing <3
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
