### PR TITLE
Stop rounding Amber Electric prices to 2 decimal places

### DIFF
--- a/homeassistant/components/amberelectric/helpers.py
+++ b/homeassistant/components/amberelectric/helpers.py
@@ -24,5 +24,5 @@ def normalize_descriptor(descriptor: PriceDescriptor | None) -> str | None:
 
 
 def format_cents_to_dollars(cents: float) -> float:
-    """Return a formatted conversion from cents to dollars."""
-    return round(cents / 100, 2)
+    """Convert cents per kWh to dollars per kWh."""
+    return cents / 100

--- a/tests/components/amberelectric/test_helpers.py
+++ b/tests/components/amberelectric/test_helpers.py
@@ -1,8 +1,12 @@
 """Test formatters."""
 
 from amberelectric.models.price_descriptor import PriceDescriptor
+import pytest
 
-from homeassistant.components.amberelectric.helpers import normalize_descriptor
+from homeassistant.components.amberelectric.helpers import (
+    format_cents_to_dollars,
+    normalize_descriptor,
+)
 
 
 def test_normalize_descriptor() -> None:
@@ -15,3 +19,18 @@ def test_normalize_descriptor() -> None:
     assert normalize_descriptor(PriceDescriptor.NEUTRAL) == "neutral"
     assert normalize_descriptor(PriceDescriptor.HIGH) == "high"
     assert normalize_descriptor(PriceDescriptor.SPIKE) == "spike"
+
+
+@pytest.mark.parametrize(
+    ("cents", "expected"),
+    [
+        pytest.param(8.8, 8.8 / 100, id="general"),
+        pytest.param(4.4, 4.4 / 100, id="controlled_load"),
+        pytest.param(1.1, 1.1 / 100, id="feed_in"),
+        pytest.param(0.09619, 0.0009619, id="near_zero"),
+        pytest.param(-0.09619, -0.0009619, id="near_zero_negative"),
+    ],
+)
+def test_format_cents_to_dollars(cents: float, expected: float) -> None:
+    """Test cents-to-dollars conversion preserves source precision."""
+    assert format_cents_to_dollars(cents) == expected

