### PR TITLE
Drop translations from the Sofar coordinator errors

### DIFF
--- a/homeassistant/components/sofar/coordinator.py
+++ b/homeassistant/components/sofar/coordinator.py
@@ -69,18 +69,22 @@ class SofarDataUpdateCoordinator(DataUpdateCoordinator[UpdateReport]):
             report = await self._retry_failed(report)
             if not report.updated:
                 errors = list(report.failed.values())
-                cause = (
-                    ExceptionGroup("all components failed to refresh", errors)
-                    if errors
-                    else None
-                )
-                # pylint: disable-next=home-assistant-exception-not-translated
-                raise UpdateFailed("No component answered") from cause
+                if not errors:
+                    raise UpdateFailed(
+                        translation_domain=DOMAIN,
+                        translation_key="no_component_answered",
+                    )
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="no_component_answered",
+                ) from ExceptionGroup("all components failed to refresh", errors)
         except ModbusError as err:
             # ModbusConnectionError (dead link) and ModbusTimeoutError reach
             # here; per-block failures once alive land in report.failed instead.
-            # pylint: disable-next=home-assistant-exception-not-translated
-            raise UpdateFailed(f"Modbus error: {err}") from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="modbus_error",
+            ) from err
         else:
             return report
 

--- a/homeassistant/components/sofar/coordinator.py
+++ b/homeassistant/components/sofar/coordinator.py
@@ -69,25 +69,18 @@ class SofarDataUpdateCoordinator(DataUpdateCoordinator[UpdateReport]):
             report = await self._retry_failed(report)
             if not report.updated:
                 errors = list(report.failed.values())
-                if not errors:
-                    raise UpdateFailed(
-                        translation_domain=DOMAIN,
-                        translation_key="no_component_answered",
-                        translation_placeholders={"name": self.name},
-                    )
-                raise UpdateFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="no_component_answered",
-                    translation_placeholders={"name": self.name},
-                ) from ExceptionGroup("all components failed to refresh", errors)
+                cause = (
+                    ExceptionGroup("all components failed to refresh", errors)
+                    if errors
+                    else None
+                )
+                # pylint: disable-next=home-assistant-exception-not-translated
+                raise UpdateFailed("No component answered") from cause
         except ModbusError as err:
             # ModbusConnectionError (dead link) and ModbusTimeoutError reach
             # here; per-block failures once alive land in report.failed instead.
-            raise UpdateFailed(
-                translation_domain=DOMAIN,
-                translation_key="modbus_error",
-                translation_placeholders={"error": str(err)},
-            ) from err
+            # pylint: disable-next=home-assistant-exception-not-translated
+            raise UpdateFailed(f"Modbus error: {err}") from err
         else:
             return report
 

--- a/homeassistant/components/sofar/strings.json
+++ b/homeassistant/components/sofar/strings.json
@@ -611,6 +611,12 @@
     "max_power_not_a_multiple_of_100": {
       "message": "Maximum power must be a multiple of 100 W."
     },
+    "modbus_error": {
+      "message": "Error communicating with the inverter."
+    },
+    "no_component_answered": {
+      "message": "No component answered."
+    },
     "unrecognized_inverter_model": {
       "message": "Unrecognized Sofar inverter model for {title}."
     },

--- a/homeassistant/components/sofar/strings.json
+++ b/homeassistant/components/sofar/strings.json
@@ -611,12 +611,6 @@
     "max_power_not_a_multiple_of_100": {
       "message": "Maximum power must be a multiple of 100 W."
     },
-    "modbus_error": {
-      "message": "{error}"
-    },
-    "no_component_answered": {
-      "message": "{name}: no component answered."
-    },
     "unrecognized_inverter_model": {
       "message": "Unrecognized Sofar inverter model for {title}."
     },

--- a/tests/components/sofar/test_init.py
+++ b/tests/components/sofar/test_init.py
@@ -346,7 +346,7 @@ async def test_every_component_failing_recovers_on_a_later_poll(
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
     # Availability alone cannot tell a failed poll from one that reported
     # every component as failed; only the logged error separates them.
-    assert "no component answered" in caplog.text
+    assert "No component answered" in caplog.text
 
     mock_connection.for_unit(1).fail_requests(None)
     freezer.tick(timedelta(seconds=SCAN_INTERVAL))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Drop the `translation_placeholders` from the coordinator's `UpdateFailed`
raises. `modbus_error` was a bare `{error}` passthrough and now carries a real
message; `no_component_answered` loses the `{name}` prefix, which the
coordinator's own log line already provides.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
