### PR TITLE
Fix EnergyZero market price regression

### DIFF
--- a/homeassistant/components/energyzero/coordinator.py
+++ b/homeassistant/components/energyzero/coordinator.py
@@ -10,6 +10,7 @@ from energyzero import (
     EnergyZeroConnectionError,
     EnergyZeroNoDataError,
     Interval,
+    PriceType,
 )
 
 from homeassistant.config_entries import ConfigEntry
@@ -61,12 +62,14 @@ class EnergyZeroDataUpdateCoordinator(DataUpdateCoordinator[EnergyZeroData]):
                 start_date=today,
                 end_date=today,
                 interval=Interval.HOUR,
+                price_type=PriceType.MARKET_WITH_VAT,
                 local_tz=local_tz,
             )
             try:
                 gas_today = await self.energyzero.get_gas_prices(
                     start_date=today,
                     end_date=today,
+                    price_type=PriceType.MARKET_WITH_VAT,
                     local_tz=local_tz,
                 )
             except EnergyZeroNoDataError:
@@ -79,6 +82,7 @@ class EnergyZeroDataUpdateCoordinator(DataUpdateCoordinator[EnergyZeroData]):
                         start_date=tomorrow,
                         end_date=tomorrow,
                         interval=Interval.HOUR,
+                        price_type=PriceType.MARKET_WITH_VAT,
                         local_tz=local_tz,
                     )
                 except EnergyZeroNoDataError:

--- a/tests/components/energyzero/snapshots/test_diagnostics.ambr
+++ b/tests/components/energyzero/snapshots/test_diagnostics.ambr
@@ -2,15 +2,15 @@
 # name: test_diagnostics_no_gas_today
   dict({
     'energy': dict({
-      'average_price': 0.25694034895833334,
-      'current_hour_price': 0.28275885,
+      'average_price': 0.14609224895833334,
+      'current_hour_price': 0.17191075,
       'highest_price_time': '2026-04-10T18:00:00+00:00',
       'hours_priced_equal_or_lower': 20,
       'lowest_price_time': '2026-04-11T06:00:00+00:00',
-      'max_price': 0.399000525,
-      'min_price': 0.188351625,
-      'next_hour_price': 0.2629693,
-      'percentage_of_max': 70.87,
+      'max_price': 0.288152425,
+      'min_price': 0.077503525,
+      'next_hour_price': 0.1521212,
+      'percentage_of_max': 59.66,
     }),
     'entry': dict({
       'title': 'energy',
@@ -24,15 +24,15 @@
 # name: test_entry_diagnostics
   dict({
     'energy': dict({
-      'average_price': 0.25694034895833334,
-      'current_hour_price': 0.28275885,
+      'average_price': 0.14609224895833334,
+      'current_hour_price': 0.17191075,
       'highest_price_time': '2026-04-10T18:00:00+00:00',
       'hours_priced_equal_or_lower': 20,
       'lowest_price_time': '2026-04-11T06:00:00+00:00',
-      'max_price': 0.399000525,
-      'min_price': 0.188351625,
-      'next_hour_price': 0.2629693,
-      'percentage_of_max': 70.87,
+      'max_price': 0.288152425,
+      'min_price': 0.077503525,
+      'next_hour_price': 0.1521212,
+      'percentage_of_max': 59.66,
     }),
     'entry': dict({
       'title': 'energy',

--- a/tests/components/energyzero/snapshots/test_sensor.ambr
+++ b/tests/components/energyzero/snapshots/test_sensor.ambr
@@ -51,7 +51,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.256940348958333',
+    'state': '0.141981021875',
   })
 # ---
 # name: test_sensor[sensor.energyzero_today_energy_current_hour_price-entry]
@@ -109,7 +109,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.28275885',
+    'state': '0.17191075',
   })
 # ---
 # name: test_sensor[sensor.energyzero_today_energy_highest_price_time-entry]
@@ -265,7 +265,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2026-04-11T06:00:00+00:00',
+    'state': '2026-04-10T01:00:00+00:00',
   })
 # ---
 # name: test_sensor[sensor.energyzero_today_energy_max_price-entry]
@@ -320,7 +320,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.399000525',
+    'state': '0.288152425',
   })
 # ---
 # name: test_sensor[sensor.energyzero_today_energy_min_price-entry]
@@ -375,7 +375,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.188351625',
+    'state': '0.08713815',
   })
 # ---
 # name: test_sensor[sensor.energyzero_today_energy_next_hour_price-entry]
@@ -430,7 +430,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0.2629693',
+    'state': '0.1521212',
   })
 # ---
 # name: test_sensor[sensor.energyzero_today_energy_percentage_of_max-entry]
