### PR TITLE
Use sentence-style capitalization for built-in integration names

### DIFF
--- a/homeassistant/components/air_quality/manifest.json
+++ b/homeassistant/components/air_quality/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "air_quality",
-  "name": "Air Quality",
+  "name": "Air quality",
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/air_quality",
   "integration_type": "entity",

--- a/homeassistant/components/air_quality/strings.json
+++ b/homeassistant/components/air_quality/strings.json
@@ -276,7 +276,7 @@
       "name": "Volatile organic compounds value"
     }
   },
-  "title": "Air Quality",
+  "title": "Air quality",
   "triggers": {
     "co2_changed": {
       "description": "Triggers when one or more carbon dioxide levels change.",

--- a/homeassistant/components/alarm_control_panel/manifest.json
+++ b/homeassistant/components/alarm_control_panel/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "alarm_control_panel",
-  "name": "Alarm Control Panel",
+  "name": "Alarm control panel",
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/alarm_control_panel",
   "integration_type": "entity",

--- a/homeassistant/components/application_credentials/manifest.json
+++ b/homeassistant/components/application_credentials/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "application_credentials",
-  "name": "Application Credentials",
+  "name": "Application credentials",
   "codeowners": ["@home-assistant/core"],
   "config_flow": false,
   "dependencies": ["auth", "websocket_api"],

--- a/homeassistant/components/application_credentials/strings.json
+++ b/homeassistant/components/application_credentials/strings.json
@@ -1,3 +1,3 @@
 {
-  "title": "Application Credentials"
+  "title": "Application credentials"
 }

--- a/homeassistant/components/binary_sensor/manifest.json
+++ b/homeassistant/components/binary_sensor/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "binary_sensor",
-  "name": "Binary Sensor",
+  "name": "Binary sensor",
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/binary_sensor",
   "integration_type": "entity",

--- a/homeassistant/components/collection_image/manifest.json
+++ b/homeassistant/components/collection_image/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "collection_image",
-  "name": "Collection Image",
+  "name": "Collection image",
   "codeowners": ["@karwosts"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/collection_image",

--- a/homeassistant/components/collection_image/strings.json
+++ b/homeassistant/components/collection_image/strings.json
@@ -28,5 +28,5 @@
       "name": "Shuffle"
     }
   },
-  "title": "Collection Image"
+  "title": "Collection image"
 }

--- a/homeassistant/components/command_line/manifest.json
+++ b/homeassistant/components/command_line/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "command_line",
-  "name": "Command Line",
+  "name": "Command line",
   "codeowners": ["@gjohansson-ST"],
   "documentation": "https://www.home-assistant.io/integrations/command_line",
   "iot_class": "local_polling",

--- a/homeassistant/components/device_automation/manifest.json
+++ b/homeassistant/components/device_automation/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "device_automation",
-  "name": "Device Automation",
+  "name": "Device automation",
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/device_automation",
   "integration_type": "system",

--- a/homeassistant/components/device_sun_light_trigger/manifest.json
+++ b/homeassistant/components/device_sun_light_trigger/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "device_sun_light_trigger",
-  "name": "Presence-based Lights",
+  "name": "Presence-based lights",
   "after_dependencies": ["device_tracker", "group", "light", "person"],
   "codeowners": [],
   "documentation": "https://www.home-assistant.io/integrations/device_sun_light_trigger",

--- a/homeassistant/components/device_tracker/manifest.json
+++ b/homeassistant/components/device_tracker/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "device_tracker",
-  "name": "Device Tracker",
+  "name": "Device tracker",
   "codeowners": ["@home-assistant/core"],
   "dependencies": ["zone"],
   "documentation": "https://www.home-assistant.io/integrations/device_tracker",

--- a/homeassistant/components/dhcp/manifest.json
+++ b/homeassistant/components/dhcp/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "dhcp",
-  "name": "DHCP Discovery",
+  "name": "DHCP discovery",
   "codeowners": ["@bdraco"],
   "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/dhcp",

