### PR TITLE
Add delay_on and delay_off when configuring a binary sensor template helpers

### DIFF
--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -225,6 +225,12 @@ class StateBinarySensorEntity(TemplateEntity, AbstractTemplateBinarySensor):
         # state with delay. Cancelled if template result changes.
         self._delay_cancel = async_call_later(self.hass, delay, _set_state)
 
+    @override
+    def _call_on_remove_callbacks(self):
+        if self._delay_cancel:
+            self._delay_cancel()
+        return super()._call_on_remove_callbacks()
+
 
 @dataclass
 class AutoOffExtraStoredData(ExtraStoredData):

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -216,7 +216,10 @@ class StateBinarySensorEntity(TemplateEntity, AbstractTemplateBinarySensor):
         def _set_state(_):
             """Set state of template binary sensor."""
             self._attr_is_on = state
-            self.async_write_ha_state()
+            if self._preview_callback:
+                self._async_preview_update()
+            else:
+                self.async_write_ha_state()
 
         delay = (self._delay_on if state else self._delay_off).total_seconds()
         # state with delay. Cancelled if template result changes.

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -51,7 +51,11 @@ from .alarm_control_panel import (
     TemplateCodeFormat,
     async_create_preview_alarm_control_panel,
 )
-from .binary_sensor import async_create_preview_binary_sensor
+from .binary_sensor import (
+    CONF_DELAY_OFF,
+    CONF_DELAY_ON,
+    async_create_preview_binary_sensor,
+)
 from .const import (
     CONF_ADDITIONAL_OPTIONS,
     CONF_AVAILABILITY,
@@ -183,6 +187,14 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
         schema |= _SCHEMA_STATE | {
             vol.Optional(CONF_DEVICE_CLASS): selector.DeviceClassSelector(
                 selector.DeviceClassSelectorConfig(domain=Platform.BINARY_SENSOR),
+            ),
+        }
+        additional_options |= {
+            vol.Optional(CONF_DELAY_ON): selector.DurationSelector(
+                selector.DurationSelectorConfig(allow_negative=False)
+            ),
+            vol.Optional(CONF_DELAY_OFF): selector.DurationSelector(
+                selector.DurationSelectorConfig(allow_negative=False)
             ),
         }
 

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -68,10 +68,14 @@
         "sections": {
           "additional_options": {
             "data": {
-              "availability": "[%key:component::template::common::availability%]"
+              "availability": "[%key:component::template::common::availability%]",
+              "delay_off": "Delay off",
+              "delay_on": "Delay on"
             },
             "data_description": {
-              "availability": "[%key:component::template::common::availability_description%]"
+              "availability": "[%key:component::template::common::availability_description%]",
+              "delay_off": "The amount of time the template state must not be met before this sensor switches to `off`.",
+              "delay_on": "The amount of time the template state must be met before this sensor switches to `on`."
             },
             "name": "[%key:component::template::common::additional_options%]"
           }
@@ -669,10 +673,14 @@
         "sections": {
           "additional_options": {
             "data": {
-              "availability": "[%key:component::template::common::availability%]"
+              "availability": "[%key:component::template::common::availability%]",
+              "delay_off": "[%key:component::template::config::step::binary_sensor::sections::additional_options::data::delay_off%]",
+              "delay_on": "[%key:component::template::config::step::binary_sensor::sections::additional_options::data::delay_on%]"
             },
             "data_description": {
-              "availability": "[%key:component::template::common::availability_description%]"
+              "availability": "[%key:component::template::common::availability_description%]",
+              "delay_off": "[%key:component::template::config::step::binary_sensor::sections::additional_options::data_description::delay_off%]",
+              "delay_on": "[%key:component::template::config::step::binary_sensor::sections::additional_options::data_description::delay_on%]"
             },
             "name": "[%key:component::template::common::additional_options%]"
           }

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -453,6 +453,18 @@ class TemplateEntity(AbstractTemplateEntity):
             self._preview_callback(None, None, None, str(errors[-1]))
             return
 
+        self._async_preview_update()
+
+    @callback
+    def _async_preview_update(self) -> None:
+        """Send an updated state to the preview callback."""
+        if not self._preview_callback:
+            return
+
+        if not self._template_result_info:
+            self._preview_callback(None, None, None, "Preview not ready")
+            return
+
         try:
             calculated_state = self._async_calculate_state()
             validate_state(calculated_state.state)

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -10,7 +10,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant import setup
+from homeassistant import config_entries, setup
 from homeassistant.components import binary_sensor, template
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -21,10 +21,12 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import Context, CoreState, HomeAssistant, State
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.helpers.restore_state import STORAGE_KEY as RESTORE_STATE_KEY
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import dt as dt_util
 
 from .conftest import (
     RESTORE_STATE_SAVED_ATTRIBUTES,
@@ -596,6 +598,136 @@ async def test_delay_off(hass: HomeAssistant, freezer: FrozenDateTimeFactory) ->
     await hass.async_block_till_done()
 
     assert hass.states.get(TEST_BINARY_SENSOR.entity_id).state == STATE_OFF
+
+
+@pytest.mark.parametrize(
+    ("advanced_input", "expected_advanced_options"),
+    [
+        ({"delay_on": {"seconds": 5}}, {"delay_on": {"seconds": 5.0}}),
+        ({"delay_off": {"minutes": 1}}, {"delay_off": {"minutes": 1.0}}),
+        (
+            {"delay_on": {"seconds": 5}, "delay_off": {"minutes": 1}},
+            {"delay_on": {"seconds": 5.0}, "delay_off": {"minutes": 1.0}},
+        ),
+    ],
+)
+async def test_config_flow_binary_sensor_delay_options(
+    hass: HomeAssistant,
+    advanced_input: dict[str, Any],
+    expected_advanced_options: dict[str, Any],
+) -> None:
+    """Test delay options in the binary sensor config flow."""
+    result = await hass.config_entries.flow.async_init(
+        template.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"next_step_id": "binary_sensor"},
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "binary_sensor"
+
+    with patch(
+        "homeassistant.components.template.async_setup_entry",
+        wraps=template.async_setup_entry,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "name": "My template",
+                "state": "{{ true }}",
+                "additional_options": advanced_input,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "My template"
+    assert result["data"] == {}
+    assert result["options"] == {
+        "name": "My template",
+        "template_type": "binary_sensor",
+        "state": "{{ true }}",
+        "additional_options": expected_advanced_options,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    config_entry = hass.config_entries.async_entries(template.DOMAIN)[0]
+    assert config_entry.data == {}
+    assert config_entry.options == {
+        "name": "My template",
+        "template_type": "binary_sensor",
+        "state": "{{ true }}",
+        "additional_options": expected_advanced_options,
+    }
+    state = hass.states.get("binary_sensor.my_template")
+    if "delay_on" in expected_advanced_options:
+        assert state.state == "unknown"
+    else:
+        assert state.state == "on"
+
+
+async def test_config_flow_preview_binary_sensor_delay(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the config flow preview with a delayed binary sensor."""
+    client = await hass_ws_client(hass)
+
+    hass.states.async_set("binary_sensor.available", "on")
+    hass.states.async_set("binary_sensor.one", "off")
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_init(
+        template.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"next_step_id": "binary_sensor"},
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "binary_sensor"
+    assert result["preview"] == "template"
+
+    await client.send_json_auto_id(
+        {
+            "type": "template/start_preview",
+            "flow_id": result["flow_id"],
+            "flow_type": "config_flow",
+            "user_input": {
+                "name": "My template",
+                "state": "{{ is_state('binary_sensor.one', 'on') }}",
+                "additional_options": {
+                    "availability": "{{ True }}",
+                    "delay_on": {"seconds": 1},
+                },
+            },
+        }
+    )
+    msg = await client.receive_json()
+    assert msg["success"]
+    assert msg["result"] is None
+
+    msg = await client.receive_json()
+    assert msg["event"]["state"] == "off"
+
+    hass.states.async_set("binary_sensor.one", "on")
+    await hass.async_block_till_done()
+
+    msg = await client.receive_json()
+    assert msg["event"]["state"] == "off"
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    msg = await client.receive_json()
+    assert msg["event"]["state"] == "on"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -601,13 +601,22 @@ async def test_delay_off(hass: HomeAssistant, freezer: FrozenDateTimeFactory) ->
 
 
 @pytest.mark.parametrize(
-    ("advanced_input", "expected_advanced_options"),
+    ("advanced_input", "expected_advanced_options", "expected_state"),
     [
-        ({"delay_on": {"seconds": 5}}, {"delay_on": {"seconds": 5.0}}),
-        ({"delay_off": {"minutes": 1}}, {"delay_off": {"minutes": 1.0}}),
+        (
+            {"delay_on": {"seconds": 5}},
+            {"delay_on": {"seconds": 5.0}},
+            STATE_UNKNOWN,
+        ),
+        (
+            {"delay_off": {"minutes": 1}},
+            {"delay_off": {"minutes": 1.0}},
+            STATE_ON,
+        ),
         (
             {"delay_on": {"seconds": 5}, "delay_off": {"minutes": 1}},
             {"delay_on": {"seconds": 5.0}, "delay_off": {"minutes": 1.0}},
+            STATE_UNKNOWN,
         ),
     ],
 )
@@ -615,6 +624,7 @@ async def test_config_flow_binary_sensor_delay_options(
     hass: HomeAssistant,
     advanced_input: dict[str, Any],
     expected_advanced_options: dict[str, Any],
+    expected_state: str,
 ) -> None:
     """Test delay options in the binary sensor config flow."""
     result = await hass.config_entries.flow.async_init(
@@ -664,10 +674,7 @@ async def test_config_flow_binary_sensor_delay_options(
         "additional_options": expected_advanced_options,
     }
     state = hass.states.get("binary_sensor.my_template")
-    if "delay_on" in expected_advanced_options:
-        assert state.state == "unknown"
-    else:
-        assert state.state == "on"
+    assert state.state == expected_state
 
 
 async def test_config_flow_preview_binary_sensor_delay(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`delay_on` and `delay_off` are two additional options of the binary sensor template helpers that are available in YAML.

This PR makes them available in the UI under an additional option section to avoid overcrowding the UI.

Referenced closed PR https://github.com/home-assistant/core/pull/160383, big thanks to @jlpouffier as most of the code is his adapted to the current codbase.

Approved arch discussion: https://github.com/home-assistant/architecture/discussions/1340#discussioncomment-18270046
Referenced Feature Request:  https://github.com/orgs/home-assistant/discussions/885

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