@@ -482,7 +482,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '70.87',
+    'state': '59.66',
   })
 # ---
 # name: test_sensor[sensor.energyzero_today_gas_current_hour_price-entry]
@@ -540,7 +540,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.5468407201224',
   })
 # ---
 # name: test_sensor[sensor.energyzero_today_gas_next_hour_price-entry]
@@ -595,6 +595,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.5468407201224',
   })
 # ---

--- a/tests/components/energyzero/test_init.py
+++ b/tests/components/energyzero/test_init.py
@@ -1,14 +1,56 @@
 """Tests for the EnergyZero integration."""
 
-from unittest.mock import MagicMock, patch
+from datetime import date
+from unittest.mock import MagicMock, call, patch
+from zoneinfo import ZoneInfo
 
-from energyzero import EnergyZeroConnectionError
+from energyzero import EnergyZeroConnectionError, Interval, PriceType
 import pytest
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
+
+
+@pytest.mark.freeze_time("2026-04-10 20:32:59")
+async def test_coordinator_requests_market_prices_with_vat(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_energyzero: MagicMock,
+) -> None:
+    """Test the coordinator requests the backwards-compatible price stream."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    local_tz = ZoneInfo(hass.config.time_zone)
+    today = date(2026, 4, 10)
+    tomorrow = date(2026, 4, 11)
+    mock_energyzero.get_electricity_prices.assert_has_awaits(
+        [
+            call(
+                start_date=today,
+                end_date=today,
+                interval=Interval.HOUR,
+                price_type=PriceType.MARKET_WITH_VAT,
+                local_tz=local_tz,
+            ),
+            call(
+                start_date=tomorrow,
+                end_date=tomorrow,
+                interval=Interval.HOUR,
+                price_type=PriceType.MARKET_WITH_VAT,
+                local_tz=local_tz,
+            ),
+        ]
+    )
+    mock_energyzero.get_gas_prices.assert_awaited_once_with(
+        start_date=today,
+        end_date=today,
+        price_type=PriceType.MARKET_WITH_VAT,
+        local_tz=local_tz,
+    )
 
 
 @pytest.mark.usefixtures("mock_energyzero")

--- a/tests/components/energyzero/test_sensor.py
+++ b/tests/components/energyzero/test_sensor.py
@@ -29,8 +29,19 @@ async def test_sensor(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test the EnergyZero - Energy sensors."""
+    await hass.config.async_set_time_zone("Europe/Amsterdam")
     with patch("homeassistant.components.energyzero.PLATFORMS", ["sensor"]):
         await setup_integration(hass, mock_config_entry)
+
+    gas_state = hass.states.get("sensor.energyzero_today_gas_current_hour_price")
+    assert gas_state
+    assert gas_state.state == "0.5468407201224"
+    assert gas_state.state != "1.2736393201224"
+
+    energy_state = hass.states.get("sensor.energyzero_today_energy_current_hour_price")
+    assert energy_state
+    assert energy_state.state == "0.17191075"
+    assert energy_state.state != "0.28275885"
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 

--- a/tests/components/energyzero/test_sensor.py
+++ b/tests/components/energyzero/test_sensor.py
@@ -36,12 +36,10 @@ async def test_sensor(
     gas_state = hass.states.get("sensor.energyzero_today_gas_current_hour_price")
     assert gas_state
     assert gas_state.state == "0.5468407201224"
-    assert gas_state.state != "1.2736393201224"
 
     energy_state = hass.states.get("sensor.energyzero_today_energy_current_hour_price")
     assert energy_state
     assert energy_state.state == "0.17191075"
-    assert energy_state.state != "0.28275885"
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Explicitly request `PriceType.MARKET_WITH_VAT` for the EnergyZero coordinator electricity and gas price requests.

This fixes the regression introduced by #168641. Before that API migration, the legacy requests used `inclBtw=true`. In energyzero 5.0.2, the equivalent stream is `MARKET_WITH_VAT` (`base_with_vat`). Leaving `price_type` unspecified instead selects the new `ALL_IN` default (`all_in_with_vat`) and silently changes the meaning of the existing entities.

The existing entities therefore keep their pre-2026.9 market-price-with-VAT semantics. Dedicated all-in entities are intentionally out of scope and should be handled separately as a feature.

Regression coverage verifies the coordinator request contract for today electricity, today gas, and tomorrow electricity. Sensor coverage also proves that the gas entity exposes the `base_with_vat` fixture value (`0.5468407201224`) rather than the `all_in_with_vat` value (`1.2736393201224`), with equivalent explicit coverage for electricity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please, be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181183
- This PR is related to issue: #168641
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of our review will go up.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
