### PR TITLE
Add stop action to MQTT lawn mower

### DIFF
--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -215,6 +215,8 @@ ABBREVIATIONS = {
     "stat_tpl": "state_template",
     "stat_val_tpl": "state_value_template",
     "step": "step",
+    "stop_cmd_t": "stop_command_topic",
+    "stop_cmd_tpl": "stop_command_template",
     "strt_mw_cmd_t": "start_mowing_command_topic",
     "strt_mw_cmd_tpl": "start_mowing_command_template",
     "stype": "subtype",

--- a/homeassistant/components/mqtt/lawn_mower.py
+++ b/homeassistant/components/mqtt/lawn_mower.py
@@ -48,6 +48,8 @@ CONF_PAUSE_COMMAND_TOPIC = "pause_command_topic"
 CONF_PAUSE_COMMAND_TEMPLATE = "pause_command_template"
 CONF_START_MOWING_COMMAND_TOPIC = "start_mowing_command_topic"
 CONF_START_MOWING_COMMAND_TEMPLATE = "start_mowing_command_template"
+CONF_STOP_COMMAND_TOPIC = "stop_command_topic"
+CONF_STOP_COMMAND_TEMPLATE = "stop_command_template"
 
 DEFAULT_NAME = "MQTT Lawn Mower"
 
@@ -56,6 +58,7 @@ MQTT_LAWN_MOWER_ATTRIBUTES_BLOCKED: frozenset[str] = frozenset()
 FEATURE_DOCK = "dock"
 FEATURE_PAUSE = "pause"
 FEATURE_START_MOWING = "start_mowing"
+FEATURE_STOP = "stop"
 
 PLATFORM_SCHEMA_MODERN = MQTT_BASE_SCHEMA.extend(
     {
@@ -70,6 +73,8 @@ PLATFORM_SCHEMA_MODERN = MQTT_BASE_SCHEMA.extend(
         vol.Optional(CONF_RETAIN, default=DEFAULT_RETAIN): cv.boolean,
         vol.Optional(CONF_START_MOWING_COMMAND_TEMPLATE): cv.template,
         vol.Optional(CONF_START_MOWING_COMMAND_TOPIC): valid_publish_topic,
+        vol.Optional(CONF_STOP_COMMAND_TEMPLATE): cv.template,
+        vol.Optional(CONF_STOP_COMMAND_TOPIC): valid_publish_topic,
     },
 ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema)
 
@@ -130,6 +135,9 @@ class MqttLawnMower(MqttEntity, LawnMowerEntity, RestoreEntity):
                 CONF_START_MOWING_COMMAND_TOPIC
             ]
             supported_features |= LawnMowerEntityFeature.START_MOWING
+        if CONF_STOP_COMMAND_TOPIC in config:
+            self._command_topics[FEATURE_STOP] = config[CONF_STOP_COMMAND_TOPIC]
+            supported_features |= LawnMowerEntityFeature.STOP
         self._attr_supported_features = supported_features
         self._command_templates = {}
         self._command_templates[FEATURE_DOCK] = MqttCommandTemplate(
@@ -140,6 +148,9 @@ class MqttLawnMower(MqttEntity, LawnMowerEntity, RestoreEntity):
         ).async_render
         self._command_templates[FEATURE_START_MOWING] = MqttCommandTemplate(
             config.get(CONF_START_MOWING_COMMAND_TEMPLATE), entity=self
+        ).async_render
+        self._command_templates[FEATURE_STOP] = MqttCommandTemplate(
+            config.get(CONF_STOP_COMMAND_TEMPLATE), entity=self
         ).async_render
 
     @callback
@@ -212,3 +223,8 @@ class MqttLawnMower(MqttEntity, LawnMowerEntity, RestoreEntity):
     async def async_pause(self) -> None:
         """Pause the lawn mower."""
         await self._async_operate("pause", LawnMowerActivity.PAUSED)
+
+    @override
+    async def async_stop(self) -> None:
+        """Stop the lawn mower."""
+        await self._async_operate("stop", LawnMowerActivity.IDLE)

--- a/tests/components/mqtt/test_lawn_mower.py
+++ b/tests/components/mqtt/test_lawn_mower.py
@@ -13,6 +13,7 @@ from homeassistant.components.lawn_mower import (
     SERVICE_DOCK,
     SERVICE_PAUSE,
     SERVICE_START_MOWING,
+    SERVICE_STOP,
     LawnMowerEntityFeature,
 )
 from homeassistant.components.mqtt.const import DOMAIN
@@ -61,6 +62,7 @@ DEFAULT_FEATURES = (
     LawnMowerEntityFeature.START_MOWING
     | LawnMowerEntityFeature.PAUSE
     | LawnMowerEntityFeature.DOCK
+    | LawnMowerEntityFeature.STOP
 )
 
 DEFAULT_CONFIG = {
@@ -70,6 +72,7 @@ DEFAULT_CONFIG = {
             "dock_command_topic": "dock-test-topic",
             "pause_command_topic": "pause-test-topic",
             "start_mowing_command_topic": "start_mowing-test-topic",
+            "stop_command_topic": "stop-test-topic",
         }
     }
 }
