### PR TITLE
Record unknown Miele ProgramID values in diagnostics

### DIFF
--- a/homeassistant/components/miele/coordinator.py
+++ b/homeassistant/components/miele/coordinator.py
@@ -19,7 +19,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN
+from .const import DOMAIN, PROGRAM_IDS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,6 +74,19 @@ class MieleDataUpdateCoordinator(DataUpdateCoordinator[MieleCoordinatorData]):
             update_interval=timedelta(seconds=120),
         )
         self.api = api
+        self.unknown_program_ids: dict[str, dict[int, str | None]] = {}
+
+    def _record_unknown_program_ids(self, devices: dict[str, MieleDevice]) -> None:
+        """Record unknown program IDs from appliance state updates."""
+        for device_id, device in devices.items():
+            if (program_id_type := PROGRAM_IDS.get(device.device_type)) is None:
+                continue
+            program_id = device.state_program_id
+            if program_id_type(program_id).name is not None:
+                continue
+            self.unknown_program_ids.setdefault(device_id, {})[program_id] = (
+                device.state_program_id_localized
+            )
 
     @override
     async def _async_update_data(self) -> MieleCoordinatorData:
@@ -82,6 +95,7 @@ class MieleDataUpdateCoordinator(DataUpdateCoordinator[MieleCoordinatorData]):
         devices = {
             device_id: MieleDevice(device) for device_id, device in devices_json.items()
         }
+        self._record_unknown_program_ids(devices)
         self.devices = devices
         actions = {}
 
@@ -117,6 +131,7 @@ class MieleDataUpdateCoordinator(DataUpdateCoordinator[MieleCoordinatorData]):
         updated_devices = {
             device_id: MieleDevice(device) for device_id, device in devices_json.items()
         }
