### PR TITLE
Type the xiaomi_aqara multicast listener with a HassKey

### DIFF
--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -163,7 +163,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: XiaomiAqaraConfigEntry) 
     entry.runtime_data = xiaomi_gateway
 
     async with data.setup_lock:
-        if data.multicast is None:
+        if (multicast := data.multicast) is None:
             multicast = AsyncXiaomiGatewayMulticast(
                 interface=entry.data[CONF_INTERFACE]
             )
@@ -183,10 +183,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: XiaomiAqaraConfigEntry) 
                 EVENT_HOMEASSISTANT_STOP, stop_xiaomi
             )
 
-    assert data.multicast is not None
-    data.multicast.register_gateway(
-        entry.data[CONF_HOST], xiaomi_gateway.multicast_callback
-    )
+    multicast.register_gateway(entry.data[CONF_HOST], xiaomi_gateway.multicast_callback)
     _LOGGER.debug(
         "Gateway with host '%s' connected, listening for broadcasts",
         entry.data[CONF_HOST],

--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -1,7 +1,7 @@
 """Support for Xiaomi Gateways."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import asyncio
+from dataclasses import dataclass, field
 import logging
 
 import voluptuous as vol
@@ -17,20 +17,12 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.hass_dict import HassKey
 
-from .const import (
-    CONF_INTERFACE,
-    CONF_KEY,
-    CONF_SID,
-    DEFAULT_DISCOVERY_RETRY,
-    DOMAIN,
-    KEY_SETUP_LOCK,
-    KEY_UNSUB_STOP,
-    LISTENER_KEY,
-)
+from .const import CONF_INTERFACE, CONF_KEY, CONF_SID, DEFAULT_DISCOVERY_RETRY, DOMAIN
 
 type XiaomiAqaraConfigEntry = ConfigEntry[XiaomiGateway]
 
@@ -139,10 +131,23 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
+@dataclass
+class XiaomiAqaraData:
+    """Multicast listener shared by every gateway."""
+
+    setup_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    multicast: AsyncXiaomiGatewayMulticast | None = None
+    unsub_stop: CALLBACK_TYPE | None = None
+
+
+# One multicast listener serves every gateway, so it is shared between config
+# entries rather than owned by any one of them.
+XIAOMI_AQARA_DATA: HassKey[XiaomiAqaraData] = HassKey(DOMAIN)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: XiaomiAqaraConfigEntry) -> bool:
     """Set up the xiaomi aqara components from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
-    setup_lock = hass.data[DOMAIN].setdefault(KEY_SETUP_LOCK, asyncio.Lock())
+    data = hass.data.setdefault(XIAOMI_AQARA_DATA, XiaomiAqaraData())
 
     # Connect to Xiaomi Aqara Gateway
     xiaomi_gateway = await hass.async_add_executor_job(
@@ -157,12 +162,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: XiaomiAqaraConfigEntry) 
     )
     entry.runtime_data = xiaomi_gateway
 
-    async with setup_lock:
-        if LISTENER_KEY not in hass.data[DOMAIN]:
+    async with data.setup_lock:
+        if data.multicast is None:
             multicast = AsyncXiaomiGatewayMulticast(
                 interface=entry.data[CONF_INTERFACE]
             )
-            hass.data[DOMAIN][LISTENER_KEY] = multicast
+            data.multicast = multicast
 
             # start listining for local pushes (only once)
             await multicast.start_listen()
@@ -174,11 +179,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: XiaomiAqaraConfigEntry) 
                 _LOGGER.debug("Shutting down Xiaomi Gateway Listener")
                 multicast.stop_listen()
 
-            unsub = hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_xiaomi)
-            hass.data[DOMAIN][KEY_UNSUB_STOP] = unsub
+            data.unsub_stop = hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STOP, stop_xiaomi
+            )
 