--- a/tests/components/amberelectric/test_sensor.py
+++ b/tests/components/amberelectric/test_sensor.py
@@ -16,11 +16,11 @@ async def test_general_price_sensor(
     assert len(hass.states.async_all()) == 6
     price = hass.states.get("sensor.mock_title_general_price")
     assert price
-    assert price.state == "0.09"
+    assert price.state == "0.088"
     attributes = price.attributes
     assert attributes["duration"] == 30
     assert attributes["date"] == "2021-09-21"
-    assert attributes["per_kwh"] == 0.09
+    assert attributes["per_kwh"] == 8.8 / 100
     assert attributes["nem_date"] == "2021-09-21T08:30:00+10:00"
     assert attributes["spot_per_kwh"] == 0.01
     assert attributes["start_time"] == "2021-09-21T08:00:00+10:00"
@@ -44,8 +44,8 @@ async def test_general_price_sensor_with_range(
     price = hass.states.get("sensor.mock_title_general_price")
     assert price
     attributes = price.attributes
-    assert attributes.get("range_min") == 0.07
-    assert attributes.get("range_max") == 0.09
+    assert attributes.get("range_min") == 6.7 / 100
+    assert attributes.get("range_max") == 9.1 / 100
 
 
 @pytest.mark.usefixtures("mock_amber_client_general_and_controlled_load")
@@ -58,11 +58,11 @@ async def test_general_and_controlled_load_price_sensor(
     assert len(hass.states.async_all()) == 9
     price = hass.states.get("sensor.mock_title_controlled_load_price")
     assert price
-    assert price.state == "0.04"
+    assert price.state == "0.044"
     attributes = price.attributes
     assert attributes["duration"] == 30
     assert attributes["date"] == "2021-09-21"
-    assert attributes["per_kwh"] == 0.04
+    assert attributes["per_kwh"] == 4.4 / 100
     assert attributes["nem_date"] == "2021-09-21T08:30:00+10:00"
     assert attributes["spot_per_kwh"] == 0.01
     assert attributes["start_time"] == "2021-09-21T08:00:00+10:00"
@@ -83,11 +83,11 @@ async def test_general_and_feed_in_price_sensor(
     assert len(hass.states.async_all()) == 9
     price = hass.states.get("sensor.mock_title_feed_in_price")
     assert price
-    assert price.state == "-0.01"
+    assert price.state == "-0.011"
     attributes = price.attributes
     assert attributes["duration"] == 30
     assert attributes["date"] == "2021-09-21"
-    assert attributes["per_kwh"] == -0.01
+    assert attributes["per_kwh"] == -1.1 / 100
     assert attributes["nem_date"] == "2021-09-21T08:30:00+10:00"
     assert attributes["spot_per_kwh"] == 0.01
     assert attributes["start_time"] == "2021-09-21T08:00:00+10:00"
@@ -108,7 +108,7 @@ async def test_general_forecast_sensor(
     assert len(hass.states.async_all()) == 6
     price = hass.states.get("sensor.mock_title_general_forecast")
     assert price
-    assert price.state == "0.09"
+    assert price.state == "0.088"
     attributes = price.attributes
     assert attributes["channel_type"] == "general"
     assert attributes["attribution"] == "Data provided by Amber Electric"
@@ -116,9 +116,9 @@ async def test_general_forecast_sensor(
     first_forecast = attributes["forecasts"][0]
     assert first_forecast["duration"] == 30
     assert first_forecast["date"] == "2021-09-21"
-    assert first_forecast["per_kwh"] == 0.09
+    assert first_forecast["per_kwh"] == 8.8 / 100
     assert first_forecast["nem_date"] == "2021-09-21T09:00:00+10:00"
-    assert first_forecast["spot_per_kwh"] == 0.01
+    assert first_forecast["spot_per_kwh"] == 1.1 / 100
     assert first_forecast["start_time"] == "2021-09-21T08:30:00+10:00"
     assert first_forecast["end_time"] == "2021-09-21T09:00:00+10:00"
     assert first_forecast["renewables"] == 50
@@ -140,8 +140,8 @@ async def test_general_forecast_sensor_with_range(
     assert price
     attributes = price.attributes
     first_forecast = attributes["forecasts"][0]
-    assert first_forecast.get("range_min") == 0.07
-    assert first_forecast.get("range_max") == 0.09
+    assert first_forecast.get("range_min") == 6.7 / 100
+    assert first_forecast.get("range_max") == 9.1 / 100
 
 
 @pytest.mark.usefixtures("mock_amber_client_general_and_controlled_load")
@@ -154,7 +154,7 @@ async def test_controlled_load_forecast_sensor(
     assert len(hass.states.async_all()) == 9
     price = hass.states.get("sensor.mock_title_controlled_load_forecast")
     assert price
-    assert price.state == "0.04"
+    assert price.state == "0.044"
     attributes = price.attributes
     assert attributes["channel_type"] == "controlledLoad"
     assert attributes["attribution"] == "Data provided by Amber Electric"
@@ -162,9 +162,9 @@ async def test_controlled_load_forecast_sensor(
     first_forecast = attributes["forecasts"][0]
     assert first_forecast["duration"] == 30
     assert first_forecast["date"] == "2021-09-21"
-    assert first_forecast["per_kwh"] == 0.04
+    assert first_forecast["per_kwh"] == 4.4 / 100
     assert first_forecast["nem_date"] == "2021-09-21T09:00:00+10:00"
-    assert first_forecast["spot_per_kwh"] == 0.01
+    assert first_forecast["spot_per_kwh"] == 1.1 / 100
     assert first_forecast["start_time"] == "2021-09-21T08:30:00+10:00"
     assert first_forecast["end_time"] == "2021-09-21T09:00:00+10:00"
     assert first_forecast["renewables"] == 50
@@ -181,7 +181,7 @@ async def test_feed_in_forecast_sensor(
     assert len(hass.states.async_all()) == 9
     price = hass.states.get("sensor.mock_title_feed_in_forecast")
     assert price
-    assert price.state == "-0.01"
+    assert price.state == "-0.011"
     attributes = price.attributes
     assert attributes["channel_type"] == "feedIn"
     assert attributes["attribution"] == "Data provided by Amber Electric"
@@ -189,9 +189,9 @@ async def test_feed_in_forecast_sensor(
     first_forecast = attributes["forecasts"][0]
     assert first_forecast["duration"] == 30
     assert first_forecast["date"] == "2021-09-21"
-    assert first_forecast["per_kwh"] == -0.01
+    assert first_forecast["per_kwh"] == -1.1 / 100
     assert first_forecast["nem_date"] == "2021-09-21T09:00:00+10:00"
-    assert first_forecast["spot_per_kwh"] == 0.01
+    assert first_forecast["spot_per_kwh"] == 1.1 / 100
     assert first_forecast["start_time"] == "2021-09-21T08:30:00+10:00"
     assert first_forecast["end_time"] == "2021-09-21T09:00:00+10:00"
     assert first_forecast["renewables"] == 50

--- a/tests/components/amberelectric/test_services.py
+++ b/tests/components/amberelectric/test_services.py
@@ -41,8 +41,8 @@ async def test_get_general_forecasts(
     assert first["duration"] == 30
     assert first["date"] == "2021-09-21"
     assert first["nem_date"] == "2021-09-21T09:00:00+10:00"
-    assert first["per_kwh"] == 0.09
-    assert first["spot_per_kwh"] == 0.01
+    assert first["per_kwh"] == 8.8 / 100
+    assert first["spot_per_kwh"] == 1.1 / 100
     assert first["start_time"] == "2021-09-21T08:30:00+10:00"
     assert first["end_time"] == "2021-09-21T09:00:00+10:00"
     assert first["renewables"] == 50
@@ -73,8 +73,8 @@ async def test_get_controlled_load_forecasts(
     assert first["duration"] == 30
     assert first["date"] == "2021-09-21"
     assert first["nem_date"] == "2021-09-21T09:00:00+10:00"
-    assert first["per_kwh"] == 0.04
-    assert first["spot_per_kwh"] == 0.01
+    assert first["per_kwh"] == 4.4 / 100
+    assert first["spot_per_kwh"] == 1.1 / 100
     assert first["start_time"] == "2021-09-21T08:30:00+10:00"
     assert first["end_time"] == "2021-09-21T09:00:00+10:00"
     assert first["renewables"] == 50
@@ -105,8 +105,8 @@ async def test_get_feed_in_forecasts(
     assert first["duration"] == 30
     assert first["date"] == "2021-09-21"
     assert first["nem_date"] == "2021-09-21T09:00:00+10:00"
-    assert first["per_kwh"] == -0.01
-    assert first["spot_per_kwh"] == 0.01
+    assert first["per_kwh"] == -1.1 / 100
+    assert first["spot_per_kwh"] == 1.1 / 100
     assert first["start_time"] == "2021-09-21T08:30:00+10:00"
     assert first["end_time"] == "2021-09-21T09:00:00+10:00"
     assert first["renewables"] == 50


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Amber reports prices in c/kWh with several decimal places. The integration converted them with `round(cents / 100, 2)`, so the native `$ / kWh` value only had cent precision.

That is enough to lose the sign of a feed-in price near zero. A raw `0.09619 c/kWh` export interval becomes `-0.0009619 $/kWh`, then `round(..., 2)` turns it into `-0.00` / `0.00`. Automations and optimisers then treat a small negative export price as free export.

`format_cents_to_dollars` is now a unit conversion only (`cents / 100`). Current price sensors, forecast sensors, and `amberelectric.get_forecasts` already share that helper, including range / spot / advanced-price fields. Feed-in sign handling is unchanged. Dashboard rounding stays a presentation concern; this only stops quantising the machine-readable value.

Existing fixtures such as `8.8 c/kWh` now expose `0.088` instead of `0.09`. Helper tests cover the near-zero collapse case.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181126
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
