### PR TITLE
Type the ios registration data with a HassKey

### DIFF
--- a/homeassistant/components/ios/__init__.py
+++ b/homeassistant/components/ios/__init__.py
@@ -1,5 +1,4 @@
 """Native Home Assistant iOS app component."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 from http import HTTPStatus
 from typing import Any
@@ -41,6 +40,7 @@ from .const import (
     CONF_ACTION_SHOW_IN_WATCH,
     CONF_ACTION_USE_CUSTOM_COLORS,
     DOMAIN,
+    IOS_DATA,
 )
 
 CONF_PUSH = "push"
@@ -217,7 +217,7 @@ def devices_with_push(hass: HomeAssistant) -> dict[str, str]:
     """Return a dictionary of push enabled targets."""
     return {
         device_name: device.get(ATTR_PUSH_ID)
-        for device_name, device in hass.data[DOMAIN][ATTR_DEVICES].items()
+        for device_name, device in hass.data[IOS_DATA][ATTR_DEVICES].items()
         if device.get(ATTR_PUSH_ID) is not None
     }
 
@@ -226,19 +226,19 @@ def enabled_push_ids(hass: HomeAssistant) -> list[str]:
     """Return a list of push enabled target push IDs."""
     return [
         device.get(ATTR_PUSH_ID)
-        for device in hass.data[DOMAIN][ATTR_DEVICES].values()
+        for device in hass.data[IOS_DATA][ATTR_DEVICES].values()
         if device.get(ATTR_PUSH_ID) is not None
     ]
 
 
 def devices(hass: HomeAssistant) -> dict[str, dict[str, Any]]:
     """Return a dictionary of all identified devices."""
-    return hass.data[DOMAIN][ATTR_DEVICES]  # type: ignore[no-any-return]
+    return hass.data[IOS_DATA][ATTR_DEVICES]  # type: ignore[no-any-return]
 
 
 def device_name_for_push_id(hass: HomeAssistant, push_id: str) -> str | None:
     """Return the device name for the push ID."""
-    for device_name, device in hass.data[DOMAIN][ATTR_DEVICES].items():
+    for device_name, device in hass.data[IOS_DATA][ATTR_DEVICES].items():
         if device.get(ATTR_PUSH_ID) is push_id:
             return device_name  # type: ignore[no-any-return]
     return None
@@ -260,7 +260,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     ios_config[CONF_USER] = conf_user
 
-    hass.data[DOMAIN] = ios_config
+    hass.data[IOS_DATA] = ios_config
 
     # No entry support for notify component yet
     discovery.load_platform(hass, Platform.NOTIFY, DOMAIN, {}, config)
@@ -282,8 +282,10 @@ async def async_setup_entry(
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     hass.http.register_view(iOSIdentifyDeviceView(hass.config.path(CONFIGURATION_FILE)))
-    hass.http.register_view(iOSPushConfigView(hass.data[DOMAIN][CONF_USER][CONF_PUSH]))
-    hass.http.register_view(iOSConfigView(hass.data[DOMAIN][CONF_USER]))
+    hass.http.register_view(
+        iOSPushConfigView(hass.data[IOS_DATA][CONF_USER][CONF_PUSH])
+    )
+    hass.http.register_view(iOSConfigView(hass.data[IOS_DATA][CONF_USER]))
 
     return True
 
@@ -341,12 +343,12 @@ class iOSIdentifyDeviceView(HomeAssistantView):
 
         device_id = data[ATTR_DEVICE_ID]
 
-        hass.data[DOMAIN][ATTR_DEVICES][device_id] = data
+        hass.data[IOS_DATA][ATTR_DEVICES][device_id] = data
 
         async_dispatcher_send(hass, f"{DOMAIN}.{device_id}", data)
 
         try:
-            save_json(self._config_path, hass.data[DOMAIN])
+            save_json(self._config_path, hass.data[IOS_DATA])
         except HomeAssistantError:
             return self.json_message(
                 "Error saving device.", HTTPStatus.INTERNAL_SERVER_ERROR

--- a/homeassistant/components/ios/__init__.py
+++ b/homeassistant/components/ios/__init__.py
@@ -1,7 +1,7 @@
 """Native Home Assistant iOS app component."""
 
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 
 from aiohttp import web
 import voluptuous as vol
@@ -233,14 +233,14 @@ def enabled_push_ids(hass: HomeAssistant) -> list[str]:
 
 def devices(hass: HomeAssistant) -> dict[str, dict[str, Any]]:
     """Return a dictionary of all identified devices."""
-    return hass.data[IOS_DATA][ATTR_DEVICES]  # type: ignore[no-any-return]
+    return hass.data[IOS_DATA][ATTR_DEVICES]
 
 
 def device_name_for_push_id(hass: HomeAssistant, push_id: str) -> str | None:
     """Return the device name for the push ID."""
     for device_name, device in hass.data[IOS_DATA][ATTR_DEVICES].items():
         if device.get(ATTR_PUSH_ID) is push_id:
-            return device_name  # type: ignore[no-any-return]
+            return device_name
     return None
 
 
@@ -260,7 +260,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     ios_config[CONF_USER] = conf_user
 
-    hass.data[IOS_DATA] = ios_config
+    hass.data[IOS_DATA] = cast(dict[str, dict[str, Any]], ios_config)
 
     # No entry support for notify component yet
     discovery.load_platform(hass, Platform.NOTIFY, DOMAIN, {}, config)

--- a/homeassistant/components/ios/__init__.py
+++ b/homeassistant/components/ios/__init__.py
@@ -248,8 +248,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the iOS component."""
     conf: ConfigType | None = config.get(DOMAIN)
 
