### PR TITLE
Bump vizaio to 0.6.1 for vizio state_extended 404 fallback fix

### DIFF
--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["vizaio"],
-  "requirements": ["vizaio==0.5.0"],
+  "requirements": ["vizaio==0.6.1"],
   "zeroconf": ["_viziocast._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3391,7 +3391,7 @@ vilfo-api-client==0.5.0
 visionpluspython==1.1.0
 
 # homeassistant.components.vizio
-vizaio==0.5.0
+vizaio==0.6.1
 
 # homeassistant.components.caldav
 vobject==0.9.9


### PR DESCRIPTION
## Proposed change

Bump `vizaio` to 0.6.1 to fix a config-entry-breaking regression for older Vizio firmware.

Since #176559 the vizio coordinator polls `/state_extended` and falls back to individual getters only when the device raises `VizioNotFoundError` (meaning "this firmware doesn't have this endpoint"). Some firmware answers an unsupported `/state_extended` request with a plain HTTP 404 instead of the documented 200 + `STATUS.RESULT=URI_NOT_FOUND` soft-error envelope. `vizaio`'s HTTP layer mapped that 404 to the generic `VizioConnectionError` instead, so the coordinator never reaches its fallback and the config entry is permanently stuck in `setup_retry`.

`vizaio` 0.6.1 (raman325/vizaio#49) fixes this at the source: a 404 on this endpoint now raises `VizioNotFoundError`, and (a related bug found while fixing this) so does the documented 200 + `URI_NOT_FOUND` envelope, which was previously never actually checked and would have silently reported the device as permanently off instead of falling back.

No changes to `homeassistant/components/vizio` itself — the coordinator's fallback logic was already correct; only the library's exception mapping was wrong. Home Assistant's own test suite for the fallback path (`tests/components/vizio/test_init.py::test_state_extended_probed_only_once`, `test_state_extended_connection_error`) mocks `VizioNotFoundError`/`VizioConnectionError` directly and already covers the coordinator's contract; it passes unchanged against 0.6.1.

Changelog: https://github.com/raman325/vizaio/compare/v0.5.0...v0.6.1
Fixing PR: https://github.com/raman325/vizaio/pull/49
Release notes: https://github.com/raman325/vizaio/releases/tag/v0.6.1

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #181128
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
