### PR TITLE
Don't mutate the module level Roomba SENSORS list

### DIFF
--- a/homeassistant/components/roomba/sensor.py
+++ b/homeassistant/components/roomba/sensor.py
@@ -149,7 +149,7 @@ async def async_setup_entry(
     roomba = domain_data.roomba
     blid = domain_data.blid
 
-    sensor_list: list[RoombaSensorEntityDescription] = SENSORS
+    sensor_list: list[RoombaSensorEntityDescription] = list(SENSORS)
 
     has_dock: bool = len(roomba_reported_state(roomba).get("dock", {})) > 0
 

--- a/tests/components/roomba/test_sensor.py
+++ b/tests/components/roomba/test_sensor.py
@@ -1,15 +1,40 @@
 """Tests for IRobotEntity usage in Roomba sensor platform."""
 
+import copy
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.components.roomba.const import CONF_BLID, CONF_CONTINUOUS, DOMAIN
+from homeassistant.const import CONF_DELAY, CONF_HOST, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
+
+
+def _config_entry(blid: str) -> MockConfigEntry:
+    """Return a config entry for an additional robot."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.0.30",
+            CONF_BLID: blid,
+            CONF_PASSWORD: "pass123",
+        },
+        options={CONF_CONTINUOUS: True, CONF_DELAY: 10},
+        unique_id=blid,
+    )
+
+
+def _dock_tank_level_entities(hass: HomeAssistant) -> list[str]:
+    """Return every dock tank level entity currently set up."""
+    return sorted(
+        entity_id
+        for entity_id in hass.states.async_entity_ids(Platform.SENSOR)
+        if "dock_tank_level" in entity_id
+    )
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -27,3 +52,53 @@ async def test_entities(
         await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_two_docked_robots_do_not_collide(
+    hass: HomeAssistant,
+    mock_roomba: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a second docked robot does not produce a duplicate dock sensor.
+
+    The dock sensors used to be appended to the module level SENSORS list, so
+    setting up a second docked robot appended them twice. The duplicate is
+    dropped by the entity platform, so the surviving entity count still looks
+    correct and only the logged error reveals the problem.
+    """
+    with patch("homeassistant.components.roomba.PLATFORMS", [Platform.SENSOR]):
+        for blid in ("blid_first", "blid_second"):
+            config_entry = _config_entry(blid)
+            config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+    assert "does not generate unique IDs" not in caplog.text
+    assert len(_dock_tank_level_entities(hass)) == 2
+
+
+async def test_robot_without_dock_has_no_dock_sensor(
+    hass: HomeAssistant,
+    mock_roomba: AsyncMock,
+) -> None:
+    """Test a robot without a dock does not get a dock sensor.
+
+    A robot reporting no dock used to inherit one when it was set up after a
+    robot that did have one.
+    """
+    docked_state = copy.deepcopy(mock_roomba.master_state)
+    dockless_state = copy.deepcopy(mock_roomba.master_state)
+    dockless_state["state"]["reported"]["dock"] = {}
+
+    with patch("homeassistant.components.roomba.PLATFORMS", [Platform.SENSOR]):
+        for blid, state in (
+            ("blid_docked", docked_state),
+            ("blid_dockless", dockless_state),
+        ):
+            mock_roomba.master_state = state
+            config_entry = _config_entry(blid)
+            config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+    assert len(_dock_tank_level_entities(hass)) == 1

--- a/tests/components/roomba/test_sensor.py
+++ b/tests/components/roomba/test_sensor.py
@@ -7,6 +7,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.roomba.const import CONF_BLID, CONF_CONTINUOUS, DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import CONF_DELAY, CONF_HOST, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -32,7 +33,7 @@ def _dock_tank_level_entities(hass: HomeAssistant) -> list[str]:
     """Return every dock tank level entity currently set up."""
     return sorted(
         entity_id
-        for entity_id in hass.states.async_entity_ids(Platform.SENSOR)
+        for entity_id in hass.states.async_entity_ids(SENSOR_DOMAIN)
         if "dock_tank_level" in entity_id
     )
 


### PR DESCRIPTION
## Proposed change

`async_setup_entry` in `sensor.py` assigned the module level `SENSORS` list to a local name rather than copying it, so extending it with `DOCK_SENSORS` mutated `SENSORS` for the lifetime of the process:

```python
sensor_list: list[RoombaSensorEntityDescription] = SENSORS
if has_dock:
    sensor_list.extend(DOCK_SENSORS)
```

The first docked robot set up correctly. A second one started from a `SENSORS` that already contained the dock sensors, appended them again, and produced two entities with the same `unique_id`. The entity platform dropped the duplicate with `Platform roomba does not generate unique IDs`, so that robot silently lost its dock sensor. It compounds: a third docked robot appends a third copy.

Confirmed against current `dev`:

```
SENSORS at import    : 12
after robot 1        : 13
after robot 2        : 14   dock_tank_level x2
ERROR ... Platform roomba does not generate unique IDs.
          ID dock_tank_level_... already exists
```

There is a second symptom, not in either issue: because `SENSORS` stays contaminated, a robot reporting **no** dock that is set up after a docked one also gets a `dock_tank_level` sensor it should never have had. Both symptoms share the one root cause and both are covered by tests here.

Building a local copy matches how `baf` and `subaru` handle the same conditional-extend pattern; both start from a fresh list rather than a module level one.

### Note for the reviewer

Most integrations declare these collections as `tuple` rather than `list` (roughly 539 to 52 across the repo), which makes this class of bug structurally impossible. I kept this to the minimal one-line fix so it stays a clean bugfix, but I am happy to convert `SENSORS` and `DOCK_SENSORS` to tuples instead if you would prefer the structural fix.

Users with a mixed docked/dockless setup may have a stale `dock_tank_level` entity in the registry from the second symptom. It never had data to report, so nothing is lost, but it will need removing manually.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #166162, fixes #169895 
- This PR is related to issue: 
- Link to documentation pull request: not needed, no user facing configuration change
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

---

Both new tests were checked against unmodified `dev` before being relied on: each **fails** there (individually and together) with the reported unique-ID error, and passes with the fix. The first version of the collision test passed on unfixed code, because the entity platform drops the duplicate and the surviving entity count still looks correct, so it now asserts on the logged error instead.

Also run: full `pytest tests/components/roomba/` (46 passed), `ruff check`, `ruff format --check`, and `python -m script.hassfest --integration-path homeassistant/components/roomba` (0 invalid).

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
