### PR TITLE
Fall back to default mireds for zeroed Hue group color temp schemas

### DIFF
--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -35,6 +35,7 @@ from .helpers import (
     normalize_hue_colortemp,
     normalize_hue_transition,
 )
+from .light import FALLBACK_MAX_MIREDS, FALLBACK_MIN_MIREDS
 
 
 async def async_setup_entry(
@@ -264,22 +265,19 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
                     if color_temp.mirek
                     else None
                 )
+                # lights may report a zeroed schema, fall back to the Hue defaults
                 self._attr_min_color_temp_kelvin = (
                     color_util.color_temperature_mired_to_kelvin(
-                        color_temp.mirek_schema.mirek_maximum
+                        color_temp.mirek_schema.mirek_maximum or FALLBACK_MAX_MIREDS
                     )
                 )
                 self._attr_max_color_temp_kelvin = (
                     color_util.color_temperature_mired_to_kelvin(
-                        color_temp.mirek_schema.mirek_minimum
+                        color_temp.mirek_schema.mirek_minimum or FALLBACK_MIN_MIREDS
                     )
                 )
                 # counters for color mode vote and average temp
-                if (
-                    light.on.on
-                    and color_temp.mirek is not None
-                    and color_temp.mirek_valid
-                ):
+                if light.on.on and color_temp.mirek and color_temp.mirek_valid:
                     lights_in_colortemp_mode += 1
                     light_in_colortemp_mode = True
                     temp_total += color_util.color_temperature_mired_to_kelvin(

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -155,7 +155,8 @@ class HueLight(HueBaseEntity, LightEntity):
     def color_temp_active(self) -> bool:
         """Return if the light is in Color Temperature mode."""
         color_temp = self.resource.color_temperature
-        if color_temp is None or color_temp.mirek is None:
+        # a zero mirek is not a valid color temperature either
+        if color_temp is None or not color_temp.mirek:
             return False
         # Official Hue lights return `mirek_valid` to indicate CT is active
         # while non-official lights do not.

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -1065,12 +1065,17 @@ async def test_light_with_zero_mirek(
 ) -> None:
     """Test lights don't crash when the bridge reports zero mirek values.
 
+    A light may report both a zeroed mirek schema and a zeroed current mirek,
+    each of which used to reach a mired -> kelvin conversion unguarded.
+
     Regression test for https://github.com/home-assistant/core/issues/116258
     and https://github.com/home-assistant/core/issues/181168
     """
     # Patch the fixture data to have zero mirek values before loading
     for resource in v2_resources_test_data:
         if resource.get("type") == "light" and "color_temperature" in resource:
+            resource["color_temperature"]["mirek"] = 0
+            resource["color_temperature"]["mirek_valid"] = True
             resource["color_temperature"]["mirek_schema"]["mirek_minimum"] = 0
             resource["color_temperature"]["mirek_schema"]["mirek_maximum"] = 0
 
@@ -1084,3 +1089,5 @@ async def test_light_with_zero_mirek(
     # Should fall back to defaults instead of crashing
     assert test_light.attributes["max_color_temp_kelvin"] == 6535
     assert test_light.attributes["min_color_temp_kelvin"] == 2000
+    # A zeroed mirek is not a usable color temperature, so it is not reported
+    assert test_light.attributes["color_temp_kelvin"] is None

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import Mock
 
+import pytest
+
 from homeassistant.components.light import (
     ATTR_EFFECT,
     DOMAIN as LIGHT_DOMAIN,
@@ -1048,26 +1050,36 @@ async def test_light_turn_on_service_deprecation(
     assert mock_bridge_v2.mock_requests[0]["json"]["effects"]["effect"] == "no_effect"
 
 
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        pytest.param("light.hue_light_with_color_and_color_temperature_1", id="light"),
+        pytest.param("light.test_zone", id="grouped_light"),
+    ],
+)
 async def test_light_with_zero_mirek(
-    hass: HomeAssistant, mock_bridge_v2: Mock, v2_resources_test_data: JsonArrayType
+    hass: HomeAssistant,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+    entity_id: str,
 ) -> None:
-    """Test light doesn't crash when bridge reports zero mirek values.
+    """Test lights don't crash when the bridge reports zero mirek values.
 
     Regression test for https://github.com/home-assistant/core/issues/116258
+    and https://github.com/home-assistant/core/issues/181168
     """
     # Patch the fixture data to have zero mirek values before loading
     for resource in v2_resources_test_data:
         if resource.get("type") == "light" and "color_temperature" in resource:
             resource["color_temperature"]["mirek_schema"]["mirek_minimum"] = 0
             resource["color_temperature"]["mirek_schema"]["mirek_maximum"] = 0
-            break
 
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
 
     # Should not raise ZeroDivisionError during setup
     await setup_platform(hass, mock_bridge_v2, Platform.LIGHT)
 
-    test_light = hass.states.get("light.hue_light_with_color_and_color_temperature_1")
+    test_light = hass.states.get(entity_id)
     assert test_light is not None
     # Should fall back to defaults instead of crashing
     assert test_light.attributes["max_color_temp_kelvin"] == 6535


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change

A Hue light can report a `mirek_schema` with `mirek_minimum`/`mirek_maximum` set to `0`. `GroupedHueLight._update_values` passes those straight into `color_temperature_mired_to_kelvin`, which raises `ZeroDivisionError`. The exception escapes through the aiohue event callback, so once it starts it repeats on every event until the integration is reloaded:

```
File "homeassistant/components/hue/v2/group.py", line 273, in _update_values
    color_util.color_temperature_mired_to_kelvin(
        color_temp.mirek_schema.mirek_minimum
    )
File "homeassistant/util/color.py", line 631, in color_temperature_mired_to_kelvin
    return math.floor(1000000 / mired_temperature)
ZeroDivisionError: division by zero
```

Individual lights already guard against this and fall back to the Hue defaults (`FALLBACK_MIN_MIREDS` / `FALLBACK_MAX_MIREDS`), added in #116258 — the grouped light path was missed. This applies the same fallback there, so a group containing such a light reports the default bounds instead of crashing.

A light can also report a zeroed *current* `mirek` alongside the zeroed schema, which is a second unguarded conversion. `HueLight.color_temp_active` only rejected `mirek is None`, so a `0` made the light report `ColorMode.COLOR_TEMP`, and reading the `color_temp_kelvin` attribute then divided by zero in `state_attributes`. It now rejects any falsy mirek, which is consistent with `max_color_temp_mireds` / `min_color_temp_mireds` right below it. The `mirek` accumulator in the group loop is switched from `is not None` to a truthiness check for the same reason.

The existing `test_light_with_zero_mirek` is parametrized to cover the grouped light as well as the individual light, and now zeroes the current `mirek` in addition to the schema. Each guard was verified to be load-bearing by reverting it individually and confirming the corresponding case fails with a `ZeroDivisionError`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #181168
- This PR is related to issue: #116258
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
