### PR TITLE
Add Imou diagnostics for config entries

### DIFF
--- a/homeassistant/components/imou/diagnostics.py
+++ b/homeassistant/components/imou/diagnostics.py
@@ -1,0 +1,56 @@
+"""Diagnostics support for Imou."""
+
+from typing import Any
+
+from pyimouapi.ha_device import ImouHaDevice
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_APP_SECRET, imou_device_identifier
+from .coordinator import ImouConfigEntry
+
+TO_REDACT = {CONF_APP_SECRET}
+
+
+def _serialize_device(device: ImouHaDevice) -> dict[str, Any]:
+    """Return a JSON-safe view of a discovered Imou device."""
+    return {
+        "identifier": imou_device_identifier(device),
+        "device_id": device.device_id,
+        "channel_id": device.channel_id,
+        "model": device.model,
+        "manufacturer": device.manufacturer,
+        "sw_version": device.swversion,
+        "product_id": device.product_id,
+        "is_ipc": device.is_ipc,
+        "buttons": sorted(device.buttons),
+        "switches": device.switches,
+        "sensors": device.sensors,
+        "selects": device.selects,
+        "binary_sensors": device.binary_sensors,
+    }
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ImouConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = entry.runtime_data
+    return async_redact_data(
+        {
+            "entry": {
+                "title": entry.title,
+                "unique_id": entry.unique_id,
+                "data": dict(entry.data),
+            },
+            "coordinator": {
+                "last_update_success": coordinator.last_update_success,
+            },
+            "devices": [
+                _serialize_device(device)
+                for device in sorted(coordinator.devices, key=imou_device_identifier)
+            ],
+        },
+        TO_REDACT,
+    )

--- a/homeassistant/components/imou/diagnostics.py
+++ b/homeassistant/components/imou/diagnostics.py
@@ -4,13 +4,10 @@ from typing import Any
 
 from pyimouapi.ha_device import ImouHaDevice
 
-from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_APP_SECRET, imou_device_identifier
+from .const import CONF_API_URL, CONF_APP_ID, imou_device_identifier
 from .coordinator import ImouConfigEntry
-
-TO_REDACT = {CONF_APP_SECRET}
 
 
 def _serialize_device(device: ImouHaDevice) -> dict[str, Any]:
@@ -24,11 +21,6 @@ def _serialize_device(device: ImouHaDevice) -> dict[str, Any]:
         "sw_version": device.swversion,
         "product_id": device.product_id,
         "is_ipc": device.is_ipc,
-        "buttons": sorted(device.buttons),
-        "switches": device.switches,
-        "sensors": device.sensors,
-        "selects": device.selects,
-        "binary_sensors": device.binary_sensors,
     }
 
 
@@ -37,20 +29,16 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     coordinator = entry.runtime_data
-    return async_redact_data(
-        {
-            "entry": {
-                "title": entry.title,
-                "unique_id": entry.unique_id,
-                "data": dict(entry.data),
-            },
-            "coordinator": {
-                "last_update_success": coordinator.last_update_success,
-            },
-            "devices": [
-                _serialize_device(device)
-                for device in sorted(coordinator.devices, key=imou_device_identifier)
-            ],
+    return {
+        "entry": {
+            CONF_API_URL: entry.data[CONF_API_URL],
+            CONF_APP_ID: entry.data[CONF_APP_ID],
         },
-        TO_REDACT,
-    )
+        "coordinator": {
+            "last_update_success": coordinator.last_update_success,
+        },
+        "devices": [
+            _serialize_device(device)
+            for device in sorted(coordinator.devices, key=imou_device_identifier)
+        ],
+    }

--- a/homeassistant/components/imou/quality_scale.yaml
+++ b/homeassistant/components/imou/quality_scale.yaml
@@ -45,7 +45,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info:
     status: exempt
     comment: Cloud hub; DHCP only surfaces the integration. Device IP is not stored or updated.

--- a/tests/components/imou/snapshots/test_diagnostics.ambr
+++ b/tests/components/imou/snapshots/test_diagnostics.ambr
@@ -6,13 +6,6 @@
     }),
     'devices': list([
       dict({
-        'binary_sensors': dict({
-        }),
-        'buttons': list([
-          'mute',
-          'ptz_up',
-          'restart_device',
-        ]),
         'channel_id': None,
         'device_id': 'd1',
         'identifier': 'd1',
@@ -20,27 +13,12 @@
         'manufacturer': 'Imou',
         'model': 'm1',
         'product_id': None,
-        'selects': dict({
-        }),
-        'sensors': dict({
-          'status': dict({
-            'state': 'online',
-            'state_variant': 'enum',
-          }),
-        }),
         'sw_version': '1.0',
-        'switches': dict({
-        }),
       }),
     ]),
     'entry': dict({
-      'data': dict({
-        'api_url': 'sg',
-        'app_id': 'test_app_id',
-        'app_secret': '**REDACTED**',
-      }),
-      'title': 'Imou',
-      'unique_id': 'test_app_id',
+      'api_url': 'sg',
+      'app_id': 'test_app_id',
     }),
   })
 # ---

--- a/tests/components/imou/snapshots/test_diagnostics.ambr
+++ b/tests/components/imou/snapshots/test_diagnostics.ambr
@@ -1,0 +1,46 @@
+# serializer version: 1
+# name: test_config_entry_diagnostics
+  dict({
+    'coordinator': dict({
+      'last_update_success': True,
+    }),
+    'devices': list([
+      dict({
+        'binary_sensors': dict({
+        }),
+        'buttons': list([
+          'mute',
+          'ptz_up',
+          'restart_device',
+        ]),
+        'channel_id': None,
+        'device_id': 'd1',
+        'identifier': 'd1',
+        'is_ipc': False,
+        'manufacturer': 'Imou',
+        'model': 'm1',
+        'product_id': None,
+        'selects': dict({
+        }),
+        'sensors': dict({
+          'status': dict({
+            'state': 'online',
+            'state_variant': 'enum',
+          }),
+        }),
+        'sw_version': '1.0',
+        'switches': dict({
+        }),
+      }),
+    ]),
+    'entry': dict({
+      'data': dict({
+        'api_url': 'sg',
+        'app_id': 'test_app_id',
+        'app_secret': '**REDACTED**',
+      }),
+      'title': 'Imou',
+      'unique_id': 'test_app_id',
+    }),
+  })
+# ---

--- a/tests/components/imou/test_diagnostics.py
+++ b/tests/components/imou/test_diagnostics.py
@@ -1,0 +1,22 @@
+"""Tests for Imou diagnostics."""
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_config_entry_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    init_integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Diagnostics include the redacted entry and current devices."""
+    assert (
+        await get_diagnostics_for_config_entry(hass, hass_client, init_integration)
+        == snapshot
+    )

--- a/tests/components/imou/test_diagnostics.py
+++ b/tests/components/imou/test_diagnostics.py
@@ -15,7 +15,7 @@ async def test_config_entry_diagnostics(
     init_integration: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Diagnostics include the redacted entry and current devices."""
+    """Diagnostics include the region, App ID, and current devices."""
     assert (
         await get_diagnostics_for_config_entry(hass, hass_client, init_integration)
         == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

<!-- N/A -->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add config entry diagnostics for Imou.

Downloading diagnostics from the integration now includes the API region, App ID, whether the last coordinator refresh succeeded, and the devices currently on the account (id, channel, model, firmware, product_id).

This is the gold `diagnostics` rule only. It does not raise the declared quality-scale tier.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr