### PR TITLE
Use discovery result in Midea for reconfigure flow

### DIFF
--- a/homeassistant/components/midea/config_flow.py
+++ b/homeassistant/components/midea/config_flow.py
@@ -730,14 +730,16 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                     list(self.supports.keys()), ip_address=user_input[CONF_IP_ADDRESS]
                 ),
             )
+            entry_device_id = entry.data[CONF_DEVICE_ID]
+            device = devices.get(entry_device_id)
             if len(devices) == 0:
                 error = "invalid_device_ip"
-            elif entry.data[CONF_DEVICE_ID] not in devices:
+            elif device is None:
                 error = "invalid_device_id_for_ip"
             else:
                 return self.async_update_reload_and_abort(
                     entry,
-                    data_updates={CONF_IP_ADDRESS: user_input[CONF_IP_ADDRESS]},
+                    data_updates={CONF_IP_ADDRESS: device.get(CONF_IP_ADDRESS)},
                 )
         return self.async_show_form(
             step_id="reconfigure",

--- a/tests/components/midea/test_config_flow.py
+++ b/tests/components/midea/test_config_flow.py
@@ -2044,7 +2044,8 @@ async def _assert_reconfigure_success(
     """Assert reconfigure success."""
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
-
+    discovery_result = DISCOVERY_RESULT
+    discovery_result[TEST_DEVICE_ID][CONF_IP_ADDRESS] = "8.8.8.8"
     with (
         patch(
             "homeassistant.components.midea.config_flow.discover",

--- a/tests/components/midea/test_config_flow.py
+++ b/tests/components/midea/test_config_flow.py
@@ -2049,7 +2049,7 @@ async def _assert_reconfigure_success(
     with (
         patch(
             "homeassistant.components.midea.config_flow.discover",
-            return_value=DISCOVERY_RESULT,
+            return_value=discovery_result,
         ) as mock_discovery,
         patch(
             "homeassistant.components.midea.config_flow.device_selector",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Instead of using the user input to reconfigure this will use the discovery result IP to reconfigure the device.

Follow up this copilot review: https://github.com/home-assistant/core/pull/180878#pullrequestreview-5100606883

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