-    multicast = hass.data[DOMAIN][LISTENER_KEY]
-    multicast.register_gateway(entry.data[CONF_HOST], xiaomi_gateway.multicast_callback)
+    assert data.multicast is not None
+    data.multicast.register_gateway(
+        entry.data[CONF_HOST], xiaomi_gateway.multicast_callback
+    )
     _LOGGER.debug(
         "Gateway with host '%s' connected, listening for broadcasts",
         entry.data[CONF_HOST],
@@ -219,11 +227,14 @@ async def async_unload_entry(
 
     if not hass.config_entries.async_loaded_entries(DOMAIN):
         # No gateways left, stop Xiaomi socket
-        unsub_stop = hass.data[DOMAIN].pop(KEY_UNSUB_STOP)
-        unsub_stop()
+        data = hass.data[XIAOMI_AQARA_DATA]
+        if data.unsub_stop is not None:
+            data.unsub_stop()
+            data.unsub_stop = None
         _LOGGER.debug("Shutting down Xiaomi Gateway Listener")
-        multicast = hass.data[DOMAIN].pop(LISTENER_KEY)
-        multicast.stop_listen()
+        if data.multicast is not None:
+            data.multicast.stop_listen()
+            data.multicast = None
 
     return unload_ok
 

--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -147,7 +147,8 @@ XIAOMI_AQARA_DATA: HassKey[XiaomiAqaraData] = HassKey(DOMAIN)
 
 async def async_setup_entry(hass: HomeAssistant, entry: XiaomiAqaraConfigEntry) -> bool:
     """Set up the xiaomi aqara components from a config entry."""
-    data = hass.data.setdefault(XIAOMI_AQARA_DATA, XiaomiAqaraData())
+    if (data := hass.data.get(XIAOMI_AQARA_DATA)) is None:
+        data = hass.data[XIAOMI_AQARA_DATA] = XiaomiAqaraData()
 
     # Connect to Xiaomi Aqara Gateway
     xiaomi_gateway = await hass.async_add_executor_job(

--- a/homeassistant/components/xiaomi_aqara/const.py
+++ b/homeassistant/components/xiaomi_aqara/const.py
@@ -2,9 +2,6 @@
 
 DOMAIN = "xiaomi_aqara"
 
-LISTENER_KEY = "listener"
-KEY_UNSUB_STOP = "unsub_stop"
-KEY_SETUP_LOCK = "setup_lock"
 
 ZEROCONF_GATEWAY = "lumi-gateway"
 ZEROCONF_ACPARTNER = "lumi-acpartner"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

One multicast listener serves every gateway, so it is shared between config entries rather than owned by any one of them — along with the setup lock that guards creating it and the stop callback that tears it down. Those three lived in `hass.data[DOMAIN]` under untyped string keys (`"listener"`, `"unsub_stop"`, `"setup_lock"`), which is why the module carried a `home-assistant-use-runtime-data` suppression. The per-gateway object already uses `entry.runtime_data`.

Since three values are involved, a single key on the integration domain holding a small dataclass seemed better than three suffixed keys:

```python
@dataclass
class XiaomiAqaraData:
    setup_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
    multicast: AsyncXiaomiGatewayMulticast | None = None
    unsub_stop: CALLBACK_TYPE | None = None


XIAOMI_AQARA_DATA: HassKey[XiaomiAqaraData] = HassKey(DOMAIN)
```

`W7405` passes afterwards, and the three key constants come out of `const.py`.

**Worth flagging for review:** unlike the sibling PRs I opened alongside this one, this is not purely a typing change. `async_unload_entry` previously did `hass.data[DOMAIN].pop(KEY_UNSUB_STOP)` and `.pop(LISTENER_KEY)`, which raise `KeyError` if either is absent; it now clears the fields after a `None` check, so the teardown is equivalent but cannot raise. Setup's `if LISTENER_KEY not in hass.data[DOMAIN]` becomes `if data.multicast is None`, which is the same condition given unload clears it.

The existing tests are config-flow focused and do not exercise the multicast lifecycle, so they pass identically before and after (13 passed) without really covering this path. Happy to add a setup/unload test for the shared listener if you would like that in this PR rather than a follow-up.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The manifest file has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  Thank you for contributing <3
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