-    ios_config = await hass.async_add_executor_job(
-        load_json_object, hass.config.path(CONFIGURATION_FILE)
+    ios_config = cast(
+        dict[str, dict[str, Any]],
+        await hass.async_add_executor_job(
+            load_json_object, hass.config.path(CONFIGURATION_FILE)
+        ),
     )
 
     if ios_config == {}:
@@ -260,7 +263,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     ios_config[CONF_USER] = conf_user
 
-    hass.data[IOS_DATA] = cast(dict[str, dict[str, Any]], ios_config)
+    hass.data[IOS_DATA] = ios_config
 
     # No entry support for notify component yet
     discovery.load_platform(hass, Platform.NOTIFY, DOMAIN, {}, config)

--- a/homeassistant/components/ios/const.py
+++ b/homeassistant/components/ios/const.py
@@ -1,6 +1,14 @@
 """Const for iOS."""
 
+from typing import Any
+
+from homeassistant.util.hass_dict import HassKey
+
 DOMAIN = "ios"
+
+# The iOS app's registration file, holding every registered device and the
+# push configuration. It is integration-wide, not per config entry.
+IOS_DATA: HassKey[dict[str, Any]] = HassKey(DOMAIN)
 
 ATTR_BATTERY = "battery"
 ATTR_BATTERY_LEVEL = "level"

--- a/homeassistant/components/ios/const.py
+++ b/homeassistant/components/ios/const.py
@@ -8,7 +8,7 @@ DOMAIN = "ios"
 
 # The iOS app's registration file, holding every registered device and the
 # push configuration. It is integration-wide, not per config entry.
-IOS_DATA: HassKey[dict[str, Any]] = HassKey(DOMAIN)
+IOS_DATA: HassKey[dict[str, dict[str, Any]]] = HassKey(DOMAIN)
 
 ATTR_BATTERY = "battery"
 ATTR_BATTERY_LEVEL = "level"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

`hass.data[DOMAIN]` holds the iOS app's registration file — every registered device plus the push configuration, loaded from `.ios.conf` and saved back on registration. That is integration-wide state rather than per config entry, which is why it lives in `hass.data` and why the module carried a `home-assistant-use-runtime-data` suppression.

This gives it a typed `HassKey` and drops the suppression rather than carrying it:

```python
IOS_DATA: HassKey[dict[str, Any]] = HassKey(DOMAIN)
```

Behaviour is unchanged; the key uses the same `DOMAIN` string, so the data is found at the same place. I verified `W7405` still fires on the current code with the suppression removed, and does not fire after this change.

The two `# type: ignore[no-any-return]` comments stay: the stored value is a JSON object, so `hass.data[IOS_DATA][ATTR_DEVICES]` is still `Any` and the ignores remain necessary. Happy to look at a `TypedDict` for the registration file in a follow-up if that would be welcome, but it seemed out of scope here.

`tests/components/ios/` passes identically before and after (3 passed).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The manifest file has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  Thank you for contributing <3
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
