### PR TITLE
Remove unused hass.data[DOMAIN] from remote_calendar

### DIFF
--- a/homeassistant/components/remote_calendar/__init__.py
+++ b/homeassistant/components/remote_calendar/__init__.py
@@ -1,12 +1,10 @@
 """The Remote Calendar integration."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import logging
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
 from .coordinator import RemoteCalendarConfigEntry, RemoteCalendarDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,7 +17,6 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: RemoteCalendarConfigEntry
 ) -> bool:
     """Set up Remote Calendar from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
     coordinator = RemoteCalendarDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

`async_setup_entry` calls `hass.data.setdefault(DOMAIN, {})`, but nothing in the integration ever reads `hass.data[DOMAIN]` — the coordinator lives on `entry.runtime_data`. The call only creates an empty dict that no one consumes, and it is the sole reason the module carries a `# pylint: disable=home-assistant-use-runtime-data` suppression.

Removing the line lets the suppression and the now-unused `DOMAIN` import go with it. `W7405` passes on the result.

`tests/components/remote_calendar/` gives an identical result before and after (48 passed, with the same pre-existing errors on `dev`).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The manifest file has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  Thank you for contributing <3
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