--- a/homeassistant/components/file_upload/manifest.json
+++ b/homeassistant/components/file_upload/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "file_upload",
-  "name": "File Upload",
+  "name": "File upload",
   "codeowners": ["@home-assistant/core"],
   "dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/file_upload",

--- a/homeassistant/components/filesize/manifest.json
+++ b/homeassistant/components/filesize/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "filesize",
-  "name": "File Size",
+  "name": "File size",
   "codeowners": ["@gjohansson-ST"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/filesize",

--- a/homeassistant/components/filesize/strings.json
+++ b/homeassistant/components/filesize/strings.json
@@ -37,5 +37,5 @@
       }
     }
   },
-  "title": "Filesize"
+  "title": "File size"
 }

--- a/homeassistant/components/folder_watcher/manifest.json
+++ b/homeassistant/components/folder_watcher/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "folder_watcher",
-  "name": "Folder Watcher",
+  "name": "Folder watcher",
   "codeowners": [],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/folder_watcher",

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "frontend",
-  "name": "Home Assistant Frontend",
+  "name": "Home Assistant frontend",
   "codeowners": ["@home-assistant/frontend"],
   "dependencies": [
     "api",

--- a/homeassistant/components/image_processing/manifest.json
+++ b/homeassistant/components/image_processing/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "image_processing",
-  "name": "Image Processing",
+  "name": "Image processing",
   "codeowners": ["@home-assistant/core"],
   "dependencies": ["camera"],
   "documentation": "https://www.home-assistant.io/integrations/image_processing",

--- a/homeassistant/components/image_upload/manifest.json
+++ b/homeassistant/components/image_upload/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "image_upload",
-  "name": "Image Upload",
+  "name": "Image upload",
   "codeowners": ["@home-assistant/core"],
   "config_flow": false,
   "dependencies": ["http"],

--- a/homeassistant/components/input_boolean/manifest.json
+++ b/homeassistant/components/input_boolean/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "input_boolean",
-  "name": "Input Boolean",
+  "name": "Input boolean",
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/input_boolean",
   "integration_type": "helper",

--- a/homeassistant/components/input_button/manifest.json
+++ b/homeassistant/components/input_button/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "input_button",
-  "name": "Input Button",
+  "name": "Input button",
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/input_button",
   "integration_type": "helper",

--- a/homeassistant/components/input_number/manifest.json
+++ b/homeassistant/components/input_number/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "input_number",
-  "name": "Input Number",
+  "name": "Input number",
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/input_number",
   "integration_type": "helper",

--- a/homeassistant/components/input_select/manifest.json
+++ b/homeassistant/components/input_select/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "input_select",
-  "name": "Input Select",
+  "name": "Input select",
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/input_select",
   "integration_type": "helper",

--- a/homeassistant/components/input_text/manifest.json
+++ b/homeassistant/components/input_text/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "input_text",
-  "name": "Input Text",
+  "name": "Input text",
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/input_text",
   "integration_type": "helper",

--- a/homeassistant/components/lawn_mower/manifest.json
+++ b/homeassistant/components/lawn_mower/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "lawn_mower",
-  "name": "Lawn Mower",
+  "name": "Lawn mower",
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/lawn_mower",
   "integration_type": "entity",

--- a/homeassistant/components/local_calendar/manifest.json
+++ b/homeassistant/components/local_calendar/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "local_calendar",
-  "name": "Local Calendar",
+  "name": "Local calendar",
   "codeowners": ["@allenporter"],
   "config_flow": true,
   "dependencies": ["file_upload"],

--- a/homeassistant/components/local_calendar/strings.json
+++ b/homeassistant/components/local_calendar/strings.json
@@ -30,5 +30,5 @@
       }
     }
   },
-  "title": "Local Calendar"
+  "title": "Local calendar"
 }

