### PR TITLE
Return 400 instead of 500 for an invalid config flow type filter

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -4,7 +4,7 @@ from asyncio import shield
 from collections.abc import Callable
 from http import HTTPStatus
 import logging
-from typing import Any, NoReturn, override
+from typing import Any, NoReturn, get_args, override
 
 from aiohttp import web
 import aiohttp.web_exceptions
@@ -30,6 +30,7 @@ from homeassistant.helpers.json import (
     json_fragment,
 )
 from homeassistant.loader import (
+    ConfigFlowTypeFilter,
     Integration,
     IntegrationNotFound,
     async_get_config_flows,
@@ -39,6 +40,8 @@ from homeassistant.loader import (
 from homeassistant.util.json import format_unserializable_data
 
 _LOGGER = logging.getLogger(__name__)
+
+VALID_FLOW_TYPE_FILTERS = frozenset(get_args(ConfigFlowTypeFilter))
 
 
 @callback
@@ -269,8 +272,13 @@ class ConfigManagerAvailableFlowView(HomeAssistantView):
         """List available flow handlers."""
         hass = request.app[KEY_HASS]
         kwargs: dict[str, Any] = {}
-        if "type" in request.query:
-            kwargs["type_filter"] = request.query["type"]
+        if (type_filter := request.query.get("type")) is not None:
+            if type_filter not in VALID_FLOW_TYPE_FILTERS:
+                return self.json_message(
+                    f"Invalid type filter specified: {type_filter}",
+                    HTTPStatus.BAD_REQUEST,
+                )
+            kwargs["type_filter"] = type_filter
         return self.json(await async_get_config_flows(hass, **kwargs))
 
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -352,7 +352,7 @@ async def async_get_custom_components(
     return comps_or_future
 
 
-ConfigFlowTypeFilter = Literal["device", "helper", "hub", "integration", "service"]
+ConfigFlowTypeFilter = Literal["helper", "integration"]
 
 
 async def async_get_config_flows(
@@ -364,9 +364,7 @@ async def async_get_config_flows(
     flows: set[str] = set()
 
     if type_filter is not None:
-        # FLOWS only buckets built-in flows as "helper" or "integration"; the more
-        # specific types only ever match custom integrations below.
-        flows.update(FLOWS.get(type_filter, []))
+        flows.update(FLOWS[type_filter])
     else:
         for type_flows in FLOWS.values():
             flows.update(type_flows)

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -369,12 +369,14 @@ async def async_get_config_flows(
         for type_flows in FLOWS.values():
             flows.update(type_flows)
 
-    flows.update(
-        integration.domain
-        for integration in integrations.values()
-        if integration.config_flow
-        and (type_filter is None or integration.integration_type == type_filter)
-    )
+    for integration in integrations.values():
+        if not integration.config_flow:
+            continue
+        # custom integrations report a finer grained integration_type than the
+        # two buckets hassfest generates FLOWS with, so map it the same way
+        bucket = "helper" if integration.integration_type == "helper" else "integration"
+        if type_filter is None or bucket == type_filter:
+            flows.add(integration.domain)
 
     return flows
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -370,6 +370,8 @@ async def async_get_config_flows(
             flows.update(type_flows)
 
     for integration in integrations.values():
+        # the custom integration replaces the built-in one with the same domain
+        flows.discard(integration.domain)
         if not integration.config_flow:
             continue
         # custom integrations report a finer grained integration_type than the

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -352,16 +352,21 @@ async def async_get_custom_components(
     return comps_or_future
 
 
+ConfigFlowTypeFilter = Literal["device", "helper", "hub", "integration", "service"]
+
+
 async def async_get_config_flows(
     hass: HomeAssistant,
-    type_filter: Literal["device", "helper", "hub", "service"] | None = None,
+    type_filter: ConfigFlowTypeFilter | None = None,
 ) -> set[str]:
     """Return cached list of config flows."""
     integrations = await async_get_custom_components(hass)
     flows: set[str] = set()
 
     if type_filter is not None:
-        flows.update(FLOWS[type_filter])
+        # FLOWS only buckets built-in flows as "helper" or "integration"; the more
+        # specific types only ever match custom integrations below.
+        flows.update(FLOWS.get(type_filter, []))
     else:
         for type_flows in FLOWS.values():
             flows.update(type_flows)

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -425,6 +425,10 @@ async def test_reload_entry_in_setup_retry(
         (None, {"hello", "another", "world"}),
         ("integration", {"hello", "another"}),
         ("helper", {"world"}),
+        # FLOWS has no bucket for these, so only custom integrations can match
+        ("device", set()),
+        ("hub", set()),
+        ("service", set()),
     ],
 )
 async def test_available_flows(
@@ -443,6 +447,29 @@ async def test_available_flows(
         assert resp.status == HTTPStatus.OK
         data = await resp.json()
         assert set(data) == result
+
+
+@pytest.mark.parametrize(
+    "type_filter",
+    [
+        # the frontend sends an array of types joined into a single value
+        "device,hub,service",
+        "not_a_type",
+        "",
+    ],
+)
+async def test_available_flows_invalid_type(
+    client: TestClient, type_filter: str
+) -> None:
+    """Test an unknown type filter is rejected instead of raising.
+
+    Regression test for https://github.com/home-assistant/core/issues/176851
+    """
+    resp = await client.get(
+        "/api/config/config_entries/flow_handlers",
+        params={"type": type_filter},
+    )
+    assert resp.status == HTTPStatus.BAD_REQUEST
 
 
 ############################

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -425,10 +425,6 @@ async def test_reload_entry_in_setup_retry(
         (None, {"hello", "another", "world"}),
         ("integration", {"hello", "another"}),
         ("helper", {"world"}),
-        # FLOWS has no bucket for these, so only custom integrations can match
-        ("device", set()),
-        ("hub", set()),
-        ("service", set()),
     ],
 )
 async def test_available_flows(
@@ -454,6 +450,10 @@ async def test_available_flows(
     [
         # the frontend sends an array of types joined into a single value
         "device,hub,service",
+        # not flow discovery buckets, FLOWS only has "helper" and "integration"
+        "device",
+        "hub",
+        "service",
         "not_a_type",
         "",
     ],

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -922,6 +922,38 @@ async def test_get_config_flows_type_filter(
         assert await loader.async_get_config_flows(hass, type_filter) == expected
 
 
+async def test_get_config_flows_custom_overrides_core(hass: HomeAssistant) -> None:
+    """Verify a custom integration replaces the built-in flow it shadows.
+
+    The custom integration is the one that gets loaded, so the built-in flow it
+    overrides must not stay behind in its original bucket.
+    """
+    # shadows a core helper domain, but reports itself as a hub
+    shadowing_hub = _get_test_integration(hass, "core_helper", True)
+    # shadows a core integration domain and has no config flow at all
+    shadowing_without_flow = _get_test_integration(hass, "core_integration", False)
+
+    with (
+        patch("homeassistant.loader.async_get_custom_components") as mock_get,
+        patch.object(
+            loader,
+            "FLOWS",
+            {"integration": ["core_integration"], "helper": ["core_helper"]},
+        ),
+    ):
+        mock_get.return_value = {
+            "core_helper": shadowing_hub,
+            "core_integration": shadowing_without_flow,
+        }
+        # the shadowed helper moved to the integration bucket, it is not in both
+        assert await loader.async_get_config_flows(hass, "helper") == set()
+        assert await loader.async_get_config_flows(hass, "integration") == {
+            "core_helper"
+        }
+        # the override without a config flow no longer exposes the built-in one
+        assert await loader.async_get_config_flows(hass) == {"core_helper"}
+
+
 async def test_get_zeroconf(hass: HomeAssistant) -> None:
     """Verify that custom components with zeroconf are found."""
     test_1_integration = _get_test_integration(hass, "test_1", True)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -876,6 +876,52 @@ async def test_get_config_flows(hass: HomeAssistant) -> None:
         assert "test_1" not in flows
 
 
+@pytest.mark.parametrize(
+    ("type_filter", "expected"),
+    [
+        (None, {"core_helper", "core_integration", "custom_helper", "custom_hub"}),
+        ("integration", {"core_integration", "custom_hub"}),
+        ("helper", {"core_helper", "custom_helper"}),
+    ],
+)
+async def test_get_config_flows_type_filter(
+    hass: HomeAssistant, type_filter: str | None, expected: set[str]
+) -> None:
+    """Verify custom integrations are bucketed like the generated flows.
+
+    Custom integrations report integration types such as "hub", which must map
+    onto the "integration" bucket the way hassfest generates FLOWS.
+    """
+    custom_hub = _get_test_integration(hass, "custom_hub", True)
+    custom_helper = loader.Integration(
+        hass,
+        "homeassistant.components.custom_helper",
+        None,
+        {
+            "name": "custom_helper",
+            "domain": "custom_helper",
+            "config_flow": True,
+            "integration_type": "helper",
+            "dependencies": [],
+            "requirements": [],
+        },
+    )
+
+    with (
+        patch("homeassistant.loader.async_get_custom_components") as mock_get,
+        patch.object(
+            loader,
+            "FLOWS",
+            {"integration": ["core_integration"], "helper": ["core_helper"]},
+        ),
+    ):
+        mock_get.return_value = {
+            "custom_hub": custom_hub,
+            "custom_helper": custom_helper,
+        }
+        assert await loader.async_get_config_flows(hass, type_filter) == expected
+
+
 async def test_get_zeroconf(hass: HomeAssistant) -> None:
     """Verify that custom components with zeroconf are found."""
     test_1_integration = _get_test_integration(hass, "test_1", True)


### PR DESCRIPTION
## Breaking change

<!-- Not a breaking change. -->

## Proposed change

`ConfigManagerAvailableFlowView.get()` passed the raw `type` query parameter straight into `async_get_config_flows()`, which looked it up in `FLOWS` with a direct dict access:

```py
if type_filter is not None:
    flows.update(FLOWS[type_filter])   # KeyError
```

`FLOWS` is only keyed by `"helper"` and `"integration"`, so any other value raises `KeyError` and the request fails with a 500 — including the comma joined `"device,hub,service"` the frontend produces by interpolating an array into the query string:

```
File "homeassistant/components/config/config_entries.py", line 259, in get
    return self.json(await async_get_config_flows(hass, **kwargs))
File "homeassistant/loader.py", line 364, in async_get_config_flows
    flows.update(FLOWS[type_filter])
KeyError: 'device,hub,service'
```

The `type_filter` annotation claimed `Literal["device", "helper", "hub", "service"]`, but config flow discovery has never had those buckets. `FLOWS`, `generated/integrations.json` and `async_get_integration_descriptions()` all bucket flows as only `"integration"` or `"helper"`, and hassfest generates `FLOWS` by putting `IntegrationType.HELPER` in `helper` and everything else in `integration`. So `?type=device`, `?type=hub` and `?type=service` were each a 500 too, despite being the documented values.

### The fix

1. Correct the annotation to `Literal["helper", "integration"]` — the buckets that actually exist — and export it as `ConfigFlowTypeFilter`.
2. Validate the `type` query parameter in the view against that set and return a 400 for anything else, instead of letting an unvalidated parameter reach a raw dict lookup.

`FLOWS[type_filter]` is then left as a direct lookup: with the annotation matching the real keys it is correct by construction, and a contract violation should surface rather than be masked.

### Follow-on corrections in `async_get_config_flows()`

Narrowing the filter to the two real buckets exposed two problems in how custom integrations are matched, both fixed here:

3. Custom integrations report a finer grained `integration_type` (`hub`, `device`, `service`, …), so comparing it directly against the filter meant `"integration"` never matched any of them and `?type=integration` silently dropped every custom config flow. They are now mapped onto the two buckets the same way hassfest does. This was already true before this PR, but it matters now that `?type=integration` is the filter the frontend should use.
4. Built-in flows shadowed by a custom integration of the same domain stayed behind in their original bucket, so a custom hub overriding a built-in helper came back under *both* filters, and an override without a config flow left the built-in flow exposed. The shadowed domain is now discarded first, the same way `async_get_integration_descriptions()` already does.

Point 4's first half is a consequence of point 3; its second half and point 3 itself predate this PR.

Tests cover a 400 for the combined value from the issue, for each of `device` / `hub` / `service`, and for an unknown or empty value; plus parametrized loader tests for built-in and custom flows in both buckets, and for a custom integration overriding a built-in domain. They fail on `dev`.

### Scope

This is the backend half. The frontend also needs `getConfigFlowHandlers()` to stop joining its type array into one value — with this PR the correct single request is `?type=integration`, matching how `async_get_integration_descriptions()` already buckets things, and it now returns custom integrations too. Until that lands the UI flow in #176851 stays broken, so this is linked as *related to* rather than closing it.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #176851
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---

Note: the first commit message says "Fixes #176851"; the link is intentionally downgraded to *related to* here, since this backend-only change does not resolve the reported UI flow on its own.

Opened as a draft: per the [AI policy](https://developers.home-assistant.io/docs/ai_policy) the checklist boxes about understanding the code are for the human contributor to tick after reviewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtCAugyYWB8vgrzZRd3a7R