+        self._record_unknown_program_ids(updated_devices)
         self.async_set_updated_data(
             MieleCoordinatorData(
                 devices={**self.data.devices, **updated_devices},

--- a/homeassistant/components/miele/coordinator.py
+++ b/homeassistant/components/miele/coordinator.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import override
+from typing import cast, override
 
 from aiohttp import ClientResponseError
 from pymiele import (
@@ -19,9 +19,16 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, PROGRAM_IDS
+from .const import DOMAIN, PROGRAM_IDS, MieleAppliance
 
 _LOGGER = logging.getLogger(__name__)
+
+_UNMAPPED_PROGRAM_ID_APPLIANCES = {
+    MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL,
+    MieleAppliance.TUMBLE_DRYER_SEMI_PROFESSIONAL,
+    MieleAppliance.MICROWAVE,
+    MieleAppliance.DIALOG_OVEN,
+}
 
 
 @dataclass
@@ -79,14 +86,24 @@ class MieleDataUpdateCoordinator(DataUpdateCoordinator[MieleCoordinatorData]):
     def _record_unknown_program_ids(self, devices: dict[str, MieleDevice]) -> None:
         """Record unknown program IDs from appliance state updates."""
         for device_id, device in devices.items():
-            if (program_id_type := PROGRAM_IDS.get(device.device_type)) is None:
+            program_id = cast(int | None, device.state_program_id)
+            if program_id is None:
                 continue
-            program_id = device.state_program_id
-            if program_id_type(program_id).name is not None:
+
+            program_id_type = PROGRAM_IDS.get(device.device_type)
+            if program_id_type is None:
+                if (
+                    device.device_type not in _UNMAPPED_PROGRAM_ID_APPLIANCES
+                    or program_id in (0, -1)
+                ):
+                    continue
+            elif program_id_type(program_id).name is not None:
                 continue
-            self.unknown_program_ids.setdefault(device_id, {})[program_id] = (
-                device.state_program_id_localized
-            )
+
+            unknown_programs = self.unknown_program_ids.setdefault(device_id, {})
+            value_localized = device.state_program_id_localized
+            if value_localized or program_id not in unknown_programs:
+                unknown_programs[program_id] = value_localized
 
     @override
     async def _async_update_data(self) -> MieleCoordinatorData:

--- a/homeassistant/components/miele/diagnostics.py
+++ b/homeassistant/components/miele/diagnostics.py
@@ -3,6 +3,7 @@
 import hashlib
 from typing import TYPE_CHECKING, Any, cast
 
+from aiohttp import ClientError, ClientResponseError
 from pymiele import completed_warnings
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -25,6 +26,26 @@ def redact_identifiers(in_data: dict[str, Any]) -> dict[str, Any]:
     for key, value in in_data.items():
         out_data[hash_identifier(key)] = value
     return out_data
+
+
+async def _async_get_programs_diagnostics(
+    config_entry: MieleConfigEntry, device_id: str
+) -> list[dict[str, int | str]] | dict[str, int | str]:
+    """Return privacy-safe program diagnostics for a device."""
+    try:
+        programs = await config_entry.runtime_data.api.get_programs(device_id)
+    except ClientResponseError as err:
+        return {"error": type(err).__name__, "status": err.status}
+    except (ClientError, TimeoutError) as err:
+        return {"error": type(err).__name__}
+
+    return [
+        {
+            "program_id": program["programId"],
+            "program": program["program"].strip(),
+        }
+        for program in sorted(programs, key=lambda program: program["programId"])
+    ]
 
 
 async def async_get_config_entry_diagnostics(
@@ -98,7 +119,7 @@ async def async_get_device_diagnostics(
         "actions": {
             hash_identifier(device_id): coordinator.data.actions[device_id].raw
         },
-        "programs": "Not implemented",
+        "programs": await _async_get_programs_diagnostics(config_entry, device_id),
     }
     miele_data["missing_code_warnings"] = (
         sorted(completed_warnings) if len(completed_warnings) > 0 else ["None"]

--- a/homeassistant/components/miele/diagnostics.py
+++ b/homeassistant/components/miele/diagnostics.py
@@ -3,14 +3,13 @@
 import hashlib
 from typing import TYPE_CHECKING, Any, cast
 
-from aiohttp import ClientError, ClientResponseError
 from pymiele import completed_warnings
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import AnyDeviceEntry, DeviceEntry
 
-from .coordinator import MieleConfigEntry
+from .coordinator import MieleConfigEntry, MieleDataUpdateCoordinator
 
 TO_REDACT = {"access_token", "refresh_token", "fabNumber"}
 
@@ -28,23 +27,18 @@ def redact_identifiers(in_data: dict[str, Any]) -> dict[str, Any]:
     return out_data
 
 
-async def _async_get_programs_diagnostics(
-    config_entry: MieleConfigEntry, device_id: str
-) -> list[dict[str, int | str]] | dict[str, int | str]:
-    """Return privacy-safe program diagnostics for a device."""
-    try:
-        programs = await config_entry.runtime_data.api.get_programs(device_id)
-    except ClientResponseError as err:
-        return {"error": type(err).__name__, "status": err.status}
-    except (ClientError, TimeoutError) as err:
-        return {"error": type(err).__name__}
-
+def _unknown_program_ids(
+    coordinator: MieleDataUpdateCoordinator, device_id: str
+) -> list[dict[str, int | str | None]]:
+    """Return unknown program IDs observed in appliance state updates."""
     return [
         {
-            "program_id": program["programId"],
-            "program": program["program"].strip(),
+            "value_raw": program_id,
+            "value_localized": value_localized,
         }
-        for program in sorted(programs, key=lambda program: program["programId"])
+        for program_id, value_localized in sorted(
+            coordinator.unknown_program_ids.get(device_id, {}).items()
+        )
     ]
 
 
@@ -76,6 +70,14 @@ async def async_get_config_entry_diagnostics(
                 for device_id, action_data in (
                     config_entry.runtime_data.coordinator.data.actions.items()
                 )
+            }
+        ),
+        "unknown_program_ids": redact_identifiers(
+            {
+                device_id: _unknown_program_ids(
+                    config_entry.runtime_data.coordinator, device_id
+                )
+                for device_id in config_entry.runtime_data.coordinator.unknown_program_ids
             }
         ),
     }
@@ -119,7 +121,7 @@ async def async_get_device_diagnostics(
         "actions": {
             hash_identifier(device_id): coordinator.data.actions[device_id].raw
         },
-        "programs": await _async_get_programs_diagnostics(config_entry, device_id),
+        "unknown_program_ids": _unknown_program_ids(coordinator, device_id),
     }
     miele_data["missing_code_warnings"] = (
         sorted(completed_warnings) if len(completed_warnings) > 0 else ["None"]

--- a/tests/components/miele/snapshots/test_diagnostics.ambr
+++ b/tests/components/miele/snapshots/test_diagnostics.ambr
@@ -1039,6 +1039,8 @@
       'missing_code_warnings': list([
         'None',
       ]),
+      'unknown_program_ids': dict({
+      }),
     }),
   })
 # ---
