### PR TITLE
Raise NeoPool quality scale to platinum

### DIFF
--- a/homeassistant/components/neopool/manifest.json
+++ b/homeassistant/components/neopool/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["neopool_modbus"],
-  "quality_scale": "silver",
+  "quality_scale": "platinum",
   "requirements": ["neopool-modbus==4.6.2"]
 }


### PR DESCRIPTION
## Proposed change

Raise the NeoPool integration quality scale from silver to platinum.

Every rule in `quality_scale.yaml` is already marked `done` or `exempt`, and the implementation meets all remaining platinum requirements:

- **strict-typing**: `neopool` is listed in `.strict-typing`; mypy passes with no issues on all 12 source files.
- **async-dependency**: the `neopool-modbus` library exposes a fully async client API (`async_read_all`, `async_set_*`), used directly by the coordinator.
- **inject-websession**: exempt. The integration talks Modbus TCP, so there is no aiohttp session to inject.
- **test-coverage**: 100% across all modules (121 tests, 149 snapshots).

The gold-tier rules are already satisfied (diagnostics, reconfiguration flow, repair issues, device/entity classes, translations, icon translations), and the discovery / stale-devices / dynamic-devices rules are exempt because a Modbus TCP gateway has no standard discovery signal and one config entry maps to one physical controller.

This PR changes only the `quality_scale` field in `manifest.json`. `quality_scale.yaml` is unchanged.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes 
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#47822
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
