### PR TITLE
Fix ZeroDivisionError in Hue grouped lights with invalid mirek schema

### DIFF
--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -57,6 +57,10 @@ DEFAULT_ROTARY_EVENT_SUBTYPES = (
     RelativeRotaryDirection.COUNTER_CLOCK_WISE,
 )
 
+FALLBACK_MIN_MIREDS = 153  # hue default for most lights
+FALLBACK_MAX_MIREDS = 500  # hue default for most lights
+FALLBACK_KELVIN = 5800  # halfway
+
 DEVICE_SPECIFIC_EVENT_TYPES = {
     # device specific overrides of specific supported button events
     "Hue tap switch": (ButtonEvent.INITIAL_PRESS,),

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -264,7 +264,6 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
                     if color_temp.mirek
                     else None
                 )
-                # fall back to the hue defaults if the light reports invalid limits
                 self._attr_min_color_temp_kelvin = (
                     color_util.color_temperature_mired_to_kelvin(
                         color_temp.mirek_schema.mirek_maximum or FALLBACK_MAX_MIREDS

--- a/homeassistant/components/hue/v2/group.py
+++ b/homeassistant/components/hue/v2/group.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import color as color_util
 
 from ..bridge import HueBridge, HueConfigEntry
-from ..const import DOMAIN
+from ..const import DOMAIN, FALLBACK_MAX_MIREDS, FALLBACK_MIN_MIREDS
 from .entity import HueBaseEntity
 from .helpers import (
     normalize_hue_brightness,
@@ -264,14 +264,15 @@ class GroupedHueLight(HueBaseEntity, LightEntity):
                     if color_temp.mirek
                     else None
                 )
+                # fall back to the hue defaults if the light reports invalid limits
                 self._attr_min_color_temp_kelvin = (
                     color_util.color_temperature_mired_to_kelvin(
-                        color_temp.mirek_schema.mirek_maximum
+                        color_temp.mirek_schema.mirek_maximum or FALLBACK_MAX_MIREDS
                     )
                 )
                 self._attr_max_color_temp_kelvin = (
                     color_util.color_temperature_mired_to_kelvin(
-                        color_temp.mirek_schema.mirek_minimum
+                        color_temp.mirek_schema.mirek_minimum or FALLBACK_MIN_MIREDS
                     )
                 )
                 # counters for color mode vote and average temp

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -30,17 +30,13 @@ from homeassistant.helpers.issue_registry import IssueSeverity, async_create_iss
 from homeassistant.util import color as color_util
 
 from ..bridge import HueBridge, HueConfigEntry
-from ..const import DOMAIN
+from ..const import DOMAIN, FALLBACK_KELVIN, FALLBACK_MAX_MIREDS, FALLBACK_MIN_MIREDS
 from .entity import HueBaseEntity
 from .helpers import (
     normalize_hue_brightness,
     normalize_hue_colortemp,
     normalize_hue_transition,
 )
-
-FALLBACK_MIN_MIREDS = 153  # hue default for most lights
-FALLBACK_MAX_MIREDS = 500  # hue default for most lights
-FALLBACK_KELVIN = 5800  # halfway
 
 # HA 2025.4 replaced the deprecated effect "None" with HA default "off"
 DEPRECATED_EFFECT_NONE = "None"

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -1072,3 +1072,27 @@ async def test_light_with_zero_mirek(
     # Should fall back to defaults instead of crashing
     assert test_light.attributes["max_color_temp_kelvin"] == 6535
     assert test_light.attributes["min_color_temp_kelvin"] == 2000
+
+
+async def test_grouped_light_with_zero_mirek(
+    hass: HomeAssistant, mock_bridge_v2: Mock, v2_resources_test_data: JsonArrayType
+) -> None:
+    """Test grouped light doesn't crash when bridge reports zero mirek values.
+
+    Regression test for https://github.com/home-assistant/core/issues/181168
+    """
+    for resource in v2_resources_test_data:
+        if resource.get("type") == "light" and "color_temperature" in resource:
+            resource["color_temperature"]["mirek_schema"]["mirek_minimum"] = 0
+            resource["color_temperature"]["mirek_schema"]["mirek_maximum"] = 0
+
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+
+    # Should not raise ZeroDivisionError while aggregating the group values
+    await setup_platform(hass, mock_bridge_v2, Platform.LIGHT)
+
+    test_entity = hass.states.get("light.test_zone")
+    assert test_entity is not None
+    # Should fall back to defaults instead of crashing
+    assert test_entity.attributes["max_color_temp_kelvin"] == 6535
+    assert test_entity.attributes["min_color_temp_kelvin"] == 2000

--- a/tests/components/hue/test_light_v2.py
+++ b/tests/components/hue/test_light_v2.py
@@ -1,5 +1,6 @@
 """Philips Hue lights platform tests for V2 bridge/api."""
 
+from copy import deepcopy
 from unittest.mock import Mock
 
 from homeassistant.components.light import (
@@ -1055,14 +1056,15 @@ async def test_light_with_zero_mirek(
 
     Regression test for https://github.com/home-assistant/core/issues/116258
     """
-    # Patch the fixture data to have zero mirek values before loading
-    for resource in v2_resources_test_data:
+    # the fixture is package scoped, so patch a copy to not affect other tests
+    test_data = deepcopy(v2_resources_test_data)
+    for resource in test_data:
         if resource.get("type") == "light" and "color_temperature" in resource:
             resource["color_temperature"]["mirek_schema"]["mirek_minimum"] = 0
             resource["color_temperature"]["mirek_schema"]["mirek_maximum"] = 0
             break
 
-    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+    await mock_bridge_v2.api.load_test_data(test_data)
 
     # Should not raise ZeroDivisionError during setup
     await setup_platform(hass, mock_bridge_v2, Platform.LIGHT)
@@ -1081,12 +1083,14 @@ async def test_grouped_light_with_zero_mirek(
 
     Regression test for https://github.com/home-assistant/core/issues/181168
     """
-    for resource in v2_resources_test_data:
+    # the fixture is package scoped, so patch a copy to not affect other tests
+    test_data = deepcopy(v2_resources_test_data)
+    for resource in test_data:
         if resource.get("type") == "light" and "color_temperature" in resource:
             resource["color_temperature"]["mirek_schema"]["mirek_minimum"] = 0
             resource["color_temperature"]["mirek_schema"]["mirek_maximum"] = 0
 
-    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+    await mock_bridge_v2.api.load_test_data(test_data)
 
     # Should not raise ZeroDivisionError while aggregating the group values
     await setup_platform(hass, mock_bridge_v2, Platform.LIGHT)


### PR DESCRIPTION
## Breaking change

<!-- Not a breaking change. -->

## Proposed change

Some Hue lights report a `mirek_schema` where `mirek_minimum` / `mirek_maximum` are `0`. `GroupedHueLight._update_values()` fed those values straight into `color_temperature_mired_to_kelvin()`, which does `math.floor(1000000 / mired_temperature)` and raises `ZeroDivisionError`.

Because `_update_values()` runs from `on_update()` on every event for the group, one bad light means the error repeats in the log until the integration is reloaded:

```
File "homeassistant/components/hue/v2/group.py", line 273, in _update_values
    color_util.color_temperature_mired_to_kelvin(
        color_temp.mirek_schema.mirek_minimum
    )
File "homeassistant/util/color.py", line 631, in color_temperature_mired_to_kelvin
    return math.floor(1000000 / mired_temperature)
ZeroDivisionError: division by zero
```

`HueLight` already handles this for individual lights — `min_color_temp_mireds` / `max_color_temp_mireds` fall back to `FALLBACK_MIN_MIREDS` / `FALLBACK_MAX_MIREDS` (added in #116258). The grouped light path never got the same treatment.

This PR moves those fallback constants from `v2/light.py` to `const.py` so both modules can share them, and applies the same fallback in `GroupedHueLight._update_values()`.

A regression test is added that patches the v2 fixture data so every light reports a zero mirek schema, and asserts the grouped light entity is still created with the fallback limits. Without the fix it fails with the exact `ZeroDivisionError` from the issue.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #181168
- This PR is related to issue: #116258 (same class of bug, fixed for single lights)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---

Opened as a draft: per the [AI policy](https://developers.home-assistant.io/docs/ai_policy) the checklist boxes about understanding the code are for the human contributor to tick after reviewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtCAugyYWB8vgrzZRd3a7R

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtCAugyYWB8vgrzZRd3a7R)_