@@ -1237,27 +1239,7 @@
       'missing_code_warnings': list([
         'None',
       ]),
-      'programs': list([
-        dict({
-          'program': 'Cottons',
-          'program_id': 1,
-        }),
-        dict({
-          'program': 'Fan plus',
-          'program_id': 13,
-        }),
-        dict({
-          'program': 'Dark garments / Denim',
-          'program_id': 123,
-        }),
-        dict({
-          'program': 'QuickPowerWash',
-          'program_id': 146,
-        }),
-        dict({
-          'program': 'Ristretto',
-          'program_id': 24000,
-        }),
+      'unknown_program_ids': list([
       ]),
     }),
   })

--- a/tests/components/miele/snapshots/test_diagnostics.ambr
+++ b/tests/components/miele/snapshots/test_diagnostics.ambr
@@ -1237,7 +1237,28 @@
       'missing_code_warnings': list([
         'None',
       ]),
-      'programs': 'Not implemented',
+      'programs': list([
+        dict({
+          'program': 'Cottons',
+          'program_id': 1,
+        }),
+        dict({
+          'program': 'Fan plus',
+          'program_id': 13,
+        }),
+        dict({
+          'program': 'Dark garments / Denim',
+          'program_id': 123,
+        }),
+        dict({
+          'program': 'QuickPowerWash',
+          'program_id': 146,
+        }),
+        dict({
+          'program': 'Ristretto',
+          'program_id': 24000,
+        }),
+      ]),
     }),
   })
 # ---

--- a/tests/components/miele/test_diagnostics.py
+++ b/tests/components/miele/test_diagnostics.py
@@ -1,8 +1,9 @@
 """Tests for the diagnostics data provided by the miele integration."""
 
-from collections.abc import Generator
 from unittest.mock import MagicMock
 
+from aiohttp import ClientConnectionError, ClientResponseError
+import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import paths
 
@@ -19,11 +20,13 @@ from tests.components.diagnostics import (
 )
 from tests.typing import ClientSessionGenerator
 
+TEST_DEVICE = "Dummy_Appliance_1"
+
 
 async def test_diagnostics_config_entry(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
-    mock_miele_client: Generator[MagicMock],
+    mock_miele_client: MagicMock,
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -40,19 +43,18 @@ async def test_diagnostics_config_entry(
             "miele_test.entry_id",
         )
     )
