### PR TITLE
Add switch platform to Electrolux integration

### DIFF
--- a/homeassistant/components/electrolux/__init__.py
+++ b/homeassistant/components/electrolux/__init__.py
@@ -47,6 +47,7 @@ PLATFORMS = [
     Platform.LIGHT,
     Platform.NUMBER,
     Platform.SENSOR,
+    Platform.SWITCH,
 ]
 
 

--- a/homeassistant/components/electrolux/icons.json
+++ b/homeassistant/components/electrolux/icons.json
@@ -40,6 +40,20 @@
       "remote_control": {
         "default": "mdi:remote"
       }
+    },
+    "switch": {
+      "bottomoven_cavity_light": {
+        "default": "mdi:lightbulb-outline"
+      },
+      "cavity_light": {
+        "default": "mdi:lightbulb-outline"
+      },
+      "child_lock": {
+        "default": "mdi:lock"
+      },
+      "upperoven_cavity_light": {
+        "default": "mdi:lightbulb-outline"
+      }
     }
   }
 }

--- a/homeassistant/components/electrolux/strings.json
+++ b/homeassistant/components/electrolux/strings.json
@@ -222,6 +222,20 @@
           "temporary_locked": "Temporarily locked"
         }
       }
+    },
+    "switch": {
+      "bottomoven_cavity_light": {
+        "name": "Lower cavity light"
+      },
+      "cavity_light": {
+        "name": "Light"
+      },
+      "child_lock": {
+        "name": "Child lock"
+      },
+      "upperoven_cavity_light": {
+        "name": "Upper cavity light"
+      }
     }
   },
   "exceptions": {

--- a/homeassistant/components/electrolux/switch.py
+++ b/homeassistant/components/electrolux/switch.py
@@ -1,0 +1,141 @@
+"""Switch entity for Electrolux Integration."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, override
+
+from electrolux_group_developer_sdk.client.appliances.appliance_data import (
+    ApplianceData,
+)
+from electrolux_group_developer_sdk.client.appliances.hb_appliance import HBAppliance
+from electrolux_group_developer_sdk.constants import (
+    RC_ENABLED,
+    RC_NOT_SAFETY_RELEVANT_ENABLED,
+)
+from electrolux_group_developer_sdk.feature_constants import CHILD_LOCK
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import ElectroluxConfigEntry, ElectroluxDataUpdateCoordinator
+from .entity import ElectroluxBaseEntity
+from .entity_helper import async_setup_entities_helper
+
+
+@dataclass(frozen=True, kw_only=True)
+class ElectroluxSwitchDescription[T: ApplianceData](SwitchEntityDescription):
+    """Custom switch description for Electrolux switches."""
+
+    exists_fn: Callable[[T], bool]
+    value_fn: Callable[[T], bool | None]
+    turn_on_fn: Callable[[T], dict[str, Any]]
+    turn_off_fn: Callable[[T], dict[str, Any]] | None = None
+    remote_control_required: bool = False
+
+
+HOB_ELECTROLUX_SWITCHES: tuple[ElectroluxSwitchDescription[HBAppliance], ...] = (
+    ElectroluxSwitchDescription[HBAppliance](
+        key="child_lock",
+        translation_key="child_lock",
+        exists_fn=lambda appliance: appliance.is_feature_supported(CHILD_LOCK),
+        value_fn=lambda appliance: appliance.get_current_child_lock(),
+        turn_on_fn=lambda appliance: appliance.get_enable_child_lock_command(),
+        remote_control_required=True,
+    ),
+)
+
+
+def build_entities_for_appliance(
+    appliance_data: ApplianceData,
+    coordinators: dict[str, ElectroluxDataUpdateCoordinator],
+) -> list[ElectroluxBaseEntity]:
+    """Return all entities for a single appliance."""
+    appliance = appliance_data.appliance
+    coordinator = coordinators[appliance.applianceId]
+    entities: list[ElectroluxBaseEntity] = []
+
+    if isinstance(appliance_data, HBAppliance):
+        entities.extend(
+            ElectroluxSwitch(appliance_data, coordinator, description)
+            for description in HOB_ELECTROLUX_SWITCHES
+            if description.exists_fn(appliance_data)
+        )
+
+    return entities
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ElectroluxConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set Switch entity for Electrolux Integration."""
+    await async_setup_entities_helper(
+        hass, entry, async_add_entities, build_entities_for_appliance
+    )
+
+
+class ElectroluxSwitch[T: HBAppliance](ElectroluxBaseEntity[T], SwitchEntity):
+    """Representation of a generic switch for Electrolux appliances."""
+
+    entity_description: ElectroluxSwitchDescription[T]
+
+    def __init__(
+        self,
+        appliance_data: T,
+        coordinator: ElectroluxDataUpdateCoordinator,
+        description: ElectroluxSwitchDescription[T],
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(
+            appliance_data,
+            coordinator,
+            description.key,
+        )
+        self.entity_description = description
+
+    @override
+    def _update_attr_state(self) -> bool:
+        new_value = self.entity_description.value_fn(self._appliance_data)
+        if self._attr_is_on != new_value:
+            self._attr_is_on = new_value
+            return True
+
+        return False
+
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        self._check_remote_control_enabled()
+        await self._async_send_command(self.entity_description.turn_on_fn)
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        turn_off_fn = self.entity_description.turn_off_fn
+        if turn_off_fn is None:
+            raise ServiceValidationError(
+                f"The {self.entity_description.name} cannot be turned off remotely"
+            )
+        self._check_remote_control_enabled()
+        await self._async_send_command(turn_off_fn)
+
+    async def _async_send_command(
+        self, command_fn: Callable[..., dict[str, Any]]
+    ) -> None:
+        command = command_fn(self._appliance_data)
+        await self.coordinator.client.send_command(self._appliance_id, command)
+        await self.coordinator.async_refresh()
+
+    def _check_remote_control_enabled(self) -> None:
+        if (
+            self.entity_description.remote_control_required
+            and self._appliance_data.get_current_remote_control()
+            not in (RC_ENABLED, RC_NOT_SAFETY_RELEVANT_ENABLED)
+        ):
+            raise ServiceValidationError(
+                translation_domain=DOMAIN, translation_key="remote_control_disabled"
+            )

--- a/tests/components/electrolux/snapshots/test_switch.ambr
+++ b/tests/components/electrolux/snapshots/test_switch.ambr
@@ -1,0 +1,51 @@
+# serializer version: 1
+# name: test_switch[switch.peacock_hob_child_lock-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.peacock_hob_child_lock',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Child lock',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Child lock',
+    'platform': 'electrolux',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'child_lock',
+    'unique_id': '999008120_00:99907833-443E073D986E_child_lock',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch[switch.peacock_hob_child_lock-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Peacock hob Child lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.peacock_hob_child_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/electrolux/test_switch.py
+++ b/tests/components/electrolux/test_switch.py
@@ -1,0 +1,93 @@
+"""Switch tests of Electrolux integration."""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import AsyncMock, call, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import get_appliance_id, merge_dict_recursive, setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def override_platforms() -> Generator[None]:
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.electrolux.PLATFORMS", [Platform.SWITCH]):
+        yield
+
+
+@pytest.mark.usefixtures("appliances")
+async def test_switch(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test states of the switch."""
+    await setup_integration(hass, mock_config_entry)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    (
+        "appliance_fixture",
+        "entity_id",
+        "appliance_state",
+        "service",
+        "data",
+        "commands",
+    ),
+    [
+        # child lock command tests
+        (
+            "peacock_hob",
+            "switch.peacock_hob_child_lock",
+            {},
+            SERVICE_TURN_ON,
+            {},
+            [{"childLock": True}],
+        ),
+    ],
+)
+async def test_commands(
+    hass: HomeAssistant,
+    appliances: AsyncMock,
+    appliance_fixture: str,
+    mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    appliance_state: dict[str, Any],
+    service: str,
+    data: dict[str, Any],
+    commands: list[dict[str, Any]],
+) -> None:
+    """Test switch commands."""
+
+    appliance_id = get_appliance_id(appliance_fixture)
+
+    state = await appliances.get_appliance_state(appliance_id)
+    state.properties["reported"] = merge_dict_recursive(
+        state.properties["reported"], appliance_state
+    )
+
+    appliances.get_appliance_state.side_effect = None
+    appliances.get_appliance_state.return_value = state
+
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: entity_id} | data,
+        blocking=True,
+    )
+    assert appliances.send_command.mock_calls == [
+        call(appliance_id, command) for command in commands
+    ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for the switch platform for the Electrolux integration, allowing users to turn on the child lock for their hobs, and see whether the child lock is enabled or not. The child lock cannot be disabled remotely.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47833
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
