### PR TITLE
Make backup util receive_file handle cancellations better

### DIFF
--- a/homeassistant/components/backup/util.py
+++ b/homeassistant/components/backup/util.py
@@ -557,4 +557,17 @@ async def receive_file(
         # task was cancelled.
         queue.put_nowait(None)
         if fut is not None:
-            await fut
+            # The executor thread can't be cancelled and is guaranteed to finish
+            # once it reads the sentinel queued above. Await it even if this task is
+            # cancelled: awaiting only through a shield keeps the executor future
+            # itself uncancelled, so the thread is fully done (file written and
+            # closed) before the caller cleans up. Re-raise any cancellation after.
+            cancelled: asyncio.CancelledError | None = None
+            while not fut.done():
+                try:
+                    await asyncio.shield(fut)
+                except asyncio.CancelledError as err:
+                    cancelled = err
+            if cancelled is not None:
+                raise cancelled
+            fut.result()

--- a/tests/components/backup/test_util.py
+++ b/tests/components/backup/test_util.py
@@ -7,6 +7,8 @@ import hashlib
 import os
 from pathlib import Path
 import tarfile
+import threading
+from typing import Self
 from unittest.mock import Mock, patch
 
 import nacl.bindings.crypto_secretstream as nss
@@ -869,3 +871,73 @@ async def test_receive_file_cancelled(hass: HomeAssistant, tmp_path: Path) -> No
     # The first chunk was flushed and the file closed before cancellation
     # completed, proving the consumer terminated rather than deadlocked.
     assert path.read_bytes() == b"chunk1"
+
+
+async def test_receive_file_cancelled_while_joining_writer(
+    hass: HomeAssistant, tmp_path: Path
+) -> None:
+    """Test a cancel while joining the writer waits for the writer to finish.
+
+    A cancellation delivered while receive_file is awaiting the executor writer
+    (the whole upload already streamed, sentinel queued) must not return until the
+    writer thread has finished, so a caller's cleanup cannot race the writer.
+    """
+    path = tmp_path / "received.bin"
+    writing_started = asyncio.Event()
+    release_writer = threading.Event()  # blocks the writer thread mid-write
+    writes: list[bytes] = []
+    blocked_once = False
+
+    class _BlockingHandle:
+        """A file handle whose first write parks the writer thread until released."""
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *exc: object) -> bool:
+            return False
+
+        def write(self, data: bytes) -> int:
+            nonlocal blocked_once
+            if not blocked_once:
+                blocked_once = True
+                hass.loop.call_soon_threadsafe(writing_started.set)
+                release_writer.wait()
+            writes.append(bytes(data))
+            return len(data)
+
+    real_open = Path.open
+
+    def _blocking_open(self: Path, *args: object, **kwargs: object) -> object:
+        if self != path:
+            return real_open(self, *args, **kwargs)
+        return _BlockingHandle()
+
+    with patch.object(Path, "open", _blocking_open):
+        task = asyncio.create_task(
+            receive_file(hass, _stream_chunks([b"chunk1", b"chunk2"]), path)
+        )
+        try:
+            # The writer thread is now blocked on its first write, so the receive
+            # task has queued every chunk plus the sentinel and is parked at the
+            # join; let it settle there so the cancel lands on the join.
+            await writing_started.wait()
+            for _ in range(3):
+                await asyncio.sleep(0)
+            task.cancel()
+            for _ in range(10):
+                await asyncio.sleep(0)
+            # Without the cancellation-safe join the task would finish here
+            # (returning while the writer thread runs on); the fix keeps it waiting.
+            assert not task.done()
+        finally:
+            # Always release the writer so a failed assertion can't leak the blocked
+            # thread and hang teardown.
+            release_writer.set()
+        _done, pending = await asyncio.wait({task}, timeout=_RECEIVE_FILE_TIMEOUT)
+
+    assert not pending
+    with pytest.raises(asyncio.CancelledError):
+        task.result()
+    # The writer finished writing both chunks before the cancellation propagated.
+    assert b"".join(writes) == b"chunk1chunk2"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make backup util `receive_file` handle cancellations better

Same fix as in https://github.com/home-assistant/core/pull/181163

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
