### PR TITLE
Fix duplicate first day of month statistics in Suez Water

### DIFF
--- a/homeassistant/components/suez_water/coordinator.py
+++ b/homeassistant/components/suez_water/coordinator.py
@@ -177,14 +177,25 @@ class SuezWaterCoordinator(DataUpdateCoordinator[SuezWaterData]):
         """Build statistics data from fetched data."""
         consumption_statistics = []
         cost_statistics = []
+        seen_dates: dict[date, float] = {}
 
         for data in usage:
-            if (
-                (last_stats is not None and data.date <= last_stats)
-                or not data.index
-                or data.volume is None
-            ):
+            if last_stats is not None and data.date <= last_stats:
                 continue
+            if not data.index or data.volume is None:
+                continue
+            if data.date in seen_dates:
+                if seen_dates[data.date] != data.volume:
+                    _LOGGER.warning(
+                        "Duplicate date %s with different volume: %.2f L vs %.2f L - keeping first value",
+                        data.date,
+                        seen_dates[data.date],
+                        data.volume,
+                    )
+                else:
+                    _LOGGER.debug("Skipping duplicate date: %s", data.date)
+                continue
+            seen_dates[data.date] = data.volume
             consumption_date = dt_util.start_of_local_day(data.date)
 
             consumption_sum += data.volume

--- a/tests/components/suez_water/test_init.py
+++ b/tests/components/suez_water/test_init.py
@@ -299,3 +299,83 @@ async def test_migration_version_1_to_2(
     assert past_entry.unique_id == MOCK_DATA[CONF_COUNTER_ID]
     assert past_entry.title == MOCK_DATA[CONF_USERNAME]
     assert past_entry.version == 2
+
+
+@pytest.mark.usefixtures("recorder_mock")
+@pytest.mark.parametrize(
+    ("duplicate_volume", "expected_log_level", "expected_log_message"),
+    [
+        (100.0, "DEBUG", "Skipping duplicate date"),
+        (999.0, "WARNING", "different volume"),
+    ],
+)
+async def test_statistics_with_duplicate_dates(
+    hass: HomeAssistant,
+    suez_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+    duplicate_volume: float,
+    expected_log_level: str,
+    expected_log_message: str,
+) -> None:
+    """Test that duplicate dates in data are handled correctly."""
+    start = datetime.fromisoformat("2024-12-04T02:00:00.0")
+    freezer.move_to(start)
+
+    origin = dt_util.start_of_local_day(start.date()) - timedelta(days=3)
+
+    result = [
+        TelemetryMeasure(
+            date=origin.date().strftime("%Y-%m-%d %H:%M:%S"),
+            volume=0.1,
+            index=0.1,
+        ),
+        TelemetryMeasure(
+            date=(origin + timedelta(days=1)).date().strftime("%Y-%m-%d %H:%M:%S"),
+            volume=0.15,
+            index=0.25,
+        ),
+        TelemetryMeasure(
+            date=(origin + timedelta(days=2)).date().strftime("%Y-%m-%d %H:%M:%S"),
+            volume=0.2,
+            index=0.45,
+        ),
+        TelemetryMeasure(
+            date=origin.date().strftime("%Y-%m-%d %H:%M:%S"),
+            volume=duplicate_volume / 1000,
+            index=0.1,
+        ),
+    ]
+    suez_client.fetch_all_daily_data.return_value = result
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    await hass.async_block_till_done(True)
+    await async_wait_recording_done(hass)
+
+    statistic_id = f"{DOMAIN}:{mock_config_entry.data[CONF_COUNTER_ID]}_water_consumption_statistics"
+    stats = await hass.async_add_executor_job(
+        statistics_during_period,
+        hass,
+        origin - timedelta(days=1),
+        None,
+        [statistic_id],
+        "hour",
+        None,
+        {"start", "state", "sum"},
+    )
+
+    assert statistic_id in stats
+    assert len(stats[statistic_id]) == 3
+
+    assert stats[statistic_id][0]["sum"] == 100.0
+    assert stats[statistic_id][1]["sum"] == 250.0
+    assert stats[statistic_id][2]["sum"] == 450.0
+
+    assert any(
+        expected_log_message in record.message
+        for record in caplog.records
+        if record.levelname == expected_log_level
+    )


### PR DESCRIPTION
## Breaking change

N/A

## Proposed change

This PR adds defensive deduplication in the Suez Water integration's statistics building process to prevent cumulative sum corruption when duplicate dates appear in the data source.

The issue (#161012) manifests as doubled water consumption statistics on the 1st day of each month. While the root cause is in the upstream pySuez library (pending fix in jb101010-2/pySuez#20), this change adds a defensive layer in Home Assistant to:

1. **Protect against duplicate dates** from any external statistics source
2. **Detect data inconsistencies** by logging a warning when duplicate dates have different volumes
3. **Maintain correct cumulative sums** by processing each date only once (first occurrence wins)

The fix uses a `dict[date, float]` to track processed dates and their volumes, ensuring O(1) lookup performance with minimal memory overhead.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #161012
- This PR is related to issue: 
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

**Note for affected users**: The incorrect cumulative values are already frozen in the statistics database. After upgrading, users should delete the `suez_water:{counter_id}_water_consumption_statistics` statistic via Developer Tools → Statistics to trigger a clean re-import.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr