### PR TITLE
Add idle state and stop action to lawn mower entity

### DIFF
--- a/homeassistant/components/kitchen_sink/lawn_mower.py
+++ b/homeassistant/components/kitchen_sink/lawn_mower.py
@@ -57,7 +57,8 @@ async def async_setup_platform(
                 LawnMowerActivity.DOCKED,
                 LawnMowerEntityFeature.DOCK
                 | LawnMowerEntityFeature.PAUSE
-                | LawnMowerEntityFeature.START_MOWING,
+                | LawnMowerEntityFeature.START_MOWING
+                | LawnMowerEntityFeature.STOP,
             ),
             DemoLawnMower(
                 "kitchen_sink_mower_006",
@@ -66,6 +67,12 @@ async def async_setup_platform(
                 LawnMowerEntityFeature.DOCK
                 | LawnMowerEntityFeature.PAUSE
                 | LawnMowerEntityFeature.START_MOWING,
+            ),
+            DemoLawnMower(
+                "kitchen_sink_mower_007",
+                "Mower can stop",
+                LawnMowerActivity.MOWING,
+                LawnMowerEntityFeature.STOP | LawnMowerEntityFeature.START_MOWING,
             ),
         ]
     )
@@ -112,4 +119,10 @@ class DemoLawnMower(LawnMowerEntity):
     async def async_pause(self) -> None:
         """Pause mower."""
         self._attr_activity = LawnMowerActivity.PAUSED
+        self.async_write_ha_state()
+
+    @override
+    async def async_stop(self) -> None:
+        """Stop mower."""
+        self._attr_activity = LawnMowerActivity.IDLE
         self.async_write_ha_state()

--- a/homeassistant/components/lawn_mower/__init__.py
+++ b/homeassistant/components/lawn_mower/__init__.py
@@ -19,6 +19,7 @@ from .const import (
     SERVICE_DOCK,
     SERVICE_PAUSE,
     SERVICE_START_MOWING,
+    SERVICE_STOP,
     LawnMowerActivity,
     LawnMowerEntityFeature,
 )
@@ -50,6 +51,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     )
     component.async_register_entity_service(
         SERVICE_DOCK, None, "async_dock", [LawnMowerEntityFeature.DOCK]
+    )
+    component.async_register_entity_service(
+        SERVICE_STOP, None, "async_stop", [LawnMowerEntityFeature.STOP]
     )
 
     return True
@@ -123,3 +127,11 @@ class LawnMowerEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     async def async_pause(self) -> None:
         """Pause the lawn mower."""
         await self.hass.async_add_executor_job(self.pause)
+
+    def stop(self) -> None:
+        """Stop the lawn mower."""
+        raise NotImplementedError
+
+    async def async_stop(self) -> None:
+        """Stop the lawn mower."""
+        await self.hass.async_add_executor_job(self.stop)