--- a/homeassistant/components/local_file/manifest.json
+++ b/homeassistant/components/local_file/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "local_file",
-  "name": "Local File",
+  "name": "Local file",
   "codeowners": [],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/local_file",

--- a/homeassistant/components/local_todo/manifest.json
+++ b/homeassistant/components/local_todo/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "local_todo",
-  "name": "Local To-do",
+  "name": "Local to-do",
   "codeowners": ["@allenporter"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/local_todo",

--- a/homeassistant/components/local_todo/strings.json
+++ b/homeassistant/components/local_todo/strings.json
@@ -13,5 +13,5 @@
       }
     }
   },
-  "title": "Local To-do"
+  "title": "Local to-do"
 }

--- a/homeassistant/components/manual/manifest.json
+++ b/homeassistant/components/manual/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "manual",
-  "name": "Manual Alarm Control Panel",
+  "name": "Manual alarm control panel",
   "codeowners": [],
   "documentation": "https://www.home-assistant.io/integrations/manual",
   "integration_type": "helper",

--- a/homeassistant/components/manual_mqtt/manifest.json
+++ b/homeassistant/components/manual_mqtt/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "manual_mqtt",
-  "name": "Manual MQTT Alarm Control Panel",
+  "name": "Manual MQTT alarm control panel",
   "codeowners": [],
   "dependencies": ["mqtt"],
   "documentation": "https://www.home-assistant.io/integrations/manual_mqtt",

--- a/homeassistant/components/media_extractor/manifest.json
+++ b/homeassistant/components/media_extractor/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "media_extractor",
-  "name": "Media Extractor",
+  "name": "Media extractor",
   "codeowners": ["@joostlek"],
   "config_flow": true,
   "dependencies": ["media_player"],

--- a/homeassistant/components/media_player/manifest.json
+++ b/homeassistant/components/media_player/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "media_player",
-  "name": "Media Player",
+  "name": "Media player",
   "codeowners": ["@home-assistant/core"],
   "dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/media_player",

--- a/homeassistant/components/media_source/manifest.json
+++ b/homeassistant/components/media_source/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "media_source",
-  "name": "Media Source",
+  "name": "Media source",
   "codeowners": ["@hunterjm"],
   "dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/media_source",

--- a/homeassistant/components/mqtt_room/manifest.json
+++ b/homeassistant/components/mqtt_room/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "mqtt_room",
-  "name": "MQTT Room Presence",
+  "name": "MQTT room presence",
   "codeowners": [],
   "dependencies": ["mqtt"],
   "documentation": "https://www.home-assistant.io/integrations/mqtt_room",

--- a/homeassistant/components/panel_custom/manifest.json
+++ b/homeassistant/components/panel_custom/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "panel_custom",
-  "name": "Custom Panel",
+  "name": "Custom panel",
   "codeowners": ["@home-assistant/frontend"],
   "dependencies": ["frontend"],
   "documentation": "https://www.home-assistant.io/integrations/panel_custom",

--- a/homeassistant/components/radio_frequency/manifest.json
+++ b/homeassistant/components/radio_frequency/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "radio_frequency",
-  "name": "Radio Frequency",
+  "name": "Radio frequency",
   "codeowners": ["@home-assistant/core"],
   "dependencies": ["websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/radio_frequency",

--- a/homeassistant/components/recovery_mode/__init__.py
+++ b/homeassistant/components/recovery_mode/__init__.py
@@ -18,6 +18,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             "Home Assistant is running in recovery mode. Check [the error"
             " log](/config/logs) to see what went wrong."
         ),
-        "Recovery Mode",
+        "Recovery mode",
     )
     return True

--- a/homeassistant/components/recovery_mode/manifest.json
+++ b/homeassistant/components/recovery_mode/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "recovery_mode",
-  "name": "Recovery Mode",
+  "name": "Recovery mode",
   "codeowners": ["@home-assistant/core"],
   "config_flow": false,
   "documentation": "https://www.home-assistant.io/integrations/recovery_mode",

