### PR TITLE
Fix host override ignored in UniFi Protect public-only mode

### DIFF
--- a/homeassistant/components/unifiprotect/utils.py
+++ b/homeassistant/components/unifiprotect/utils.py
@@ -134,6 +134,7 @@ def async_create_api_client(
             public_api_session=async_create_clientsession(hass),
             devices_ws_subscribed_models=DEVICES_WS_SUBSCRIBED_MODELS,
             ignore_unadopted=False,
+            override_connection_host=entry.options.get(CONF_OVERRIDE_CHOST, False),
         )
 
     return _async_create_full_client(hass, entry)

--- a/tests/components/unifiprotect/test_utils.py
+++ b/tests/components/unifiprotect/test_utils.py
@@ -1,14 +1,30 @@
 """Test the UniFi Protect utils."""
 
+import pytest
+
 from homeassistant.components.unifiprotect.const import (
     CONF_CONNECTION_MODE,
+    CONF_OVERRIDE_CHOST,
     CONNECTION_MODE_API_KEY_ONLY,
+    DOMAIN,
 )
-from homeassistant.components.unifiprotect.utils import async_create_session_client
-from homeassistant.const import CONF_PASSWORD
+from homeassistant.components.unifiprotect.utils import (
+    async_create_api_client,
+    async_create_session_client,
+)
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
 from homeassistant.core import HomeAssistant
 
 from .utils import MockUFPFixture
+
+from tests.common import MockConfigEntry
 
 
 async def test_session_client_is_full_access_for_api_key_only_entry(
@@ -41,3 +57,42 @@ async def test_session_client_none_without_credentials(
     )
 
     assert async_create_session_client(hass, ufp.entry) is None
+
+
+@pytest.mark.parametrize(
+    ("connection_mode", "public_only"),
+    [
+        pytest.param({}, False, id="hybrid"),
+        pytest.param(
+            {CONF_CONNECTION_MODE: CONNECTION_MODE_API_KEY_ONLY}, True, id="public_only"
+        ),
+    ],
+)
+async def test_host_override_reaches_the_client(
+    hass: HomeAssistant, connection_mode: dict[str, str], public_only: bool
+) -> None:
+    """The host override option has to reach the client in both modes.
+
+    The library rewrites the host of the public RTSPS URLs only when the
+    client carries the flag, and a public-only entry has no other stream
+    source to fall back on.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "1.1.1.1",
+            CONF_PORT: 443,
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "test-password",
+            CONF_API_KEY: "test-api-key",
+            CONF_VERIFY_SSL: False,
+            **connection_mode,
+        },
+        options={CONF_OVERRIDE_CHOST: True},
+    )
+    entry.add_to_hass(hass)
+
+    protect = async_create_api_client(hass, entry)
+
+    assert protect.is_public_only is public_only
+    assert protect.override_connection_host is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Pass the "Override connection host" option to the API-key-only client. The full-access client already carries it; the public-only client was created without it, so the option was silently ignored in that mode and the library never rewrote the host of the public RTSPS stream URLs. A public-only entry has no other stream source to fall back on.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176487
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
