### PR TITLE
Add Z-Wave JS node status trigger

### DIFF
--- a/homeassistant/components/zwave_js/icons.json
+++ b/homeassistant/components/zwave_js/icons.json
@@ -136,6 +136,9 @@
     "event": {
       "trigger": "mdi:z-wave"
     },
+    "node_status": {
+      "trigger": "mdi:heart-pulse"
+    },
     "value_updated": {
       "trigger": "mdi:update"
     }

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -1162,10 +1162,14 @@
       "name": "Z-Wave JS event received"
     },
     "node_status": {
-      "description": "Triggers when the status of one or more Z-Wave JS nodes changes. Target nodes by device, area, floor, or label, or select their node status sensors directly.",
+      "description": "Triggers when the status of one or more Z-Wave JS nodes changes.",
       "fields": {
         "behavior": {
           "name": "[%key:component::zwave_js::common::trigger_behavior_name%]"
+        },
+        "device_id": {
+          "description": "The Z-Wave JS devices whose node status to watch.",
+          "name": "Devices"
         },
         "for": {
           "name": "[%key:component::zwave_js::common::trigger_for_name%]"

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -7,7 +7,9 @@
     "condition_endpoint_description": "Endpoint of the value.",
     "condition_endpoint_name": "Endpoint",
     "condition_value_description": "The value to compare with, either the raw value or its state label.",
-    "condition_value_name": "Value"
+    "condition_value_name": "Value",
+    "trigger_behavior_name": "Trigger when",
+    "trigger_for_name": "For at least"
   },
   "conditions": {
     "config_parameter": {
@@ -1158,6 +1160,26 @@
         }
       },
       "name": "Z-Wave JS event received"
+    },
+    "node_status": {
+      "description": "Triggers when the status of one or more Z-Wave JS nodes changes. Target nodes by device, area, floor, or label, or select their node status sensors directly.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::zwave_js::common::trigger_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::zwave_js::common::trigger_for_name%]"
+        },
+        "from": {
+          "description": "Only trigger when the previous status is one of these.",
+          "name": "From"
+        },
+        "to": {
+          "description": "Only trigger when the new status is one of these.",
+          "name": "To"
+        }
+      },
+      "name": "Z-Wave JS node status changed"
     },
     "value_updated": {
       "description": "Triggers when a Z-Wave value on one or more nodes changes.",

--- a/homeassistant/components/zwave_js/trigger.py
+++ b/homeassistant/components/zwave_js/trigger.py
@@ -3,10 +3,11 @@
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.trigger import Trigger
 
-from .triggers import event, value_updated
+from .triggers import event, node_status, value_updated
 
 TRIGGERS = {
     event.RELATIVE_PLATFORM_TYPE: event.EventTrigger,
+    node_status.RELATIVE_PLATFORM_TYPE: node_status.NodeStatusTrigger,
     value_updated.RELATIVE_PLATFORM_TYPE: value_updated.ValueUpdatedTrigger,
 }
 

--- a/homeassistant/components/zwave_js/triggers.yaml
+++ b/homeassistant/components/zwave_js/triggers.yaml
@@ -18,6 +18,18 @@
         - integration: zwave_js
       multiple: true
 
+.node_status_list: &node_status_list
+  required: false
+  selector:
+    select:
+      translation_key: node_status
+      multiple: true
+      options:
+        - alive
+        - asleep
+        - awake
+        - dead
+
 event:
   fields:
     event_source:
@@ -50,6 +62,28 @@ event:
       default: false
       selector:
         boolean:
+
+node_status:
+  target:
+    entity:
+      - integration: zwave_js
+        domain: sensor
+    device:
+      - integration: zwave_js
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+    for:
+      required: true
+      default: 00:00:00
+      selector:
+        duration:
+    from: *node_status_list
+    to: *node_status_list
 
 value_updated:
   fields:

--- a/homeassistant/components/zwave_js/triggers.yaml
+++ b/homeassistant/components/zwave_js/triggers.yaml
@@ -70,6 +70,7 @@ node_status:
         domain: sensor
     device:
       - integration: zwave_js
+    primary_entities_only: false
   fields:
     behavior:
       required: true

--- a/homeassistant/components/zwave_js/triggers.yaml
+++ b/homeassistant/components/zwave_js/triggers.yaml
@@ -64,14 +64,15 @@ event:
         boolean:
 
 node_status:
-  target:
-    entity:
-      - integration: zwave_js
-        domain: sensor
-    device:
-      - integration: zwave_js
-    primary_entities_only: false
   fields:
+    device_id:
+      required: true
+      example: 8f4219cfa57e23f6f669c4616c2205e2
+      selector:
+        device:
+          filter:
+            - integration: zwave_js
+          multiple: true
     behavior:
       required: true
       default: each

--- a/homeassistant/components/zwave_js/triggers/node_status.py
+++ b/homeassistant/components/zwave_js/triggers/node_status.py
@@ -1,0 +1,81 @@
+"""Offer Z-Wave JS node status automation trigger."""
+
+from typing import Any, override
+
+import voluptuous as vol
+
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import CONF_OPTIONS
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.automation import DomainSpec
+from homeassistant.helpers.trigger import (
+    ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR,
+    EntityTriggerBase,
+    NotTriggeredReasonReporter,
+    TriggerConfig,
+)
+
+from ..const import DOMAIN, NODE_STATUSES
+
+# Relative platform type should be <SUBMODULE_NAME>
+RELATIVE_PLATFORM_TYPE = f"{__name__.rsplit('.', maxsplit=1)[-1]}"
+
+# Platform type should be <DOMAIN>.<SUBMODULE_NAME>
+PLATFORM_TYPE = f"{DOMAIN}.{RELATIVE_PLATFORM_TYPE}"
+
+CONF_FROM = "from"
+CONF_TO = "to"
+
+_STATUS_LIST = vol.All(cv.ensure_list, [vol.In(NODE_STATUSES)])
+
+_OPTIONS_SCHEMA_DICT: dict[vol.Marker, Any] = {
+    vol.Optional(CONF_FROM): _STATUS_LIST,
+    vol.Optional(CONF_TO): _STATUS_LIST,
+}
+
+_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR.extend(
+    {vol.Required(CONF_OPTIONS, default={}): _OPTIONS_SCHEMA_DICT}
+)
+
+
+class NodeStatusTrigger(EntityTriggerBase):
+    """Trigger on Z-Wave JS node status changes."""
+
+    _domain_specs = {SENSOR_DOMAIN: DomainSpec()}
+    _primary_entities_only = False
+    _schema = _TRIGGER_SCHEMA
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the trigger."""
+        super().__init__(hass, config)
+        self._from_states = set(self._options.get(CONF_FROM, []))
+        self._to_states = set(self._options.get(CONF_TO, []))
+
+    @override
+    def entity_filter(self, entities: set[str]) -> set[str]:
+        """Keep only Z-Wave JS node status sensors."""
+        ent_reg = er.async_get(self._hass)
+        return {
+            entity_id
+            for entity_id in super().entity_filter(entities)
+            if (entry := ent_reg.async_get(entity_id))
+            and entry.platform == DOMAIN
+            and entry.translation_key == "node_status"
+        }
+
+    @override
+    def is_valid_state(
+        self, state: State, report_not_triggered: NotTriggeredReasonReporter
+    ) -> bool:
+        """Check the new status can satisfy the trigger."""
+        if self._to_states:
+            return state.state in self._to_states
+        return state.state not in self._from_states
+
+    @override
+    def is_valid_transition(self, from_state: State, to_state: State) -> bool:
+        """Check the status changed from a wanted status."""
+        return from_state.state != to_state.state and (
+            not self._from_states or from_state.state in self._from_states
+        )

--- a/homeassistant/components/zwave_js/triggers/node_status.py
+++ b/homeassistant/components/zwave_js/triggers/node_status.py
@@ -1,16 +1,20 @@
 """Offer Z-Wave JS node status automation trigger."""
 
+from dataclasses import replace
 from typing import Any, override
 
 import voluptuous as vol
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import CONF_OPTIONS
+from homeassistant.const import ATTR_DEVICE_ID, CONF_FOR, CONF_OPTIONS
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.trigger import (
-    ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR,
+    ATTR_BEHAVIOR,
+    BEHAVIOR_ALL,
+    BEHAVIOR_EACH,
+    BEHAVIOR_FIRST,
     EntityTriggerBase,
     NotTriggeredReasonReporter,
     TriggerConfig,
@@ -30,11 +34,16 @@ CONF_TO = "to"
 _STATUS_LIST = vol.All(cv.ensure_list, [vol.In(NODE_STATUSES)])
 
 _OPTIONS_SCHEMA_DICT: dict[vol.Marker, Any] = {
+    vol.Required(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
+    vol.Required(ATTR_BEHAVIOR, default=BEHAVIOR_EACH): vol.In(
+        [BEHAVIOR_FIRST, BEHAVIOR_ALL, BEHAVIOR_EACH]
+    ),
+    vol.Optional(CONF_FOR): cv.positive_time_period,
     vol.Optional(CONF_FROM): _STATUS_LIST,
     vol.Optional(CONF_TO): _STATUS_LIST,
 }
 
-_TRIGGER_SCHEMA = ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR.extend(
+_TRIGGER_SCHEMA = vol.Schema(
     {vol.Required(CONF_OPTIONS, default={}): _OPTIONS_SCHEMA_DICT}
 )
 
@@ -48,7 +57,12 @@ class NodeStatusTrigger(EntityTriggerBase):
 
     def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
         """Initialize the trigger."""
-        super().__init__(hass, config)
+        options = config.options or {}
+        # A node is picked as a device; the base class tracks the node status
+        # sensor each one expands to.
+        super().__init__(
+            hass, replace(config, target={ATTR_DEVICE_ID: options[ATTR_DEVICE_ID]})
+        )
         self._from_states = set(self._options.get(CONF_FROM, []))
         self._to_states = set(self._options.get(CONF_TO, []))
 

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -1954,7 +1954,9 @@ async def test_node_status_trigger_invalid_status(
 async def test_node_status_trigger_description(hass: HomeAssistant) -> None:
     """Test the described node status fields match the schema and statuses."""
     descriptions = await trigger.async_get_all_descriptions(hass)
-    fields = descriptions[f"{DOMAIN}.node_status"]["fields"]
+    description = descriptions[f"{DOMAIN}.node_status"]
+    assert description["target"]["primary_entities_only"] is False
+    fields = description["fields"]
     assert set(fields) == {"behavior", "for"} | {
         str(key) for key in NODE_STATUS_OPTIONS_SCHEMA_DICT
     }

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -33,12 +33,7 @@ from homeassistant.components.zwave_js.triggers.value_updated import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.helpers import (
-    area_registry as ar,
-    device_registry as dr,
-    entity_registry as er,
-    trigger,
-)
+from homeassistant.helpers import device_registry as dr, entity_registry as er, trigger
 from homeassistant.helpers.translation import async_get_translations
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -1684,7 +1679,9 @@ def _node_event(node: Node, event: str) -> None:
 
 
 async def _setup_node_status_automation(
-    hass: HomeAssistant, target: dict[str, Any], options: dict[str, Any] | None = None
+    hass: HomeAssistant,
+    device_id: str | list[str],
+    options: dict[str, Any] | None = None,
 ) -> None:
     """Set up one automation on the node status trigger."""
     assert await async_setup_component(
@@ -1694,8 +1691,7 @@ async def _setup_node_status_automation(
             automation.DOMAIN: {
                 "trigger": {
                     "trigger": f"{DOMAIN}.node_status",
-                    "target": target,
-                    **({"options": options} if options is not None else {}),
+                    "options": {"device_id": device_id, **(options or {})},
                 },
                 "action": {
                     "service": "test.automation",
@@ -1710,7 +1706,6 @@ async def _setup_node_status_automation(
     )
 
 
-@pytest.mark.parametrize("target_kind", ["device", "area", "entity"])
 async def test_node_status_trigger_fires(
     hass: HomeAssistant,
     client: MagicMock,
@@ -1718,27 +1713,18 @@ async def test_node_status_trigger_fires(
     integration: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    area_registry: ar.AreaRegistry,
     service_calls: list[ServiceCall],
-    target_kind: str,
 ) -> None:
-    """Test the trigger fires on a status change for device, area, and entity targets."""
+    """Test the trigger fires on a status change of a targeted device's node."""
     device = device_registry.async_get_device_by_identifier(
         get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
-    area = area_registry.async_create("Hall")
-    device_registry.async_update_device(device.id, area_id=area.id)
     entity_id = async_get_node_status_sensor_entity_id(
         hass, device.id, entity_registry, device_registry
     )
     assert entity_id
-    targets = {
-        "device": {"device_id": device.id},
-        "area": {"area_id": area.id},
-        "entity": {"entity_id": entity_id},
-    }
-    await _setup_node_status_automation(hass, targets[target_kind], {})
+    await _setup_node_status_automation(hass, device.id, {})
 
     _node_event(lock_schlage_be469, "dead")
     await hass.async_block_till_done()
@@ -1784,7 +1770,7 @@ async def test_node_status_trigger_filters(
         get_device_id(client.driver, lock_schlage_be469), integration.entry_id
     )
     assert device
-    await _setup_node_status_automation(hass, {"device_id": device.id}, options)
+    await _setup_node_status_automation(hass, device.id, options)
 
     for event in events:
         _node_event(lock_schlage_be469, event)
@@ -1809,7 +1795,7 @@ async def test_node_status_trigger_for(
     # The firmware update entities poll once the fake clock passes their delay.
     client.async_send_command.return_value = {"updates": []}
     await _setup_node_status_automation(
-        hass, {"device_id": device.id}, {"to": ["dead"], "for": {"minutes": 1}}
+        hass, device.id, {"to": ["dead"], "for": {"minutes": 1}}
     )
 
     _node_event(lock_schlage_be469, "dead")
@@ -1856,7 +1842,7 @@ async def test_node_status_trigger_behavior(
         for node in (lock_schlage_be469, multisensor_6)
     ]
     await _setup_node_status_automation(
-        hass, {"device_id": device_ids}, {"behavior": behavior, "to": ["dead"]}
+        hass, device_ids, {"behavior": behavior, "to": ["dead"]}
     )
 
     _node_event(lock_schlage_be469, "dead")
@@ -1895,7 +1881,7 @@ async def test_node_status_trigger_from_only_for(
     # The firmware update entities poll once the fake clock passes their delay.
     client.async_send_command.return_value = {"updates": []}
     await _setup_node_status_automation(
-        hass, {"device_id": device.id}, {"from": ["alive"], "for": {"minutes": 1}}
+        hass, device.id, {"from": ["alive"], "for": {"minutes": 1}}
     )
 
     _node_event(lock_schlage_be469, "dead")
@@ -1910,16 +1896,22 @@ async def test_node_status_trigger_from_only_for(
 
 async def test_node_status_trigger_ignores_other_entities(
     hass: HomeAssistant,
+    client: MagicMock,
     lock_schlage_be469: Node,
     integration: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
     service_calls: list[ServiceCall],
 ) -> None:
-    """Test targeting a non node status entity of a node never fires."""
+    """Test a device's entities other than its node status sensor never fire."""
     assert integration.state is ConfigEntryState.LOADED
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
+    )
+    assert device
     assert hass.states.get(SCHLAGE_BE469_LOCK_ENTITY)
-    await _setup_node_status_automation(hass, {"entity_id": SCHLAGE_BE469_LOCK_ENTITY})
+    await _setup_node_status_automation(hass, device.id)
 
-    _node_event(lock_schlage_be469, "dead")
+    hass.states.async_set(SCHLAGE_BE469_LOCK_ENTITY, "unlocked")
     await hass.async_block_till_done()
 
     assert len(service_calls) == 0
@@ -1943,8 +1935,7 @@ async def test_node_status_trigger_invalid_status(
             [
                 {
                     "platform": f"{DOMAIN}.node_status",
-                    "target": {"device_id": device.id},
-                    "options": {"to": ["sleeping"]},
+                    "options": {"device_id": device.id, "to": ["sleeping"]},
                 }
             ],
         )
@@ -1955,10 +1946,12 @@ async def test_node_status_trigger_description(hass: HomeAssistant) -> None:
     """Test the described node status fields match the schema and statuses."""
     descriptions = await trigger.async_get_all_descriptions(hass)
     description = descriptions[f"{DOMAIN}.node_status"]
-    assert description["target"]["primary_entities_only"] is False
+    # Nodes are picked with a device selector field, not a target selector
+    assert "target" not in description
     fields = description["fields"]
-    assert set(fields) == {"behavior", "for"} | {
-        str(key) for key in NODE_STATUS_OPTIONS_SCHEMA_DICT
-    }
+    assert set(fields) == {str(key) for key in NODE_STATUS_OPTIONS_SCHEMA_DICT}
+    selector = fields["device_id"]["selector"]["device"]
+    assert selector["filter"] == [{"integration": DOMAIN}]
+    assert selector["multiple"] is True
     for name in ("from", "to"):
         assert set(fields[name]["selector"]["select"]["options"]) == set(NODE_STATUSES)

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -2,6 +2,8 @@
 
 from contextlib import AbstractContextManager, nullcontext as does_not_raise
 import copy
+from datetime import timedelta
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,27 +14,38 @@ from zwave_js_server.model.node import Node
 
 from homeassistant.components import automation
 from homeassistant.components.zwave_js import DOMAIN
+from homeassistant.components.zwave_js.const import NODE_STATUSES
 from homeassistant.components.zwave_js.helpers import (
     async_bypass_dynamic_config_validation,
+    async_get_node_status_sensor_entity_id,
     get_device_id,
 )
 from homeassistant.components.zwave_js.trigger import TRIGGERS
 from homeassistant.components.zwave_js.triggers.event import (
     _OPTIONS_SCHEMA_DICT as EVENT_OPTIONS_SCHEMA_DICT,
 )
+from homeassistant.components.zwave_js.triggers.node_status import (
+    _OPTIONS_SCHEMA_DICT as NODE_STATUS_OPTIONS_SCHEMA_DICT,
+)
 from homeassistant.components.zwave_js.triggers.value_updated import (
     _OPTIONS_SCHEMA_DICT as VALUE_UPDATED_OPTIONS_SCHEMA_DICT,
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import SERVICE_RELOAD
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, trigger
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import (
+    area_registry as ar,
+    device_registry as dr,
+    entity_registry as er,
+    trigger,
+)
 from homeassistant.helpers.translation import async_get_translations
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from .common import COMMAND_CLASS_MARKERS, SCHLAGE_BE469_LOCK_ENTITY
 
-from tests.common import MockConfigEntry, async_capture_events
+from tests.common import MockConfigEntry, async_capture_events, async_fire_time_changed
 
 
 async def test_zwave_js_value_updated(
@@ -1661,3 +1674,289 @@ async def test_trigger_description_fields_match_schema(
     assert {name for name, field in fields.items() if field["required"]} == {
         str(key) for key in options_schema if isinstance(key, vol.Required)
     }
+
+
+def _node_event(node: Node, event: str) -> None:
+    """Emit a node status event."""
+    node.receive_event(
+        Event(event, data={"source": "node", "event": event, "nodeId": node.node_id})
+    )
+
+
+async def _setup_node_status_automation(
+    hass: HomeAssistant, target: dict[str, Any], options: dict[str, Any] | None = None
+) -> None:
+    """Set up one automation on the node status trigger."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "trigger": f"{DOMAIN}.node_status",
+                    "target": target,
+                    **({"options": options} if options is not None else {}),
+                },
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {
+                        "entity_id": "{{ trigger.entity_id }}",
+                        "from_state": "{{ trigger.from_state.state }}",
+                        "to_state": "{{ trigger.to_state.state }}",
+                    },
+                },
+            }
+        },
+    )
+
+
+@pytest.mark.parametrize("target_kind", ["device", "area", "entity"])
+async def test_node_status_trigger_fires(
+    hass: HomeAssistant,
+    client: MagicMock,
+    lock_schlage_be469: Node,
+    integration: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    area_registry: ar.AreaRegistry,
+    service_calls: list[ServiceCall],
+    target_kind: str,
+) -> None:
+    """Test the trigger fires on a status change for device, area, and entity targets."""
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
+    )
+    assert device
+    area = area_registry.async_create("Hall")
+    device_registry.async_update_device(device.id, area_id=area.id)
+    entity_id = async_get_node_status_sensor_entity_id(
+        hass, device.id, entity_registry, device_registry
+    )
+    assert entity_id
+    targets = {
+        "device": {"device_id": device.id},
+        "area": {"area_id": area.id},
+        "entity": {"entity_id": entity_id},
+    }
+    await _setup_node_status_automation(hass, targets[target_kind], {})
+
+    _node_event(lock_schlage_be469, "dead")
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 1
+    assert service_calls[0].data == {
+        "entity_id": entity_id,
+        "from_state": "alive",
+        "to_state": "dead",
+    }
+
+
+@pytest.mark.parametrize(
+    ("options", "events", "expected_calls"),
+    [
+        pytest.param({"to": ["dead"]}, ["sleep", "dead"], 1, id="to_filter"),
+        pytest.param(
+            {"from": ["alive", "awake"]},
+            ["dead", "alive", "sleep"],
+            2,
+            id="from_filter",
+        ),
+        pytest.param(
+            {"from": "alive", "to": "dead"}, ["dead", "alive", "dead"], 2, id="scalar"
+        ),
+        pytest.param({"to": ["asleep"]}, ["dead", "alive"], 0, id="no_match"),
+        pytest.param(None, ["dead"], 1, id="no_options"),
+    ],
+)
+async def test_node_status_trigger_filters(
+    hass: HomeAssistant,
+    client: MagicMock,
+    lock_schlage_be469: Node,
+    integration: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    service_calls: list[ServiceCall],
+    options: dict[str, Any] | None,
+    events: list[str],
+    expected_calls: int,
+) -> None:
+    """Test from and to filters, including scalar values and no options at all."""
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
+    )
+    assert device
+    await _setup_node_status_automation(hass, {"device_id": device.id}, options)
+
+    for event in events:
+        _node_event(lock_schlage_be469, event)
+        await hass.async_block_till_done()
+
+    assert len(service_calls) == expected_calls
+
+
+async def test_node_status_trigger_for(
+    hass: HomeAssistant,
+    client: MagicMock,
+    lock_schlage_be469: Node,
+    integration: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test the for duration fires late and is cancelled by a recovery."""
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
+    )
+    assert device
+    # The firmware update entities poll once the fake clock passes their delay.
+    client.async_send_command.return_value = {"updates": []}
+    await _setup_node_status_automation(
+        hass, {"device_id": device.id}, {"to": ["dead"], "for": {"minutes": 1}}
+    )
+
+    _node_event(lock_schlage_be469, "dead")
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+    _node_event(lock_schlage_be469, "alive")
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=2))
+    await hass.async_block_till_done()
+    assert len(service_calls) == 0
+
+    _node_event(lock_schlage_be469, "dead")
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=2))
+    await hass.async_block_till_done()
+    assert len(service_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("behavior", "calls_after_first_node", "expected_from_states"),
+    [
+        pytest.param("each", 1, {"alive", "asleep"}, id="each"),
+        pytest.param("all", 0, {"asleep"}, id="all"),
+    ],
+)
+async def test_node_status_trigger_behavior(
+    hass: HomeAssistant,
+    client: MagicMock,
+    lock_schlage_be469: Node,
+    multisensor_6: Node,
+    integration: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    service_calls: list[ServiceCall],
+    behavior: str,
+    calls_after_first_node: int,
+    expected_from_states: set[str],
+) -> None:
+    """Test each fires once per node while all waits for the last node."""
+    device_ids = [
+        device_registry.async_get_device_by_identifier(
+            get_device_id(client.driver, node), integration.entry_id
+        ).id
+        for node in (lock_schlage_be469, multisensor_6)
+    ]
+    await _setup_node_status_automation(
+        hass, {"device_id": device_ids}, {"behavior": behavior, "to": ["dead"]}
+    )
+
+    _node_event(lock_schlage_be469, "dead")
+    await hass.async_block_till_done()
+    assert len(service_calls) == calls_after_first_node
+
+    _node_event(multisensor_6, "dead")
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == len(expected_from_states)
+    assert {call.data["from_state"] for call in service_calls} == expected_from_states
+
+
+@pytest.mark.parametrize(
+    ("second_event", "expected_calls"),
+    [
+        pytest.param("alive", 0, id="back_to_from_status_cancels"),
+        pytest.param("sleep", 1, id="further_change_stays_armed"),
+    ],
+)
+async def test_node_status_trigger_from_only_for(
+    hass: HomeAssistant,
+    client: MagicMock,
+    lock_schlage_be469: Node,
+    integration: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    service_calls: list[ServiceCall],
+    second_event: str,
+    expected_calls: int,
+) -> None:
+    """Test a from-only timer only survives while the node has left the status."""
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
+    )
+    assert device
+    # The firmware update entities poll once the fake clock passes their delay.
+    client.async_send_command.return_value = {"updates": []}
+    await _setup_node_status_automation(
+        hass, {"device_id": device.id}, {"from": ["alive"], "for": {"minutes": 1}}
+    )
+
+    _node_event(lock_schlage_be469, "dead")
+    await hass.async_block_till_done()
+    _node_event(lock_schlage_be469, second_event)
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=2))
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == expected_calls
+
+
+async def test_node_status_trigger_ignores_other_entities(
+    hass: HomeAssistant,
+    lock_schlage_be469: Node,
+    integration: MockConfigEntry,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test targeting a non node status entity of a node never fires."""
+    assert integration.state is ConfigEntryState.LOADED
+    assert hass.states.get(SCHLAGE_BE469_LOCK_ENTITY)
+    await _setup_node_status_automation(hass, {"entity_id": SCHLAGE_BE469_LOCK_ENTITY})
+
+    _node_event(lock_schlage_be469, "dead")
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 0
+
+
+async def test_node_status_trigger_invalid_status(
+    hass: HomeAssistant,
+    client: MagicMock,
+    lock_schlage_be469: Node,
+    integration: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test an unknown status is rejected."""
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(client.driver, lock_schlage_be469), integration.entry_id
+    )
+    assert device
+    with pytest.raises(vol.Invalid):
+        await trigger.async_validate_trigger_config(
+            hass,
+            [
+                {
+                    "platform": f"{DOMAIN}.node_status",
+                    "target": {"device_id": device.id},
+                    "options": {"to": ["sleeping"]},
+                }
+            ],
+        )
+
+
+@pytest.mark.usefixtures("integration")
+async def test_node_status_trigger_description(hass: HomeAssistant) -> None:
+    """Test the described node status fields match the schema and statuses."""
+    descriptions = await trigger.async_get_all_descriptions(hass)
+    fields = descriptions[f"{DOMAIN}.node_status"]["fields"]
+    assert set(fields) == {"behavior", "for"} | {
+        str(key) for key in NODE_STATUS_OPTIONS_SCHEMA_DICT
+    }
+    for name in ("from", "to"):
+        assert set(fields[name]["selector"]["select"]["options"]) == set(NODE_STATUSES)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#181129 and #181133 have both landed on `dev`, and this branch has been rebased onto `dev`, so it no longer carries their commits. It still reuses the `selector.node_status` translations added in #181133.