--- a/homeassistant/components/lawn_mower/condition.py
+++ b/homeassistant/components/lawn_mower/condition.py
@@ -10,6 +10,7 @@ CONDITIONS: dict[str, type[Condition]] = {
     "is_encountering_an_error": make_entity_state_condition(
         DOMAIN, LawnMowerActivity.ERROR
     ),
+    "is_idle": make_entity_state_condition(DOMAIN, LawnMowerActivity.IDLE),
     "is_mowing": make_entity_state_condition(DOMAIN, LawnMowerActivity.MOWING),
     "is_paused": make_entity_state_condition(DOMAIN, LawnMowerActivity.PAUSED),
     "is_returning": make_entity_state_condition(DOMAIN, LawnMowerActivity.RETURNING),

--- a/homeassistant/components/lawn_mower/conditions.yaml
+++ b/homeassistant/components/lawn_mower/conditions.yaml
@@ -17,6 +17,7 @@
 
 is_docked: *condition_common
 is_encountering_an_error: *condition_common
+is_idle: *condition_common
 is_mowing: *condition_common
 is_paused: *condition_common
 is_returning: *condition_common

--- a/homeassistant/components/lawn_mower/const.py
+++ b/homeassistant/components/lawn_mower/const.py
@@ -23,7 +23,7 @@ class LawnMowerActivity(StrEnum):
     """Device is returning."""
 
     IDLE = "idle"
-    """Device is idle, stopped but not docked."""
+    """Device is stopped, but neither docked nor paused."""
 
 
 class LawnMowerEntityFeature(IntFlag):

--- a/homeassistant/components/lawn_mower/const.py
+++ b/homeassistant/components/lawn_mower/const.py
@@ -22,6 +22,9 @@ class LawnMowerActivity(StrEnum):
     RETURNING = "returning"
     """Device is returning."""
 
+    IDLE = "idle"
+    """Device is idle, stopped but not docked."""
+
 
 class LawnMowerEntityFeature(IntFlag):
     """Supported features of the lawn mower entity."""
@@ -29,6 +32,7 @@ class LawnMowerEntityFeature(IntFlag):
     START_MOWING = 1
     PAUSE = 2
     DOCK = 4
+    STOP = 8
 
 
 DOMAIN: Final = "lawn_mower"
@@ -36,3 +40,4 @@ DOMAIN: Final = "lawn_mower"
 SERVICE_START_MOWING = "start_mowing"
 SERVICE_PAUSE = "pause"
 SERVICE_DOCK = "dock"
+SERVICE_STOP = "stop"

--- a/homeassistant/components/lawn_mower/icons.json
+++ b/homeassistant/components/lawn_mower/icons.json
@@ -30,6 +30,9 @@
     },
     "start_mowing": {
       "service": "mdi:play"
+    },
+    "stop": {
+      "service": "mdi:stop"
     }
   },
   "triggers": {

--- a/homeassistant/components/lawn_mower/icons.json
+++ b/homeassistant/components/lawn_mower/icons.json
@@ -6,6 +6,9 @@
     "is_encountering_an_error": {
       "condition": "mdi:alert-circle-outline"
     },
+    "is_idle": {
+      "condition": "mdi:stop"
+    },
     "is_mowing": {
       "condition": "mdi:play"
     },
@@ -36,6 +39,9 @@
     }
   },
   "triggers": {
+    "became_idle": {
+      "trigger": "mdi:stop"
+    },
     "errored": {
       "trigger": "mdi:alert-circle-outline"
     },

--- a/homeassistant/components/lawn_mower/services.yaml
+++ b/homeassistant/components/lawn_mower/services.yaml
@@ -20,3 +20,10 @@ pause:
       domain: lawn_mower
       supported_features:
         - lawn_mower.LawnMowerEntityFeature.PAUSE
+
+stop:
+  target:
+    entity:
+      domain: lawn_mower
+      supported_features:
+        - lawn_mower.LawnMowerEntityFeature.STOP

--- a/homeassistant/components/lawn_mower/strings.json
+++ b/homeassistant/components/lawn_mower/strings.json
@@ -73,6 +73,7 @@
       "state": {
         "docked": "Docked",
         "error": "[%key:common::state::error%]",
+        "idle": "[%key:common::state::idle%]",
         "mowing": "Mowing",
         "paused": "[%key:common::state::paused%]",
         "returning": "Returning"
@@ -91,6 +92,10 @@
     "start_mowing": {
       "description": "Starts a lawn mower's mowing task.",
       "name": "Start lawn mower"
+    },
+    "stop": {
+      "description": "Stops a lawn mower's current task.",
+      "name": "Stop lawn mower"
     }
   },
   "title": "Lawn mower",

--- a/homeassistant/components/lawn_mower/strings.json
+++ b/homeassistant/components/lawn_mower/strings.json
@@ -30,6 +30,18 @@
       },
       "name": "Lawn mower is encountering an error"
     },
+    "is_idle": {
+      "description": "Tests if one or more lawn mowers are idle.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::lawn_mower::common::condition_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::lawn_mower::common::condition_for_name%]"
+        }
+      },
+      "name": "Lawn mower is idle"
+    },
     "is_mowing": {
       "description": "Tests if one or more lawn mowers are mowing.",
       "fields": {
@@ -100,6 +112,18 @@
   },
   "title": "Lawn mower",
   "triggers": {
+    "became_idle": {
+      "description": "Triggers when one or more lawn mowers become idle.",
+      "fields": {
+        "behavior": {
+          "name": "[%key:component::lawn_mower::common::trigger_behavior_name%]"
+        },
+        "for": {
+          "name": "[%key:component::lawn_mower::common::trigger_for_name%]"
+        }
+      },
+      "name": "Lawn mower became idle"
+    },
     "errored": {
       "description": "Triggers when one or more lawn mowers encounter an error.",
       "fields": {

--- a/homeassistant/components/lawn_mower/trigger.py
+++ b/homeassistant/components/lawn_mower/trigger.py
@@ -17,6 +17,7 @@ TRIGGERS: dict[str, type[Trigger]] = {
     "started_returning": make_entity_target_state_trigger(
         DOMAIN, LawnMowerActivity.RETURNING
     ),
+    "became_idle": make_entity_target_state_trigger(DOMAIN, LawnMowerActivity.IDLE),
 }
 
 

--- a/homeassistant/components/lawn_mower/triggers.yaml
+++ b/homeassistant/components/lawn_mower/triggers.yaml
@@ -20,3 +20,4 @@ errored: *trigger_common
 paused_mowing: *trigger_common
 started_mowing: *trigger_common
 started_returning: *trigger_common
+became_idle: *trigger_common

--- a/tests/components/kitchen_sink/snapshots/test_lawn_mower.ambr
+++ b/tests/components/kitchen_sink/snapshots/test_lawn_mower.ambr
@@ -4,7 +4,7 @@
     StateSnapshot({
       'attributes': ReadOnlyDict({
         <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mower can do all',
-        <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <LawnMowerEntityFeature: 7>,
+        <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <LawnMowerEntityFeature: 15>,
       }),
       'context': <ANY>,
       'entity_id': 'lawn_mower.mower_can_do_all',
@@ -60,6 +60,18 @@
       'last_reported': <ANY>,
       'last_updated': <ANY>,
       'state': 'returning',
+    }),
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mower can stop',
+        <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <LawnMowerEntityFeature: 9>,
+      }),
+      'context': <ANY>,
+      'entity_id': 'lawn_mower.mower_can_stop',
+      'last_changed': <ANY>,
+      'last_reported': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'mowing',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({

--- a/tests/components/kitchen_sink/test_lawn_mower.py
+++ b/tests/components/kitchen_sink/test_lawn_mower.py
@@ -11,6 +11,7 @@ from homeassistant.components.lawn_mower import (
     SERVICE_DOCK,
     SERVICE_PAUSE,
     SERVICE_START_MOWING,
+    SERVICE_STOP,
     LawnMowerActivity,
 )
 from homeassistant.const import ATTR_ENTITY_ID, EVENT_STATE_CHANGED, Platform
@@ -78,6 +79,12 @@ async def test_states(hass: HomeAssistant, snapshot: SnapshotAssertion) -> None:
             LawnMowerActivity.RETURNING,
             LawnMowerActivity.DOCKED,
         ),
+        (
+            "lawn_mower.mower_can_stop",
+            SERVICE_STOP,
+            LawnMowerActivity.MOWING,
+            LawnMowerActivity.IDLE,
+        ),
     ],
 )
 async def test_mower(
@@ -109,6 +116,7 @@ async def test_mower(
         SERVICE_DOCK,
         SERVICE_START_MOWING,
         SERVICE_PAUSE,
+        SERVICE_STOP,
     ],
 )
 async def test_service_calls_mocked(hass: HomeAssistant, service_call) -> None:

--- a/tests/components/lawn_mower/test_condition.py
+++ b/tests/components/lawn_mower/test_condition.py
@@ -32,6 +32,7 @@ async def target_lawn_mowers(hass: HomeAssistant) -> dict[str, list[str]]:
 _CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
     "is_docked": TargetSupport.STANDARD,
     "is_encountering_an_error": TargetSupport.STANDARD,
+    "is_idle": TargetSupport.STANDARD,
     "is_mowing": TargetSupport.STANDARD,
     "is_paused": TargetSupport.STANDARD,
     "is_returning": TargetSupport.STANDARD,
@@ -43,6 +44,7 @@ _CONDITION_TARGET_SUPPORT: dict[str, TargetSupport] = {
     [
         ("lawn_mower.is_docked", {}, True, True),
         ("lawn_mower.is_encountering_an_error", {}, True, True),
+        ("lawn_mower.is_idle", {}, True, True),
         ("lawn_mower.is_mowing", {}, True, True),
         ("lawn_mower.is_paused", {}, True, True),
         ("lawn_mower.is_returning", {}, True, True),
@@ -86,6 +88,11 @@ def test_condition_target_support() -> None:
             condition="lawn_mower.is_encountering_an_error",
             target_states=[LawnMowerActivity.ERROR],
             other_states=other_states(LawnMowerActivity.ERROR),
+        ),
+        *parametrize_condition_states_any(
+            condition="lawn_mower.is_idle",
+            target_states=[LawnMowerActivity.IDLE],
+            other_states=other_states(LawnMowerActivity.IDLE),
         ),
         *parametrize_condition_states_any(
             condition="lawn_mower.is_mowing",
@@ -143,6 +150,11 @@ async def test_lawn_mower_state_condition_behavior_any(
             condition="lawn_mower.is_encountering_an_error",
             target_states=[LawnMowerActivity.ERROR],
             other_states=other_states(LawnMowerActivity.ERROR),
+        ),
+        *parametrize_condition_states_all(
+            condition="lawn_mower.is_idle",
+            target_states=[LawnMowerActivity.IDLE],
+            other_states=other_states(LawnMowerActivity.IDLE),
         ),
         *parametrize_condition_states_all(
             condition="lawn_mower.is_mowing",

--- a/tests/components/lawn_mower/test_init.py
+++ b/tests/components/lawn_mower/test_init.py
@@ -160,6 +160,17 @@ async def test_sync_pause(hass: HomeAssistant) -> None:
     assert lawn_mower.pause.called
 
 
+async def test_sync_stop(hass: HomeAssistant) -> None:
+    """Test if async stop calls sync stop."""
+    lawn_mower = MockLawnMowerEntity()
+    lawn_mower.hass = hass
+
+    lawn_mower.stop = MagicMock()
+    await lawn_mower.async_stop()
+
+    assert lawn_mower.stop.called
+
+
 async def test_lawn_mower_default(hass: HomeAssistant) -> None:
     """Test lawn mower entity with defaults."""
     lawn_mower = MockLawnMowerEntity()

--- a/tests/components/lawn_mower/test_trigger.py
+++ b/tests/components/lawn_mower/test_trigger.py
@@ -35,6 +35,7 @@ _TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
     "paused_mowing": TargetSupport.STANDARD,
     "started_mowing": TargetSupport.STANDARD,
     "started_returning": TargetSupport.STANDARD,
+    "became_idle": TargetSupport.STANDARD,
 }
 
 
@@ -46,6 +47,7 @@ _TRIGGER_TARGET_SUPPORT: dict[str, TargetSupport] = {
         ("lawn_mower.paused_mowing", {}, True, True),
         ("lawn_mower.started_mowing", {}, True, True),
         ("lawn_mower.started_returning", {}, True, True),
+        ("lawn_mower.became_idle", {}, True, True),
     ],
 )
 async def test_lawn_mower_trigger_options_validation(
@@ -101,6 +103,11 @@ def test_trigger_target_support() -> None:
             trigger="lawn_mower.started_returning",
             target_states=[LawnMowerActivity.RETURNING],
             other_states=other_states(LawnMowerActivity.RETURNING),
+        ),
+        *parametrize_trigger_states(
+            trigger="lawn_mower.became_idle",
+            target_states=[LawnMowerActivity.IDLE],
+            other_states=other_states(LawnMowerActivity.IDLE),
         ),
     ],
 )
@@ -159,6 +166,11 @@ async def test_lawn_mower_state_trigger_behavior_each(
             target_states=[LawnMowerActivity.RETURNING],
             other_states=other_states(LawnMowerActivity.RETURNING),
         ),
+        *parametrize_trigger_states(
+            trigger="lawn_mower.became_idle",
+            target_states=[LawnMowerActivity.IDLE],
+            other_states=other_states(LawnMowerActivity.IDLE),
+        ),
     ],
 )
 async def test_lawn_mower_state_trigger_behavior_first(
@@ -215,6 +227,11 @@ async def test_lawn_mower_state_trigger_behavior_first(
             trigger="lawn_mower.started_returning",
             target_states=[LawnMowerActivity.RETURNING],
             other_states=other_states(LawnMowerActivity.RETURNING),
+        ),
+        *parametrize_trigger_states(
+            trigger="lawn_mower.became_idle",
+            target_states=[LawnMowerActivity.IDLE],
+            other_states=other_states(LawnMowerActivity.IDLE),
         ),
     ],
 )

--- a/tests/components/mqtt/test_lawn_mower.py
+++ b/tests/components/mqtt/test_lawn_mower.py
@@ -741,8 +741,8 @@ async def test_mqtt_payload_not_a_valid_activity_warning(
 
     assert (
         "Invalid activity for lawn_mower.test_lawn_mower: 'painting' "
-        "(valid activities: ['error', 'paused', 'mowing', 'docked', 'returning'])"
-        in caplog.text
+        "(valid activities: ['error', 'paused', 'mowing', 'docked', 'returning', "
+        "'idle'])" in caplog.text
     )
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The lawn mower entity has no way to cancel the current task. `pause` keeps the task to resume it later and `dock` sends the mower home but most integrations keep the task and resume it on the next `start_mowing`. Integrations work around this: Ecovacs maps its idle state to `paused`, both Husqvarna integrations map their stopped state to `error`, and Google Assistant sends `dock` for its stop command.

This adds a `stop` action with a `LawnMowerEntityFeature.STOP` feature flag and `stop`/`async_stop` entity methods, following the vacuum entity. It also adds a `LawnMowerActivity.IDLE` activity for a mower that is stopped but neither docked nor paused.

The new activity gets a matching `is_idle` condition and `became_idle` trigger, so every lawn mower activity keeps a condition and a trigger in the automation editor.

Kitchen sink gets the new feature on "Mower can do all" and a new "Mower can stop" entity that only supports start and stop, so the frontend can test the stop button alone.

Approved in home-assistant/architecture#1376. Integrations (Ecovacs, Husqvarna Automower, Husqvarna Automower BLE, MQTT) and Google Assistant will be updated in follow-up PRs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/discussions/1376
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47873
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3333
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53957

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr




