### PR TITLE
Fix Besen config flow schema serialization

### DIFF
--- a/homeassistant/components/besen/config_flow.py
+++ b/homeassistant/components/besen/config_flow.py
@@ -34,13 +34,10 @@ def _normalize_address(address: str) -> str:
     return address.strip().upper()
 
 
-PIN_SCHEMA = vol.All(
-    selector.TextSelector(
-        selector.TextSelectorConfig(
-            type=selector.TextSelectorType.PASSWORD,
-        )
-    ),
-    vol.Match(r"^\d{6}$"),
+PIN_SCHEMA = selector.TextSelector(
+    selector.TextSelectorConfig(
+        type=selector.TextSelectorType.PASSWORD,
+    )
 )
 
 PIN_ONLY_SCHEMA = vol.Schema(
@@ -76,6 +73,9 @@ async def _async_validate_input(
     name: str | None,
 ) -> str:
     """Validate setup by logging into the charger."""
+
+    if len(pin) != 6 or not pin.isdecimal():
+        raise InvalidAuth("PIN must be exactly 6 digits")
 
     def _ble_device_provider() -> BLEDevice | None:
         return bluetooth.async_ble_device_from_address(

--- a/tests/components/besen/test_config_flow.py
+++ b/tests/components/besen/test_config_flow.py
@@ -3,8 +3,8 @@
 from unittest.mock import Mock
 
 from besen.exceptions import CannotConnect, InvalidAuth
+from probatio import to_field_list
 import pytest
-import voluptuous as vol
 
 from homeassistant.components.besen.const import DOMAIN
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
@@ -12,6 +12,7 @@ from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_USER
 from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_PIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import config_validation as cv
 
 from .conftest import (
     FIXTURE_ADDRESS,
@@ -91,6 +92,7 @@ async def test_bluetooth_step_sets_discovered_context(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "bluetooth_confirm"
+    assert to_field_list(result["data_schema"], custom_serializer=cv.custom_serializer)
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -243,25 +245,32 @@ async def test_user_step_success(
     _assert_create_entry(result)
 
 
-@pytest.mark.usefixtures("mock_besen_client", "mock_setup_entry")
+@pytest.mark.parametrize("invalid_pin", ["12345", "¹²³⁴⁵⁶"])
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_user_step_rejects_invalid_pin(
     hass: HomeAssistant,
+    mock_besen_client: Mock,
+    invalid_pin: str,
 ) -> None:
-    """Test the user step PIN schema rejects invalid values."""
+    """Test the user step rejects invalid PIN values."""
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
     )
 
-    with pytest.raises(vol.Invalid):
-        await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_ADDRESS: FIXTURE_ADDRESS,
-                CONF_PIN: "12345",
-            },
-        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ADDRESS: FIXTURE_ADDRESS,
+            CONF_PIN: invalid_pin,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_auth"}
+    mock_besen_client.async_start.assert_not_awaited()
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],


### PR DESCRIPTION
## Proposed change

Fix the Besen setup flow failing before the PIN form can be displayed.

The PIN field used `vol.Match`, which cannot be serialized for the frontend. This removes that validator from the rendered schema and keeps the same six-digit validation in the input validation path. A regression assertion verifies that the returned form schema can be serialized.

Apologies for missing this serialization path in the initial integration.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #181210
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr