### PR TITLE
Type the nmap_tracker device registry with a HassKey

### DIFF
--- a/homeassistant/components/nmap_tracker/__init__.py
+++ b/homeassistant/components/nmap_tracker/__init__.py
@@ -32,7 +32,7 @@ from .const import (
     CONF_MAC_EXCLUDE,
     CONF_OPTIONS,
     DOMAIN,
-    NMAP_TRACKED_DEVICES,
+    NMAP_TRACKER_DATA,
     PLATFORMS,
     TRACKER_SCAN_INTERVAL,
 )
@@ -89,7 +89,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: NmapTrackerConfigEntry) -> bool:
     """Set up Nmap Tracker from a config entry."""
-    devices = hass.data.setdefault(NMAP_TRACKED_DEVICES, NmapTrackedDevices())
+    devices = hass.data.setdefault(NMAP_TRACKER_DATA, NmapTrackedDevices())
     scanner = NmapDeviceScanner(hass, entry, devices)
     await scanner.async_setup()
     entry.runtime_data = scanner
@@ -142,7 +142,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 @callback
 def _async_untrack_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Remove tracking for devices owned by this config entry."""
-    devices = hass.data[NMAP_TRACKED_DEVICES]
+    devices = hass.data[NMAP_TRACKER_DATA]
     remove_mac_addresses = [
         mac_address
         for mac_address, entry_id in devices.config_entry_owner.items()

--- a/homeassistant/components/nmap_tracker/__init__.py
+++ b/homeassistant/components/nmap_tracker/__init__.py
@@ -1,5 +1,4 @@
 """The Nmap Tracker integration."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import asyncio
 from dataclasses import dataclass
@@ -90,8 +89,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: NmapTrackerConfigEntry) -> bool:
     """Set up Nmap Tracker from a config entry."""
-    domain_data = hass.data.setdefault(DOMAIN, {})
-    devices = domain_data.setdefault(NMAP_TRACKED_DEVICES, NmapTrackedDevices())
+    devices = hass.data.setdefault(NMAP_TRACKED_DEVICES, NmapTrackedDevices())
     scanner = NmapDeviceScanner(hass, entry, devices)
     await scanner.async_setup()
     entry.runtime_data = scanner
@@ -144,9 +142,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 @callback
 def _async_untrack_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Remove tracking for devices owned by this config entry."""
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=home-assistant-use-runtime-data
-    devices = hass.data[DOMAIN][NMAP_TRACKED_DEVICES]
+    devices = hass.data[NMAP_TRACKED_DEVICES]
     remove_mac_addresses = [
         mac_address
         for mac_address, entry_id in devices.config_entry_owner.items()

--- a/homeassistant/components/nmap_tracker/__init__.py
+++ b/homeassistant/components/nmap_tracker/__init__.py
@@ -89,7 +89,8 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: NmapTrackerConfigEntry) -> bool:
     """Set up Nmap Tracker from a config entry."""
-    devices = hass.data.setdefault(NMAP_TRACKER_DATA, NmapTrackedDevices())
+    if (devices := hass.data.get(NMAP_TRACKER_DATA)) is None:
+        devices = hass.data[NMAP_TRACKER_DATA] = NmapTrackedDevices()
     scanner = NmapDeviceScanner(hass, entry, devices)
     await scanner.async_setup()
     entry.runtime_data = scanner

--- a/homeassistant/components/nmap_tracker/const.py
+++ b/homeassistant/components/nmap_tracker/const.py
@@ -14,7 +14,7 @@ PLATFORMS: Final = [Platform.DEVICE_TRACKER]
 
 # Tracked devices are keyed by MAC across every config entry, so the registry
 # is shared rather than owned by any one entry.
-NMAP_TRACKED_DEVICES: HassKey[NmapTrackedDevices] = HassKey(DOMAIN)
+NMAP_TRACKER_DATA: HassKey[NmapTrackedDevices] = HassKey(DOMAIN)
 
 # Interval in minutes to exclude devices from a scan while they are home
 CONF_HOME_INTERVAL: Final = "home_interval"

--- a/homeassistant/components/nmap_tracker/const.py
+++ b/homeassistant/components/nmap_tracker/const.py
@@ -1,14 +1,20 @@
 """The Nmap Tracker integration."""
 
-from typing import Final
+from typing import TYPE_CHECKING, Final
 
 from homeassistant.const import Platform
+from homeassistant.util.hass_dict import HassKey
+
+if TYPE_CHECKING:
+    from . import NmapTrackedDevices
 
 DOMAIN: Final = "nmap_tracker"
 
 PLATFORMS: Final = [Platform.DEVICE_TRACKER]
 
-NMAP_TRACKED_DEVICES: Final = "nmap_tracked_devices"
+# Tracked devices are keyed by MAC across every config entry, so the registry
+# is shared rather than owned by any one entry.
+NMAP_TRACKED_DEVICES: HassKey[NmapTrackedDevices] = HassKey("nmap_tracked_devices")
 
 # Interval in minutes to exclude devices from a scan while they are home
 CONF_HOME_INTERVAL: Final = "home_interval"

--- a/homeassistant/components/nmap_tracker/const.py
+++ b/homeassistant/components/nmap_tracker/const.py
@@ -14,7 +14,7 @@ PLATFORMS: Final = [Platform.DEVICE_TRACKER]
 
 # Tracked devices are keyed by MAC across every config entry, so the registry
 # is shared rather than owned by any one entry.
-NMAP_TRACKED_DEVICES: HassKey[NmapTrackedDevices] = HassKey("nmap_tracked_devices")
+NMAP_TRACKED_DEVICES: HassKey[NmapTrackedDevices] = HassKey(DOMAIN)
 
 # Interval in minutes to exclude devices from a scan while they are home
 CONF_HOME_INTERVAL: Final = "home_interval"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Tracked devices are keyed by MAC across every config entry — `_async_untrack_devices` reaches into that shared registry to drop the MACs a particular entry owned, via `devices.config_entry_owner` — so `NmapTrackedDevices` is not per-entry state. That is why it lives in `hass.data`, and why the module carried two `home-assistant-use-runtime-data` suppressions. (The per-entry scanner already uses `entry.runtime_data`.)

This gives the registry a typed `HassKey` and drops both suppressions rather than carrying them. Storing it under its own key also removes the single-entry `hass.data[DOMAIN]` dict that wrapped it and the untyped `"nmap_tracked_devices"` string that indexed it:

```python
NMAP_TRACKED_DEVICES: HassKey[NmapTrackedDevices] = HassKey("nmap_tracked_devices")
...
devices = hass.data.setdefault(NMAP_TRACKED_DEVICES, NmapTrackedDevices())
```

Behaviour is unchanged. I verified `W7405` still fires on the current code with the suppressions removed, and does not fire after this change.

No test is added: this is a typing change with identical runtime behaviour, and `tests/components/nmap_tracker/` gives an identical result before and after (13 passed, same pre-existing errors on `dev`).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The manifest file has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  Thank you for contributing <3
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
