### PR TITLE
Add a Wi-Fi signal strength sensor to Roomba

### DIFF
--- a/homeassistant/components/roomba/sensor.py
+++ b/homeassistant/components/roomba/sensor.py
@@ -12,7 +12,13 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfArea, UnitOfTime
+from homeassistant.const import (
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    EntityCategory,
+    UnitOfArea,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -135,6 +141,15 @@ SENSORS: list[RoombaSensorEntityDescription] = [
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda self: self.last_mission,
         entity_registry_enabled_default=False,
+    ),
+    RoombaSensorEntityDescription(
+        key="rssi",
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda self: self.vacuum_state.get("signal", {}).get("rssi"),
     ),
 ]
 

--- a/homeassistant/components/roomba/sensor.py
+++ b/homeassistant/components/roomba/sensor.py
@@ -33,6 +33,11 @@ class RoombaSensorEntityDescription(SensorEntityDescription):
 
     value_fn: Callable[[IRobotEntity], StateType]
 
+    # IRobotEntity.new_state_filter drops messages whose only reported key is
+    # "signal", so that a Wi-Fi update does not wake every entity. Sensors that
+    # actually read "signal" have to opt back in or they never refresh.
+    refresh_on_signal: bool = False
+
 
 DOCK_SENSORS: list[RoombaSensorEntityDescription] = [
     RoombaSensorEntityDescription(
@@ -149,6 +154,7 @@ SENSORS: list[RoombaSensorEntityDescription] = [
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        refresh_on_signal=True,
         value_fn=lambda self: self.vacuum_state.get("signal", {}).get("rssi"),
     ),
 ]
@@ -191,6 +197,13 @@ class RoombaSensor(IRobotEntity, SensorEntity):
         """Initialize Roomba sensor."""
         super().__init__(roomba, blid)
         self.entity_description = entity_description
+
+    @override
+    def new_state_filter(self, new_state):
+        """Also accept Wi-Fi only messages for sensors that read them."""
+        if self.entity_description.refresh_on_signal and "signal" in new_state:
+            return True
+        return super().new_state_filter(new_state)
 
     @property
     @override

--- a/tests/components/roomba/conftest.py
+++ b/tests/components/roomba/conftest.py
@@ -50,6 +50,7 @@ def mock_roomba() -> Generator[AsyncMock]:
                 "softwareVer": "3.2.1",
                 "hardwareRev": "1.0",
                 "bin": {"present": True, "full": False},
+                "signal": {"rssi": -47, "snr": 21, "noise": -68},
             }
         }
     }

--- a/tests/components/roomba/snapshots/test_sensor.ambr
+++ b/tests/components/roomba/snapshots/test_sensor.ambr
@@ -419,6 +419,61 @@
     'state': 'unknown',
   })
 # ---
+# name: test_entities[sensor.test_roomba_signal_strength-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_roomba_signal_strength',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Signal strength',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.SIGNAL_STRENGTH: 'signal_strength'>,
+    'original_icon': None,
+    'original_name': 'Signal strength',
+    'platform': 'roomba',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'rssi_blid123',
+    'unit_of_measurement': 'dBm',
+  })
+# ---
+# name: test_entities[sensor.test_roomba_signal_strength-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'signal_strength',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Roomba Signal strength',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'dBm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_roomba_signal_strength',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '-47',
+  })
+# ---
 # name: test_entities[sensor.test_roomba_successful_missions-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/roomba/test_sensor.py
+++ b/tests/components/roomba/test_sensor.py
@@ -103,3 +103,35 @@ async def test_robot_without_dock_has_no_dock_sensor(
             await hass.async_block_till_done()
 
     assert len(_dock_tank_level_entities(hass)) == 1
+
+
+async def test_rssi_refreshes_on_wifi_only_message(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_roomba: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the RSSI sensor refreshes on a message that only carries signal.
+
+    IRobotEntity.new_state_filter drops messages whose only reported key is
+    "signal" so a Wi-Fi update does not wake every entity. The RSSI sensor
+    reads exactly that key, so it has to opt back in or it never updates.
+    """
+    entity_id = "sensor.test_roomba_signal_strength"
+    with patch("homeassistant.components.roomba.PLATFORMS", [Platform.SENSOR]):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_registry.async_update_entity(entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == "-47"
+
+    # A Wi-Fi only update, which is what the robot sends most often.
+    mock_roomba.master_state["state"]["reported"]["signal"]["rssi"] = -62
+    for call in mock_roomba.register_on_message_callback.call_args_list:
+        call.args[0]({"state": {"reported": {"signal": {"rssi": -62}}}})
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == "-62"


### PR DESCRIPTION
## Proposed change

The robot reports its Wi-Fi signal in the `signal` object of its state and the integration does not surface any of it.

Captured from an i4 (`i415020`, firmware `daredevil+2.6.0`) by diffing a docked snapshot against one taken mid-mission. The values move as the robot travels:

```
signal.rssi   -45 -> -47
signal.snr     22 -> 21
signal.noise  -67 -> -68
```

This adds `rssi` as a diagnostic sensor. It makes weak coverage visible, which is worth something on a device that deliberately drives away from its access point and still has to report back. A run where RSSI collapses in one room is a useful thing to be able to see.

### Choices worth flagging

**Only `rssi`, not `snr` or `noise`.** RSSI maps cleanly onto `SensorDeviceClass.SIGNAL_STRENGTH` with an established unit. The other two have no device class and no obvious presentation, so I left them out rather than invent one. Happy to add them if you would like them.

**No `translation_key`.** The name comes from the device class. That is what the large majority of integrations with a `SIGNAL_STRENGTH` sensor do (88 of them, versus 12 that override the name), and it keeps the diff to code plus tests with no strings change.

**Disabled by default and marked diagnostic**, consistent with how other integrations expose RSSI.

**Read defensively** as `self.vacuum_state.get("signal", {}).get("rssi")`, so a model that does not report a `signal` object produces an unknown state rather than an error. I could only test against an i4, so I did not want to assume every model reports it.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: home-assistant/home-assistant.io#47880
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

---

The test fixture gains a `signal` block using the real values captured above. Confirmed the snapshot test genuinely asserts the new entity: removing its snapshot entries fails `test_entities`, rather than passing quietly.

Also run: `pytest tests/components/roomba/` (44 passed), `ruff check`, `ruff format --check`, `script.hassfest` (0 invalid), `pylint` on both the component and the tests, and `mypy` (no errors in the changed file). The two pre-existing `E7403` pylint findings in `entity.py` and `binary_sensor.py` are unrelated and present on a clean `dev`.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