@@ -110,6 +113,13 @@ async def test_run_lawn_mower_setup_and_state_updates(
 
     state = hass.states.get("lawn_mower.test_lawn_mower")
     assert state.state == "returning"
+
+    async_fire_mqtt_message(hass, "test/lawn_mower_stat", "idle")
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get("lawn_mower.test_lawn_mower")
+    assert state.state == "idle"
 
     async_fire_mqtt_message(hass, "test/lawn_mower_stat", "docked")
 
@@ -156,6 +166,17 @@ async def test_run_lawn_mower_setup_and_state_updates(
                 }
             },
             LawnMowerEntityFeature.START_MOWING | LawnMowerEntityFeature.DOCK,
+        ),
+        (
+            {
+                DOMAIN: {
+                    lawn_mower.DOMAIN: {
+                        "stop_command_topic": "stop-test-topic",
+                        "name": "test",
+                    }
+                }
+            },
+            LawnMowerEntityFeature.STOP,
         ),
     ],
 )
@@ -285,6 +306,20 @@ async def test_run_lawn_mower_service_optimistic(
     state = hass.states.get("lawn_mower.test")
     assert state.state == "docked"
 
+    await hass.services.async_call(
+        lawn_mower.DOMAIN,
+        SERVICE_STOP,
+        {ATTR_ENTITY_ID: "lawn_mower.test"},
+        blocking=True,
+    )
+
+    mqtt_mock.async_publish.assert_called_once_with(
+        "stop-test-topic", "stop", 0, False, message_expiry_interval=None
+    )
+    mqtt_mock.async_publish.reset_mock()
+    state = hass.states.get("lawn_mower.test")
+    assert state.state == "idle"
+
 
 @pytest.mark.parametrize(
     "hass_config",
@@ -325,6 +360,8 @@ async def test_restore_lawn_mower_from_invalid_state(
                     "pause_command_template": '{"action": "{{ value }}"}',
                     "start_mowing_command_topic": "test/lawn_mower_start_mowing_cmd",
                     "start_mowing_command_template": '{"action": "{{ value }}"}',
+                    "stop_command_topic": "test/lawn_mower_stop_cmd",
+                    "stop_command_template": '{"action": "{{ value }}"}',
                 }
             }
         }
@@ -396,6 +433,24 @@ async def test_run_lawn_mower_service_optimistic_with_command_templates(
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("lawn_mower.test_lawn_mower")
     assert state.state == "docked"
+
+    await hass.services.async_call(
+        lawn_mower.DOMAIN,
+        SERVICE_STOP,
+        {ATTR_ENTITY_ID: "lawn_mower.test_lawn_mower"},
+        blocking=True,
+    )
+
+    mqtt_mock.async_publish.assert_called_once_with(
+        "test/lawn_mower_stop_cmd",
+        '{"action": "stop"}',
+        0,
+        False,
+        message_expiry_interval=None,
+    )
+    mqtt_mock.async_publish.reset_mock()
+    state = hass.states.get("lawn_mower.test_lawn_mower")
+    assert state.state == "idle"
 
 
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
@@ -675,6 +730,13 @@ async def test_entity_id_update_discovery_update(
             "test/lawn_mower_stat",
             "dock-test-topic",
         ),
+        (
+            SERVICE_STOP,
+            "stop",
+            "idle",
+            "test/lawn_mower_stat",
+            "stop-test-topic",
+        ),
     ],
 )
 async def test_entity_debug_info_message(
@@ -694,6 +756,7 @@ async def test_entity_debug_info_message(
                 "dock_command_topic": "dock-test-topic",
                 "pause_command_topic": "pause-test-topic",
                 "start_mowing_command_topic": "start_mowing-test-topic",
+                "stop_command_topic": "stop-test-topic",
                 "name": "test",
             }
         }
@@ -770,6 +833,13 @@ async def test_mqtt_payload_not_a_valid_activity_warning(
             "dock",
             "dock_command_template",
         ),
+        (
+            SERVICE_STOP,
+            "stop_command_topic",
+            {},
+            "stop",
+            "stop_command_template",
+        ),
     ],
 )
 async def test_publishing_with_custom_encoding(
@@ -816,6 +886,7 @@ async def test_reloadable(
         ("activity_state_topic", "docked", None, "docked"),
         ("activity_state_topic", "returning", None, "returning"),
         ("activity_state_topic", "mowing", None, "mowing"),
+        ("activity_state_topic", "idle", None, "idle"),
     ],
 )
 async def test_encoding_subscribable_topics(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds `stop_command_topic` and `stop_command_template` to the MQTT lawn mower, following the existing dock, pause and start mowing options. When the topic is set, the entity reports `LawnMowerEntityFeature.STOP`, publishes `stop` on it when the `lawn_mower.stop` action is called, and switches to `idle` in optimistic mode. The `idle` activity is accepted on the activity state topic like any other activity. Discovery abbreviations `stop_cmd_t` and `stop_cmd_tpl` are added.

Stacked on #181188, which adds the `stop` action and `idle` activity to the lawn mower entity. Only the last commit belongs to this PR. It will be marked ready for review once #181188 is merged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/discussions/1376
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47874
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

