### PR TITLE
Resolve colliding orphans through the orphan indexes

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1786,13 +1786,7 @@ class DeletedDeviceRegistryItems(DeviceRegistryItems[DeletedDeviceEntry]):
         connections: set[tuple[str, str]],
         domain: str,
     ) -> list[DeletedDeviceEntry]:
-        """Return the orphans of a domain sharing an identifier or connection.
-
-        Resolved through the orphan indexes, so orphaning a device costs its own
-        identifiers and connections rather than a scan of every deleted device.
-        Both sets are taken from a stored entry, so their connections are already
-        normalized and match the index keys.
-        """
+        """Return the orphans of a domain sharing an identifier or connection."""
         orphans: dict[str, DeletedDeviceEntry] = {}
         for identifier in identifiers:
             orphans.update(self._orphaned_identifiers.get(identifier, {}))
@@ -4426,10 +4420,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 and pending_move.config_entry_id == config_entry_id
             ):
                 self._devices[device.id] = attr.evolve(device, pending_move=None)
-        # Iterate ids rather than entries: a snapshot of the entries would hold
-        # every deleted device alive while the loop replaces them, doubling the
-        # registry's footprint on a large store. Re-reading each id also skips an
-        # entry the orphan dedupe dropped mid-loop instead of resurrecting it.
+        # Not `list(self._deleted_devices.values())`, which would keep every entry
+        # alive until the loop ends.
         for deleted_device_id in list(self._deleted_devices):
             deleted_device = self._deleted_devices.get(deleted_device_id)
             if (
@@ -4469,6 +4461,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 and pending_move.config_subentry_id == config_subentry_id
             ):
                 self._devices[device.id] = attr.evolve(device, pending_move=None)
+        # Not `list(self._deleted_devices.values())`, which would keep every entry
+        # alive until the loop ends.
         for deleted_device_id in list(self._deleted_devices):
             deleted_device = self._deleted_devices.get(deleted_device_id)
             if (
@@ -4487,6 +4481,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         growing without bound.
         """
         now_time = time.time()
+        # Not `list(self._deleted_devices.values())`, which would keep every entry
+        # alive until the loop ends.
         for deleted_device_id in list(self._deleted_devices):
             deleted_device = self._deleted_devices.get(deleted_device_id)
             if deleted_device is None or deleted_device.orphaned_timestamp is None:
@@ -4505,6 +4501,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             self._async_update_device(device.id, area_id=None)
         for child_device in self._child_devices.get_devices_for_area_id(area_id):
             self._async_update_child_device(child_device.id, area_id=None)
+        # Not `list(self._deleted_devices.values())`, which would keep every entry
+        # alive until the loop ends.
         for deleted_device_id in list(self._deleted_devices):
             deleted_device = self._deleted_devices.get(deleted_device_id)
             if deleted_device is None or deleted_device.area_id != area_id:
@@ -4523,6 +4521,8 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             self._async_update_child_device(
                 child_device.id, labels=child_device.labels - {label_id}
             )
+        # Not `list(self._deleted_devices.values())`, which would keep every entry
+        # alive until the loop ends.
         for deleted_device_id in list(self._deleted_devices):
             deleted_device = self._deleted_devices.get(deleted_device_id)
             if deleted_device is None or label_id not in deleted_device.labels:

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -4426,8 +4426,16 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 and pending_move.config_entry_id == config_entry_id
             ):
                 self._devices[device.id] = attr.evolve(device, pending_move=None)
-        for deleted_device in list(self._deleted_devices.values()):
-            if deleted_device.config_entry_id != config_entry_id:
+        # Iterate ids rather than entries: a snapshot of the entries would hold
+        # every deleted device alive while the loop replaces them, doubling the
+        # registry's footprint on a large store. Re-reading each id also skips an
+        # entry the orphan dedupe dropped mid-loop instead of resurrecting it.
+        for deleted_device_id in list(self._deleted_devices):
+            deleted_device = self._deleted_devices.get(deleted_device_id)
+            if (
+                deleted_device is None
+                or deleted_device.config_entry_id != config_entry_id
+            ):
                 continue
             self._async_orphan_deleted_device(deleted_device, domain, now_time)
 
@@ -4461,9 +4469,11 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 and pending_move.config_subentry_id == config_subentry_id
             ):
                 self._devices[device.id] = attr.evolve(device, pending_move=None)
-        for deleted_device in list(self._deleted_devices.values()):
+        for deleted_device_id in list(self._deleted_devices):
+            deleted_device = self._deleted_devices.get(deleted_device_id)
             if (
-                deleted_device.config_entry_id != config_entry_id
+                deleted_device is None
+                or deleted_device.config_entry_id != config_entry_id
                 or deleted_device.config_subentry_id != config_subentry_id
             ):
                 continue
@@ -4477,8 +4487,9 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         growing without bound.
         """
         now_time = time.time()
-        for deleted_device in list(self._deleted_devices.values()):
-            if deleted_device.orphaned_timestamp is None:
+        for deleted_device_id in list(self._deleted_devices):
+            deleted_device = self._deleted_devices.get(deleted_device_id)
+            if deleted_device is None or deleted_device.orphaned_timestamp is None:
                 continue
 
             if (
@@ -4494,8 +4505,9 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             self._async_update_device(device.id, area_id=None)
         for child_device in self._child_devices.get_devices_for_area_id(area_id):
             self._async_update_child_device(child_device.id, area_id=None)
-        for deleted_device in list(self._deleted_devices.values()):
-            if deleted_device.area_id != area_id:
+        for deleted_device_id in list(self._deleted_devices):
+            deleted_device = self._deleted_devices.get(deleted_device_id)
+            if deleted_device is None or deleted_device.area_id != area_id:
                 continue
             self._deleted_devices[deleted_device.id] = attr.evolve(
                 deleted_device, area_id=None
@@ -4511,8 +4523,9 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             self._async_update_child_device(
                 child_device.id, labels=child_device.labels - {label_id}
             )
-        for deleted_device in list(self._deleted_devices.values()):
-            if label_id not in deleted_device.labels:
+        for deleted_device_id in list(self._deleted_devices):
+            deleted_device = self._deleted_devices.get(deleted_device_id)
+            if deleted_device is None or label_id not in deleted_device.labels:
                 continue
             self._deleted_devices[deleted_device.id] = attr.evolve(
                 deleted_device, labels=deleted_device.labels - {label_id}

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1780,6 +1780,26 @@ class DeletedDeviceRegistryItems(DeviceRegistryItems[DeletedDeviceEntry]):
                 return entry
         return None
 
+    def get_overlapping_orphans(
+        self,
+        identifiers: set[tuple[str, str]],
+        connections: set[tuple[str, str]],
+        domain: str,
+    ) -> list[DeletedDeviceEntry]:
+        """Return the orphans of a domain sharing an identifier or connection.
+
+        Resolved through the orphan indexes, so orphaning a device costs its own
+        identifiers and connections rather than a scan of every deleted device.
+        Both sets are taken from a stored entry, so their connections are already
+        normalized and match the index keys.
+        """
+        orphans: dict[str, DeletedDeviceEntry] = {}
+        for identifier in identifiers:
+            orphans.update(self._orphaned_identifiers.get(identifier, {}))
+        for connection in connections:
+            orphans.update(self._orphaned_connections.get(connection, {}))
+        return [entry for entry in orphans.values() if entry.domain == domain]
+
 
 class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
     """Class to hold a registry of devices."""
@@ -4353,16 +4373,10 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             # device from the same integration is orphaned, drop any existing orphan
             # it overlaps so the newest one wins deterministically instead of shadowing
             # it.
-            for existing in list(self._deleted_devices.values()):
-                if (
-                    existing.config_entry_id is None
-                    and existing.domain == domain
-                    and (
-                        existing.connections & deleted_device.connections
-                        or existing.identifiers & deleted_device.identifiers
-                    )
-                ):
-                    del self._deleted_devices[existing.id]
+            for existing in self._deleted_devices.get_overlapping_orphans(
+                deleted_device.identifiers, deleted_device.connections, domain
+            ):
+                del self._deleted_devices[existing.id]
         self._deleted_devices[deleted_device.id] = attr.evolve(
             deleted_device,
             config_entry_id=None,

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -3041,36 +3041,59 @@ async def test_orphan_not_restored_for_other_domain(
     assert device.id in device_registry._deleted_devices
 
 
+@pytest.mark.parametrize(
+    ("connections_1", "identifiers_1", "connections_2", "identifiers_2"),
+    [
+        pytest.param(
+            {(dr.CONNECTION_NETWORK_MAC, "12:34:56:ab:cd:ef")},
+            {("hue", "1")},
+            {(dr.CONNECTION_NETWORK_MAC, "12:34:56:ab:cd:ef")},
+            {("hue", "2")},
+            id="shared_connection",
+        ),
+        pytest.param(
+            {(dr.CONNECTION_NETWORK_MAC, "12:34:56:ab:cd:01")},
+            {("hue", "shared")},
+            {(dr.CONNECTION_NETWORK_MAC, "12:34:56:ab:cd:02")},
+            {("hue", "shared")},
+            id="shared_identifier",
+        ),
+    ],
+)
 async def test_orphaning_replaces_colliding_same_domain_orphan(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    connections_1: set[tuple[str, str]],
+    identifiers_1: set[tuple[str, str]],
+    connections_2: set[tuple[str, str]],
+    identifiers_2: set[tuple[str, str]],
 ) -> None:
     """Orphaning a device drops a stale same-domain orphan it collides with.
 
-    Two devices from the same integration sharing a connection both orphan under
-    config_entry_id=None and would collide in the lookup index; the newest orphan replaces
-    the stale one so a re-add restores it deterministically.
+    Two devices from the same integration sharing a connection or an identifier both
+    orphan under config_entry_id=None and would collide in the lookup index; the newest
+    orphan replaces the stale one so a re-add restores it deterministically.
     """
-    connections = {(dr.CONNECTION_NETWORK_MAC, "12:34:56:ab:cd:ef")}
     entry_1 = MockConfigEntry(domain="hue")
     entry_1.add_to_hass(hass)
     device_1 = device_registry.async_get_or_create(
         config_entry_id=entry_1.entry_id,
-        connections=connections,
-        identifiers={("hue", "1")},
+        connections=connections_1,
+        identifiers=identifiers_1,
     )
     entry_2 = MockConfigEntry(domain="hue")
     entry_2.add_to_hass(hass)
     device_2 = device_registry.async_get_or_create(
         config_entry_id=entry_2.entry_id,
-        connections=connections,
-        identifiers={("hue", "2")},
+        connections=connections_2,
+        identifiers=identifiers_2,
     )
 
     device_registry.async_clear_config_entry(entry_1.entry_id, entry_1.domain)
     assert device_1.id in device_registry._deleted_devices
 
     device_registry.async_clear_config_entry(entry_2.entry_id, entry_2.domain)
-    # The newer orphan replaces the stale one it collides with on the shared connection
+    # The newer orphan replaces the stale one it collides with
     assert device_1.id not in device_registry._deleted_devices
     assert device_2.id in device_registry._deleted_devices
 
@@ -3079,8 +3102,8 @@ async def test_orphaning_replaces_colliding_same_domain_orphan(
     entry_3.add_to_hass(hass)
     restored = device_registry.async_get_or_create(
         config_entry_id=entry_3.entry_id,
-        connections=connections,
-        identifiers={("hue", "2")},
+        connections=connections_2,
+        identifiers=identifiers_2,
     )
     assert restored.id == device_2.id
 

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -3085,6 +3085,47 @@ async def test_orphaning_replaces_colliding_same_domain_orphan(
     assert restored.id == device_2.id
 
 
+async def test_orphaning_keeps_non_overlapping_same_domain_orphans(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Orphaning a device leaves same-domain orphans it does not collide with.
+
+    Only an orphan sharing an identifier or connection would collide in the lookup
+    index, so orphaning must drop exactly those and not every orphan of the domain.
+    """
+    entries = []
+    devices = []
+    for index in range(3):
+        entry = MockConfigEntry(domain="hue")
+        entry.add_to_hass(hass)
+        entries.append(entry)
+        devices.append(
+            device_registry.async_get_or_create(
+                config_entry_id=entry.entry_id,
+                connections={(dr.CONNECTION_NETWORK_MAC, f"12:34:56:ab:cd:0{index}")},
+                identifiers={("hue", str(index))},
+            )
+        )
+
+    for entry in entries:
+        device_registry.async_clear_config_entry(entry.entry_id, entry.domain)
+
+    # None of them overlap, so all three orphans survive
+    for device in devices:
+        assert device.id in device_registry._deleted_devices
+
+    # Each is still restorable by its own identifier
+    for index, device in enumerate(devices):
+        entry = MockConfigEntry(domain="hue")
+        entry.add_to_hass(hass)
+        restored = device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            connections={(dr.CONNECTION_NETWORK_MAC, f"12:34:56:ab:cd:0{index}")},
+            identifiers={("hue", str(index))},
+        )
+        assert restored.id == device.id
+
+
 async def test_orphaned_domain_survives_store_round_trip(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:


### PR DESCRIPTION

## Proposed change

Two independent problems in the device registry's handling of deleted devices, both
of which turn a large `deleted_devices` store into a hang or a memory spike. Deleted
devices whose config entry still exists are never purged, so that store grows without
bound; a reporter in #181120 has 739562 of them.

**Orphaning scanned every deleted device.** `_async_orphan_deleted_device` searched the
whole collection for the same-domain orphans a device collides with, so clearing a
config entry cost O(n^2) and could block the event loop for hours. The orphan connection
and identifier indexes already hold exactly the orphans a device can collide with, so
the collisions are looked up there instead. Clearing a config entry is now linear:
~10us per deleted device, flat from 100 to 25600 entries, where it previously took
282ms at 1600 entries alone.

**The rewrite loops held every entry alive.** Five loops snapshotted the entries
themselves, so every deleted device stayed alive while the loop replaced them one by
one with `attr.evolve` copies, transiently doubling the registry's footprint. Measured
while clearing one config entry over 200000 entries: peak live entries 340000 against
a baseline of 180001, or 1.89x. They now snapshot the ids and re-read each entry, so a
replaced entry is freed immediately; peak live entries match the baseline exactly
(1.00x). Re-reading also skips an entry the orphan dedupe dropped earlier in the same
loop, which the entry snapshot would resurrect.

This addresses the failure mode but not the unbounded growth itself, which needs a
retention policy decision, nor whatever produced 739562 removals in the first place.

## Type of change


- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes #
- This PR is related to issue: #181120
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist


- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.



To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``


[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr