### PR TITLE
Fix ADS integration not reconnecting after a link drop

### DIFF
--- a/homeassistant/components/ads/__init__.py
+++ b/homeassistant/components/ads/__init__.py
@@ -11,7 +11,8 @@ from homeassistant.const import (
     CONF_PORT,
     EVENT_HOMEASSISTANT_STOP,
 )
-from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.core import Event, HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
@@ -48,6 +49,8 @@ CONF_ADS_VALUE = "value"
 
 SERVICE_WRITE_DATA_BY_NAME = "write_data_by_name"
 
+TASK_WATCHDOG = "ads_connection_watchdog"
+
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
@@ -70,7 +73,7 @@ SCHEMA_SERVICE_WRITE_DATA_BY_NAME = vol.Schema(
 )
 
 
-def setup(hass: HomeAssistant, config: ConfigType) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the ADS component."""
 
     conf = config[DOMAIN]
@@ -82,7 +85,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     client = pyads.Connection(net_id, port, ip_address)
 
     try:
-        ads = AdsHub(client)
+        ads = await hass.async_add_executor_job(AdsHub, client)
     except pyads.ADSError:
         _LOGGER.error(
             "Could not connect to ADS host (netid=%s, ip=%s, port=%s)",
@@ -93,7 +96,13 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
         return False
 
     hass.data[DATA_ADS] = ads
-    hass.bus.listen(EVENT_HOMEASSISTANT_STOP, ads.shutdown)
+    hass.async_create_background_task(ads.async_watch_connection(hass), TASK_WATCHDOG)
+
+    async def async_shutdown(event: Event) -> None:
+        """Close the connection when Home Assistant stops."""
+        await hass.async_add_executor_job(ads.shutdown)
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_shutdown)
 
     def handle_write_data_by_name(call: ServiceCall) -> None:
         """Write a value to the connected ADS device."""
@@ -104,9 +113,9 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
         try:
             ads.write_by_name(ads_var, value, ADS_TYPEMAP[ads_type])
         except pyads.ADSError as err:
-            _LOGGER.error(err)
+            raise HomeAssistantError(f"Error writing {ads_var}: {err}") from err
 
-    hass.services.register(
+    hass.services.async_register(
         DOMAIN,
         SERVICE_WRITE_DATA_BY_NAME,
         handle_write_data_by_name,

--- a/homeassistant/components/ads/hub.py
+++ b/homeassistant/components/ads/hub.py
@@ -1,12 +1,17 @@
 """Support for Automation Device Specification (ADS)."""
 
+import asyncio
 from collections import namedtuple
 import ctypes
+from enum import Enum
 import logging
 import struct
 import threading
 
 import pyads
+import pyads.errorcodes
+
+from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -14,6 +19,19 @@ _LOGGER = logging.getLogger(__name__)
 NotificationItem = namedtuple(  # noqa: PYI024
     "NotificationItem", "hnotify huser name plc_datatype callback"
 )
+
+DEFAULT_TIMEOUT_MS = 5000
+OFFLINE_TIMEOUT_MS = 100
+WATCHDOG_INTERVAL = 5.0
+WATCHDOG_MAX_BACKOFF = 120.0
+
+
+class ConnectionState(Enum):
+    """Representation of the ADS connection state."""
+
+    CONNECTED = 1
+    READY_TO_RECONNECT = 2
+    DISCONNECTED = 3
 
 
 class AdsHub:
@@ -23,6 +41,7 @@ class AdsHub:
         """Initialize the ADS hub."""
         self._client = ads_client
         self._client.open()
+        self._is_running = True
 
         # All ADS devices are registered here
         self._devices = []
@@ -33,22 +52,25 @@ class AdsHub:
         """Shutdown ADS connection."""
 
         _LOGGER.debug("Shutting down ADS")
-        for notification_item in self._notification_items.values():
-            _LOGGER.debug(
-                "Deleting device notification %d, %d",
-                notification_item.hnotify,
-                notification_item.huser,
-            )
-            try:
-                self._client.del_device_notification(
-                    notification_item.hnotify, notification_item.huser
+        self._is_running = False
+
+        with self._lock:
+            for notification_item in self._notification_items.values():
+                _LOGGER.debug(
+                    "Deleting device notification %d, %d",
+                    notification_item.hnotify,
+                    notification_item.huser,
                 )
+                try:
+                    self._client.del_device_notification(
+                        notification_item.hnotify, notification_item.huser
+                    )
+                except pyads.ADSError as err:
+                    _LOGGER.error(err)
+            try:
+                self._client.close()
             except pyads.ADSError as err:
                 _LOGGER.error(err)
-        try:
-            self._client.close()
-        except pyads.ADSError as err:
-            _LOGGER.error(err)
 
     def register_device(self, device):
         """Register a new device."""
@@ -93,6 +115,110 @@ class AdsHub:
                 _LOGGER.debug(
                     "Added device notification %d for variable %s", hnotify, name
                 )
+
+    async def async_watch_connection(
+        self,
+        hass: HomeAssistant,
+        interval: float = WATCHDOG_INTERVAL,
+        max_backoff: float = WATCHDOG_MAX_BACKOFF,
+    ) -> None:
+        """Watch the connection and restore it after an outage."""
+        was_disconnected = False
+        wait_time = interval
+
+        while self._is_running:
+            try:
+                state = await hass.async_add_executor_job(self._check_connection)
+
+                if state is ConnectionState.CONNECTED:
+                    if was_disconnected:
+                        _LOGGER.info("Reconnected to the ADS device")
+                        await hass.async_add_executor_job(self._restore_notifications)
+                        was_disconnected = False
+                        wait_time = interval
+
+                    await asyncio.sleep(wait_time)
+                    continue
+
+                if not was_disconnected:
+                    _LOGGER.warning(
+                        "Lost connection to the ADS device, waiting for it to return"
+                    )
+                    was_disconnected = True
+                    wait_time = interval
+                    await hass.async_add_executor_job(self._suspend_notifications)
+
+                if state is ConnectionState.READY_TO_RECONNECT:
+                    await hass.async_add_executor_job(self._reconnect)
+                    if self._client.is_open:
+                        wait_time = interval
+
+                await asyncio.sleep(wait_time)
+                wait_time = min(wait_time * 2, max_backoff)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                _LOGGER.exception("Unexpected error while watching the ADS connection")
+                await asyncio.sleep(interval)
+
+    def _check_connection(self) -> ConnectionState:
+        """Return the current state of the connection."""
+
+        with self._lock:
+            if not self._client.is_open:
+                return ConnectionState.READY_TO_RECONNECT
+
+            try:
+                state = self._client.read_state()
+            except pyads.ADSError as err:
+                if getattr(err, "err_code", None) not in pyads.errorcodes.ERROR_CODES:
+                    return ConnectionState.READY_TO_RECONNECT
+                return ConnectionState.DISCONNECTED
+
+            if state is None:
+                return ConnectionState.READY_TO_RECONNECT
+
+            return ConnectionState.CONNECTED
+
+    def _reconnect(self) -> None:
+        """Reopen the connection to the device."""
+
+        with self._lock:
+            try:
+                self._client.close()
+                self._client.open()
+            except pyads.ADSError as err:
+                _LOGGER.debug("Reconnect attempt failed: %s", err)
+
+    def _suspend_notifications(self) -> None:
+        """Shorten the timeout and drop the notifications the device still holds."""
+
+        self._client.set_timeout(OFFLINE_TIMEOUT_MS)
+
+        with self._lock:
+            for notification_item in self._notification_items.values():
+                try:
+                    self._client.del_device_notification(
+                        notification_item.hnotify, notification_item.huser
+                    )
+                except pyads.ADSError as err:
+                    _LOGGER.debug(
+                        "Could not delete notification for %s: %s",
+                        notification_item.name,
+                        err,
+                    )
+
+    def _restore_notifications(self) -> None:
+        """Restore the timeout and subscribe again to every variable."""
+
+        self._client.set_timeout(DEFAULT_TIMEOUT_MS)
+
+        with self._lock:
+            items = list(self._notification_items.values())
+            self._notification_items.clear()
+
+        for item in items:
+            self.add_device_notification(item.name, item.plc_datatype, item.callback)
 
     def _device_notification_callback(self, notification, name):
         """Handle device notifications."""


### PR DESCRIPTION
Based on home-assistant/core#119521.
## Proposed change

The ADS connection is opened once in `setup()` and never restored. After any network interruption the port stays dead: device notifications silently stop arriving, writes fail with `timeout elapsed (1861)` and then `Unknown Error (-1)`, and the entities keep showing stale values. Because nothing polls the device, Home Assistant never learns that the link is gone. The only way back is restarting Home Assistant.

Verified against a real TwinCAT PLC with 57 subscribed variables. The connection now recovers on its own, without restarting Home Assistant:

```
Lost connection to the ADS device, waiting for it to return
Connected to 192.168.x.x
Reconnected to the ADS device
```

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #99258
- This PR is related to issue: #134052, #124866, #119521
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly. Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`. Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