+    mock_miele_client.get_programs.assert_not_awaited()
 
 
 async def test_diagnostics_device(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     device_registry: DeviceRegistry,
-    mock_miele_client: Generator[MagicMock],
+    mock_miele_client: MagicMock,
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test diagnostics for device."""
-
-    TEST_DEVICE = "Dummy_Appliance_1"
 
     await setup_integration(hass, mock_config_entry)
     device_entry = device_registry.async_get_device_by_identifier(
@@ -69,3 +71,45 @@ async def test_diagnostics_device(
             "miele_test.entry_id",
         )
     )
+    mock_miele_client.get_programs.assert_awaited_once_with(TEST_DEVICE)
+
+
+@pytest.mark.parametrize(
+    ("programs_error", "expected_programs_diagnostics"),
+    [
+        pytest.param(
+            ClientResponseError(MagicMock(), (), status=404),
+            {"error": "ClientResponseError", "status": 404},
+            id="unsupported",
+        ),
+        pytest.param(
+            ClientConnectionError(),
+            {"error": "ClientConnectionError"},
+            id="offline",
+        ),
+        pytest.param(TimeoutError(), {"error": "TimeoutError"}, id="timeout"),
+    ],
+)
+async def test_device_diagnostics_programs_unavailable(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    device_registry: DeviceRegistry,
+    mock_miele_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    programs_error: Exception,
+    expected_programs_diagnostics: dict[str, int | str],
+) -> None:
+    """Test device diagnostics remain available when programs are unavailable."""
+    await setup_integration(hass, mock_config_entry)
+    mock_miele_client.get_programs.side_effect = programs_error
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE), mock_config_entry.entry_id
+    )
+    assert device_entry is not None
+
+    result = await get_diagnostics_for_device(
+        hass, hass_client, mock_config_entry, device_entry
+    )
+
+    assert result["miele_data"]["programs"] == expected_programs_diagnostics
+    assert "devices" in result["miele_data"]

--- a/tests/components/miele/test_diagnostics.py
+++ b/tests/components/miele/test_diagnostics.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from aiohttp import ClientConnectionError, ClientResponseError
+from pymiele import MieleDevices, completed_warnings
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import paths
@@ -11,7 +11,7 @@ from homeassistant.components.miele.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceRegistry
 
-from . import setup_integration
+from . import get_data_callback, setup_integration
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import (
@@ -71,45 +71,45 @@ async def test_diagnostics_device(
             "miele_test.entry_id",
         )
     )
-    mock_miele_client.get_programs.assert_awaited_once_with(TEST_DEVICE)
+    mock_miele_client.get_programs.assert_not_awaited()
 
 
-@pytest.mark.parametrize(
-    ("programs_error", "expected_programs_diagnostics"),
-    [
-        pytest.param(
-            ClientResponseError(MagicMock(), (), status=404),
-            {"error": "ClientResponseError", "status": 404},
-            id="unsupported",
-        ),
-        pytest.param(
-            ClientConnectionError(),
-            {"error": "ClientConnectionError"},
-            id="offline",
-        ),
-        pytest.param(TimeoutError(), {"error": "TimeoutError"}, id="timeout"),
-    ],
-)
-async def test_device_diagnostics_programs_unavailable(
+@pytest.mark.parametrize("load_device_file", ["coffee_system.json"])
+async def test_device_diagnostics_retains_unknown_program(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     device_registry: DeviceRegistry,
     mock_miele_client: MagicMock,
     mock_config_entry: MockConfigEntry,
-    programs_error: Exception,
-    expected_programs_diagnostics: dict[str, int | str],
+    device_fixture: MieleDevices,
 ) -> None:
-    """Test device diagnostics remain available when programs are unavailable."""
-    await setup_integration(hass, mock_config_entry)
-    mock_miele_client.get_programs.side_effect = programs_error
-    device_entry = device_registry.async_get_device_by_identifier(
-        (DOMAIN, TEST_DEVICE), mock_config_entry.entry_id
-    )
-    assert device_entry is not None
+    """Test diagnostics retain unknown programs after the program finishes."""
+    device_id = "DummyAppliance_CoffeeSystem"
+    warning = "Missing CoffeeSystemProgramId code: 99999 - defaulting to Unknown"
+    try:
+        await setup_integration(hass, mock_config_entry)
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), mock_config_entry.entry_id
+        )
+        assert device_entry is not None
 
-    result = await get_diagnostics_for_device(
-        hass, hass_client, mock_config_entry, device_entry
-    )
+        program_id = device_fixture[device_id]["state"]["ProgramID"]
+        program_id["value_raw"] = 99999
+        program_id["value_localized"] = "Mystery drink"
+        data_callback = get_data_callback(mock_miele_client)
+        await data_callback(device_fixture)
 
-    assert result["miele_data"]["programs"] == expected_programs_diagnostics
-    assert "devices" in result["miele_data"]
+        program_id["value_raw"] = 0
+        program_id["value_localized"] = ""
+        await data_callback(device_fixture)
+
+        result = await get_diagnostics_for_device(
+            hass, hass_client, mock_config_entry, device_entry
+        )
+
+        assert result["miele_data"]["unknown_program_ids"] == [
+            {"value_raw": 99999, "value_localized": "Mystery drink"}
+        ]
+        mock_miele_client.get_programs.assert_not_awaited()
+    finally:
+        completed_warnings.discard(warning)

--- a/tests/components/miele/test_diagnostics.py
+++ b/tests/components/miele/test_diagnostics.py
@@ -7,7 +7,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import paths
 
-from homeassistant.components.miele.const import DOMAIN
+from homeassistant.components.miele.const import DOMAIN, MieleAppliance
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceRegistry
 
@@ -99,8 +99,13 @@ async def test_device_diagnostics_retains_unknown_program(
         data_callback = get_data_callback(mock_miele_client)
         await data_callback(device_fixture)
 
-        program_id["value_raw"] = 0
         program_id["value_localized"] = ""
+        await data_callback(device_fixture)
+
+        program_id["value_raw"] = 0
+        await data_callback(device_fixture)
+
+        program_id["value_raw"] = None
         await data_callback(device_fixture)
 
         result = await get_diagnostics_for_device(
@@ -113,3 +118,45 @@ async def test_device_diagnostics_retains_unknown_program(
         mock_miele_client.get_programs.assert_not_awaited()
     finally:
         completed_warnings.discard(warning)
+
+
+@pytest.mark.parametrize("load_device_file", ["coffee_system.json"])
+async def test_device_diagnostics_records_unmapped_program(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    device_registry: DeviceRegistry,
+    mock_miele_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    device_fixture: MieleDevices,
+) -> None:
+    """Test diagnostics record programs for appliances without an enum mapping."""
+    device_id = "DummyAppliance_CoffeeSystem"
+    device = device_fixture[device_id]
+    device["ident"]["type"]["value_raw"] = (
+        MieleAppliance.WASHING_MACHINE_SEMI_PROFESSIONAL
+    )
+    program_id = device["state"]["ProgramID"]
+    program_id["value_raw"] = 31001
+    program_id["value_localized"] = "Cottons"
+
+    await setup_integration(hass, mock_config_entry)
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, device_id), mock_config_entry.entry_id
+    )
+    assert device_entry is not None
+
+    data_callback = get_data_callback(mock_miele_client)
+    program_id["value_raw"] = 0
+    program_id["value_localized"] = ""
+    await data_callback(device_fixture)
+    program_id["value_raw"] = -1
+    await data_callback(device_fixture)
+
+    result = await get_diagnostics_for_device(
+        hass, hass_client, mock_config_entry, device_entry
+    )
+
+    assert result["miele_data"]["unknown_program_ids"] == [
+        {"value_raw": 31001, "value_localized": "Cottons"}
+    ]
+    mock_miele_client.get_programs.assert_not_awaited()

--- a/tests/components/miele/test_diagnostics.py
+++ b/tests/components/miele/test_diagnostics.py
@@ -115,6 +115,15 @@ async def test_device_diagnostics_retains_unknown_program(
         assert result["miele_data"]["unknown_program_ids"] == [
             {"value_raw": 99999, "value_localized": "Mystery drink"}
         ]
+
+        config_result = await get_diagnostics_for_config_entry(
+            hass, hass_client, mock_config_entry
+        )
+        assert config_result["miele_data"]["unknown_program_ids"] == {
+            "**REDACTED_bd62a0d31ec35172": [
+                {"value_raw": 99999, "value_localized": "Mystery drink"}
+            ]
+        }
         mock_miele_client.get_programs.assert_not_awaited()
     finally:
         completed_warnings.discard(warning)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Not a breaking change.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Retain unknown values from Miele's `ProgramID` state field observed during normal appliance updates and include their raw and localized values in diagnostics. For appliance types with a static enum, this means values missing from that enum; for program-bearing appliance types without an enum, non-sentinel values are retained. This preserves the exact display-side evidence behind an `unknown` sensor state, even when diagnostics are downloaded after the appliance state has changed.

For example, an appliance can provide a raw value without a localized label:

```json
{
  "missing_code_warnings": [
    "Missing CoffeeSystemProgramId code: 17006 - defaulting to Unknown"
  ],
  "unknown_program_ids": [
    {
      "value_raw": 17006,
      "value_localized": ""
    }
  ]
}
```

The example does not assume that `17006` is a runnable program or that it should receive an enum mapping. The retained evidence allows maintainers to decide whether an unknown value represents a missing display mapping, a transient appliance state, or a value that should remain unmapped.

This approach deliberately uses the same `ProgramID` state payload that caused the sensor to report `unknown`. It does not call `get_programs` from diagnostics or compare the display-state value with the separate start-action program catalogue.

The retained observations have the following boundaries:

- Only unknown, non-sentinel `ProgramID` values actually seen since the integration was loaded are included. Null readings and the `0`/`-1` no-program values from appliance types without an enum are ignored.
- Device diagnostics include observations for that device; config-entry diagnostics group observations under hashed device identifiers.
- Observations are kept in memory and reset when the integration or Home Assistant restarts.
- `value_localized` is the text supplied by the appliance at observation time and may be empty or null. A later empty value does not replace an earlier useful label.
- Downloading diagnostics performs no additional Miele API request.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: #166114
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