--- a/homeassistant/components/rss_feed_template/manifest.json
+++ b/homeassistant/components/rss_feed_template/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "rss_feed_template",
-  "name": "RSS Feed Template",
+  "name": "RSS feed template",
   "codeowners": ["@home-assistant/core"],
   "dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/rss_feed_template",

--- a/homeassistant/components/shopping_list/__init__.py
+++ b/homeassistant/components/shopping_list/__init__.py
@@ -58,7 +58,7 @@ async def _async_setup(hass: HomeAssistant) -> None:
         translation_key="deprecated_yaml",
         translation_placeholders={
             "domain": DOMAIN,
-            "integration_title": "Shopping List",
+            "integration_title": "Shopping list",
         },
     )
 

--- a/homeassistant/components/shopping_list/manifest.json
+++ b/homeassistant/components/shopping_list/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "shopping_list",
-  "name": "Shopping List",
+  "name": "Shopping list",
   "codeowners": [],
   "config_flow": true,
   "dependencies": ["http"],

--- a/homeassistant/components/shopping_list/strings.json
+++ b/homeassistant/components/shopping_list/strings.json
@@ -81,5 +81,5 @@
       "name": "Sort shopping list"
     }
   },
-  "title": "Shopping List"
+  "title": "Shopping list"
 }

--- a/homeassistant/components/systemmonitor/manifest.json
+++ b/homeassistant/components/systemmonitor/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "systemmonitor",
-  "name": "System Monitor",
+  "name": "System monitor",
   "codeowners": ["@gjohansson-ST"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/systemmonitor",

--- a/homeassistant/components/water_heater/manifest.json
+++ b/homeassistant/components/water_heater/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "water_heater",
-  "name": "Water Heater",
+  "name": "Water heater",
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/water_heater",
   "integration_type": "entity",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1175,7 +1175,7 @@
       "iot_class": "local_push"
     },
     "command_line": {
-      "name": "Command Line",
+      "name": "Command line",
       "integration_type": "hub",
       "config_flow": false,
       "iot_class": "local_polling"
@@ -1383,7 +1383,7 @@
       "iot_class": "local_polling"
     },
     "device_sun_light_trigger": {
-      "name": "Presence-based Lights",
+      "name": "Presence-based lights",
       "integration_type": "hub",
       "config_flow": false,
       "iot_class": "calculated"
@@ -2249,7 +2249,7 @@
       "iot_class": "local_polling"
     },
     "folder_watcher": {
-      "name": "Folder Watcher",
+      "name": "Folder watcher",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -4063,7 +4063,7 @@
       "iot_class": "local_polling"
     },
     "local_file": {
-      "name": "Local File",
+      "name": "Local file",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"
@@ -4291,7 +4291,7 @@
       "iot_class": "local_polling"
     },
     "media_extractor": {
-      "name": "Media Extractor",
+      "name": "Media extractor",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "calculated",
@@ -4653,7 +4653,7 @@
           "integration_type": "hub",
           "config_flow": false,
           "iot_class": "local_push",
-          "name": "Manual MQTT Alarm Control Panel"
+          "name": "Manual MQTT alarm control panel"
         },
         "mqtt": {
           "integration_type": "service",
@@ -4677,7 +4677,7 @@
           "integration_type": "hub",
           "config_flow": false,
           "iot_class": "local_push",
-          "name": "MQTT Room Presence"
+          "name": "MQTT room presence"
         },
         "mqtt_statestream": {
           "integration_type": "hub",
@@ -6244,7 +6244,7 @@
       "iot_class": "cloud_polling"
     },
     "rss_feed_template": {
-      "name": "RSS Feed Template",
+      "name": "RSS feed template",
       "integration_type": "hub",
       "config_flow": false,
       "iot_class": "local_push"
@@ -7209,7 +7209,7 @@
       "iot_class": "local_push"
     },
     "systemmonitor": {
-      "name": "System Monitor",
+      "name": "System monitor",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_push",
@@ -8648,7 +8648,7 @@
       "iot_class": "local_push"
     },
     "manual": {
-      "name": "Manual Alarm Control Panel",
+      "name": "Manual alarm control panel",
       "integration_type": "helper",
       "config_flow": false,
       "iot_class": "calculated"

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -37,6 +37,7 @@ ALLOW_NAME_TRANSLATION = {
     "emulated_roku",
     "energenie_power_sockets",
     "faa_delays",
+    "filesize",
     "garages_amsterdam",
     "generic",
     "google_travel_time",

--- a/tests/components/cloud/snapshots/test_http_api.ambr
+++ b/tests/components/cloud/snapshots/test_http_api.ambr
@@ -30,7 +30,7 @@
   --- | ---
   ai_task | AI Task
   auth | Auth
-  binary_sensor | Binary Sensor
+  binary_sensor | Binary sensor
   cloud | Home Assistant Cloud
   cloud.ai_task | Unknown
   cloud.binary_sensor | Unknown
@@ -43,7 +43,7 @@
   http | HTTP
   intent | Intent
   llm | LLM
-  media_source | Media Source
+  media_source | Media source
   mock_no_info_integration | mock_no_info_integration
   repairs | Repairs
   stt | Speech-to-text (STT)
@@ -166,7 +166,7 @@
   --- | ---
   ai_task | AI Task
   auth | Auth
-  binary_sensor | Binary Sensor
+  binary_sensor | Binary sensor
   cloud | Home Assistant Cloud
   cloud.ai_task | Unknown
   cloud.binary_sensor | Unknown
@@ -179,7 +179,7 @@
   http | HTTP
   intent | Intent
   llm | LLM
-  media_source | Media Source
+  media_source | Media source
   mock_no_info_integration | mock_no_info_integration
   repairs | Repairs
   stt | Speech-to-text (STT)

--- a/tests/components/conversation/test_trace.py
+++ b/tests/components/conversation/test_trace.py
@@ -55,7 +55,7 @@ async def test_converation_trace(
     assert trace_event.get("data") == {
         "intent_name": "HassListAddItem",
         "slots": {
-            "name": "Shopping List",
+            "name": "Shopping list",
             "item": "apples",
         },
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

We use sentence-style capitalization in the UI and in the documentation. A number of built-in, non-brand integrations still carry Title Case names in their manifest. Core is already inconsistent with itself here: 12 of them have a sentence-style `title` in their `strings.json` (for example "Input boolean" in strings versus "Input Boolean" in the manifest), and the documentation was adjusted to sentence style by our technical writers a while ago.

This PR makes the manifest the source of truth for the documentation, so it needs to carry the right name:

- Rename 38 manifests to sentence style, for example "Input Boolean" becomes "Input boolean", "Media Player" becomes "Media player", and "Manual Alarm Control Panel" becomes "Manual alarm control panel".
- Align the 7 `strings.json` titles that were still Title Case (air quality, application credentials, collection image, file size, local calendar, local to-do, shopping list). File size had three spellings and now has one.
- Update the two hard-coded display strings that show the integration name: the shopping list YAML deprecation repair placeholder and the recovery mode notification title.
- Add `filesize` to `ALLOW_NAME_TRANSLATION`, because its strings title now equals the manifest name and hassfest flags that for anything not on the list.
- Regenerate `homeassistant/generated/integrations.json` with hassfest.

Brand and product names are untouched. Entity and device names, like the system monitor device or the default local file camera name, are also untouched, as those are not the integration name.

One side effect worth knowing: the shopping list to-do entity and its config flow step take their name from the integration title through a `[%key:component::shopping_list::title%]` reference. The default friendly name of that entity therefore changes from "Shopping List" to "Shopping list". The entity ID does not change, and a custom name set by the user is left alone.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