Adds the new-style trigger `zwave_js.node_status`, which fires when the status of one or more Z-Wave JS nodes changes, so "alert me when any node goes dead" no longer needs a per-device trigger or a template over node status sensors.

Design decisions:

- **Built on core's `EntityTriggerBase` over the per-node node status sensors** (diagnostic, enabled by default), so target tracking, `for:`, first/all/each `behavior`, and trace diagnostics all come from core. This is the same mechanism the legacy `state.node_status` device trigger uses (it delegates to the state trigger on that sensor); the device trigger is untouched.
- **Nodes are picked with a `device_id` field and a Z-Wave JS device selector**, not a target selector, matching the conditions in #181133: a node is a device, so entity, area and label selection would only ever be an indirect way of naming one. The devices are expanded to the node status sensors behind them, including diagnostic entities, and an entity filter keeps only zwave_js entities with translation key `node_status`, so a node's other entities such as a lock never fire.
- **Optional `from` / `to` status lists** (single values coerced to lists) restricted to alive, asleep, awake, dead. `unknown` and `unavailable` are excluded by core on both sides of a transition. With `to` unset, a matching state is one that is not in `from`, mirroring core's origin-state triggers, so `for:` and `behavior: all` behave sensibly for `from`-only triggers.
- **Only `device_id` is required**; a trigger with no filters fires on any status change of those nodes.
- **Described in `triggers.yaml`, `strings.json`, and `icons.json`**; a drift test pins the described fields to the schema and the `from`/`to` options to `NODE_STATUSES`, and checks the device selector is filtered to zwave_js and accepts multiple. Tests cover device targets, from/to filters, `for` with cancellation, each and all behavior over two nodes, a device's other entities being ignored, and invalid statuses.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/48059
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

