### PR TITLE
Add full Silla Prism EVSE controls

### DIFF
--- a/homeassistant/components/silla_prism/__init__.py
+++ b/homeassistant/components/silla_prism/__init__.py
@@ -1,21 +1,265 @@
-"""The Silla Prism integration."""
+"""silla_prism_async."""
 
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.typing import ConfigType
 
-from .const import PLATFORMS
-from .coordinator import PrismConfigEntry, PrismCoordinator
+from .const import (
+    CONF_BATTERY_DISCHARGE_POSITIVE,
+    CONF_BATTERY_MAX_CHARGE_POWER,
+    CONF_BATTERY_POWER_SENSOR,
+    CONF_BATTERY_SOC_SENSOR,
+    CONF_HOME_LOAD_INCLUDES_EV,
+    CONF_HOME_LOAD_POWER_SENSOR,
+    CONF_MAX_CURRENT,
+    CONF_PORTS,
+    CONF_POWERWALL,
+    CONF_SERIAL,
+    CONF_SOLAR_BALANCE_DEADBAND_POWER,
+    CONF_SOLAR_BALANCE_DECREASE_STEP,
+    CONF_SOLAR_BALANCE_DRY_RUN,
+    CONF_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+    CONF_SOLAR_BALANCE_INCREASE_INTERVAL,
+    CONF_SOLAR_BALANCE_INCREASE_STEP,
+    CONF_SOLAR_BALANCE_MID_RESERVE_POWER,
+    CONF_SOLAR_BALANCE_PHASES,
+    CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+    CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+    CONF_SOLAR_BALANCE_SOC_HIGH,
+    CONF_SOLAR_BALANCE_SOC_MID,
+    CONF_SOLAR_BALANCE_START_DELAY,
+    CONF_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+    CONF_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+    CONF_SOLAR_BATTERY_BALANCE,
+    CONF_SOLAR_PRODUCTION_POWER_SENSOR,
+    CONF_TOPIC,
+    CONF_VSENSORS,
+    DEFAULT_BATTERY_DISCHARGE_POSITIVE,
+    DEFAULT_BATTERY_MAX_CHARGE_POWER,
+    DEFAULT_BATTERY_POWER_SENSOR,
+    DEFAULT_BATTERY_SOC_SENSOR,
+    DEFAULT_HOME_LOAD_INCLUDES_EV,
+    DEFAULT_HOME_LOAD_POWER_SENSOR,
+    DEFAULT_MAX_CURRENT,
+    DEFAULT_PORTS,
+    DEFAULT_POWERWALL,
+    DEFAULT_SERIAL,
+    DEFAULT_SOLAR_BALANCE_DEADBAND_POWER,
+    DEFAULT_SOLAR_BALANCE_DECREASE_STEP,
+    DEFAULT_SOLAR_BALANCE_DRY_RUN,
+    DEFAULT_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+    DEFAULT_SOLAR_BALANCE_INCREASE_INTERVAL,
+    DEFAULT_SOLAR_BALANCE_INCREASE_STEP,
+    DEFAULT_SOLAR_BALANCE_MID_RESERVE_POWER,
+    DEFAULT_SOLAR_BALANCE_PHASES,
+    DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+    DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+    DEFAULT_SOLAR_BALANCE_SOC_HIGH,
+    DEFAULT_SOLAR_BALANCE_SOC_MID,
+    DEFAULT_SOLAR_BALANCE_START_DELAY,
+    DEFAULT_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+    DEFAULT_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+    DEFAULT_SOLAR_BATTERY_BALANCE,
+    DEFAULT_SOLAR_PRODUCTION_POWER_SENSOR,
+    DEFAULT_VSENSORS,
+    DOMAIN,
+)
+from .coordinator import PrismCoordinator
+from .entry_data import RuntimeEntryData
+
+_LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: PrismConfigEntry) -> bool:
-    """Set up Silla Prism from a config entry."""
-    coordinator = PrismCoordinator(hass, entry)
-    await coordinator.async_config_entry_first_refresh()
-    entry.runtime_data = coordinator
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Silla Prism integration."""
+    return True
 
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
+
+
+def _get_device_identifier(port: int, serial: str) -> str:
+    if serial == "" and port == 0:
+        return "prism"
+    if serial == "":
+        return f"PrismPort{port}"
+    return f"Prism_Port{port}_Serial{serial}"
+
+
+def _get_device_name(port: int, serial: str) -> str:
+    if serial == "" and port == 0:
+        return "Prism"
+    if serial == "":
+        return f"Prism Port {port}"
+    return f"Prism Serial {serial} Port {port}"
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up the Silla Prism component."""
+    _topic = entry.data[CONF_TOPIC].rstrip("/") + "/"
+    _ports = entry.data.get(CONF_PORTS, DEFAULT_PORTS)
+    _serial = entry.data.get(CONF_SERIAL, DEFAULT_SERIAL)
+    _vsensors = entry.data.get(CONF_VSENSORS, DEFAULT_VSENSORS)
+    _powerwall = entry.data.get(CONF_POWERWALL, DEFAULT_POWERWALL)
+    _maxcurr = entry.data.get(CONF_MAX_CURRENT, DEFAULT_MAX_CURRENT)
+    _solar_battery_balance = entry.data.get(
+        CONF_SOLAR_BATTERY_BALANCE, DEFAULT_SOLAR_BATTERY_BALANCE
+    )
+    _battery_power_sensor = entry.data.get(
+        CONF_BATTERY_POWER_SENSOR, DEFAULT_BATTERY_POWER_SENSOR
+    )
+    _solar_production_power_sensor = entry.data.get(
+        CONF_SOLAR_PRODUCTION_POWER_SENSOR,
+        DEFAULT_SOLAR_PRODUCTION_POWER_SENSOR,
+    )
+    _home_load_power_sensor = entry.data.get(
+        CONF_HOME_LOAD_POWER_SENSOR, DEFAULT_HOME_LOAD_POWER_SENSOR
+    )
+    _home_load_includes_ev = entry.data.get(
+        CONF_HOME_LOAD_INCLUDES_EV, DEFAULT_HOME_LOAD_INCLUDES_EV
+    )
+    _battery_soc_sensor = entry.data.get(
+        CONF_BATTERY_SOC_SENSOR, DEFAULT_BATTERY_SOC_SENSOR
+    )
+    _battery_discharge_positive = entry.data.get(
+        CONF_BATTERY_DISCHARGE_POSITIVE, DEFAULT_BATTERY_DISCHARGE_POSITIVE
+    )
+    _battery_max_charge_power = entry.data.get(
+        CONF_BATTERY_MAX_CHARGE_POWER, DEFAULT_BATTERY_MAX_CHARGE_POWER
+    )
+    _solar_balance_phases = entry.data.get(
+        CONF_SOLAR_BALANCE_PHASES, DEFAULT_SOLAR_BALANCE_PHASES
+    )
+    _solar_balance_start_delay = entry.data.get(
+        CONF_SOLAR_BALANCE_START_DELAY, DEFAULT_SOLAR_BALANCE_START_DELAY
+    )
+    _solar_balance_use_battery_charge = entry.data.get(
+        CONF_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+        DEFAULT_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+    )
+    _solar_balance_soc_mid = entry.data.get(
+        CONF_SOLAR_BALANCE_SOC_MID, DEFAULT_SOLAR_BALANCE_SOC_MID
+    )
+    _solar_balance_soc_high = entry.data.get(
+        CONF_SOLAR_BALANCE_SOC_HIGH, DEFAULT_SOLAR_BALANCE_SOC_HIGH
+    )
+    _solar_balance_mid_reserve_power = entry.data.get(
+        CONF_SOLAR_BALANCE_MID_RESERVE_POWER,
+        DEFAULT_SOLAR_BALANCE_MID_RESERVE_POWER,
+    )
+    _solar_balance_high_reserve_power = entry.data.get(
+        CONF_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+        DEFAULT_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+    )
+    _solar_balance_target_export_power = entry.data.get(
+        CONF_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+        DEFAULT_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+    )
+    _solar_balance_deadband_power = entry.data.get(
+        CONF_SOLAR_BALANCE_DEADBAND_POWER,
+        DEFAULT_SOLAR_BALANCE_DEADBAND_POWER,
+    )
+    _solar_balance_increase_interval = entry.data.get(
+        CONF_SOLAR_BALANCE_INCREASE_INTERVAL,
+        DEFAULT_SOLAR_BALANCE_INCREASE_INTERVAL,
+    )
+    _solar_balance_increase_step = entry.data.get(
+        CONF_SOLAR_BALANCE_INCREASE_STEP,
+        DEFAULT_SOLAR_BALANCE_INCREASE_STEP,
+    )
+    _solar_balance_decrease_step = entry.data.get(
+        CONF_SOLAR_BALANCE_DECREASE_STEP,
+        DEFAULT_SOLAR_BALANCE_DECREASE_STEP,
+    )
+    _solar_balance_residual_export_power = entry.data.get(
+        CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+        DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+    )
+    _solar_balance_residual_export_delay = entry.data.get(
+        CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+        DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+    )
+    _solar_balance_dry_run = entry.data.get(
+        CONF_SOLAR_BALANCE_DRY_RUN,
+        DEFAULT_SOLAR_BALANCE_DRY_RUN,
+    )
+    _devices_info = []
+    _devices_info.append(
+        DeviceInfo(
+            identifiers={(DOMAIN, _get_device_identifier(0, _serial))},
+            name=_get_device_name(0, _serial),
+            manufacturer="Silla",
+            model="Prism",
+            serial_number=_serial,
+        )
+    )
+
+    _devices_info.extend(
+        [
+            DeviceInfo(
+                identifiers={(DOMAIN, _get_device_identifier(port, _serial))},
+                name=_get_device_name(port, _serial),
+                manufacturer="Silla",
+                model="Prism",
+                serial_number=_serial,
+            )
+            for port in range(1, _ports + 1)
+        ]
+    )
+
+    entry_data = RuntimeEntryData(
+        topic=_topic,
+        ports=_ports,
+        serial=_serial,
+        vsensors=_vsensors,
+        powerwall=_powerwall,
+        maxcurr=_maxcurr,
+        solar_battery_balance=_solar_battery_balance,
+        battery_power_sensor=_battery_power_sensor,
+        solar_production_power_sensor=_solar_production_power_sensor,
+        home_load_power_sensor=_home_load_power_sensor,
+        home_load_includes_ev=_home_load_includes_ev,
+        battery_soc_sensor=_battery_soc_sensor,
+        battery_discharge_positive=_battery_discharge_positive,
+        battery_max_charge_power=_battery_max_charge_power,
+        solar_balance_phases=_solar_balance_phases,
+        solar_balance_start_delay=_solar_balance_start_delay,
+        solar_balance_use_battery_charge=_solar_balance_use_battery_charge,
+        solar_balance_soc_mid=_solar_balance_soc_mid,
+        solar_balance_soc_high=_solar_balance_soc_high,
+        solar_balance_mid_reserve_power=_solar_balance_mid_reserve_power,
+        solar_balance_high_reserve_power=_solar_balance_high_reserve_power,
+        solar_balance_target_export_power=_solar_balance_target_export_power,
+        solar_balance_deadband_power=_solar_balance_deadband_power,
+        solar_balance_increase_interval=_solar_balance_increase_interval,
+        solar_balance_increase_step=_solar_balance_increase_step,
+        solar_balance_decrease_step=_solar_balance_decrease_step,
+        solar_balance_residual_export_power=_solar_balance_residual_export_power,
+        solar_balance_residual_export_delay=_solar_balance_residual_export_delay,
+        solar_balance_dry_run=_solar_balance_dry_run,
+        devices=_devices_info,
+        coordinator=PrismCoordinator(hass, entry),
+    )
+    entry.runtime_data = entry_data
+    await entry_data.coordinator.async_config_entry_first_refresh()
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: PrismConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    _LOGGER.debug("async_unload_entry")
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/silla_prism/binary_sensor.py
+++ b/homeassistant/components/silla_prism/binary_sensor.py
@@ -1,0 +1,348 @@
+"""Contains numbers configurations for Prism wallbox integration."""
+
+from datetime import datetime
+import logging
+from typing import override
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_call_later
+
+from .const import BINARY_SENSOR_DOMAIN
+from .entity import PrismBaseEntity
+from .entry_data import RuntimeEntryData
+from .touch_events import normalize_touch_payload
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Add entities for passed config_entry in HA."""
+    entry_data: RuntimeEntryData = entry.runtime_data
+    _LOGGER.debug("async_setup_entry for binary sensors: %s", entry_data)
+    binsens = [
+        PrismBinarySensor(entry_data, description, 0)
+        for description in BASE_BINARYSENSORS
+    ]
+
+    ports = entry_data.ports
+    for port in range(1, ports + 1):
+        binsens.extend(
+            [
+                PrismErrorBinarySensor(entry_data, description, port)
+                for description in ERROR_BINARYSENSORS
+            ]
+        )
+        binsens.extend(
+            [
+                PrismEventBinarySensor(entry_data, description, port)
+                for description in EVENTS_BINARYSENSORS
+            ]
+        )
+
+    async_add_entities(binsens)
+
+
+class PrismBinarySensorEntityDescription(
+    BinarySensorEntityDescription, frozen_or_thawed=True
+):
+    """A class that describes prism binary sensor entities."""
+
+    expire_after: float = 600
+    topic: str | None = None
+
+
+class PrismEventBinarySensorEntityDescription(
+    PrismBinarySensorEntityDescription, frozen_or_thawed=True
+):
+    """A class that describes prism button event sensor entities."""
+
+    sequence: tuple[int, ...] = (1,)
+    accepted_sequences: tuple[tuple[int, ...], ...] | None = None
+
+
+class PrismBinarySensor(PrismBaseEntity, BinarySensorEntity):
+    """Prism binary sensor entity."""
+
+    _attr_has_entity_name = True
+
+    entity_description: PrismBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        entry_data: RuntimeEntryData,
+        description: PrismBinarySensorEntityDescription,
+        port: int,
+    ) -> None:
+        """Init Prism select."""
+        _LOGGER.debug("PrismBinarySensor.__init__: %s", entry_data)
+        ismultiport = entry_data.ports > 1
+        if not ismultiport:
+            device = entry_data.devices[0]
+        else:
+            device = entry_data.devices[port]
+        super().__init__(entry_data, BINARY_SENSOR_DOMAIN, description, device)
+        self._attr_is_on = False
+
+    @override
+    def _message_received(self, msg) -> None:
+        """Update the sensor with the most recent event."""
+        self.schedule_expiration_callback()
+
+        # Handle online presence
+        if not self._attr_is_on:
+            self._attr_is_on = True
+            self.schedule_update_ha_state()
+
+    @override
+    def _value_is_expired(self):
+        """Triggered when value is expired."""
+        self._attr_is_on = False
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to mqtt."""
+        await self._subscribe_topic()
+
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe from mqtt."""
+        _LOGGER.debug("async_will_remove_from_hass")
+        await super().async_will_remove_from_hass()
+        self.cleanup_expiration_trigger()
+
+
+class PrismErrorBinarySensor(PrismBinarySensor):
+    """Prism error binary sensor entity."""
+
+    _attr_has_entity_name = True
+
+    entity_description: PrismBinarySensorEntityDescription
+
+    def _get_description(
+        self,
+        port: int,
+        mulitport: bool,
+        description: PrismBinarySensorEntityDescription,
+    ) -> PrismBinarySensorEntityDescription:
+        if port == 0:
+            return description
+        assert description.topic is not None
+        if mulitport:
+            return PrismBinarySensorEntityDescription(
+                key=description.key.format(port),
+                topic=description.topic.format(port),
+                entity_category=description.entity_category,
+                device_class=description.device_class,
+                has_entity_name=description.has_entity_name,
+                translation_key=description.translation_key,
+                expire_after=description.expire_after,
+            )
+        return PrismBinarySensorEntityDescription(
+            key=description.key[:-3],
+            topic=description.topic.format(port),
+            entity_category=description.entity_category,
+            device_class=description.device_class,
+            has_entity_name=description.has_entity_name,
+            translation_key=description.translation_key,
+            expire_after=description.expire_after,
+        )
+
+    def __init__(
+        self,
+        entry_data: RuntimeEntryData,
+        description: PrismBinarySensorEntityDescription,
+        port: int,
+    ) -> None:
+        """Init Prism error binary sensor."""
+        ismultiport = entry_data.ports > 1
+        super().__init__(
+            entry_data, self._get_description(port, ismultiport, description), port
+        )
+
+    @override
+    def _message_received(self, msg) -> None:
+        """Update the error sensor with the most recent event."""
+        self.schedule_expiration_callback()
+
+        try:
+            error_value = int(msg.payload)
+            # OFF when value is 0, ON when different from 0
+            self._attr_is_on = error_value != 0
+        except ValueError, TypeError:
+            # If we can't parse the value, assume there's an error
+            self._attr_is_on = True
+
+        self.schedule_update_ha_state()
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to mqtt."""
+        await super().async_added_to_hass()
+
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe from mqtt."""
+        _LOGGER.debug("async_will_remove_from_hass")
+        await super().async_will_remove_from_hass()
+        self.cleanup_expiration_trigger()
+
+
+class PrismEventBinarySensor(PrismBinarySensor):
+    """Prism button event sensor entity."""
+
+    _attr_has_entity_name = True
+
+    entity_description: PrismEventBinarySensorEntityDescription
+
+    def _get_description(
+        self,
+        port: int,
+        mulitport: bool,
+        description: PrismEventBinarySensorEntityDescription,
+    ) -> PrismEventBinarySensorEntityDescription:
+        if port == 0:
+            return description
+        assert description.topic is not None
+        if mulitport:
+            return PrismEventBinarySensorEntityDescription(
+                key=description.key.format(port),
+                topic=description.topic.format(port),
+                entity_category=description.entity_category,
+                device_class=description.device_class,
+                has_entity_name=description.has_entity_name,
+                sequence=description.sequence,
+                accepted_sequences=description.accepted_sequences,
+                translation_key=description.translation_key,
+                expire_after=description.expire_after,
+            )
+        return PrismEventBinarySensorEntityDescription(
+            key=description.key[:-3],
+            topic=description.topic.format(port),
+            entity_category=description.entity_category,
+            device_class=description.device_class,
+            has_entity_name=description.has_entity_name,
+            sequence=description.sequence,
+            accepted_sequences=description.accepted_sequences,
+            translation_key=description.translation_key,
+            expire_after=description.expire_after,
+        )
+
+    def __init__(
+        self,
+        entry_data: RuntimeEntryData,
+        description: PrismEventBinarySensorEntityDescription,
+        port: int,
+    ) -> None:
+        """Init Prism event binary sensor."""
+        ismultiport = entry_data.ports > 1
+        super().__init__(
+            entry_data, self._get_description(port, ismultiport, description), port
+        )
+        self._accepted_sequences = description.accepted_sequences or (
+            description.sequence,
+        )
+
+    @override
+    def _message_received(self, msg) -> None:
+        """Update the sensor with the most recent event."""
+        self.schedule_expiration_callback()
+
+        sequence = normalize_touch_payload(msg.payload)
+        if sequence not in self._accepted_sequences:
+            _LOGGER.debug(
+                "Ignoring touch payload %r parsed as %s for topic %s; expected %s",
+                msg.payload,
+                sequence,
+                self._topic,
+                self._accepted_sequences,
+            )
+            return
+
+        if self._expiration_trigger:
+            self._expiration_trigger()
+        self._attr_is_on = True
+        self._expiration_trigger = async_call_later(self.hass, 2.0, self._restore_value)
+        self.schedule_update_ha_state()
+
+    @callback
+    def _restore_value(self, *_: datetime) -> None:
+        """Triggered when value is expired."""
+        _LOGGER.debug("entity _value_is_expired for topic %s", self._topic)
+        self._expiration_trigger = None
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+
+BASE_BINARYSENSORS = [
+    PrismBinarySensorEntityDescription(
+        key="online",
+        topic="1/volt",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        has_entity_name=True,
+        translation_key="online",
+        expire_after=150,
+    ),
+]
+
+ERROR_BINARYSENSORS = [
+    PrismBinarySensorEntityDescription(
+        key="error_{}",
+        topic="{}/error",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+        has_entity_name=True,
+        translation_key="error",
+    ),
+]
+
+EVENTS_BINARYSENSORS = [
+    PrismEventBinarySensorEntityDescription(
+        key="touch_single_{}",
+        topic="{}/input/touch",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.MOTION,
+        has_entity_name=True,
+        sequence=(1,),
+        accepted_sequences=((1,),),
+        translation_key="touch_single",
+        expire_after=0,
+    ),
+    PrismEventBinarySensorEntityDescription(
+        key="touch_double_{}",
+        topic="{}/input/touch",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.MOTION,
+        has_entity_name=True,
+        sequence=(
+            1,
+            1,
+        ),
+        accepted_sequences=((1, 1), (2,)),
+        translation_key="touch_double",
+        expire_after=0,
+    ),
+    PrismEventBinarySensorEntityDescription(
+        key="touch_long_{}",
+        topic="{}/input/touch",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=BinarySensorDeviceClass.MOTION,
+        has_entity_name=True,
+        sequence=(3,),
+        accepted_sequences=((3,),),
+        translation_key="touch_long",
+        expire_after=0,
+    ),
+]

--- a/homeassistant/components/silla_prism/button.py
+++ b/homeassistant/components/silla_prism/button.py
@@ -1,0 +1,117 @@
+"""Silla Prism button entity module."""
+
+from typing import override
+
+from homeassistant.components import mqtt
+from homeassistant.components.button import (
+    ButtonDeviceClass,
+    ButtonEntity,
+    ButtonEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .entity import _get_unique_id
+from .entry_data import RuntimeEntryData
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Add entities for passed config_entry in HA."""
+    entry_data: RuntimeEntryData = entry.runtime_data
+
+    ports = entry_data.ports
+    selects = []
+    for port in range(1, ports + 1):
+        selects.extend(
+            [PrismCommand(entry_data, description, port) for description in BUTTONS]
+        )
+    async_add_entities(selects)
+
+
+class PrismCommandEntityDescription(ButtonEntityDescription, frozen_or_thawed=True):
+    """A class that describes prism binary sensor entities."""
+
+    command: str | None = None
+    parameter: str | None = None
+
+
+class PrismCommand(ButtonEntity):
+    """A Command entity for Prism wallbox devices."""
+
+    _attr_has_entity_name = True
+
+    entity_description: PrismCommandEntityDescription
+
+    def __init__(
+        self,
+        entry_data: RuntimeEntryData,
+        description: PrismCommandEntityDescription,
+        port: int,
+    ) -> None:
+        """Init Prism select."""
+        super().__init__()
+        self._base_topic = entry_data.topic
+        self._port = port
+        self._attr_device_info = self._get_device(entry_data, port)
+        self.entity_description = description
+        self._attr_unique_id = _get_unique_id(entry_data.serial, description.key)
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to mqtt."""
+        await super().async_added_to_hass()
+
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe from mqtt."""
+        await super().async_will_remove_from_hass()
+
+    @override
+    async def async_press(self) -> None:
+        """Press the button."""
+        await mqtt.async_publish(
+            self.hass,
+            self._get_topic(),
+            self.entity_description.parameter,
+        )
+
+    def _get_device(self, entry_data: RuntimeEntryData, port: int) -> DeviceInfo:
+        """Get the device info."""
+        ismultiport = entry_data.ports > 1
+        if not ismultiport:
+            return entry_data.devices[0]
+        return entry_data.devices[port]
+
+    def _get_topic(self) -> str:
+        """Get the topic."""
+        return (
+            f"{self._base_topic}{self._port}/command/{self.entity_description.command}"
+        )
+
+
+BUTTONS: tuple[PrismCommandEntityDescription, ...] = (
+    PrismCommandEntityDescription(
+        key="set_mode_traps_auth",
+        has_entity_name=True,
+        translation_key="set_mode_traps_auth",
+        command="set_mode_traps",
+        device_class=ButtonDeviceClass.IDENTIFY,
+        parameter="-auth",
+    ),
+    PrismCommandEntityDescription(
+        key="set_mode_traps_noauth",
+        has_entity_name=True,
+        translation_key="set_mode_traps_noauth",
+        command="set_mode_traps",
+        device_class=ButtonDeviceClass.IDENTIFY,
+        parameter="+auth",
+    ),
+)

--- a/homeassistant/components/silla_prism/config_flow.py
+++ b/homeassistant/components/silla_prism/config_flow.py
@@ -1,120 +1,832 @@
-"""Config flow for the Silla Prism integration."""
+"""Silla Prism for Home Assistant."""
 
 import asyncio
+import logging
+import re
 from typing import Any, override
 
 from pysillaprism import parse_hello, parse_message
 from pysillaprism.exceptions import PrismParseError
 import voluptuous as vol
 
-from homeassistant.components.mqtt import (
-    ReceiveMessage,
-    async_wait_for_mqtt_client,
-    client as mqtt,
-    valid_publish_topic,
+from homeassistant.components import mqtt
+from homeassistant.components.mqtt import ReceiveMessage, async_wait_for_mqtt_client
+from homeassistant.config_entries import (
+    SOURCE_RECONFIGURE,
+    ConfigFlow,
+    ConfigFlowResult,
 )
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv, selector
 from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
 
-from .const import CONF_BASE_TOPIC, DEFAULT_BASE_TOPIC, DOMAIN
+from .const import (
+    CONF_BATTERY_DISCHARGE_POSITIVE,
+    CONF_BATTERY_MAX_CHARGE_POWER,
+    CONF_BATTERY_POWER_SENSOR,
+    CONF_BATTERY_SOC_SENSOR,
+    CONF_HOME_LOAD_INCLUDES_EV,
+    CONF_HOME_LOAD_POWER_SENSOR,
+    CONF_MAX_CURRENT,
+    CONF_PORTS,
+    CONF_POWERWALL,
+    CONF_SERIAL,
+    CONF_SOLAR_BALANCE_DEADBAND_POWER,
+    CONF_SOLAR_BALANCE_DECREASE_STEP,
+    CONF_SOLAR_BALANCE_DRY_RUN,
+    CONF_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+    CONF_SOLAR_BALANCE_INCREASE_INTERVAL,
+    CONF_SOLAR_BALANCE_INCREASE_STEP,
+    CONF_SOLAR_BALANCE_MID_RESERVE_POWER,
+    CONF_SOLAR_BALANCE_PHASES,
+    CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+    CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+    CONF_SOLAR_BALANCE_SOC_HIGH,
+    CONF_SOLAR_BALANCE_SOC_MID,
+    CONF_SOLAR_BALANCE_START_DELAY,
+    CONF_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+    CONF_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+    CONF_SOLAR_BATTERY_BALANCE,
+    CONF_SOLAR_PRODUCTION_POWER_SENSOR,
+    CONF_TOPIC,
+    CONF_VSENSORS,
+    DEFAULT_BATTERY_DISCHARGE_POSITIVE,
+    DEFAULT_BATTERY_MAX_CHARGE_POWER,
+    DEFAULT_BATTERY_POWER_SENSOR,
+    DEFAULT_BATTERY_SOC_SENSOR,
+    DEFAULT_HOME_LOAD_INCLUDES_EV,
+    DEFAULT_HOME_LOAD_POWER_SENSOR,
+    DEFAULT_MAX_CURRENT,
+    DEFAULT_PORTS,
+    DEFAULT_POWERWALL,
+    DEFAULT_SERIAL,
+    DEFAULT_SOLAR_BALANCE_DEADBAND_POWER,
+    DEFAULT_SOLAR_BALANCE_DECREASE_STEP,
+    DEFAULT_SOLAR_BALANCE_DRY_RUN,
+    DEFAULT_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+    DEFAULT_SOLAR_BALANCE_INCREASE_INTERVAL,
+    DEFAULT_SOLAR_BALANCE_INCREASE_STEP,
+    DEFAULT_SOLAR_BALANCE_MID_RESERVE_POWER,
+    DEFAULT_SOLAR_BALANCE_PHASES,
+    DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+    DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+    DEFAULT_SOLAR_BALANCE_SOC_HIGH,
+    DEFAULT_SOLAR_BALANCE_SOC_MID,
+    DEFAULT_SOLAR_BALANCE_START_DELAY,
+    DEFAULT_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+    DEFAULT_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+    DEFAULT_SOLAR_BATTERY_BALANCE,
+    DEFAULT_SOLAR_PRODUCTION_POWER_SENSOR,
+    DEFAULT_TOPIC,
+    DEFAULT_VSENSORS,
+    DOMAIN,
+)
 
-#: How long to wait for a retained status message when validating a base topic.
+_LOGGER = logging.getLogger(__name__)
 _PROBE_TIMEOUT = 5
+type ConfigValue = bool | int | str | None
+
+BATTERY_SENSOR_SELECTOR = selector.EntitySelector(
+    selector.EntitySelectorConfig(domain="sensor")
+)
+
+SILLA_PRISM_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_TOPIC, default=DEFAULT_TOPIC): cv.string,
+        vol.Required(CONF_PORTS, default=DEFAULT_PORTS): cv.positive_int,
+        vol.Optional(CONF_SERIAL, default=DEFAULT_SERIAL): cv.string,
+        vol.Optional(CONF_VSENSORS, default=DEFAULT_VSENSORS): cv.boolean,
+        vol.Optional(CONF_POWERWALL, default=DEFAULT_POWERWALL): cv.boolean,
+        vol.Optional(CONF_MAX_CURRENT, default=DEFAULT_MAX_CURRENT): cv.positive_int,
+        vol.Optional(
+            CONF_SOLAR_BATTERY_BALANCE, default=DEFAULT_SOLAR_BATTERY_BALANCE
+        ): cv.boolean,
+        vol.Optional(CONF_BATTERY_POWER_SENSOR): BATTERY_SENSOR_SELECTOR,
+        vol.Optional(CONF_SOLAR_PRODUCTION_POWER_SENSOR): BATTERY_SENSOR_SELECTOR,
+        vol.Optional(CONF_HOME_LOAD_POWER_SENSOR): BATTERY_SENSOR_SELECTOR,
+        vol.Optional(
+            CONF_HOME_LOAD_INCLUDES_EV, default=DEFAULT_HOME_LOAD_INCLUDES_EV
+        ): cv.boolean,
+        vol.Optional(CONF_BATTERY_SOC_SENSOR): BATTERY_SENSOR_SELECTOR,
+        vol.Optional(
+            CONF_BATTERY_DISCHARGE_POSITIVE,
+            default=DEFAULT_BATTERY_DISCHARGE_POSITIVE,
+        ): cv.boolean,
+        vol.Optional(
+            CONF_BATTERY_MAX_CHARGE_POWER, default=DEFAULT_BATTERY_MAX_CHARGE_POWER
+        ): cv.positive_int,
+        vol.Optional(
+            CONF_SOLAR_BALANCE_PHASES, default=DEFAULT_SOLAR_BALANCE_PHASES
+        ): vol.In([1, 3]),
+        vol.Optional(
+            CONF_SOLAR_BALANCE_START_DELAY,
+            default=DEFAULT_SOLAR_BALANCE_START_DELAY,
+        ): vol.All(vol.Coerce(int), vol.Range(min=0, max=60)),
+        vol.Optional(
+            CONF_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+            default=DEFAULT_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+        ): cv.boolean,
+        vol.Optional(
+            CONF_SOLAR_BALANCE_SOC_MID, default=DEFAULT_SOLAR_BALANCE_SOC_MID
+        ): vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
+        vol.Optional(
+            CONF_SOLAR_BALANCE_SOC_HIGH, default=DEFAULT_SOLAR_BALANCE_SOC_HIGH
+        ): vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
+        vol.Optional(
+            CONF_SOLAR_BALANCE_MID_RESERVE_POWER,
+            default=DEFAULT_SOLAR_BALANCE_MID_RESERVE_POWER,
+        ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+        vol.Optional(
+            CONF_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+            default=DEFAULT_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+        ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+        vol.Optional(
+            CONF_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+            default=DEFAULT_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+        ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+        vol.Optional(
+            CONF_SOLAR_BALANCE_DEADBAND_POWER,
+            default=DEFAULT_SOLAR_BALANCE_DEADBAND_POWER,
+        ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+        vol.Optional(
+            CONF_SOLAR_BALANCE_INCREASE_INTERVAL,
+            default=DEFAULT_SOLAR_BALANCE_INCREASE_INTERVAL,
+        ): vol.All(vol.Coerce(int), vol.Range(min=0, max=300)),
+        vol.Optional(
+            CONF_SOLAR_BALANCE_INCREASE_STEP,
+            default=DEFAULT_SOLAR_BALANCE_INCREASE_STEP,
+        ): vol.All(vol.Coerce(int), vol.Range(min=1, max=10)),
+        vol.Optional(
+            CONF_SOLAR_BALANCE_DECREASE_STEP,
+            default=DEFAULT_SOLAR_BALANCE_DECREASE_STEP,
+        ): vol.All(vol.Coerce(int), vol.Range(min=1, max=10)),
+        vol.Optional(
+            CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+            default=DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+        ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+        vol.Optional(
+            CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+            default=DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+        ): vol.All(vol.Coerce(int), vol.Range(min=0, max=600)),
+        vol.Optional(
+            CONF_SOLAR_BALANCE_DRY_RUN,
+            default=DEFAULT_SOLAR_BALANCE_DRY_RUN,
+        ): cv.boolean,
+    }
+)
 
 
 class PrismConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle the Silla Prism config flow."""
+    """Handle a Silla Prism config flow."""
 
     VERSION = 1
+    MINOR_VERSION = 10
 
     def __init__(self) -> None:
-        """Initialize the flow."""
-        self._base_topic: str = DEFAULT_BASE_TOPIC
-        self._serial: str | None = None
-
-    @override
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle a flow started by the user."""
-        errors: dict[str, str] = {}
-
-        if user_input is not None:
-            base_topic = user_input[CONF_BASE_TOPIC].strip().strip("/")
-            try:
-                valid_publish_topic(base_topic)
-            except vol.Invalid:
-                errors[CONF_BASE_TOPIC] = "invalid_base_topic"
-            else:
-                await self.async_set_unique_id(base_topic)
-                self._abort_if_unique_id_configured()
-
-                # Nothing the user can enter in this form brings the broker
-                # back, so this is a dead end rather than a form error.
-                if not await async_wait_for_mqtt_client(self.hass):
-                    return self.async_abort(reason="mqtt_unavailable")
-
-                if await self._async_probe(base_topic):
-                    return self.async_create_entry(
-                        title="Silla Prism", data={CONF_BASE_TOPIC: base_topic}
-                    )
-                errors["base"] = "no_device"
-
-        return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_BASE_TOPIC, default=DEFAULT_BASE_TOPIC): str,
-                }
-            ),
-            errors=errors,
+        """Initialize flow."""
+        self._topic: str | None = DEFAULT_TOPIC
+        self._ports: int = DEFAULT_PORTS
+        self._vsensors: bool = DEFAULT_VSENSORS
+        self._powerwall: bool = DEFAULT_POWERWALL
+        self._serial: str = DEFAULT_SERIAL
+        self._max_current: int = DEFAULT_MAX_CURRENT
+        self._solar_battery_balance: bool = DEFAULT_SOLAR_BATTERY_BALANCE
+        self._battery_power_sensor: str = DEFAULT_BATTERY_POWER_SENSOR
+        self._solar_production_power_sensor: str = DEFAULT_SOLAR_PRODUCTION_POWER_SENSOR
+        self._home_load_power_sensor: str = DEFAULT_HOME_LOAD_POWER_SENSOR
+        self._home_load_includes_ev: bool = DEFAULT_HOME_LOAD_INCLUDES_EV
+        self._battery_discharge_positive: bool = DEFAULT_BATTERY_DISCHARGE_POSITIVE
+        self._battery_max_charge_power: int = DEFAULT_BATTERY_MAX_CHARGE_POWER
+        self._solar_balance_phases: int = DEFAULT_SOLAR_BALANCE_PHASES
+        self._solar_balance_start_delay: int = DEFAULT_SOLAR_BALANCE_START_DELAY
+        self._solar_balance_use_battery_charge: bool = (
+            DEFAULT_SOLAR_BALANCE_USE_BATTERY_CHARGE
         )
+        self._battery_soc_sensor: str = DEFAULT_BATTERY_SOC_SENSOR
+        self._solar_balance_soc_mid: int = DEFAULT_SOLAR_BALANCE_SOC_MID
+        self._solar_balance_soc_high: int = DEFAULT_SOLAR_BALANCE_SOC_HIGH
+        self._solar_balance_mid_reserve_power: int = (
+            DEFAULT_SOLAR_BALANCE_MID_RESERVE_POWER
+        )
+        self._solar_balance_high_reserve_power: int = (
+            DEFAULT_SOLAR_BALANCE_HIGH_RESERVE_POWER
+        )
+        self._solar_balance_target_export_power: int = (
+            DEFAULT_SOLAR_BALANCE_TARGET_EXPORT_POWER
+        )
+        self._solar_balance_deadband_power: int = DEFAULT_SOLAR_BALANCE_DEADBAND_POWER
+        self._solar_balance_increase_interval: int = (
+            DEFAULT_SOLAR_BALANCE_INCREASE_INTERVAL
+        )
+        self._solar_balance_increase_step: int = DEFAULT_SOLAR_BALANCE_INCREASE_STEP
+        self._solar_balance_decrease_step: int = DEFAULT_SOLAR_BALANCE_DECREASE_STEP
+        self._solar_balance_residual_export_power: int = (
+            DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER
+        )
+        self._solar_balance_residual_export_delay: int = (
+            DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY
+        )
+        self._solar_balance_dry_run: bool = DEFAULT_SOLAR_BALANCE_DRY_RUN
+        self._discovered_serial: str = ""
+
+    async def fetch_device_info(self) -> str | None:
+        """Fetch information from MQTT."""
+        assert self._topic is not None
+        if await self._async_probe(self._topic):
+            return None
+        return "no_device"
 
     async def _async_probe(self, base_topic: str) -> bool:
-        """Return True if a recognizable Prism message is seen under ``base_topic``."""
+        """Return True if a recognizable Prism message is seen under the base topic."""
+        normalized_topic = base_topic.strip().strip("/")
         seen = asyncio.Event()
 
         @callback
         def _message(msg: ReceiveMessage) -> None:
             if isinstance(msg.payload, str) and (
-                parse_message(base_topic, msg.topic, msg.payload) is not None
+                parse_message(normalized_topic, msg.topic, msg.payload) is not None
             ):
                 seen.set()
 
-        unsubscribe = await mqtt.async_subscribe(self.hass, f"{base_topic}/#", _message)
+        unsubscribe = await mqtt.async_subscribe(
+            self.hass, f"{normalized_topic}/#", _message
+        )
         try:
-            async with asyncio.timeout(_PROBE_TIMEOUT):
-                await seen.wait()
+            await asyncio.wait_for(seen.wait(), _PROBE_TIMEOUT)
         except TimeoutError:
             return False
         finally:
             unsubscribe()
         return True
 
+    async def _async_validate_device(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        _LOGGER.debug("Called with user input: %s source: %s", user_input, self.source)
+
+        assert user_input is not None
+
+        normalized_topic = user_input[CONF_TOPIC].strip().strip("/")
+        if not normalized_topic:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=SILLA_PRISM_SCHEMA,
+                errors={CONF_TOPIC: "invalid_base_topic"},
+            )
+        try:
+            mqtt.valid_publish_topic(normalized_topic)
+        except vol.Invalid:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=SILLA_PRISM_SCHEMA,
+                errors={CONF_TOPIC: "invalid_base_topic"},
+            )
+
+        if self.source == SOURCE_RECONFIGURE:
+            entry = self._get_reconfigure_entry()
+            self._ports = entry.data.get(CONF_PORTS, DEFAULT_PORTS)
+            self._serial = entry.data.get(CONF_SERIAL, DEFAULT_SERIAL)
+            self._vsensors = entry.data.get(CONF_VSENSORS, DEFAULT_VSENSORS)
+            self._powerwall = entry.data.get(CONF_POWERWALL, DEFAULT_POWERWALL)
+        else:
+            self._ports = user_input.get(CONF_PORTS, DEFAULT_PORTS)
+            self._serial = re.sub(
+                r"[^a-zA-Z0-9]", "", user_input.get(CONF_SERIAL, DEFAULT_SERIAL)
+            )
+            self._vsensors = user_input.get(CONF_VSENSORS, DEFAULT_VSENSORS)
+            self._powerwall = user_input.get(CONF_POWERWALL, DEFAULT_POWERWALL)
+
+        self._topic = normalized_topic
+        self._max_current = max(
+            min(user_input.get(CONF_MAX_CURRENT, DEFAULT_MAX_CURRENT), 32), 6
+        )  # clamp between 6 and 32
+        self._solar_battery_balance = user_input.get(
+            CONF_SOLAR_BATTERY_BALANCE, DEFAULT_SOLAR_BATTERY_BALANCE
+        )
+        self._battery_power_sensor = user_input.get(
+            CONF_BATTERY_POWER_SENSOR, DEFAULT_BATTERY_POWER_SENSOR
+        ).strip()
+        self._solar_production_power_sensor = user_input.get(
+            CONF_SOLAR_PRODUCTION_POWER_SENSOR,
+            DEFAULT_SOLAR_PRODUCTION_POWER_SENSOR,
+        ).strip()
+        self._home_load_power_sensor = user_input.get(
+            CONF_HOME_LOAD_POWER_SENSOR, DEFAULT_HOME_LOAD_POWER_SENSOR
+        ).strip()
+        self._home_load_includes_ev = user_input.get(
+            CONF_HOME_LOAD_INCLUDES_EV, DEFAULT_HOME_LOAD_INCLUDES_EV
+        )
+        self._battery_soc_sensor = user_input.get(
+            CONF_BATTERY_SOC_SENSOR, DEFAULT_BATTERY_SOC_SENSOR
+        ).strip()
+        self._battery_discharge_positive = user_input.get(
+            CONF_BATTERY_DISCHARGE_POSITIVE, DEFAULT_BATTERY_DISCHARGE_POSITIVE
+        )
+        self._battery_max_charge_power = user_input.get(
+            CONF_BATTERY_MAX_CHARGE_POWER, DEFAULT_BATTERY_MAX_CHARGE_POWER
+        )
+        self._solar_balance_phases = user_input.get(
+            CONF_SOLAR_BALANCE_PHASES, DEFAULT_SOLAR_BALANCE_PHASES
+        )
+        self._solar_balance_start_delay = user_input.get(
+            CONF_SOLAR_BALANCE_START_DELAY, DEFAULT_SOLAR_BALANCE_START_DELAY
+        )
+        self._solar_balance_use_battery_charge = user_input.get(
+            CONF_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+            DEFAULT_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+        )
+        self._solar_balance_soc_mid = user_input.get(
+            CONF_SOLAR_BALANCE_SOC_MID, DEFAULT_SOLAR_BALANCE_SOC_MID
+        )
+        self._solar_balance_soc_high = user_input.get(
+            CONF_SOLAR_BALANCE_SOC_HIGH, DEFAULT_SOLAR_BALANCE_SOC_HIGH
+        )
+        self._solar_balance_mid_reserve_power = user_input.get(
+            CONF_SOLAR_BALANCE_MID_RESERVE_POWER,
+            DEFAULT_SOLAR_BALANCE_MID_RESERVE_POWER,
+        )
+        self._solar_balance_high_reserve_power = user_input.get(
+            CONF_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+            DEFAULT_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+        )
+        self._solar_balance_target_export_power = user_input.get(
+            CONF_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+            DEFAULT_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+        )
+        self._solar_balance_deadband_power = user_input.get(
+            CONF_SOLAR_BALANCE_DEADBAND_POWER,
+            DEFAULT_SOLAR_BALANCE_DEADBAND_POWER,
+        )
+        self._solar_balance_increase_interval = user_input.get(
+            CONF_SOLAR_BALANCE_INCREASE_INTERVAL,
+            DEFAULT_SOLAR_BALANCE_INCREASE_INTERVAL,
+        )
+        self._solar_balance_increase_step = user_input.get(
+            CONF_SOLAR_BALANCE_INCREASE_STEP,
+            DEFAULT_SOLAR_BALANCE_INCREASE_STEP,
+        )
+        self._solar_balance_decrease_step = user_input.get(
+            CONF_SOLAR_BALANCE_DECREASE_STEP,
+            DEFAULT_SOLAR_BALANCE_DECREASE_STEP,
+        )
+        self._solar_balance_residual_export_power = user_input.get(
+            CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+            DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+        )
+        self._solar_balance_residual_export_delay = user_input.get(
+            CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+            DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+        )
+        self._solar_balance_dry_run = user_input.get(
+            CONF_SOLAR_BALANCE_DRY_RUN,
+            DEFAULT_SOLAR_BALANCE_DRY_RUN,
+        )
+        if self.source != SOURCE_RECONFIGURE:
+            await self.async_set_unique_id(self._topic)
+            self._abort_if_unique_id_configured()
+
+        if self._solar_balance_soc_mid > self._solar_balance_soc_high:
+            (
+                self._solar_balance_soc_mid,
+                self._solar_balance_soc_high,
+            ) = (
+                self._solar_balance_soc_high,
+                self._solar_balance_soc_mid,
+            )
+
+        if self._solar_battery_balance and self._battery_power_sensor == "":
+            return await self._async_step_user_base(error="battery_sensor_required")
+        if (
+            self._solar_battery_balance
+            and self._home_load_power_sensor != ""
+            and self._solar_production_power_sensor == ""
+        ):
+            return await self._async_step_user_base(error="solar_sensor_required")
+
+        return await self._async_try_fetch_device_info()
+
+    async def _async_step_user_base(
+        self, user_input: dict[str, Any] | None = None, error: str | None = None
+    ) -> ConfigFlowResult:
+        _LOGGER.info("Async_step_user %s", DOMAIN)
+        if user_input is not None:
+            return await self._async_validate_device(user_input)
+
+        errors = {}
+        if error is not None:
+            errors["base"] = error
+
+        if self.source == SOURCE_RECONFIGURE:
+            # We are reconfiguring an existing device
+            entry = self._get_reconfigure_entry()
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_TOPIC, default=entry.data[CONF_TOPIC]
+                        ): cv.string,
+                        vol.Optional(
+                            CONF_MAX_CURRENT,
+                            default=entry.data.get(
+                                CONF_MAX_CURRENT, DEFAULT_MAX_CURRENT
+                            ),
+                        ): cv.positive_int,
+                        vol.Optional(
+                            CONF_SOLAR_BATTERY_BALANCE,
+                            default=entry.data.get(
+                                CONF_SOLAR_BATTERY_BALANCE,
+                                DEFAULT_SOLAR_BATTERY_BALANCE,
+                            ),
+                        ): cv.boolean,
+                        vol.Optional(
+                            CONF_BATTERY_POWER_SENSOR,
+                            default=entry.data.get(
+                                CONF_BATTERY_POWER_SENSOR,
+                                DEFAULT_BATTERY_POWER_SENSOR,
+                            ),
+                        ): BATTERY_SENSOR_SELECTOR,
+                        vol.Optional(
+                            CONF_SOLAR_PRODUCTION_POWER_SENSOR,
+                            default=entry.data.get(
+                                CONF_SOLAR_PRODUCTION_POWER_SENSOR,
+                                DEFAULT_SOLAR_PRODUCTION_POWER_SENSOR,
+                            ),
+                        ): BATTERY_SENSOR_SELECTOR,
+                        vol.Optional(
+                            CONF_HOME_LOAD_POWER_SENSOR,
+                            default=entry.data.get(
+                                CONF_HOME_LOAD_POWER_SENSOR,
+                                DEFAULT_HOME_LOAD_POWER_SENSOR,
+                            ),
+                        ): BATTERY_SENSOR_SELECTOR,
+                        vol.Optional(
+                            CONF_HOME_LOAD_INCLUDES_EV,
+                            default=entry.data.get(
+                                CONF_HOME_LOAD_INCLUDES_EV,
+                                DEFAULT_HOME_LOAD_INCLUDES_EV,
+                            ),
+                        ): cv.boolean,
+                        vol.Optional(
+                            CONF_BATTERY_SOC_SENSOR,
+                            default=entry.data.get(
+                                CONF_BATTERY_SOC_SENSOR,
+                                DEFAULT_BATTERY_SOC_SENSOR,
+                            ),
+                        ): BATTERY_SENSOR_SELECTOR,
+                        vol.Optional(
+                            CONF_BATTERY_DISCHARGE_POSITIVE,
+                            default=entry.data.get(
+                                CONF_BATTERY_DISCHARGE_POSITIVE,
+                                DEFAULT_BATTERY_DISCHARGE_POSITIVE,
+                            ),
+                        ): cv.boolean,
+                        vol.Optional(
+                            CONF_BATTERY_MAX_CHARGE_POWER,
+                            default=entry.data.get(
+                                CONF_BATTERY_MAX_CHARGE_POWER,
+                                DEFAULT_BATTERY_MAX_CHARGE_POWER,
+                            ),
+                        ): cv.positive_int,
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_PHASES,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_PHASES,
+                                DEFAULT_SOLAR_BALANCE_PHASES,
+                            ),
+                        ): vol.In([1, 3]),
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_START_DELAY,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_START_DELAY,
+                                DEFAULT_SOLAR_BALANCE_START_DELAY,
+                            ),
+                        ): vol.All(vol.Coerce(int), vol.Range(min=0, max=60)),
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+                                DEFAULT_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+                            ),
+                        ): cv.boolean,
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_SOC_MID,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_SOC_MID,
+                                DEFAULT_SOLAR_BALANCE_SOC_MID,
+                            ),
+                        ): vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_SOC_HIGH,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_SOC_HIGH,
+                                DEFAULT_SOLAR_BALANCE_SOC_HIGH,
+                            ),
+                        ): vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_MID_RESERVE_POWER,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_MID_RESERVE_POWER,
+                                DEFAULT_SOLAR_BALANCE_MID_RESERVE_POWER,
+                            ),
+                        ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+                                DEFAULT_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+                            ),
+                        ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+                                DEFAULT_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+                            ),
+                        ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_DEADBAND_POWER,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_DEADBAND_POWER,
+                                DEFAULT_SOLAR_BALANCE_DEADBAND_POWER,
+                            ),
+                        ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_INCREASE_INTERVAL,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_INCREASE_INTERVAL,
+                                DEFAULT_SOLAR_BALANCE_INCREASE_INTERVAL,
+                            ),
+                        ): vol.All(vol.Coerce(int), vol.Range(min=0, max=300)),
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_INCREASE_STEP,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_INCREASE_STEP,
+                                DEFAULT_SOLAR_BALANCE_INCREASE_STEP,
+                            ),
+                        ): vol.All(vol.Coerce(int), vol.Range(min=1, max=10)),
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_DECREASE_STEP,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_DECREASE_STEP,
+                                DEFAULT_SOLAR_BALANCE_DECREASE_STEP,
+                            ),
+                        ): vol.All(vol.Coerce(int), vol.Range(min=1, max=10)),
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+                                DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+                            ),
+                        ): vol.All(vol.Coerce(int), vol.Range(min=0)),
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+                                DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+                            ),
+                        ): vol.All(vol.Coerce(int), vol.Range(min=0, max=600)),
+                        vol.Optional(
+                            CONF_SOLAR_BALANCE_DRY_RUN,
+                            default=entry.data.get(
+                                CONF_SOLAR_BALANCE_DRY_RUN,
+                                DEFAULT_SOLAR_BALANCE_DRY_RUN,
+                            ),
+                        ): cv.boolean,
+                    }
+                ),
+                errors=errors,
+            )
+        # We are creating a new device
+        return self.async_show_form(
+            step_id="user",
+            data_schema=SILLA_PRISM_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a reconfiguration flow initialized by the user."""
+        if user_input is not None:
+            return await self._async_validate_device(user_input)
+
+        return await self._async_step_user_base()
+
+    async def _async_try_fetch_device_info(self) -> ConfigFlowResult:
+        """Try to fetch device info and return any errors."""
+        error = None
+
+        # Make sure MQTT integration is enabled and the client is available
+        if not await async_wait_for_mqtt_client(self.hass):
+            if self.source != SOURCE_RECONFIGURE:
+                return self.async_abort(reason="mqtt_unavailable")
+            error = "mqtt_unavailable"
+            _LOGGER.error("MQTT integration is not available")
+
+        if error is None:
+            error = await self.fetch_device_info()
+
+        if error is None:
+            if self.source == SOURCE_RECONFIGURE:
+                return await self._async_update_entry()
+            return await self._async_create_entry()
+
+        if self.source == SOURCE_RECONFIGURE:
+            return await self.async_step_reconfigure()
+        return await self._async_step_user_base(error=error)
+
+    async def _async_create_entry(self) -> ConfigFlowResult:
+        config_data: dict[str, ConfigValue] = {
+            CONF_TOPIC: self._topic,
+        }
+        optional_data: dict[str, tuple[ConfigValue, ConfigValue]] = {
+            CONF_PORTS: (self._ports, DEFAULT_PORTS),
+            CONF_SERIAL: (self._serial, DEFAULT_SERIAL),
+            CONF_VSENSORS: (self._vsensors, DEFAULT_VSENSORS),
+            CONF_POWERWALL: (self._powerwall, DEFAULT_POWERWALL),
+            CONF_MAX_CURRENT: (self._max_current, DEFAULT_MAX_CURRENT),
+            CONF_SOLAR_BATTERY_BALANCE: (
+                self._solar_battery_balance,
+                DEFAULT_SOLAR_BATTERY_BALANCE,
+            ),
+            CONF_BATTERY_POWER_SENSOR: (
+                self._battery_power_sensor,
+                DEFAULT_BATTERY_POWER_SENSOR,
+            ),
+            CONF_SOLAR_PRODUCTION_POWER_SENSOR: (
+                self._solar_production_power_sensor,
+                DEFAULT_SOLAR_PRODUCTION_POWER_SENSOR,
+            ),
+            CONF_HOME_LOAD_POWER_SENSOR: (
+                self._home_load_power_sensor,
+                DEFAULT_HOME_LOAD_POWER_SENSOR,
+            ),
+            CONF_HOME_LOAD_INCLUDES_EV: (
+                self._home_load_includes_ev,
+                DEFAULT_HOME_LOAD_INCLUDES_EV,
+            ),
+            CONF_BATTERY_SOC_SENSOR: (
+                self._battery_soc_sensor,
+                DEFAULT_BATTERY_SOC_SENSOR,
+            ),
+            CONF_BATTERY_DISCHARGE_POSITIVE: (
+                self._battery_discharge_positive,
+                DEFAULT_BATTERY_DISCHARGE_POSITIVE,
+            ),
+            CONF_BATTERY_MAX_CHARGE_POWER: (
+                self._battery_max_charge_power,
+                DEFAULT_BATTERY_MAX_CHARGE_POWER,
+            ),
+            CONF_SOLAR_BALANCE_PHASES: (
+                self._solar_balance_phases,
+                DEFAULT_SOLAR_BALANCE_PHASES,
+            ),
+            CONF_SOLAR_BALANCE_START_DELAY: (
+                self._solar_balance_start_delay,
+                DEFAULT_SOLAR_BALANCE_START_DELAY,
+            ),
+            CONF_SOLAR_BALANCE_USE_BATTERY_CHARGE: (
+                self._solar_balance_use_battery_charge,
+                DEFAULT_SOLAR_BALANCE_USE_BATTERY_CHARGE,
+            ),
+            CONF_SOLAR_BALANCE_SOC_MID: (
+                self._solar_balance_soc_mid,
+                DEFAULT_SOLAR_BALANCE_SOC_MID,
+            ),
+            CONF_SOLAR_BALANCE_SOC_HIGH: (
+                self._solar_balance_soc_high,
+                DEFAULT_SOLAR_BALANCE_SOC_HIGH,
+            ),
+            CONF_SOLAR_BALANCE_MID_RESERVE_POWER: (
+                self._solar_balance_mid_reserve_power,
+                DEFAULT_SOLAR_BALANCE_MID_RESERVE_POWER,
+            ),
+            CONF_SOLAR_BALANCE_HIGH_RESERVE_POWER: (
+                self._solar_balance_high_reserve_power,
+                DEFAULT_SOLAR_BALANCE_HIGH_RESERVE_POWER,
+            ),
+            CONF_SOLAR_BALANCE_TARGET_EXPORT_POWER: (
+                self._solar_balance_target_export_power,
+                DEFAULT_SOLAR_BALANCE_TARGET_EXPORT_POWER,
+            ),
+            CONF_SOLAR_BALANCE_DEADBAND_POWER: (
+                self._solar_balance_deadband_power,
+                DEFAULT_SOLAR_BALANCE_DEADBAND_POWER,
+            ),
+            CONF_SOLAR_BALANCE_INCREASE_INTERVAL: (
+                self._solar_balance_increase_interval,
+                DEFAULT_SOLAR_BALANCE_INCREASE_INTERVAL,
+            ),
+            CONF_SOLAR_BALANCE_INCREASE_STEP: (
+                self._solar_balance_increase_step,
+                DEFAULT_SOLAR_BALANCE_INCREASE_STEP,
+            ),
+            CONF_SOLAR_BALANCE_DECREASE_STEP: (
+                self._solar_balance_decrease_step,
+                DEFAULT_SOLAR_BALANCE_DECREASE_STEP,
+            ),
+            CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER: (
+                self._solar_balance_residual_export_power,
+                DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER,
+            ),
+            CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY: (
+                self._solar_balance_residual_export_delay,
+                DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY,
+            ),
+            CONF_SOLAR_BALANCE_DRY_RUN: (
+                self._solar_balance_dry_run,
+                DEFAULT_SOLAR_BALANCE_DRY_RUN,
+            ),
+        }
+        config_data.update(
+            {
+                key: value
+                for key, (value, default) in optional_data.items()
+                if value != default
+            }
+        )
+        return self.async_create_entry(
+            title="Silla Prism",
+            data=config_data,
+        )
+
+    async def _async_update_entry(self) -> ConfigFlowResult:
+        entry = self._get_reconfigure_entry()
+
+        config_data = {
+            CONF_TOPIC: self._topic,
+            CONF_PORTS: entry.data.get(CONF_PORTS, DEFAULT_PORTS),
+            CONF_SERIAL: entry.data.get(CONF_SERIAL, DEFAULT_SERIAL),
+            CONF_VSENSORS: entry.data.get(CONF_VSENSORS, DEFAULT_VSENSORS),
+            CONF_POWERWALL: entry.data.get(CONF_POWERWALL, DEFAULT_POWERWALL),
+            CONF_MAX_CURRENT: self._max_current,
+            CONF_SOLAR_BATTERY_BALANCE: self._solar_battery_balance,
+            CONF_BATTERY_POWER_SENSOR: self._battery_power_sensor,
+            CONF_SOLAR_PRODUCTION_POWER_SENSOR: self._solar_production_power_sensor,
+            CONF_HOME_LOAD_POWER_SENSOR: self._home_load_power_sensor,
+            CONF_HOME_LOAD_INCLUDES_EV: self._home_load_includes_ev,
+            CONF_BATTERY_SOC_SENSOR: self._battery_soc_sensor,
+            CONF_BATTERY_DISCHARGE_POSITIVE: self._battery_discharge_positive,
+            CONF_BATTERY_MAX_CHARGE_POWER: self._battery_max_charge_power,
+            CONF_SOLAR_BALANCE_PHASES: self._solar_balance_phases,
+            CONF_SOLAR_BALANCE_START_DELAY: self._solar_balance_start_delay,
+            CONF_SOLAR_BALANCE_USE_BATTERY_CHARGE: (
+                self._solar_balance_use_battery_charge
+            ),
+            CONF_SOLAR_BALANCE_SOC_MID: self._solar_balance_soc_mid,
+            CONF_SOLAR_BALANCE_SOC_HIGH: self._solar_balance_soc_high,
+            CONF_SOLAR_BALANCE_MID_RESERVE_POWER: (
+                self._solar_balance_mid_reserve_power
+            ),
+            CONF_SOLAR_BALANCE_HIGH_RESERVE_POWER: (
+                self._solar_balance_high_reserve_power
+            ),
+            CONF_SOLAR_BALANCE_TARGET_EXPORT_POWER: (
+                self._solar_balance_target_export_power
+            ),
+            CONF_SOLAR_BALANCE_DEADBAND_POWER: self._solar_balance_deadband_power,
+            CONF_SOLAR_BALANCE_INCREASE_INTERVAL: (
+                self._solar_balance_increase_interval
+            ),
+            CONF_SOLAR_BALANCE_INCREASE_STEP: self._solar_balance_increase_step,
+            CONF_SOLAR_BALANCE_DECREASE_STEP: self._solar_balance_decrease_step,
+            CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER: (
+                self._solar_balance_residual_export_power
+            ),
+            CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY: (
+                self._solar_balance_residual_export_delay
+            ),
+            CONF_SOLAR_BALANCE_DRY_RUN: self._solar_balance_dry_run,
+        }
+        return self.async_update_reload_and_abort(
+            self._get_reconfigure_entry(),
+            data_updates=config_data,
+        )
+
     @override
     async def async_step_mqtt(
         self, discovery_info: MqttServiceInfo
     ) -> ConfigFlowResult:
-        """Handle discovery via the Prism ``hello`` topic."""
+        """Handle discovery via the Prism hello topic."""
         payload = discovery_info.payload
         if not payload or not isinstance(payload, str):
             return self.async_abort(reason="invalid_discovery_info")
 
-        # Discovery is registered on "<base_topic>/hello".
-        self._base_topic = discovery_info.topic.removesuffix("/hello")
-        if self._base_topic == discovery_info.topic:
+        self._topic = discovery_info.topic.removesuffix("/hello")
+        if self._topic == discovery_info.topic:
             return self.async_abort(reason="invalid_discovery_info")
 
         try:
-            self._serial = parse_hello(payload).serial
+            discovered_serial = parse_hello(payload).serial
         except PrismParseError:
             return self.async_abort(reason="invalid_discovery_info")
 
-        await self.async_set_unique_id(self._base_topic)
+        await self.async_set_unique_id(self._topic)
         self._abort_if_unique_id_configured()
 
-        self.context["title_placeholders"] = {"serial": self._serial}
+        self.context["title_placeholders"] = {"serial": discovered_serial}
+        self._discovered_serial = discovered_serial
         return await self.async_step_discovery_confirm()
 
     async def async_step_discovery_confirm(
@@ -122,11 +834,17 @@ class PrismConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Confirm a discovered Prism."""
         if user_input is not None:
-            return self.async_create_entry(
-                title="Silla Prism", data={CONF_BASE_TOPIC: self._base_topic}
-            )
+            return await self._async_create_entry()
 
         return self.async_show_form(
             step_id="discovery_confirm",
-            description_placeholders={"serial": self._serial or ""},
+            description_placeholders={"serial": self._discovered_serial},
         )
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a flow initialized by the user."""
+        _LOGGER.info("Async_step_user %s", DOMAIN)
+        return await self._async_step_user_base(user_input=user_input)

--- a/homeassistant/components/silla_prism/const.py
+++ b/homeassistant/components/silla_prism/const.py
@@ -1,20 +1,82 @@
-"""Constants for the Silla Prism integration."""
-
-from typing import Final
+"""Constants for Prism integration."""
 
 from homeassistant.const import Platform
 
-DOMAIN: Final = "silla_prism"
+DOMAIN = "silla_prism"
+SENSOR_DOMAIN = "sensor"
+BINARY_SENSOR_DOMAIN = "binary_sensor"
+NUMBER_DOMAIN = "number"
+SELECT_DOMAIN = "select"
+BUTTON_DOMAIN = "button"
+SWITCH_DOMAIN = "switch"
+CONF_TOPIC = "topic"
+CONF_BASE_TOPIC = CONF_TOPIC
+CONF_VSENSORS = "vsensors"
+CONF_POWERWALL = "powerwall"
+CONF_PORTS = "ports"
+CONF_SERIAL = "serial"
+CONF_MAX_CURRENT = "maxcurr"
+CONF_SOLAR_BATTERY_BALANCE = "solar_battery_balance"
+CONF_BATTERY_POWER_SENSOR = "battery_power_sensor"
+CONF_SOLAR_PRODUCTION_POWER_SENSOR = "solar_production_power_sensor"
+CONF_HOME_LOAD_POWER_SENSOR = "home_load_power_sensor"
+CONF_HOME_LOAD_INCLUDES_EV = "home_load_includes_ev"
+CONF_BATTERY_DISCHARGE_POSITIVE = "battery_discharge_positive"
+CONF_BATTERY_MAX_CHARGE_POWER = "battery_max_charge_power"
+CONF_SOLAR_BALANCE_PHASES = "solar_balance_phases"
+CONF_SOLAR_BALANCE_START_DELAY = "solar_balance_start_delay"
+CONF_SOLAR_BALANCE_USE_BATTERY_CHARGE = "solar_balance_use_battery_charge"
+CONF_BATTERY_SOC_SENSOR = "battery_soc_sensor"
+CONF_SOLAR_BALANCE_SOC_MID = "solar_balance_soc_mid"
+CONF_SOLAR_BALANCE_SOC_HIGH = "solar_balance_soc_high"
+CONF_SOLAR_BALANCE_MID_RESERVE_POWER = "solar_balance_mid_reserve_power"
+CONF_SOLAR_BALANCE_HIGH_RESERVE_POWER = "solar_balance_high_reserve_power"
+CONF_SOLAR_BALANCE_TARGET_EXPORT_POWER = "solar_balance_target_export_power"
+CONF_SOLAR_BALANCE_DEADBAND_POWER = "solar_balance_deadband_power"
+CONF_SOLAR_BALANCE_INCREASE_INTERVAL = "solar_balance_increase_interval"
+CONF_SOLAR_BALANCE_INCREASE_STEP = "solar_balance_increase_step"
+CONF_SOLAR_BALANCE_DECREASE_STEP = "solar_balance_decrease_step"
+CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER = "solar_balance_residual_export_power"
+CONF_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY = "solar_balance_residual_export_delay"
+CONF_SOLAR_BALANCE_DRY_RUN = "solar_balance_dry_run"
+DEFAULT_TOPIC = "prism/"
+DEFAULT_VSENSORS = False
+DEFAULT_POWERWALL = False
+DEFAULT_PORTS = 1
+DEFAULT_SERIAL = ""
+DEFAULT_MAX_CURRENT = 16
+DEFAULT_SOLAR_BATTERY_BALANCE = False
+DEFAULT_BATTERY_POWER_SENSOR = ""
+DEFAULT_SOLAR_PRODUCTION_POWER_SENSOR = ""
+DEFAULT_HOME_LOAD_POWER_SENSOR = ""
+DEFAULT_HOME_LOAD_INCLUDES_EV = False
+DEFAULT_BATTERY_DISCHARGE_POSITIVE = True
+DEFAULT_BATTERY_MAX_CHARGE_POWER = 2700
+DEFAULT_SOLAR_BALANCE_PHASES = 1
+DEFAULT_SOLAR_BALANCE_START_DELAY = 5
+DEFAULT_SOLAR_BALANCE_USE_BATTERY_CHARGE = False
+DEFAULT_BATTERY_SOC_SENSOR = ""
+DEFAULT_SOLAR_BALANCE_SOC_MID = 40
+DEFAULT_SOLAR_BALANCE_SOC_HIGH = 80
+DEFAULT_SOLAR_BALANCE_MID_RESERVE_POWER = 1500
+DEFAULT_SOLAR_BALANCE_HIGH_RESERVE_POWER = 1000
+DEFAULT_SOLAR_BALANCE_TARGET_EXPORT_POWER = 150
+DEFAULT_SOLAR_BALANCE_DEADBAND_POWER = 150
+DEFAULT_SOLAR_BALANCE_INCREASE_INTERVAL = 15
+DEFAULT_SOLAR_BALANCE_INCREASE_STEP = 1
+DEFAULT_SOLAR_BALANCE_DECREASE_STEP = 3
+DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_POWER = 400
+DEFAULT_SOLAR_BALANCE_RESIDUAL_EXPORT_DELAY = 60
+DEFAULT_SOLAR_BALANCE_DRY_RUN = False
 
-PLATFORMS: Final = [Platform.SENSOR]
+CONF_ALLOW_SERVICE_CALLS = "allow_service_calls"
+DEFAULT_NEW_CONFIG_ALLOW_ALLOW_SERVICE_CALLS = False
 
-CONF_BASE_TOPIC: Final = "base_topic"
-
-DEFAULT_BASE_TOPIC: Final = "prism"
-
-MANUFACTURER: Final = "Silla"
-MODEL: Final = "Prism"
-
-#: Charging port targeted by this integration. Single-cable Prisms only expose
-#: port 1; DUO support (port 2) is intentionally left for a follow-up.
-PORT: Final = 1
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]

--- a/homeassistant/components/silla_prism/entity.py
+++ b/homeassistant/components/silla_prism/entity.py
@@ -1,25 +1,99 @@
-"""Base entity for the Silla Prism integration."""
+"""Contains sensors exposed by the Prism integration."""
 
+from datetime import datetime
+import logging
+from typing import Any
+
+from homeassistant.components import mqtt
+from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.entity import Entity, EntityDescription
+from homeassistant.helpers.event import async_call_later
 
-from .const import DOMAIN, MANUFACTURER, MODEL
-from .coordinator import PrismCoordinator
+from .entry_data import RuntimeEntryData
+
+_LOGGER = logging.getLogger(__name__)
 
 
-class PrismEntity(CoordinatorEntity[PrismCoordinator]):
-    """Base class linking every entity to the single Prism device."""
+def _get_unique_id(serial: str, key: str) -> str:
+    """Get a unique entity id."""
+    return "prism_" + key + "_001" if serial == "" else f"prism_{serial}_{key}"
 
-    _attr_has_entity_name = True
 
-    def __init__(self, coordinator: PrismCoordinator, key: str) -> None:
-        """Initialize the entity."""
-        super().__init__(coordinator)
-        base_topic = coordinator.base_topic
-        self._attr_unique_id = f"{base_topic}_{key}"
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, base_topic)},
-            manufacturer=MANUFACTURER,
-            model=MODEL,
-            name="Silla Prism",
-        )
+class PrismBaseEntityDescription(EntityDescription, frozen_or_thawed=True):
+    """A class that describes base prism entities."""
+
+    expire_after: float = 600
+    topic: str | None = None
+
+
+class PrismBaseEntity(Entity):
+    """A base Entity that is registered under a Prism device."""
+
+    _expire_after: float | None
+    _expiration_trigger: CALLBACK_TYPE | None = None
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        entry_data: RuntimeEntryData,
+        sensor_domain: str,
+        description: Any,
+        device: DeviceInfo,
+    ) -> None:
+        """Initialize the device info and set the update coordinator."""
+        # Create device instance
+        self._attr_device_info = device
+        self.entity_description = description
+        # Preload attributes
+        self._attr_unique_id = _get_unique_id(entry_data.serial, description.key)
+        self._topic = entry_data.topic + description.topic
+        self._expire_after = description.expire_after
+        # Init expire proceudre
+        if self._expire_after is not None and self._expire_after > 0:
+            self._attr_available = False
+
+    @callback
+    def value_is_expired(self, *_: datetime) -> None:
+        """Triggered when value is expired."""
+        _LOGGER.debug("entity value_is_expired for topic %s", self._topic)
+        self._expiration_trigger = None
+        self._value_is_expired()
+        self.async_write_ha_state()
+
+    async def _subscribe_topic(self):
+        """Subscribe to mqtt topic."""
+        _LOGGER.debug("_subscribe_topic: %s", self._topic)
+        await mqtt.async_subscribe(self.hass, self._topic, self.message_received)
+
+    def _value_is_expired(self):
+        """Triggered when value is expired. To be overridden."""
+        self._attr_available = False
+
+    def _message_received(self, msg) -> None:
+        """Change the selected option."""
+        raise NotImplementedError
+
+    def message_received(self, msg) -> None:
+        """Update the sensor with the most recent event."""
+        self.hass.loop.call_soon_threadsafe(self._message_received, msg)
+
+    def schedule_expiration_callback(self) -> None:
+        """When self._expire_after is set, and we receive a message, assume device is not expired since it has to be to receive the message."""
+        if self._expire_after is not None and self._expire_after > 0:
+            self._attr_available = True
+            if self._expiration_trigger:
+                # Reset old trigger
+                self._expiration_trigger()
+            else:
+                # Set new trigger
+                self._expiration_trigger = async_call_later(
+                    self.hass, self._expire_after, self.value_is_expired
+                )
+
+    def cleanup_expiration_trigger(self) -> None:
+        """Clean up expiration triggers."""
+        if self._expiration_trigger:
+            self._expiration_trigger()
+            self._expiration_trigger = None
+            self._attr_available = True

--- a/homeassistant/components/silla_prism/entry_data.py
+++ b/homeassistant/components/silla_prism/entry_data.py
@@ -1,0 +1,49 @@
+"""Runtime entry data for Silla Prism stored in hass.data."""
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.device_registry import DeviceInfo
+
+if TYPE_CHECKING:
+    from .coordinator import PrismCoordinator
+
+from .solar_balance import SolarBalanceState
+
+
+@dataclass(slots=True)
+class RuntimeEntryData:
+    """Store runtime data shared by all entities in one config entry."""
+
+    topic: str
+    ports: int
+    vsensors: bool
+    powerwall: bool
+    serial: str
+    maxcurr: int
+    solar_battery_balance: bool
+    battery_power_sensor: str
+    solar_production_power_sensor: str
+    home_load_power_sensor: str
+    home_load_includes_ev: bool
+    battery_soc_sensor: str
+    battery_discharge_positive: bool
+    battery_max_charge_power: int
+    solar_balance_phases: int
+    solar_balance_start_delay: int
+    solar_balance_use_battery_charge: bool
+    solar_balance_soc_mid: int
+    solar_balance_soc_high: int
+    solar_balance_mid_reserve_power: int
+    solar_balance_high_reserve_power: int
+    solar_balance_target_export_power: int
+    solar_balance_deadband_power: int
+    solar_balance_increase_interval: int
+    solar_balance_increase_step: int
+    solar_balance_decrease_step: int
+    solar_balance_residual_export_power: int
+    solar_balance_residual_export_delay: int
+    solar_balance_dry_run: bool
+    devices: list[DeviceInfo]
+    coordinator: PrismCoordinator
+    solar_balance_states: dict[int, SolarBalanceState] = field(default_factory=dict)

--- a/homeassistant/components/silla_prism/number.py
+++ b/homeassistant/components/silla_prism/number.py
@@ -1,0 +1,193 @@
+"""Contains numbers configurations for Prism wallbox integration."""
+
+import logging
+from typing import override
+
+from homeassistant.components import mqtt
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import NUMBER_DOMAIN
+from .entity import PrismBaseEntity
+from .entry_data import RuntimeEntryData
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Add entities for passed config_entry in HA."""
+    entry_data: RuntimeEntryData = entry.runtime_data
+    _LOGGER.debug("async_setup_entry for numbers: %s", entry_data)
+
+    ports = entry_data.ports
+
+    numbers = []
+    for port in range(1, ports + 1):
+        numbers.extend(
+            [PrismNumber(entry_data, description, port) for description in NUMBERS]
+        )
+
+    async_add_entities(numbers)
+
+
+class PrismNumberEntityDescription(NumberEntityDescription, frozen_or_thawed=True):
+    """A class that describes prism binary sensor entities."""
+
+    expire_after: float = 0
+    topic: str | None = None
+    topic_out: str | None = None
+
+
+class PrismNumber(PrismBaseEntity, NumberEntity):
+    """Prism number entity."""
+
+    _attr_has_entity_name = True
+
+    entity_description: PrismNumberEntityDescription
+
+    def description(
+        self,
+        port: int,
+        mulitport: bool,
+        max_current: int,
+        description: PrismNumberEntityDescription,
+    ) -> PrismNumberEntityDescription:
+        """Create a Number entity for Prism EVSE devices."""
+        assert description.topic is not None
+        assert description.topic_out is not None
+        if mulitport:
+            return PrismNumberEntityDescription(
+                key=description.key.format(port),
+                topic=description.topic.format(port),
+                topic_out=description.topic_out.format(port),
+                entity_category=description.entity_category,
+                device_class=description.device_class,
+                native_min_value=description.native_min_value,
+                native_max_value=max_current,
+                native_step=description.native_step,
+                mode=description.mode,
+                has_entity_name=description.has_entity_name,
+                translation_key=description.translation_key,
+            )
+        return PrismNumberEntityDescription(
+            key=description.key[:-3],
+            topic=description.topic.format(port),
+            topic_out=description.topic_out.format(port),
+            entity_category=description.entity_category,
+            device_class=description.device_class,
+            native_min_value=description.native_min_value,
+            native_max_value=max_current,
+            native_step=description.native_step,
+            mode=description.mode,
+            has_entity_name=description.has_entity_name,
+            translation_key=description.translation_key,
+        )
+
+    def __init__(
+        self,
+        entry_data: RuntimeEntryData,
+        description: PrismNumberEntityDescription,
+        port: int,
+    ) -> None:
+        """Init Prism select."""
+        max_current = entry_data.maxcurr
+        ismultiport = entry_data.ports > 1
+        if not ismultiport:
+            device = entry_data.devices[0]
+        else:
+            device = entry_data.devices[port]
+
+        self._entry_data = entry_data
+        self._port = port
+        _description = self.description(port, ismultiport, max_current, description)
+        super().__init__(
+            entry_data,
+            NUMBER_DOMAIN,
+            _description,
+            device,
+        )
+
+        self._topic_out = (
+            entry_data.topic + _description.topic_out
+            if _description.topic_out
+            else None
+        )
+        self._attr_native_value = self.native_min_value
+
+    @override
+    def _message_received(self, msg) -> None:
+        """Update the sensor with the most recent event."""
+        self._attr_native_value = msg.payload
+        self.schedule_update_ha_state()
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to mqtt."""
+        if self.entity_description.topic:
+            await self._subscribe_topic()
+
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe from mqtt."""
+        _LOGGER.debug("async_will_remove_from_hass key:%s", self.entity_description.key)
+        await super().async_will_remove_from_hass()
+        self.cleanup_expiration_trigger()
+
+    @override
+    def set_native_value(self, _: float) -> None:
+        """Set the native value."""
+        raise NotImplementedError
+
+    @override
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+        # _LOGGER.debug(
+        #     "async_set_native_value key:%s topic:%s value:%f",
+        #     self.entity_description.key,
+        #     self._topic_out,
+        #     value,
+        # )
+        int_value = int(value)
+        if self._topic_out is not None:
+            await mqtt.async_publish(self.hass, self._topic_out, int_value)
+
+
+NUMBERS: tuple[PrismNumberEntityDescription, ...] = (
+    PrismNumberEntityDescription(
+        key="set_max_current_{}",
+        topic="{}/user_amp",
+        topic_out="{}/command/set_current_user",
+        entity_category=EntityCategory.CONFIG,
+        device_class=NumberDeviceClass.CURRENT,
+        native_min_value=6,
+        native_max_value=16,
+        mode=NumberMode.BOX,
+        has_entity_name=True,
+        translation_key="set_max_current",
+    ),
+    PrismNumberEntityDescription(
+        key="set_current_limit_{}",
+        topic="{}/pilot",
+        topic_out="{}/command/set_current_limit",
+        entity_category=EntityCategory.CONFIG,
+        device_class=NumberDeviceClass.CURRENT,
+        native_min_value=6,
+        native_max_value=16,
+        has_entity_name=True,
+        translation_key="set_current_limit",
+    ),
+)

--- a/homeassistant/components/silla_prism/select.py
+++ b/homeassistant/components/silla_prism/select.py
@@ -1,0 +1,162 @@
+"""Silla Prism select entity module."""
+
+import logging
+from typing import override
+
+from homeassistant.components import mqtt
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import SELECT_DOMAIN
+from .entity import PrismBaseEntity
+from .entry_data import RuntimeEntryData
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Add entities for passed config_entry in HA."""
+    entry_data: RuntimeEntryData = entry.runtime_data
+    _LOGGER.debug("async_setup_entry for select: %s", entry_data)
+
+    ports = entry_data.ports
+    selects = []
+    for port in range(1, ports + 1):
+        selects.extend(
+            [PrismSelect(entry_data, description, port) for description in SELECTS]
+        )
+    async_add_entities(selects)
+
+
+class PrismSelectEntityDescription(SelectEntityDescription, frozen_or_thawed=True):
+    """A class that describes prism binary sensor entities."""
+
+    expire_after: float = 0
+    topic: str | None = None
+    topic_out: str | None = None
+
+
+class PrismSelect(PrismBaseEntity, SelectEntity):
+    """A Select for Prism wallbox devices."""
+
+    _attr_has_entity_name = True
+
+    entity_description: PrismSelectEntityDescription
+
+    def description(
+        self, port: int, mulitport: bool, description: PrismSelectEntityDescription
+    ) -> PrismSelectEntityDescription:
+        """Create a Select entity for Prism EVSE devices."""
+        assert description.topic is not None
+        assert description.topic_out is not None
+        if mulitport:
+            return PrismSelectEntityDescription(
+                key=description.key.format(port),
+                topic=description.topic.format(port),
+                entity_category=description.entity_category,
+                device_class=description.device_class,
+                options=description.options,
+                has_entity_name=description.has_entity_name,
+                translation_key=description.translation_key,
+                topic_out=description.topic_out.format(port),
+            )
+        return PrismSelectEntityDescription(
+            key=description.key[0:-3],
+            topic=description.topic.format(port),
+            entity_category=description.entity_category,
+            device_class=description.device_class,
+            options=description.options,
+            has_entity_name=description.has_entity_name,
+            translation_key=description.translation_key,
+            topic_out=description.topic_out.format(port),
+        )
+
+    def __init__(
+        self,
+        entry_data: RuntimeEntryData,
+        description: PrismSelectEntityDescription,
+        port: int,
+    ) -> None:
+        """Init Prism select."""
+        ismultiport = entry_data.ports > 1
+        if not ismultiport:
+            device = entry_data.devices[0]
+        else:
+            device = entry_data.devices[port]
+
+        _description = self.description(port, ismultiport, description)
+        super().__init__(
+            entry_data,
+            SELECT_DOMAIN,
+            _description,
+            device,
+        )
+
+        self._attr_current_option = None
+        assert _description.topic_out is not None
+        self._topic_out = entry_data.topic + _description.topic_out
+
+    @override
+    def _message_received(self, msg) -> None:
+        """Update the sensor with the most recent event."""
+        try:
+            _sel = int(msg.payload) - 1
+        except ValueError:
+            _LOGGER.warning(
+                "Invalid topic payload: topic:%s payload:%s",
+                self._topic,
+                msg.payload,
+            )
+            return
+
+        # Update state if value is valid and different from current option
+        if (
+            0 <= _sel < len(self.options)
+            and self.options[_sel] != self._attr_current_option
+        ):
+            self._attr_current_option = self.options[_sel]
+            self.schedule_update_ha_state()
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to mqtt."""
+        _LOGGER.debug("async_added_to_hass key:%s", self.entity_description.key)
+        await self._subscribe_topic()
+
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe from mqtt."""
+        _LOGGER.debug("async_will_remove_from_hass key:%s", self.entity_description.key)
+        await super().async_will_remove_from_hass()
+        self.cleanup_expiration_trigger()
+
+    @override
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        self._attr_current_option = option
+        self.schedule_update_ha_state()
+        await mqtt.async_publish(
+            self.hass, self._topic_out, self.options.index(option) + 1
+        )
+
+
+SELECTS: tuple[PrismSelectEntityDescription, ...] = (
+    PrismSelectEntityDescription(
+        key="set_mode_{}",
+        topic="{}/mode",
+        topic_out="{}/command/set_mode",
+        entity_category=EntityCategory.CONFIG,
+        options=["solar", "normal", "paused", "hybrid"],
+        has_entity_name=True,
+        translation_key="set_port_mode",
+    ),
+)

--- a/homeassistant/components/silla_prism/sensor.py
+++ b/homeassistant/components/silla_prism/sensor.py
@@ -1,272 +1,785 @@
-"""Sensor platform for the Silla Prism integration."""
+"""Contains sensors exposed by the Prism wallbox integration."""
 
-from collections.abc import Callable
-from dataclasses import dataclass
-from datetime import datetime, timedelta
+from contextlib import suppress
+from decimal import Decimal
 import logging
 from typing import override
 
-from pysillaprism import PortError, PortState, PrismStatus
-
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
     SensorStateClass,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    EntityCategory,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
     UnitOfPower,
     UnitOfTemperature,
+    UnitOfTime,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.typing import StateType
-from homeassistant.util.dt import utcnow
+from homeassistant.helpers.event import async_track_state_change_event
 
-from .const import PORT
-from .coordinator import PrismConfigEntry, PrismCoordinator
-from .entity import PrismEntity
-
-PARALLEL_UPDATES = 0
+from .const import SENSOR_DOMAIN
+from .entity import PrismBaseEntity, _get_unique_id
+from .entry_data import RuntimeEntryData
+from .solar_balance import (
+    SOLAR_BALANCE_CHARGING_SURPLUS,
+    SOLAR_BALANCE_DISABLED,
+    SOLAR_BALANCE_EXTERNAL_PAUSED,
+    SOLAR_BALANCE_LOW_SURPLUS_KEEP_CHARGING,
+    SOLAR_BALANCE_PAUSED_LOW_SURPLUS,
+    SOLAR_BALANCE_WAITING_BATTERY_DATA,
+    SOLAR_BALANCE_WAITING_DATA,
+    SOLAR_BALANCE_WAITING_SOLAR_MODE,
+    SOLAR_BALANCE_WAITING_STABLE_SURPLUS,
+    SolarBalanceState,
+    get_solar_balance_signal,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-
-@dataclass(frozen=True, kw_only=True)
-class PrismSensorEntityDescription(SensorEntityDescription):
-    """Describes a Prism sensor."""
-
-    value_fn: Callable[[PrismStatus], StateType]
-
-
-# The Home Assistant state vocabulary differs from the protocol naming.
-PORT_STATE_OPTIONS = {
-    PortState.IDLE: "idle",
-    PortState.WAITING: "waiting",
-    PortState.CHARGING: "charging",
-    PortState.PAUSE: "paused",
-}
-
-
-# The MQTT protocol only documents 0 as "no error". The fault codes are not
-# specified, so they are reported as unknown rather than guessed, and logged so
-# that this mapping can grow with the codes seen in the field.
-ERROR_OPTIONS = {
-    PortError.NONE: "none",
-}
-
-
-def _port_state(status: PrismStatus) -> str | None:
-    state = status.port(PORT).state
-    return PORT_STATE_OPTIONS.get(state) if state is not None else None
-
-
-SENSORS: tuple[PrismSensorEntityDescription, ...] = (
-    PrismSensorEntityDescription(
-        key="status",
-        translation_key="status",
-        device_class=SensorDeviceClass.ENUM,
-        options=list(PORT_STATE_OPTIONS.values()),
-        value_fn=_port_state,
-    ),
-    PrismSensorEntityDescription(
-        key="power",
-        device_class=SensorDeviceClass.POWER,
-        native_unit_of_measurement=UnitOfPower.WATT,
-        state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda status: status.port(PORT).power,
-    ),
-    PrismSensorEntityDescription(
-        key="current",
-        device_class=SensorDeviceClass.CURRENT,
-        native_unit_of_measurement=UnitOfElectricCurrent.MILLIAMPERE,
-        suggested_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda status: status.port(PORT).current,
-    ),
-    PrismSensorEntityDescription(
-        key="voltage",
-        device_class=SensorDeviceClass.VOLTAGE,
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda status: status.port(PORT).voltage,
-    ),
-    PrismSensorEntityDescription(
-        key="pilot",
-        translation_key="pilot",
-        device_class=SensorDeviceClass.CURRENT,
-        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda status: status.port(PORT).pilot,
-    ),
-    PrismSensorEntityDescription(
-        key="session_energy",
-        translation_key="session_energy",
-        device_class=SensorDeviceClass.ENERGY,
-        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
-        state_class=SensorStateClass.TOTAL,
-        value_fn=lambda status: status.port(PORT).session_energy,
-    ),
-    PrismSensorEntityDescription(
-        key="total_energy",
-        translation_key="total_energy",
-        device_class=SensorDeviceClass.ENERGY,
-        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        value_fn=lambda status: status.port(PORT).total_energy,
-    ),
-    PrismSensorEntityDescription(
-        key="temperature",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        state_class=SensorStateClass.MEASUREMENT,
-        entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda status: status.temperature,
-    ),
-    PrismSensorEntityDescription(
-        key="grid_power",
-        translation_key="grid_power",
-        device_class=SensorDeviceClass.POWER,
-        native_unit_of_measurement=UnitOfPower.WATT,
-        state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda status: status.energy.power_grid,
-    ),
-)
-
-ERROR = PrismSensorEntityDescription(
-    key="error",
-    translation_key="error",
-    device_class=SensorDeviceClass.ENUM,
-    options=list(ERROR_OPTIONS.values()),
-    entity_category=EntityCategory.DIAGNOSTIC,
-    value_fn=lambda status: status.port(PORT).error,
-)
-
-SESSION_START = PrismSensorEntityDescription(
-    key="session_start",
-    translation_key="session_start",
-    device_class=SensorDeviceClass.TIMESTAMP,
-    entity_category=EntityCategory.DIAGNOSTIC,
-    value_fn=lambda status: status.port(PORT).session_time,
-)
-
-# Prism reports the elapsed session time once a minute, and its counter runs
-# about a second off the Home Assistant clock, so the derived start time jitters
-# between messages. Deviations below this threshold keep the previous value.
-SESSION_START_DEVIATION = timedelta(seconds=5)
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: PrismConfigEntry,
+    entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up Prism sensors."""
-    coordinator = entry.runtime_data
-    entities: list[PrismSensor] = [
-        PrismSensor(coordinator, description) for description in SENSORS
-    ]
-    entities.append(PrismErrorSensor(coordinator, ERROR))
-    entities.append(PrismSessionStartSensor(coordinator, SESSION_START))
-    async_add_entities(entities)
+    """Set up all sensors for this entry."""
+    entry_data: RuntimeEntryData = entry.runtime_data
+    _LOGGER.debug("async_setup_entry for sensors: %s", entry_data)
+    ports = entry_data.ports
+
+    sensors: list[SensorEntity] = []
+    for port in range(1, ports + 1):
+        sensors.extend(
+            [PrismSensor(entry_data, description, port) for description in SENSORS]
+        )
+    sensors.extend(
+        [PrismSensor(entry_data, description, 0) for description in BASE_SENSORS]
+    )
+    if entry_data.powerwall:
+        sensors.extend(
+            [
+                PrismSensor(entry_data, description, 0)
+                for description in POWERWALL_SENSORS
+            ]
+        )
+    if entry_data.vsensors:
+        sensors.append(PrismGridEnergy(entry_data, VSENSORS[0]))
+    if entry_data.solar_battery_balance:
+        for port in range(1, ports + 1):
+            entry_data.solar_balance_states.setdefault(port, SolarBalanceState())
+            sensors.extend(
+                [
+                    PrismSolarBalanceSensor(entry_data, description, port)
+                    for description in SOLAR_BALANCE_SENSORS
+                ]
+            )
+    async_add_entities(sensors)
 
 
-class PrismSensor(PrismEntity, SensorEntity):
-    """A Prism sensor backed by an accumulated status field."""
+class PrismSensorEntityDescription(SensorEntityDescription, frozen_or_thawed=True):
+    """A class that describes prism binary sensor entities."""
+
+    expire_after: float = 600
+    topic: str | None = None
+
+
+class PrismSolarBalanceSensorEntityDescription(
+    SensorEntityDescription, frozen_or_thawed=True
+):
+    """A class that describes Prism solar balance sensors."""
+
+    value_key: str | None = None
+
+
+class PrismGridEnergy(RestoreSensor):
+    """A Sensor that compute the integral of energy take from grid."""
+
+    _attr_has_entity_name = True
+
+    _attr_should_poll = False
+    _attr_translation_key = "input_grid_energy"
+
+    def __init__(
+        self, entry_data: RuntimeEntryData, description: SensorEntityDescription
+    ) -> None:
+        """Init Prism energy sensor."""
+        self._attr_device_info = entry_data.devices[0]
+        self.entity_description = description
+        self._attr_unique_id = _get_unique_id(entry_data.serial, description.key)
+        self._integral: Decimal = Decimal(0)
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Sensor is added to hass."""
+        _LOGGER.debug("async_added_to_hass %s", self.entity_description.key)
+        await super().async_added_to_hass()
+
+        if state := await self.async_get_last_state():
+            _LOGGER.debug("async_added_to_hass last state %s", state)
+            if state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+                with suppress(ValueError):
+                    self._integral = Decimal(state.state)
+                    self._attr_native_value = round(self._integral, 1)
+            else:
+                _LOGGER.warning(
+                    "Can't restore state of %s",
+                    self.entity_description.key,
+                )
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, "sensor.silla_prism_input_grid_power", self._calc_integral
+            )
+        )
+
+    @callback
+    def _calc_integral(self, event: Event[EventStateChangedData]) -> None:
+        """Handle the sensor state changes."""
+        old_state = event.data["old_state"]
+        new_state = event.data["new_state"]
+
+        if old_state is None or new_state is None:
+            return
+
+        if old_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE) or new_state.state in (
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
+        ):
+            if self._attr_available:
+                self._attr_available = False
+                self.async_write_ha_state()
+            return
+
+        elapsed_time = Decimal(
+            ((new_state.last_updated - old_state.last_updated).total_seconds()) / 3600
+        )
+
+        # Wh to kWh conversion is Wh/1000
+        average_value = (Decimal(new_state.state) + Decimal(old_state.state)) / Decimal(
+            2000
+        )
+
+        self._integral += elapsed_time * average_value
+
+        # _LOGGER.debug(
+        #     "Elapsed_time: %s, average_value: %s, integral: %s",
+        #     elapsed_time,
+        #     average_value,
+        #     self._integral,
+        # )
+
+        self._attr_native_value = round(self._integral, 1)
+
+        if not self._attr_available:
+            self._attr_available = True
+        self.async_write_ha_state()
+
+
+class PrismSensor(PrismBaseEntity, SensorEntity):
+    """A Sensor for Prism EVSE devices."""
+
+    _attr_has_entity_name = True
 
     entity_description: PrismSensorEntityDescription
 
-    def __init__(
-        self,
-        coordinator: PrismCoordinator,
-        description: PrismSensorEntityDescription,
-    ) -> None:
-        """Initialize the sensor."""
-        super().__init__(coordinator, description.key)
-        self.entity_description = description
-
-    @property
-    @override
-    def native_value(self) -> StateType | datetime:
-        """Return the current value from the accumulated status."""
-        return self.entity_description.value_fn(self.coordinator.device.status)
-
-
-class PrismErrorSensor(PrismSensor):
-    """Reports the port error code.
-
-    Codes missing from the enum read as unknown and are logged once each, so
-    that undocumented fault codes can be reported and mapped.
-    """
-
-    def __init__(
-        self,
-        coordinator: PrismCoordinator,
-        description: PrismSensorEntityDescription,
-    ) -> None:
-        """Initialize the sensor."""
-        super().__init__(coordinator, description)
-        self._logged_codes: set[int] = set()
-
-    @property
-    @override
-    def native_value(self) -> str | None:
-        """Return the mapped error code."""
-        code = self.coordinator.device.status.port(PORT).error
-        if code is None:
-            return None
-
-        try:
-            state = ERROR_OPTIONS[PortError(code)]
-        except KeyError, ValueError:
-            if code not in self._logged_codes:
-                self._logged_codes.add(code)
-                _LOGGER.warning(
-                    "Unknown error code: %s, please report at https://github.com/home-assistant/core/issues",
-                    code,
-                )
-            return None
-        return state
-
-
-class PrismSessionStartSensor(PrismSensor):
-    """Reports when the running charging session started.
-
-    Prism only publishes the elapsed session time, which is stale as soon as it
-    is received. Reporting the derived start time instead keeps the value
-    accurate between messages.
-    """
+    def _get_description(
+        self, port: int, mulitport: bool, description: PrismSensorEntityDescription
+    ) -> PrismSensorEntityDescription:
+        if port == 0:
+            return description
+        assert description.topic is not None
+        if mulitport:
+            return PrismSensorEntityDescription(
+                key=description.key.format(port),
+                topic=description.topic.format(port),
+                device_class=description.device_class,
+                state_class=description.state_class,
+                native_unit_of_measurement=description.native_unit_of_measurement,
+                suggested_display_precision=description.suggested_display_precision,
+                options=description.options,
+                has_entity_name=description.has_entity_name,
+                translation_key=description.translation_key,
+            )
+        return PrismSensorEntityDescription(
+            key=description.key[:-3],
+            topic=description.topic.format(port),
+            device_class=description.device_class,
+            state_class=description.state_class,
+            native_unit_of_measurement=description.native_unit_of_measurement,
+            suggested_display_precision=description.suggested_display_precision,
+            options=description.options,
+            has_entity_name=description.has_entity_name,
+            translation_key=description.translation_key,
+        )
 
     def __init__(
         self,
-        coordinator: PrismCoordinator,
+        entry_data: RuntimeEntryData,
         description: PrismSensorEntityDescription,
+        port: int,
     ) -> None:
-        """Initialize the sensor."""
-        super().__init__(coordinator, description)
-        self._session_start: datetime | None = None
+        """Init Prism sensor."""
+        ismultiport = entry_data.ports > 1
+        if not ismultiport:
+            device = entry_data.devices[0]
+        else:
+            device = entry_data.devices[port]
+        super().__init__(
+            entry_data,
+            SENSOR_DOMAIN,
+            self._get_description(port, ismultiport, description),
+            device,
+        )
 
-    @property
     @override
-    def native_value(self) -> datetime | None:
-        """Return the start time derived from the elapsed session time."""
-        elapsed = self.entity_description.value_fn(self.coordinator.device.status)
-        # Prism reports zero while no vehicle is connected.
-        if not elapsed:
-            self._session_start = None
-            return None
+    def _message_received(self, msg) -> None:
+        """Update the sensor with the most recent event."""
+        self.schedule_expiration_callback()
+        # Update native value
+        if self.options is not None:
+            try:
+                self._attr_native_value = self.options[int(msg.payload) - 1]
+            except IndexError:
+                self._attr_native_value = None
+        else:
+            self._attr_native_value = msg.payload
+        # Schedule update ha state
+        self.schedule_update_ha_state()
 
-        start = utcnow() - timedelta(seconds=float(elapsed))
-        if (
-            self._session_start is None
-            or abs(start - self._session_start) > SESSION_START_DEVIATION
-        ):
-            self._session_start = start
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to mqtt."""
+        # _LOGGER.debug("async_added_to_hass")
+        self._attr_available = False
+        await self._subscribe_topic()
 
-        return self._session_start
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove entity from hass."""
+        _LOGGER.debug("called async_will_remove_from_hass fir %s", self.entity_id)
+        await super().async_will_remove_from_hass()
+        # Clean up expire triggers
+        if self._expiration_trigger:
+            self._expiration_trigger()
+            self._expiration_trigger = None
+            self._attr_available = True
+
+
+class PrismSolarBalanceSensor(SensorEntity):
+    """Expose the latest solar battery balance calculation."""
+
+    _attr_has_entity_name = True
+
+    entity_description: PrismSolarBalanceSensorEntityDescription
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        entry_data: RuntimeEntryData,
+        description: PrismSolarBalanceSensorEntityDescription,
+        port: int,
+    ) -> None:
+        """Initialize Prism solar balance sensor."""
+        self._entry_data = entry_data
+        self._port = port
+        self.entity_description = self._get_description(
+            port, entry_data.ports > 1, description
+        )
+        if entry_data.ports > 1:
+            self._attr_device_info = entry_data.devices[port]
+        else:
+            self._attr_device_info = entry_data.devices[0]
+        self._attr_unique_id = _get_unique_id(
+            entry_data.serial, self.entity_description.key
+        )
+        self._balance_state = entry_data.solar_balance_states.setdefault(
+            port, SolarBalanceState()
+        )
+        self._apply_balance_state(self._balance_state)
+
+    def _get_description(
+        self,
+        port: int,
+        multiport: bool,
+        description: PrismSolarBalanceSensorEntityDescription,
+    ) -> PrismSolarBalanceSensorEntityDescription:
+        if multiport:
+            key = description.key.format(port)
+        else:
+            key = description.key[:-3]
+        return PrismSolarBalanceSensorEntityDescription(
+            key=key,
+            device_class=description.device_class,
+            state_class=description.state_class,
+            native_unit_of_measurement=description.native_unit_of_measurement,
+            suggested_display_precision=description.suggested_display_precision,
+            options=description.options,
+            has_entity_name=description.has_entity_name,
+            translation_key=description.translation_key,
+            value_key=description.value_key,
+        )
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Listen for solar balance updates."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                get_solar_balance_signal(self._entry_data.serial, self._port),
+                self._balance_state_updated,
+            )
+        )
+
+    @callback
+    def _balance_state_updated(self, state: SolarBalanceState) -> None:
+        """Handle a solar balance state update."""
+        self._balance_state = state
+        self._apply_balance_state(state)
+        self.async_write_ha_state()
+
+    def _apply_balance_state(self, state: SolarBalanceState) -> None:
+        if self.entity_description.value_key == "status":
+            self._attr_native_value = state.status
+        elif self.entity_description.value_key == "surplus_current":
+            self._attr_native_value = state.surplus_current
+        elif self.entity_description.value_key == "start_delay_remaining":
+            self._attr_native_value = state.start_delay_remaining or 0
+        elif self.entity_description.value_key == "available_power":
+            self._attr_native_value = state.available_power
+        elif self.entity_description.value_key == "battery_power_used":
+            self._attr_native_value = state.battery_power_used
+        elif self.entity_description.value_key == "grid_power":
+            self._attr_native_value = state.grid_power
+        elif self.entity_description.value_key == "solar_power":
+            self._attr_native_value = state.solar_power
+        elif self.entity_description.value_key == "home_load_power":
+            self._attr_native_value = state.home_load_power
+        elif self.entity_description.value_key == "target_current":
+            self._attr_native_value = state.target_current
+        elif self.entity_description.value_key == "raw_target_current":
+            self._attr_native_value = state.raw_target_current
+        elif self.entity_description.value_key == "theoretical_target_current":
+            self._attr_native_value = state.theoretical_target_current
+        elif self.entity_description.value_key == "battery_reserve_power":
+            self._attr_native_value = state.battery_reserve_power
+        elif self.entity_description.value_key == "battery_reserve_shortfall_power":
+            self._attr_native_value = state.battery_reserve_shortfall_power
+        elif self.entity_description.value_key == "target_export_power":
+            self._attr_native_value = state.target_export_power
+        elif self.entity_description.value_key == "unused_export_power":
+            self._attr_native_value = state.unused_export_power
+        elif self.entity_description.value_key == "residual_export_remaining":
+            self._attr_native_value = state.residual_export_remaining or 0
+        elif self.entity_description.value_key == "decision_reason":
+            self._attr_native_value = state.decision_reason
+        elif self.entity_description.value_key == "decision_summary":
+            self._attr_native_value = state.decision_summary
+
+        self._attr_extra_state_attributes = {
+            "decision_summary": state.decision_summary,
+            "available_power": state.available_power,
+            "target_power": state.target_power,
+            "start_delay_remaining": state.start_delay_remaining,
+            "grid_power": state.grid_power,
+            "ev_power": state.ev_power,
+            "solar_power": state.solar_power,
+            "home_load_power": state.home_load_power,
+            "battery_power": state.battery_power,
+            "battery_charge_power": state.battery_charge_power,
+            "battery_discharge_power": state.battery_discharge_power,
+            "battery_power_used": state.battery_power_used,
+            "battery_max_charge_power": state.battery_max_charge_power,
+            "battery_soc": state.battery_soc,
+            "battery_reserve_power": state.battery_reserve_power,
+            "battery_reserve_shortfall_power": state.battery_reserve_shortfall_power,
+            "surplus_source": state.surplus_source,
+            "target_export_power": state.target_export_power,
+            "deadband_power": state.deadband_power,
+            "raw_target_current": state.raw_target_current,
+            "target_current": state.target_current,
+            "theoretical_target_current": state.theoretical_target_current,
+            "reported_current_limit": state.reported_current_limit,
+            "unused_export_power": state.unused_export_power,
+            "excess_import_power": state.excess_import_power,
+            "residual_export_remaining": state.residual_export_remaining,
+            "deadband_active": state.deadband_active,
+            "ramp_limited": state.ramp_limited,
+            "ramp_direction": state.ramp_direction,
+            "current_limit_reason": state.current_limit_reason,
+            "decision_reason": state.decision_reason,
+            "missing_data_reason": state.missing_data_reason,
+        }
+
+
+SOLAR_BALANCE_SENSORS: tuple[PrismSolarBalanceSensorEntityDescription, ...] = (
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_status_{}",
+        device_class=SensorDeviceClass.ENUM,
+        options=[
+            SOLAR_BALANCE_DISABLED,
+            SOLAR_BALANCE_WAITING_DATA,
+            SOLAR_BALANCE_WAITING_BATTERY_DATA,
+            SOLAR_BALANCE_WAITING_SOLAR_MODE,
+            SOLAR_BALANCE_WAITING_STABLE_SURPLUS,
+            SOLAR_BALANCE_PAUSED_LOW_SURPLUS,
+            SOLAR_BALANCE_EXTERNAL_PAUSED,
+            SOLAR_BALANCE_CHARGING_SURPLUS,
+            SOLAR_BALANCE_LOW_SURPLUS_KEEP_CHARGING,
+        ],
+        has_entity_name=True,
+        translation_key="solar_balance_status",
+        value_key="status",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_surplus_current_{}",
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        suggested_display_precision=1,
+        has_entity_name=True,
+        translation_key="solar_balance_surplus_current",
+        value_key="surplus_current",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_start_countdown_{}",
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="solar_balance_start_countdown",
+        value_key="start_delay_remaining",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_available_power_{}",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="solar_balance_available_power",
+        value_key="available_power",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_battery_power_used_{}",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="solar_balance_battery_power_used",
+        value_key="battery_power_used",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_grid_power_{}",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="solar_balance_grid_power",
+        value_key="grid_power",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_solar_power_{}",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="solar_balance_solar_power",
+        value_key="solar_power",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_home_load_power_{}",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="solar_balance_home_load_power",
+        value_key="home_load_power",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_target_current_{}",
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        suggested_display_precision=1,
+        has_entity_name=True,
+        translation_key="solar_balance_target_current",
+        value_key="target_current",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_raw_target_current_{}",
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        suggested_display_precision=1,
+        has_entity_name=True,
+        translation_key="solar_balance_raw_target_current",
+        value_key="raw_target_current",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_theoretical_target_current_{}",
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        suggested_display_precision=1,
+        has_entity_name=True,
+        translation_key="solar_balance_theoretical_target_current",
+        value_key="theoretical_target_current",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_battery_reserve_power_{}",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="solar_balance_battery_reserve_power",
+        value_key="battery_reserve_power",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_battery_reserve_shortfall_power_{}",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="solar_balance_battery_reserve_shortfall_power",
+        value_key="battery_reserve_shortfall_power",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_target_export_power_{}",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="solar_balance_target_export_power",
+        value_key="target_export_power",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_unused_export_power_{}",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="solar_balance_unused_export_power",
+        value_key="unused_export_power",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_residual_export_countdown_{}",
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="solar_balance_residual_export_countdown",
+        value_key="residual_export_remaining",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_decision_reason_{}",
+        device_class=SensorDeviceClass.ENUM,
+        options=[
+            SOLAR_BALANCE_DISABLED,
+            SOLAR_BALANCE_WAITING_DATA,
+            SOLAR_BALANCE_WAITING_BATTERY_DATA,
+            SOLAR_BALANCE_WAITING_SOLAR_MODE,
+            SOLAR_BALANCE_WAITING_STABLE_SURPLUS,
+            SOLAR_BALANCE_PAUSED_LOW_SURPLUS,
+            SOLAR_BALANCE_EXTERNAL_PAUSED,
+            SOLAR_BALANCE_CHARGING_SURPLUS,
+            SOLAR_BALANCE_LOW_SURPLUS_KEEP_CHARGING,
+        ],
+        has_entity_name=True,
+        translation_key="solar_balance_decision_reason",
+        value_key="decision_reason",
+    ),
+    PrismSolarBalanceSensorEntityDescription(
+        key="solar_balance_decision_summary_{}",
+        has_entity_name=True,
+        translation_key="solar_balance_decision_summary",
+        value_key="decision_summary",
+    ),
+)
+
+SENSORS: tuple[PrismSensorEntityDescription, ...] = (
+    PrismSensorEntityDescription(
+        key="current_state_{}",
+        topic="{}/state",
+        device_class=SensorDeviceClass.ENUM,
+        options=["idle", "waiting", "charging", "pause"],
+        has_entity_name=True,
+        translation_key="current_state",
+    ),
+    PrismSensorEntityDescription(
+        key="power_grid_voltage_{}",
+        topic="{}/volt",
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="power_grid_voltage",
+    ),
+    PrismSensorEntityDescription(
+        key="output_power_{}",
+        topic="{}/w",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="output_power",
+    ),
+    PrismSensorEntityDescription(
+        key="output_current_{}",
+        topic="{}/amp",
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.MILLIAMPERE,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="output_current",
+    ),
+    PrismSensorEntityDescription(
+        key="output_car_current_{}",
+        topic="{}/pilot",
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="output_car_current",
+    ),
+    PrismSensorEntityDescription(
+        key="current_set_by_user_{}",
+        topic="{}/user_amp",
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="current_set_by_user",
+    ),
+    PrismSensorEntityDescription(
+        key="session_time_{}",
+        topic="{}/session_time",
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="session_time",
+    ),
+    PrismSensorEntityDescription(
+        key="session_output_energy_{}",
+        topic="{}/wh",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="session_output_energy",
+    ),
+    PrismSensorEntityDescription(
+        key="total_output_energy_{}",
+        topic="{}/wh_total",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="total_output_energy",
+    ),
+    PrismSensorEntityDescription(
+        key="current_port_mode_{}",
+        topic="{}/mode",
+        device_class=SensorDeviceClass.ENUM,
+        options=[
+            "solar",
+            "normal",
+            "paused",
+            "hybrid",
+            "suspended",
+            "unknown",
+            "autolimit",
+        ],
+        has_entity_name=True,
+        translation_key="current_port_mode",
+    ),
+)
+
+BASE_SENSORS: tuple[PrismSensorEntityDescription, ...] = (
+    PrismSensorEntityDescription(
+        key="input_grid_power",
+        topic="energy_data/power_grid",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="input_grid_power",
+    ),
+    PrismSensorEntityDescription(
+        key="core_temperature",
+        topic="0/info/temperature/core",
+        expire_after=86400,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="core_temperature",
+    ),
+)
+
+POWERWALL_SENSORS: tuple[PrismSensorEntityDescription, ...] = (
+    PrismSensorEntityDescription(
+        key="powerwall_solar",
+        topic="energy_data/power_solar",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="powerwall_solar",
+    ),
+    PrismSensorEntityDescription(
+        key="powerwall_house",
+        topic="energy_data/power_house",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        suggested_display_precision=0,
+        has_entity_name=True,
+        translation_key="powerwall_house",
+    ),
+)
+
+VSENSORS: list[SensorEntityDescription] = [
+    SensorEntityDescription(
+        key="input_grid_energy",
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        has_entity_name=True,
+        translation_key="input_grid_energy",
+    )
+]

--- a/homeassistant/components/silla_prism/solar_balance.py
+++ b/homeassistant/components/silla_prism/solar_balance.py
@@ -1,0 +1,490 @@
+"""Shared state for Prism solar battery balancing."""
+
+from dataclasses import dataclass
+
+from .const import DOMAIN
+
+SOLAR_BALANCE_DISABLED = "disabled"
+SOLAR_BALANCE_WAITING_DATA = "waiting_data"
+SOLAR_BALANCE_WAITING_BATTERY_DATA = "waiting_battery_data"
+SOLAR_BALANCE_WAITING_SOLAR_MODE = "waiting_solar_mode"
+SOLAR_BALANCE_WAITING_STABLE_SURPLUS = "waiting_stable_surplus"
+SOLAR_BALANCE_PAUSED_LOW_SURPLUS = "paused_low_surplus"
+SOLAR_BALANCE_EXTERNAL_PAUSED = "external_paused"
+SOLAR_BALANCE_CHARGING_SURPLUS = "charging_surplus"
+SOLAR_BALANCE_LOW_SURPLUS_KEEP_CHARGING = "low_surplus_keep_charging"
+
+SURPLUS_SOURCE_SOLAR_HOME_LOAD = "solar_home_load"
+SURPLUS_SOURCE_PRISM_GRID_BATTERY = "prism_grid_battery"
+
+
+@dataclass(slots=True)
+class SolarBalanceState:
+    """Store one complete balancing decision for diagnostics.
+
+    The switch entity owns the control loop; sensor entities only render this
+    snapshot so users can see why the controller changed, held or skipped
+    current.
+    """
+
+    status: str = SOLAR_BALANCE_WAITING_DATA
+    surplus_current: float | None = None
+    available_power: float | None = None
+    target_power: float | None = None
+    start_delay_remaining: int | None = None
+    grid_power: float | None = None
+    ev_power: float | None = None
+    solar_power: float | None = None
+    home_load_power: float | None = None
+    battery_power: float | None = None
+    battery_charge_power: float | None = None
+    battery_discharge_power: float | None = None
+    battery_power_used: float | None = None
+    battery_max_charge_power: float | None = None
+    battery_soc: float | None = None
+    battery_reserve_power: float | None = None
+    battery_reserve_shortfall_power: float | None = None
+    surplus_source: str | None = None
+    target_export_power: float | None = None
+    deadband_power: float | None = None
+    raw_target_current: float | None = None
+    target_current: float | None = None
+    theoretical_target_current: float | None = None
+    reported_current_limit: float | None = None
+    unused_export_power: float | None = None
+    excess_import_power: float | None = None
+    residual_export_remaining: int | None = None
+    deadband_active: bool | None = None
+    ramp_limited: bool | None = None
+    ramp_direction: str | None = None
+    current_limit_reason: str | None = None
+    decision_reason: str | None = None
+    decision_summary: str | None = None
+    missing_data_reason: str | None = None
+    dry_run: bool = False
+
+
+@dataclass(slots=True, frozen=True)
+class BatteryPowerBreakdown:
+    """Normalized battery power values used by the balancer.
+
+    Positive normalized power means discharge, negative means charge.
+    """
+
+    normalized_power: float
+    charge_power: float
+    discharge_power: float
+    charge_available_above_reserve: float
+    power_to_exclude: float
+
+
+@dataclass(slots=True, frozen=True)
+class AvailablePowerResult:
+    """Calculated EV surplus and the source used for the calculation."""
+
+    available_power: float
+    source: str
+    effective_home_load_power: float | None
+
+
+def normalize_battery_power(
+    battery_power: float,
+    battery_discharge_positive: bool,
+    battery_reserve_power: float,
+    use_battery_charge: bool,
+) -> BatteryPowerBreakdown:
+    """Normalize battery power and return the pieces used by the algorithm."""
+    normalized_power = battery_power if battery_discharge_positive else -battery_power
+    charge_power = max(-normalized_power, 0)
+    discharge_power = max(normalized_power, 0)
+    charge_available = max(charge_power - battery_reserve_power, 0)
+    power_to_exclude = discharge_power - (charge_available if use_battery_charge else 0)
+    return BatteryPowerBreakdown(
+        normalized_power=normalized_power,
+        charge_power=charge_power,
+        discharge_power=discharge_power,
+        charge_available_above_reserve=charge_available,
+        power_to_exclude=power_to_exclude,
+    )
+
+
+def get_battery_reserve_power(
+    battery_soc: float | None,
+    battery_max_charge_power: float,
+    soc_mid: float,
+    soc_high: float,
+    mid_reserve_power: float,
+    high_reserve_power: float,
+) -> float:
+    """Return how much battery charge power should be reserved."""
+    if battery_soc is None:
+        return battery_max_charge_power
+    if battery_soc >= 95:
+        return 0
+    if battery_soc >= soc_high:
+        return high_reserve_power
+    if battery_soc >= soc_mid:
+        return mid_reserve_power
+    return battery_max_charge_power
+
+
+def calculate_available_power(
+    *,
+    ev_power: float,
+    grid_power: float,
+    battery_charge_available: float,
+    battery_reserve_shortfall: float,
+    battery_power_to_exclude: float,
+    use_battery_charge: bool,
+    solar_power: float | None = None,
+    home_load_power: float | None = None,
+    home_load_includes_ev: bool = False,
+) -> AvailablePowerResult:
+    """Return EV surplus power from direct sensors or Prism fallback data."""
+    if solar_power is not None and home_load_power is not None:
+        solar_production = max(solar_power, 0)
+        effective_home_load = max(home_load_power, 0)
+        if home_load_includes_ev:
+            effective_home_load = max(effective_home_load - ev_power, 0)
+        available_power = (
+            solar_production - effective_home_load - max(battery_reserve_shortfall, 0)
+        )
+        if use_battery_charge and available_power > 0:
+            available_power += battery_charge_available
+        return AvailablePowerResult(
+            available_power=available_power,
+            source=SURPLUS_SOURCE_SOLAR_HOME_LOAD,
+            effective_home_load_power=effective_home_load,
+        )
+
+    return AvailablePowerResult(
+        available_power=(
+            ev_power
+            - grid_power
+            - battery_power_to_exclude
+            - max(battery_reserve_shortfall, 0)
+        ),
+        source=SURPLUS_SOURCE_PRISM_GRID_BATTERY,
+        effective_home_load_power=None,
+    )
+
+
+def describe_solar_balance_state(  # noqa: C901
+    state: SolarBalanceState, language: str | None = None
+) -> str:
+    """Return a concise human-readable explanation for the latest decision."""
+    reason = state.current_limit_reason or state.decision_reason or state.status
+    is_italian = (language or "").lower().startswith("it")
+    target = (
+        f"{state.target_current:g}A"
+        if isinstance(state.target_current, (int, float))
+        else ("nessuna corrente" if is_italian else "no current")
+    )
+    available = (
+        f"{state.available_power:.0f}W"
+        if isinstance(state.available_power, (int, float))
+        else ("surplus sconosciuto" if is_italian else "unknown surplus")
+    )
+    context = _describe_decision_context(state, is_italian)
+
+    if is_italian:
+        if state.dry_run and isinstance(state.target_current, (int, float)):
+            return (
+                f"Simulazione: comanderei {target} in modalita solare, "
+                f"ma non invio MQTT. {context}"
+            ).strip()
+        if (
+            reason in ("low_surplus_hold_6a", "target_current")
+            and isinstance(state.target_current, (int, float))
+            and isinstance(state.reported_current_limit, (int, float))
+            and round(state.reported_current_limit) != round(state.target_current)
+        ):
+            return (
+                f"Richiedo {target}: Prism riporta ancora pilot "
+                f"{state.reported_current_limit:g}A."
+            )
+        if reason == "low_surplus_hold_6a":
+            return _with_context(
+                f"Mantengo 6A: il surplus calcolato e basso ({available}).",
+                context,
+            )
+        if reason == "residual_export_recovery":
+            return _with_context(
+                f"Salgo a {target}: l'esportazione residua e rimasta disponibile "
+                "abbastanza a lungo.",
+                context,
+            )
+        if reason == "battery_charge_target":
+            return _with_context(
+                f"Salgo a {target}: la batteria sta caricando oltre la riserva "
+                "configurata.",
+                context,
+            )
+        if reason == "deadband_hold":
+            return _with_context(
+                f"Mantengo {target}: import/export dalla rete e dentro la banda morta.",
+                context,
+            )
+        if reason == "waiting_stable_surplus":
+            remaining = state.start_delay_remaining or 0
+            return _with_context(
+                f"Attendo {remaining}s: il surplus deve restare stabile prima "
+                "di aumentare.",
+                context,
+            )
+        if reason == "restart_min_current":
+            return _with_context(
+                "Riparto da 6A: dopo un blocco per surplus basso non uso il "
+                "vecchia soglia corrente come base.",
+                context,
+            )
+        if reason == "waiting_solar_mode":
+            return _with_context(
+                "Attendo: Prism non e in modalita solare, quindi non invio "
+                "corrente o modalita.",
+                context,
+            )
+        if reason == "autolimit_low_surplus":
+            return (
+                "Attendo: l'autolimit Prism e attivo e l'import dalla rete e "
+                "ancora troppo alto."
+            )
+        if reason == "autolimit_wait_stable_surplus":
+            remaining = state.residual_export_remaining or 0
+            return (
+                f"Attendo {remaining}s: l'autolimit Prism e attivo e serve "
+                "export stabile prima del recupero."
+            )
+        if reason == "autolimit_recovery_6a":
+            return (
+                "Provo il recupero a 6A: l'autolimit Prism e rientrato nella "
+                "banda morta."
+            )
+        if reason == "external_pause":
+            if isinstance(state.theoretical_target_current, (int, float)):
+                return (
+                    "Pausa da Prism o app: non invio setpoint alla wallbox. "
+                    f"Target teorico {state.theoretical_target_current:g}A."
+                )
+            return (
+                "Pausa da Prism o app: l'integrazione non riavvia la carica "
+                "automaticamente."
+            )
+        if reason == "ramp_up_wait":
+            return _with_context(
+                f"Mantengo {target}: attendo il prossimo intervallo consentito "
+                "per aumentare.",
+                context,
+            )
+        if reason in ("ramp_up_limited", "ramp_down_limited"):
+            return _with_context(
+                f"Mi sposto a {target}: la rampa sta rendendo graduale la variazione.",
+                context,
+            )
+        if state.status == SOLAR_BALANCE_CHARGING_SURPLUS:
+            return _with_context(
+                f"Carico a {target}: surplus disponibile ({available}).",
+                context,
+            )
+        if state.status == SOLAR_BALANCE_DISABLED:
+            return "Bilanciamento solare disattivato."
+        if state.status == SOLAR_BALANCE_WAITING_DATA:
+            if state.missing_data_reason:
+                return f"In attesa dei dati necessari: {state.missing_data_reason}."
+            return "In attesa dei dati necessari dai sensori."
+        if state.status == SOLAR_BALANCE_WAITING_BATTERY_DATA:
+            return "In attesa del dato potenza batteria."
+        if state.status == SOLAR_BALANCE_WAITING_SOLAR_MODE:
+            return "In attesa della modalita solare Prism."
+        return f"Decisione: {reason or state.status}."
+
+    if state.dry_run and isinstance(state.target_current, (int, float)):
+        return (
+            f"Dry run: would request {target} and solar mode, but no MQTT "
+            f"command is sent. {context}"
+        ).strip()
+    if (
+        reason in ("low_surplus_hold_6a", "target_current")
+        and isinstance(state.target_current, (int, float))
+        and isinstance(state.reported_current_limit, (int, float))
+        and round(state.reported_current_limit) != round(state.target_current)
+    ):
+        return (
+            f"Requesting {target}: Prism is still reporting pilot "
+            f"{state.reported_current_limit:g}A."
+        )
+    if reason == "low_surplus_hold_6a":
+        return _with_context(
+            f"Holding 6A: calculated surplus is low ({available}).",
+            context,
+        )
+    if reason == "residual_export_recovery":
+        return _with_context(
+            f"Raising to {target}: residual export stayed available long enough.",
+            context,
+        )
+    if reason == "battery_charge_target":
+        return _with_context(
+            f"Raising to {target}: battery is charging above the configured reserve.",
+            context,
+        )
+    if reason == "deadband_hold":
+        return _with_context(
+            f"Holding {target}: grid import/export is inside the deadband.",
+            context,
+        )
+    if reason == "waiting_stable_surplus":
+        remaining = state.start_delay_remaining or 0
+        return _with_context(
+            f"Waiting {remaining}s: surplus must stay stable before increasing.",
+            context,
+        )
+    if reason == "restart_min_current":
+        return _with_context(
+            "Restarting from 6A: after a low-surplus block, the old current "
+            "limit is not used as the ramp base.",
+            context,
+        )
+    if reason == "waiting_solar_mode":
+        return _with_context(
+            "Waiting: Prism is not in solar mode, so the integration will not "
+            "command current or mode.",
+            context,
+        )
+    if reason == "autolimit_low_surplus":
+        return "Waiting: Prism autolimit is active and grid import is still too high."
+    if reason == "autolimit_wait_stable_surplus":
+        remaining = state.residual_export_remaining or 0
+        return (
+            f"Waiting {remaining}s: Prism autolimit is active and stable export "
+            "is required before recovery."
+        )
+    if reason == "autolimit_recovery_6a":
+        return "Trying 6A recovery: Prism autolimit cleared inside the deadband."
+    if reason == "external_pause":
+        if isinstance(state.theoretical_target_current, (int, float)):
+            return (
+                "Paused by Prism or app: the integration will not command the "
+                f"wallbox. Theoretical target {state.theoretical_target_current:g}A."
+            )
+        return "Paused by Prism or app: the integration will not resume automatically."
+    if reason == "ramp_up_wait":
+        return _with_context(
+            f"Holding {target}: waiting for the next allowed ramp-up interval.",
+            context,
+        )
+    if reason in ("ramp_up_limited", "ramp_down_limited"):
+        return _with_context(
+            f"Moving to {target}: ramp limit is smoothing the current change.",
+            context,
+        )
+    if state.status == SOLAR_BALANCE_CHARGING_SURPLUS:
+        return _with_context(
+            f"Charging at {target}: surplus is available ({available}).",
+            context,
+        )
+    if state.status == SOLAR_BALANCE_DISABLED:
+        return "Solar balancing is disabled."
+    if state.status == SOLAR_BALANCE_WAITING_DATA:
+        if state.missing_data_reason:
+            return f"Waiting for required sensor data: {state.missing_data_reason}."
+        return "Waiting for required sensor data."
+    if state.status == SOLAR_BALANCE_WAITING_BATTERY_DATA:
+        return "Waiting for battery power data."
+    if state.status == SOLAR_BALANCE_WAITING_SOLAR_MODE:
+        return "Waiting for Prism solar mode."
+    return f"Decision: {reason or state.status}."
+
+
+def _describe_decision_context(state: SolarBalanceState, is_italian: bool) -> str:
+    """Return the dominant constraint and next release condition."""
+    if state.missing_data_reason:
+        if is_italian:
+            return f"Vincolo: manca {state.missing_data_reason}."
+        return f"Constraint: missing {state.missing_data_reason}."
+
+    if state.current_limit_reason == "waiting_stable_surplus":
+        remaining = state.start_delay_remaining or 0
+        if is_italian:
+            return f"Vincolo: surplus non ancora stabile. Prossimo sblocco tra {remaining}s."
+        return f"Constraint: surplus is not stable yet. Next release in {remaining}s."
+
+    if state.current_limit_reason == "ramp_up_wait":
+        if is_italian:
+            return "Vincolo: intervallo minimo tra aumenti corrente."
+        return "Constraint: minimum current increase interval."
+
+    if state.current_limit_reason == "restart_min_current":
+        if is_italian:
+            return "Vincolo: ripartenza prudente dal minimo Type 2."
+        return "Constraint: conservative restart from the Type 2 minimum."
+
+    if state.current_limit_reason in ("ramp_up_limited", "ramp_down_limited"):
+        if is_italian:
+            return "Vincolo: rampa graduale per evitare oscillazioni."
+        return "Constraint: ramp limit is smoothing the current change."
+
+    if state.current_limit_reason == "deadband_hold":
+        if is_italian:
+            return "Vincolo: rete dentro la banda morta."
+        return "Constraint: grid import/export is inside the deadband."
+
+    if state.current_limit_reason == "battery_charge_target":
+        reserve = _format_watts(state.battery_reserve_power, is_italian)
+        charge = _format_watts(state.battery_charge_power, is_italian)
+        if is_italian:
+            return f"Vincolo: batteria sopra la riserva ({charge} > {reserve})."
+        return f"Constraint: battery charge is above reserve ({charge} > {reserve})."
+
+    if state.current_limit_reason == "residual_export_recovery":
+        export = _format_watts(state.unused_export_power, is_italian)
+        if is_italian:
+            return f"Vincolo: export residuo disponibile ({export})."
+        return f"Constraint: residual export is available ({export})."
+
+    if state.decision_reason == SOLAR_BALANCE_EXTERNAL_PAUSED:
+        if is_italian:
+            return "Vincolo: pausa comandata da Prism o app."
+        return "Constraint: Prism or app pause."
+
+    if state.current_limit_reason == "low_surplus_hold_6a":
+        available = _format_watts(state.available_power, is_italian)
+        if is_italian:
+            return f"Vincolo: surplus sotto il minimo Type 2 ({available})."
+        return f"Constraint: surplus is below the Type 2 minimum ({available})."
+
+    if (
+        state.battery_reserve_shortfall_power
+        and state.battery_reserve_shortfall_power > 0
+    ):
+        shortfall = _format_watts(state.battery_reserve_shortfall_power, is_italian)
+        if is_italian:
+            return f"Vincolo: mancano {shortfall} alla riserva batteria."
+        return f"Constraint: battery reserve is short by {shortfall}."
+
+    if isinstance(state.available_power, (int, float)):
+        available = _format_watts(state.available_power, is_italian)
+        if is_italian:
+            return f"Surplus calcolato: {available}."
+        return f"Calculated surplus: {available}."
+
+    return ""
+
+
+def _with_context(message: str, context: str) -> str:
+    """Append diagnostic context when available."""
+    if not context:
+        return message
+    return f"{message} {context}"
+
+
+def _format_watts(value: float | None, is_italian: bool) -> str:
+    """Format power for diagnostic summaries."""
+    if not isinstance(value, (int, float)):
+        return "sconosciuto" if is_italian else "unknown"
+    return f"{value:.0f}W"
+
+
+def get_solar_balance_signal(serial: str, port: int) -> str:
+    """Return the dispatcher signal for one Prism solar balance port."""
+    return f"{DOMAIN}_solar_balance_{serial}_{port}"

--- a/homeassistant/components/silla_prism/strings.json
+++ b/homeassistant/components/silla_prism/strings.json
@@ -1,64 +1,284 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "invalid_discovery_info": "Invalid discovery information received.",
-      "mqtt_unavailable": "The MQTT integration is not available. Set it up first."
+      "already_configured": "Device is already configured",
+      "cannot_connect": "Unable to connect to the device",
+      "discover_timeout": "Unable to discover requested device",
+      "invalid_discovery_info": "Invalid discovery information",
+      "mqtt_unavailable": "MQTT is not available",
+      "reconfigure_successful": "Device reconfigured successfully",
+      "unknown": "Unknown error occurred"
     },
     "error": {
-      "invalid_base_topic": "This is not a valid MQTT topic. Enter the plain topic prefix from the Silla app, without wildcards.",
-      "no_device": "No Prism messages were received on this base topic. Check that the topic matches the one configured in the Silla app and that Prism is online."
+      "battery_sensor_required": "Enter a battery power sensor to enable solar battery balancing",
+      "invalid_base_topic": "Invalid base topic",
+      "linking": "Unknown linking error occurred.",
+      "mqtt_unavailable": "MQTT is not available",
+      "no_device": "No Silla Prism traffic was found on this topic",
+      "register_failed": "Failed to register, please try again",
+      "solar_sensor_required": "Enter a solar production sensor when using a home load sensor"
     },
-    "flow_title": "{serial}",
     "step": {
-      "discovery_confirm": {
-        "description": "Do you want to set up the discovered Prism {serial}?",
-        "title": "Set up Silla Prism"
-      },
       "user": {
         "data": {
-          "base_topic": "Base topic"
+          "battery_discharge_positive": "Battery discharge is a positive value",
+          "battery_max_charge_power": "Battery reserve power at low SOC (W)",
+          "battery_power_sensor": "Battery power sensor",
+          "battery_soc_sensor": "Home battery SOC sensor (%)",
+          "home_load_includes_ev": "Home load sensor includes the EV charger",
+          "home_load_power_sensor": "Home load power sensor",
+          "maxcurr": "Maximum settable current 6A-32A",
+          "ports": "Number of available ports",
+          "powerwall": "Enable Powerwall sensors",
+          "serial": "Unique device code. Use if you have multiple devices",
+          "solar_balance_deadband_power": "Import/export deadband (W)",
+          "solar_balance_decrease_step": "Maximum current decrease step (A)",
+          "solar_balance_dry_run": "Solar balance dry run",
+          "solar_balance_high_reserve_power": "Battery reserve power at high SOC (W)",
+          "solar_balance_increase_interval": "Minimum current increase interval (s)",
+          "solar_balance_increase_step": "Maximum current increase step (A)",
+          "solar_balance_mid_reserve_power": "Battery reserve power at medium SOC (W)",
+          "solar_balance_phases": "Number of charging phases",
+          "solar_balance_residual_export_delay": "Residual export time before recovery (s)",
+          "solar_balance_residual_export_power": "Residual export for current recovery (W)",
+          "solar_balance_soc_high": "High home battery SOC for EV priority (%)",
+          "solar_balance_soc_mid": "Medium home battery SOC for EV priority (%)",
+          "solar_balance_start_delay": "Minimum stable surplus time before charging (minutes)",
+          "solar_balance_target_export_power": "Target grid export (W)",
+          "solar_balance_use_battery_charge": "Also treat battery charging power as EV surplus",
+          "solar_battery_balance": "Enable solar battery balancing",
+          "solar_production_power_sensor": "Solar production power sensor",
+          "topic": "Topic",
+          "vsensors": "Enable virtual sensors"
         },
         "data_description": {
-          "base_topic": "The MQTT topic prefix Prism publishes to, without a trailing slash."
+          "battery_discharge_positive": "Enable when the battery sensor is positive while discharging and negative while charging. Disable it if your sensor uses the opposite sign.",
+          "battery_max_charge_power": "Power reserved for the home battery when SOC is low. For this setup the typical value is 2700 W.",
+          "battery_power_sensor": "Home Assistant sensor for home-battery power in W. Example: sensor.battery_power.",
+          "battery_soc_sensor": "Home Assistant sensor for home-battery percentage. Example: sensor.battery_soc.",
+          "home_load_includes_ev": "Enable when the home load sensor is a total-load sensor that also includes EV charging. The balancer subtracts EV power before calculating surplus.",
+          "home_load_power_sensor": "Optional Home Assistant sensor for house load in W. If it also includes the EV charger, enable the option below.",
+          "maxcurr": "Maximum current the balancer may set on Prism. Example: 16 to never exceed 16A.",
+          "ports": "Number of physical Prism outputs. Use 1 for a single Prism, 2 for Prism Duo.",
+          "powerwall": "Enables virtual sensors compatible with the original project's legacy Powerwall view.",
+          "serial": "Optional value used to distinguish multiple Prism devices in the same Home Assistant instance. Example: PRISMBOX.",
+          "solar_balance_deadband_power": "Range where current is left unchanged. Example: 150 W avoids constant oscillation near zero.",
+          "solar_balance_decrease_step": "Maximum amps removed at each correction. Example: 3A reacts faster to house loads.",
+          "solar_balance_dry_run": "Calculate the solar balancing decision and update diagnostics without sending current or mode MQTT commands to Prism.",
+          "solar_balance_high_reserve_power": "Approximate maximum battery charge power left for the home battery at high SOC. Example: 1000 W.",
+          "solar_balance_increase_interval": "Minimum seconds between current increases. Example: 15 ramps up gradually during the day.",
+          "solar_balance_increase_step": "Maximum amps added at each increase. Example: 1A is conservative.",
+          "solar_balance_mid_reserve_power": "Approximate maximum battery charge power left for the home battery at medium SOC. Example: 1500 W.",
+          "solar_balance_phases": "EV charging phases. Use 1 for single phase, 3 for three phase.",
+          "solar_balance_residual_export_delay": "Seconds residual export must stay stable before adding current. Example: 60.",
+          "solar_balance_residual_export_power": "Extra export that must remain unused before recovering current. Example: 400 W.",
+          "solar_balance_soc_high": "SOC threshold where priority moves more strongly to the EV. Example: 80%.",
+          "solar_balance_soc_mid": "SOC threshold where battery reserve drops to the medium value. Example: 40%.",
+          "solar_balance_start_delay": "Minutes of stable surplus before starting from pause. Example: 5 reduces useless starts during short clouds.",
+          "solar_balance_target_export_power": "Small intentional grid export to avoid accidental import. Example: 150 W.",
+          "solar_balance_use_battery_charge": "When enabled, EV current can rise gradually to keep home-battery charging around the configured reserve.",
+          "solar_battery_balance": "Creates the switch that automatically adjusts EV current from solar, grid and home-battery data.",
+          "solar_production_power_sensor": "Home Assistant sensor for real PV production in W. Use this when Prism energy_data/power_solar is not populated.",
+          "topic": "Base MQTT topic configured on Prism. Example: prism/ with the trailing slash.",
+          "vsensors": "Creates additional calculated sensors, such as total grid import energy."
         },
-        "description": "Enter the MQTT base topic configured on the Prism (in the Silla app, under the MQTT settings). The default is \"prism\".",
-        "title": "Connect your Silla Prism"
+        "description": "Please enter connection settings of your device",
+        "title": "Configure Silla Prism Integration"
       }
     }
   },
   "entity": {
-    "sensor": {
+    "binary_sensor": {
       "error": {
-        "name": "Error",
+        "name": "Error status"
+      },
+      "online": {
+        "name": "Connection status",
         "state": {
-          "none": "None"
+          "off": "Offline",
+          "on": "Online"
         }
       },
-      "grid_power": {
-        "name": "Grid power"
+      "touch_double": {
+        "name": "Double touch"
       },
-      "pilot": {
-        "name": "Pilot current"
+      "touch_long": {
+        "name": "Long touch"
       },
-      "session_energy": {
-        "name": "Session energy"
+      "touch_single": {
+        "name": "Single touch"
+      }
+    },
+    "button": {
+      "set_mode_traps_auth": {
+        "name": "Charge authorization"
       },
-      "session_start": {
-        "name": "Session start"
+      "set_mode_traps_noauth": {
+        "name": "Revoke charge authorization"
+      }
+    },
+    "number": {
+      "set_current_limit": {
+        "name": "Current limit"
       },
-      "status": {
-        "name": "Status",
+      "set_max_current": {
+        "name": "Current limited by user"
+      }
+    },
+    "select": {
+      "set_port_mode": {
+        "name": "Set port output mode",
         "state": {
-          "charging": "[%key:common::state::charging%]",
-          "idle": "[%key:common::state::idle%]",
-          "paused": "[%key:common::state::paused%]",
+          "hybrid": "Hybrid",
+          "normal": "Normal",
+          "paused": "Paused",
+          "solar": "Solar"
+        }
+      }
+    },
+    "sensor": {
+      "core_temperature": {
+        "name": "CPU temperature"
+      },
+      "current_port_mode": {
+        "name": "Current port output mode",
+        "state": {
+          "autolimit": "Auto limit",
+          "hybrid": "Hybrid",
+          "normal": "Normal",
+          "paused": "Paused",
+          "solar": "Solar",
+          "suspended": "Suspended",
+          "unknown": "Unknown"
+        }
+      },
+      "current_set_by_user": {
+        "name": "Current limited by user"
+      },
+      "current_state": {
+        "name": "Wallbox current state",
+        "state": {
+          "charging": "Charging",
+          "idle": "Idle",
+          "pause": "Paused",
           "waiting": "Waiting"
         }
       },
-      "total_energy": {
+      "input_grid_energy": {
+        "name": "Total energy from grid"
+      },
+      "input_grid_power": {
+        "name": "Power from utility"
+      },
+      "output_car_current": {
+        "name": "Car requested by car"
+      },
+      "output_current": {
+        "name": "Output current"
+      },
+      "output_power": {
+        "name": "Power provided to car"
+      },
+      "power_grid_voltage": {
+        "name": "Power grid voltage"
+      },
+      "powerwall_house": {
+        "name": "Power consumed by the house"
+      },
+      "powerwall_solar": {
+        "name": "Power produced by PV"
+      },
+      "session_output_energy": {
+        "name": "Energy provided in last session"
+      },
+      "session_time": {
+        "name": "Session time"
+      },
+      "solar_balance_available_power": {
+        "name": "Calculated total surplus"
+      },
+      "solar_balance_battery_power_used": {
+        "name": "Battery power used in calculation"
+      },
+      "solar_balance_battery_reserve_power": {
+        "name": "Battery reserve power"
+      },
+      "solar_balance_battery_reserve_shortfall_power": {
+        "name": "Battery reserve shortfall"
+      },
+      "solar_balance_decision_reason": {
+        "name": "Decision reason",
+        "state": {
+          "charging_surplus": "Charging from surplus",
+          "disabled": "Disabled",
+          "external_paused": "Paused by wallbox",
+          "low_surplus_keep_charging": "Low surplus, keeping charge at 6A",
+          "paused_low_surplus": "Paused for low surplus",
+          "waiting_battery_data": "Waiting for battery data",
+          "waiting_data": "Waiting for data",
+          "waiting_solar_mode": "Waiting for solar mode",
+          "waiting_stable_surplus": "Waiting for stable surplus"
+        }
+      },
+      "solar_balance_decision_summary": {
+        "name": "Decision summary"
+      },
+      "solar_balance_grid_power": {
+        "name": "Grid power used in calculation"
+      },
+      "solar_balance_home_load_power": {
+        "name": "Home load used in calculation"
+      },
+      "solar_balance_raw_target_current": {
+        "name": "Raw target current"
+      },
+      "solar_balance_residual_export_countdown": {
+        "name": "Residual export countdown"
+      },
+      "solar_balance_solar_power": {
+        "name": "Solar production used in calculation"
+      },
+      "solar_balance_start_countdown": {
+        "name": "Stable surplus countdown"
+      },
+      "solar_balance_status": {
+        "name": "Solar balance status",
+        "state": {
+          "charging_surplus": "Charging from surplus",
+          "disabled": "Disabled",
+          "external_paused": "Paused by wallbox",
+          "low_surplus_keep_charging": "Low surplus, keeping charge at 6A",
+          "paused_low_surplus": "Paused for low surplus",
+          "waiting_battery_data": "Waiting for battery data",
+          "waiting_data": "Waiting for data",
+          "waiting_solar_mode": "Waiting for solar mode",
+          "waiting_stable_surplus": "Waiting for stable surplus"
+        }
+      },
+      "solar_balance_surplus_current": {
+        "name": "Solar surplus current"
+      },
+      "solar_balance_target_current": {
+        "name": "Calculated target current"
+      },
+      "solar_balance_target_export_power": {
+        "name": "Target export power"
+      },
+      "solar_balance_theoretical_target_current": {
+        "name": "Theoretical target current"
+      },
+      "solar_balance_unused_export_power": {
+        "name": "Unused export power"
+      },
+      "total_output_energy": {
         "name": "Total energy"
       }
+    },
+    "switch": {
+      "solar_battery_balance": {
+        "name": "Solar battery balancing"
+      }
     }
-  }
+  },
+  "title": "Silla Prism Integration"
 }

--- a/homeassistant/components/silla_prism/switch.py
+++ b/homeassistant/components/silla_prism/switch.py
@@ -1,0 +1,1192 @@
+"""Switches for Prism wallbox integration."""
+
+from collections.abc import Callable
+from datetime import datetime
+import logging
+from math import ceil, floor
+from typing import Any, override
+
+from homeassistant.components import mqtt
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    Event,
+    EventStateChangedData,
+    HomeAssistant,
+    callback,
+)
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_call_later, async_track_state_change_event
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util.dt import utcnow
+
+from .entity import _get_unique_id
+from .entry_data import RuntimeEntryData
+from .solar_balance import (
+    SOLAR_BALANCE_CHARGING_SURPLUS,
+    SOLAR_BALANCE_DISABLED,
+    SOLAR_BALANCE_EXTERNAL_PAUSED,
+    SOLAR_BALANCE_LOW_SURPLUS_KEEP_CHARGING,
+    SOLAR_BALANCE_PAUSED_LOW_SURPLUS,
+    SOLAR_BALANCE_WAITING_BATTERY_DATA,
+    SOLAR_BALANCE_WAITING_DATA,
+    SOLAR_BALANCE_WAITING_SOLAR_MODE,
+    SOLAR_BALANCE_WAITING_STABLE_SURPLUS,
+    SolarBalanceState,
+    calculate_available_power,
+    describe_solar_balance_state,
+    get_battery_reserve_power,
+    get_solar_balance_signal,
+    normalize_battery_power,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
+
+MIN_CHARGE_CURRENT = 6
+DEFAULT_GRID_VOLTAGE = 230.0
+MODE_SOLAR = "1"
+MODE_NORMAL = "2"
+MODE_PAUSED = "3"
+MODE_AUTOLIMIT = "7"
+STATE_PAUSE = "4"
+AUTOLIMIT_RECOVERY_COOLDOWN = 300
+CURRENT_REPUBLISH_INTERVAL = 15
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Add switch entities for passed config_entry in HA."""
+    entry_data: RuntimeEntryData = entry.runtime_data
+
+    if not entry_data.solar_battery_balance:
+        return
+
+    switches = [
+        PrismSolarBatteryBalance(entry_data, description, port)
+        for port in range(1, entry_data.ports + 1)
+        for description in SWITCHES
+    ]
+    async_add_entities(switches)
+
+
+class PrismSwitchEntityDescription(SwitchEntityDescription, frozen_or_thawed=True):
+    """A class that describes Prism switch entities."""
+
+
+class PrismSolarBatteryBalance(SwitchEntity, RestoreEntity):
+    """Balance EV charging against PV surplus and battery power."""
+
+    _attr_has_entity_name = True
+
+    entity_description: PrismSwitchEntityDescription
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        entry_data: RuntimeEntryData,
+        description: PrismSwitchEntityDescription,
+        port: int,
+    ) -> None:
+        """Initialize the solar battery balance switch."""
+        self._port = port
+        self._entry_data = entry_data
+        self._base_topic = entry_data.topic
+        self._battery_sensor = entry_data.battery_power_sensor
+        self._solar_production_sensor = entry_data.solar_production_power_sensor
+        self._home_load_sensor = entry_data.home_load_power_sensor
+        self._home_load_includes_ev = entry_data.home_load_includes_ev
+        self._battery_soc_sensor = entry_data.battery_soc_sensor
+        self._battery_discharge_positive = entry_data.battery_discharge_positive
+        self._battery_max_charge_power = entry_data.battery_max_charge_power
+        self._phases = entry_data.solar_balance_phases
+        self._start_delay_seconds = entry_data.solar_balance_start_delay * 60
+        self._use_battery_charge = entry_data.solar_balance_use_battery_charge
+        self._soc_mid = entry_data.solar_balance_soc_mid
+        self._soc_high = entry_data.solar_balance_soc_high
+        self._mid_reserve_power = entry_data.solar_balance_mid_reserve_power
+        self._high_reserve_power = entry_data.solar_balance_high_reserve_power
+        self._target_export_power = entry_data.solar_balance_target_export_power
+        self._deadband_power = entry_data.solar_balance_deadband_power
+        self._increase_interval = entry_data.solar_balance_increase_interval
+        self._increase_step = entry_data.solar_balance_increase_step
+        self._decrease_step = entry_data.solar_balance_decrease_step
+        self._residual_export_power = entry_data.solar_balance_residual_export_power
+        self._residual_export_delay = entry_data.solar_balance_residual_export_delay
+        self._dry_run = entry_data.solar_balance_dry_run
+        self._max_current = entry_data.maxcurr
+        self._attr_device_info = self._get_device(entry_data, port)
+        self.entity_description = self._get_description(
+            port, entry_data.ports > 1, description
+        )
+        self._attr_unique_id = _get_unique_id(
+            entry_data.serial, self.entity_description.key
+        )
+        self._attr_is_on = True
+
+        self._grid_power: float | None = None
+        self._ev_power: float | None = None
+        self._solar_power: float | None = None
+        self._home_load_power: float | None = None
+        self._effective_home_load_power: float | None = None
+        self._grid_voltage: float | None = None
+        self._battery_power: float | None = None
+        self._battery_soc: float | None = None
+        self._last_current_command: int | None = None
+        self._reported_current_limit: int | None = None
+        self._last_current_publish: datetime | None = None
+        self._last_current_increase: datetime | None = None
+        self._last_mode_command: str | None = None
+        self._reported_mode: str | None = None
+        self._reported_state: str | None = None
+        self._raw_target_current: float | None = None
+        self._unused_export_power: float = 0
+        self._excess_import_power: float = 0
+        self._residual_export_remaining: int = 0
+        self._deadband_active = False
+        self._ramp_limited = False
+        self._ramp_direction = "none"
+        self._current_limit_reason = "waiting_data"
+        self._charging_from_surplus = False
+        self._restart_from_min_current = False
+        self._last_autolimit_recovery: datetime | None = None
+        self._surplus_since: datetime | None = None
+        self._residual_export_since: datetime | None = None
+        self._start_delay_trigger: CALLBACK_TYPE | None = None
+        self._unsubs: list[Callable[[], None]] = []
+
+    def _get_description(
+        self,
+        port: int,
+        multiport: bool,
+        description: PrismSwitchEntityDescription,
+    ) -> PrismSwitchEntityDescription:
+        if multiport:
+            key = description.key.format(port)
+        else:
+            key = description.key[:-3]
+        return PrismSwitchEntityDescription(
+            key=key,
+            entity_category=description.entity_category,
+            has_entity_name=description.has_entity_name,
+            translation_key=description.translation_key,
+        )
+
+    def _get_device(self, entry_data: RuntimeEntryData, port: int) -> DeviceInfo:
+        if entry_data.ports > 1:
+            return entry_data.devices[port]
+        return entry_data.devices[0]
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Restore state, subscribe to MQTT, and track the battery sensor."""
+        if state := await self.async_get_last_state():
+            self._attr_is_on = state.state == "on"
+
+        self._unsubs.extend(
+            [
+                await mqtt.async_subscribe(
+                    self.hass,
+                    f"{self._base_topic}energy_data/power_grid",
+                    self._mqtt_grid_power_received,
+                ),
+                await mqtt.async_subscribe(
+                    self.hass,
+                    f"{self._base_topic}{self._port}/w",
+                    self._mqtt_ev_power_received,
+                ),
+                await mqtt.async_subscribe(
+                    self.hass,
+                    f"{self._base_topic}{self._port}/pilot",
+                    self._mqtt_current_limit_received,
+                ),
+                await mqtt.async_subscribe(
+                    self.hass,
+                    f"{self._base_topic}{self._port}/volt",
+                    self._mqtt_grid_voltage_received,
+                ),
+                await mqtt.async_subscribe(
+                    self.hass,
+                    f"{self._base_topic}{self._port}/mode",
+                    self._mqtt_mode_received,
+                ),
+                await mqtt.async_subscribe(
+                    self.hass,
+                    f"{self._base_topic}{self._port}/state",
+                    self._mqtt_state_received,
+                ),
+            ]
+        )
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, self._battery_sensor, self._battery_power_received
+            )
+        )
+        if self._solar_production_sensor:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass,
+                    self._solar_production_sensor,
+                    self._solar_production_power_received,
+                )
+            )
+        if self._home_load_sensor:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass, self._home_load_sensor, self._home_load_power_received
+                )
+            )
+        if self._battery_soc_sensor:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass, self._battery_soc_sensor, self._battery_soc_received
+                )
+            )
+
+        if battery_state := self.hass.states.get(self._battery_sensor):
+            self._battery_power = self._parse_state(battery_state.state)
+        if self._solar_production_sensor and (
+            solar_production_state := self.hass.states.get(
+                self._solar_production_sensor
+            )
+        ):
+            self._solar_power = self._parse_state(solar_production_state.state)
+        if self._home_load_sensor and (
+            home_load_state := self.hass.states.get(self._home_load_sensor)
+        ):
+            self._home_load_power = self._parse_state(home_load_state.state)
+        if self._battery_soc_sensor and (
+            battery_soc_state := self.hass.states.get(self._battery_soc_sensor)
+        ):
+            self._battery_soc = self._parse_state(battery_soc_state.state)
+        await self._async_update_balance()
+
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Unsubscribe from MQTT topics."""
+        for unsub in self._unsubs:
+            unsub()
+        self._unsubs.clear()
+        self._cancel_start_delay()
+        await super().async_will_remove_from_hass()
+
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable solar battery balancing."""
+        self._attr_is_on = True
+        self.async_write_ha_state()
+        await self._async_update_balance()
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable solar battery balancing."""
+        self._attr_is_on = False
+        self.async_write_ha_state()
+        self._reset_start_delay()
+        self._reset_residual_export()
+        self._charging_from_surplus = False
+        self._restart_from_min_current = False
+        self._update_solar_balance_state(
+            SOLAR_BALANCE_DISABLED,
+            0,
+            None,
+            None,
+            None,
+            decision_reason="disabled",
+        )
+
+    @callback
+    def _mqtt_grid_power_received(self, msg) -> None:
+        self._grid_power = self._parse_state(msg.payload)
+        self.hass.async_create_task(self._async_update_balance())
+
+    @callback
+    def _battery_soc_received(self, event: Event[EventStateChangedData]) -> None:
+        new_state = event.data["new_state"]
+        if new_state is None or new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            self._battery_soc = None
+        else:
+            self._battery_soc = self._parse_state(new_state.state)
+        self.hass.async_create_task(self._async_update_balance())
+
+    @callback
+    def _mqtt_ev_power_received(self, msg) -> None:
+        self._ev_power = self._parse_state(msg.payload)
+        self.hass.async_create_task(self._async_update_balance())
+
+    @callback
+    def _mqtt_current_limit_received(self, msg) -> None:
+        current_limit = self._parse_state(msg.payload)
+        self._reported_current_limit = (
+            round(current_limit) if current_limit is not None else None
+        )
+        self.hass.async_create_task(self._async_update_balance())
+
+    @callback
+    def _mqtt_grid_voltage_received(self, msg) -> None:
+        self._grid_voltage = self._parse_state(msg.payload)
+        self.hass.async_create_task(self._async_update_balance())
+
+    @callback
+    def _mqtt_mode_received(self, msg) -> None:
+        self._reported_mode = str(msg.payload)
+        self.hass.async_create_task(self._async_update_balance())
+
+    @callback
+    def _mqtt_state_received(self, msg) -> None:
+        self._reported_state = str(msg.payload).strip()
+        self.hass.async_create_task(self._async_update_balance())
+
+    @callback
+    def _battery_power_received(self, event: Event[EventStateChangedData]) -> None:
+        new_state = event.data["new_state"]
+        if new_state is None or new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            self._battery_power = None
+        else:
+            self._battery_power = self._parse_state(new_state.state)
+        self.hass.async_create_task(self._async_update_balance())
+
+    @callback
+    def _home_load_power_received(self, event: Event[EventStateChangedData]) -> None:
+        new_state = event.data["new_state"]
+        if new_state is None or new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            self._home_load_power = None
+        else:
+            self._home_load_power = self._parse_state(new_state.state)
+        self.hass.async_create_task(self._async_update_balance())
+
+    @callback
+    def _solar_production_power_received(
+        self, event: Event[EventStateChangedData]
+    ) -> None:
+        new_state = event.data["new_state"]
+        if new_state is None or new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            self._solar_power = None
+        else:
+            self._solar_power = self._parse_state(new_state.state)
+        self.hass.async_create_task(self._async_update_balance())
+
+    def _parse_state(self, value: str) -> float | None:
+        try:
+            return float(value)
+        except TypeError, ValueError:
+            _LOGGER.debug(
+                "Invalid solar balance value for %s: %s",
+                self.entity_description.key,
+                value,
+            )
+            return None
+
+    async def _async_update_balance(self) -> None:
+        if not self.is_on:
+            self._reset_start_delay()
+            self._reset_residual_export()
+            self._charging_from_surplus = False
+            self._update_solar_balance_state(
+                SOLAR_BALANCE_DISABLED,
+                0,
+                None,
+                None,
+                None,
+                decision_reason="disabled",
+            )
+            return
+
+        if not self._has_required_values:
+            self._reset_start_delay()
+            self._reset_residual_export()
+            self._charging_from_surplus = False
+            missing_data_reason = self._get_missing_data_reason()
+            status = (
+                SOLAR_BALANCE_WAITING_BATTERY_DATA
+                if missing_data_reason == "battery_power"
+                else SOLAR_BALANCE_WAITING_DATA
+            )
+            self._update_solar_balance_state(
+                status,
+                None,
+                None,
+                None,
+                None,
+                decision_reason=status,
+                missing_data_reason=missing_data_reason,
+            )
+            return
+
+        assert self._grid_power is not None
+        assert self._ev_power is not None
+        assert self._battery_power is not None
+        if self._solar_production_sensor and self._home_load_sensor:
+            assert self._solar_power is not None
+            assert self._home_load_power is not None
+
+        voltage = self._grid_voltage or DEFAULT_GRID_VOLTAGE
+        battery_reserve_power = self._get_battery_reserve_power()
+        battery_breakdown = normalize_battery_power(
+            self._battery_power,
+            self._battery_discharge_positive,
+            battery_reserve_power,
+            self._use_battery_charge,
+        )
+        battery_power = battery_breakdown.normalized_power
+        battery_charge_power = battery_breakdown.charge_power
+        battery_discharge_power = battery_breakdown.discharge_power
+        battery_reserve_shortfall_power = max(
+            battery_reserve_power - battery_charge_power, 0
+        )
+        battery_power_to_exclude = battery_breakdown.power_to_exclude
+        available_power, surplus_source = self._get_available_power(
+            battery_breakdown.charge_available_above_reserve,
+            battery_reserve_shortfall_power,
+            battery_power_to_exclude,
+        )
+        # Target power keeps a small export buffer so noisy measurements do not
+        # accidentally pull from the grid while the EV current ramps.
+        target_power = available_power - self._target_export_power
+        min_power = MIN_CHARGE_CURRENT * voltage * self._phases
+        watts_per_amp = voltage * self._phases
+        already_charging = self._is_charging_from_surplus(min_power)
+        self._reset_current_diagnostics()
+
+        theoretical_target_current = self._get_theoretical_target_current(
+            target_power, watts_per_amp, min_power
+        )
+        if self._is_externally_paused:
+            self._reset_start_delay()
+            self._reset_residual_export()
+            self._charging_from_surplus = False
+            self._restart_from_min_current = False
+            self._track_grid_error()
+            self._update_solar_balance_state(
+                SOLAR_BALANCE_EXTERNAL_PAUSED,
+                0,
+                available_power,
+                target_power,
+                0,
+                battery_power,
+                battery_charge_power,
+                battery_discharge_power,
+                battery_power_to_exclude,
+                battery_reserve_power,
+                battery_reserve_shortfall_power,
+                surplus_source=surplus_source,
+                raw_target_current=theoretical_target_current,
+                target_current=0,
+                theoretical_target_current=theoretical_target_current,
+                current_limit_reason="external_pause",
+                decision_reason=SOLAR_BALANCE_EXTERNAL_PAUSED,
+            )
+            return
+
+        if not self._is_solar_control_mode:
+            self._reset_start_delay()
+            self._reset_residual_export()
+            self._charging_from_surplus = False
+            self._restart_from_min_current = False
+            self._track_grid_error()
+            self._update_solar_balance_state(
+                SOLAR_BALANCE_WAITING_SOLAR_MODE,
+                0,
+                available_power,
+                target_power,
+                0,
+                battery_power,
+                battery_charge_power,
+                battery_discharge_power,
+                battery_power_to_exclude,
+                battery_reserve_power,
+                battery_reserve_shortfall_power,
+                surplus_source=surplus_source,
+                raw_target_current=theoretical_target_current,
+                target_current=0,
+                theoretical_target_current=theoretical_target_current,
+                current_limit_reason="waiting_solar_mode",
+                decision_reason=SOLAR_BALANCE_WAITING_SOLAR_MODE,
+            )
+            return
+
+        if target_power < min_power:
+            # Type 2 charging cannot run below 6A. In low-surplus situations we
+            # keep Prism in solar mode at the minimum, unless Prism itself is in
+            # autolimit. The next restart is forced to begin from 6A.
+            self._reset_start_delay()
+            self._restart_from_min_current = True
+            surplus_current = max(target_power / watts_per_amp, 0)
+            if self._reported_mode == MODE_AUTOLIMIT:
+                if self._can_recover_from_autolimit():
+                    self._charging_from_surplus = True
+                    self._last_autolimit_recovery = utcnow()
+                    self._update_solar_balance_state(
+                        SOLAR_BALANCE_LOW_SURPLUS_KEEP_CHARGING,
+                        surplus_current,
+                        available_power,
+                        target_power,
+                        0,
+                        battery_power,
+                        battery_charge_power,
+                        battery_discharge_power,
+                        battery_power_to_exclude,
+                        battery_reserve_power,
+                        battery_reserve_shortfall_power,
+                        surplus_source=surplus_source,
+                        raw_target_current=surplus_current,
+                        target_current=MIN_CHARGE_CURRENT,
+                        theoretical_target_current=MIN_CHARGE_CURRENT,
+                        current_limit_reason="autolimit_recovery_6a",
+                        decision_reason=SOLAR_BALANCE_LOW_SURPLUS_KEEP_CHARGING,
+                    )
+                    await self._async_publish_current(MIN_CHARGE_CURRENT)
+                    await self._async_publish_mode(MODE_SOLAR)
+                    return
+
+                self._charging_from_surplus = False
+                autolimit_reason = (
+                    "autolimit_wait_stable_surplus"
+                    if self._unused_export_power >= self._residual_export_power
+                    else "autolimit_low_surplus"
+                )
+                self._update_solar_balance_state(
+                    SOLAR_BALANCE_WAITING_STABLE_SURPLUS,
+                    0,
+                    available_power,
+                    target_power,
+                    None,
+                    battery_power,
+                    battery_charge_power,
+                    battery_discharge_power,
+                    battery_power_to_exclude,
+                    battery_reserve_power,
+                    battery_reserve_shortfall_power,
+                    surplus_source=surplus_source,
+                    raw_target_current=0,
+                    target_current=0,
+                    theoretical_target_current=MIN_CHARGE_CURRENT,
+                    current_limit_reason=autolimit_reason,
+                    decision_reason=autolimit_reason,
+                )
+                return
+
+            self._charging_from_surplus = False
+            self._track_grid_error()
+            self._track_residual_export()
+            self._update_solar_balance_state(
+                SOLAR_BALANCE_PAUSED_LOW_SURPLUS,
+                surplus_current,
+                available_power,
+                target_power,
+                0,
+                battery_power,
+                battery_charge_power,
+                battery_discharge_power,
+                battery_power_to_exclude,
+                battery_reserve_power,
+                battery_reserve_shortfall_power,
+                surplus_source=surplus_source,
+                raw_target_current=surplus_current,
+                target_current=0,
+                theoretical_target_current=MIN_CHARGE_CURRENT,
+                current_limit_reason=SOLAR_BALANCE_PAUSED_LOW_SURPLUS,
+                decision_reason=SOLAR_BALANCE_PAUSED_LOW_SURPLUS,
+            )
+            await self._async_publish_current(MIN_CHARGE_CURRENT)
+            await self._async_publish_mode(MODE_PAUSED)
+            return
+
+        target_current = floor(target_power / (voltage * self._phases))
+        target_current = max(MIN_CHARGE_CURRENT, min(target_current, self._max_current))
+        self._raw_target_current = target_current
+        if self._should_restart_from_min_current():
+            self._reset_residual_export()
+            self._current_limit_reason = "restart_min_current"
+            self._update_solar_balance_state(
+                SOLAR_BALANCE_CHARGING_SURPLUS,
+                MIN_CHARGE_CURRENT,
+                available_power,
+                target_power,
+                0,
+                battery_power,
+                battery_charge_power,
+                battery_discharge_power,
+                battery_power_to_exclude,
+                battery_reserve_power,
+                battery_reserve_shortfall_power,
+                surplus_source=surplus_source,
+                raw_target_current=self._raw_target_current,
+                target_current=MIN_CHARGE_CURRENT,
+                theoretical_target_current=target_current,
+                current_limit_reason="restart_min_current",
+                decision_reason="charging_surplus",
+            )
+            await self._async_publish_current(MIN_CHARGE_CURRENT)
+            await self._async_publish_mode(MODE_SOLAR)
+            self._charging_from_surplus = True
+            return
+
+        target_current = self._apply_current_optimizations(
+            target_current,
+            watts_per_amp,
+            battery_charge_power,
+            battery_reserve_power,
+        )
+        delay_remaining = self._get_start_delay_remaining()
+        if delay_remaining > 0 and not already_charging:
+            preview_current = (
+                MIN_CHARGE_CURRENT if self._use_battery_charge else target_current
+            )
+            self._update_solar_balance_state(
+                SOLAR_BALANCE_WAITING_STABLE_SURPLUS,
+                preview_current,
+                available_power,
+                min_power if self._use_battery_charge else target_power,
+                delay_remaining,
+                battery_power,
+                battery_charge_power,
+                battery_discharge_power,
+                battery_power_to_exclude,
+                battery_reserve_power,
+                battery_reserve_shortfall_power,
+                surplus_source=surplus_source,
+                raw_target_current=self._raw_target_current,
+                target_current=preview_current,
+                theoretical_target_current=target_current,
+                current_limit_reason="waiting_stable_surplus",
+                decision_reason="waiting_stable_surplus",
+            )
+            await self._async_publish_current(MIN_CHARGE_CURRENT)
+            self._schedule_start_delay(delay_remaining)
+            return
+
+        self._cancel_start_delay()
+        self._update_solar_balance_state(
+            SOLAR_BALANCE_CHARGING_SURPLUS,
+            target_current,
+            available_power,
+            target_power,
+            0,
+            battery_power,
+            battery_charge_power,
+            battery_discharge_power,
+            battery_power_to_exclude,
+            battery_reserve_power,
+            battery_reserve_shortfall_power,
+            surplus_source=surplus_source,
+            raw_target_current=self._raw_target_current,
+            target_current=target_current,
+            theoretical_target_current=target_current,
+            current_limit_reason=self._current_limit_reason,
+            decision_reason="charging_surplus",
+        )
+        await self._async_publish_current(target_current)
+        await self._async_publish_mode(MODE_SOLAR)
+        self._charging_from_surplus = True
+
+    def _is_charging_from_surplus(self, min_power: float) -> bool:
+        """Return True when Prism appears to be actively charging already."""
+        return self._charging_from_surplus or (
+            self._ev_power is not None and self._ev_power >= min_power * 0.5
+        )
+
+    def _get_available_power(
+        self,
+        battery_charge_available: float,
+        battery_reserve_shortfall: float,
+        battery_power_to_exclude: float,
+    ) -> tuple[float, str]:
+        """Return EV surplus power and the source used to calculate it."""
+        assert self._ev_power is not None
+        assert self._grid_power is not None
+        result = calculate_available_power(
+            ev_power=self._ev_power,
+            grid_power=self._grid_power,
+            battery_charge_available=battery_charge_available,
+            battery_reserve_shortfall=battery_reserve_shortfall,
+            battery_power_to_exclude=battery_power_to_exclude,
+            use_battery_charge=self._use_battery_charge,
+            solar_power=(
+                self._solar_power
+                if self._solar_production_sensor and self._home_load_sensor
+                else None
+            ),
+            home_load_power=(
+                self._home_load_power
+                if self._solar_production_sensor and self._home_load_sensor
+                else None
+            ),
+            home_load_includes_ev=self._home_load_includes_ev,
+        )
+        self._effective_home_load_power = result.effective_home_load_power
+        return result.available_power, result.source
+
+    def _can_recover_from_autolimit(self) -> bool:
+        """Return True when autolimit can be probed without command loops."""
+        if self._grid_power is None:
+            return False
+
+        self._track_grid_error()
+        if self._grid_power > self._deadband_power:
+            self._reset_residual_export()
+            return False
+
+        if not self._track_residual_export():
+            return False
+
+        if self._last_autolimit_recovery is None:
+            return True
+
+        elapsed = (utcnow() - self._last_autolimit_recovery).total_seconds()
+        return elapsed >= AUTOLIMIT_RECOVERY_COOLDOWN
+
+    def _get_theoretical_target_current(
+        self, target_power: float, watts_per_amp: float, min_power: float
+    ) -> float:
+        """Return the current that would be requested if commanding were allowed."""
+        if watts_per_amp <= 0:
+            return 0
+        if target_power < min_power:
+            return MIN_CHARGE_CURRENT
+        return max(
+            MIN_CHARGE_CURRENT,
+            min(floor(target_power / watts_per_amp), self._max_current),
+        )
+
+    def _get_battery_reserve_power(self) -> float:
+        """Return how much battery charge power should be reserved for home storage."""
+        return get_battery_reserve_power(
+            self._battery_soc,
+            self._battery_max_charge_power,
+            self._soc_mid,
+            self._soc_high,
+            self._mid_reserve_power,
+            self._high_reserve_power,
+        )
+
+    def _apply_current_optimizations(
+        self,
+        target_current: int,
+        watts_per_amp: float,
+        battery_charge_power: float,
+        battery_reserve_power: float,
+    ) -> int:
+        """Apply hysteresis, proportional correction and ramp limits."""
+        last_current = self._get_reference_current()
+        if last_current is None:
+            self._track_grid_error()
+            self._track_residual_export()
+            self._current_limit_reason = "initial_target"
+            return target_current
+
+        self._track_grid_error()
+        # Battery feedback can ask for more EV current even when the grid is
+        # inside the deadband, because the battery is still charging above the
+        # configured target.
+        battery_charge_target_current = self._get_battery_charge_target_current(
+            target_current,
+            last_current,
+            watts_per_amp,
+            battery_charge_power,
+            battery_reserve_power,
+        )
+        battery_charge_target_active = battery_charge_target_current > target_current
+        target_current = battery_charge_target_current
+
+        if self._deadband_active and not battery_charge_target_active:
+            self._reset_residual_export()
+            self._current_limit_reason = "deadband_hold"
+            return last_current
+
+        target_current = self._apply_residual_export_recovery(target_current)
+
+        if target_current > last_current:
+            return self._limit_current_increase(
+                target_current, last_current, watts_per_amp
+            )
+        if target_current < last_current:
+            self._reset_residual_export()
+            self._ramp_direction = "down"
+            step = self._get_proportional_decrease_step(watts_per_amp)
+            limited_current = max(target_current, last_current - step)
+            self._ramp_limited = limited_current != target_current
+            self._current_limit_reason = (
+                "ramp_down_limited" if self._ramp_limited else "target_current"
+            )
+            return limited_current
+        self._current_limit_reason = "target_current"
+        return target_current
+
+    def _get_low_surplus_target_current(self, watts_per_amp: float) -> int:
+        """Hold at the 6A minimum while there is not enough surplus to restart."""
+        self._track_grid_error()
+        self._track_residual_export()
+        self._current_limit_reason = "target_current"
+        return MIN_CHARGE_CURRENT
+
+    def _get_battery_charge_target_current(
+        self,
+        target_current: int,
+        last_current: int,
+        watts_per_amp: float,
+        battery_charge_power: float,
+        battery_reserve_power: float,
+    ) -> int:
+        """Raise current toward the configured maximum battery charge target."""
+        if not self._use_battery_charge or watts_per_amp <= 0:
+            return target_current
+
+        # The reserve is treated as an approximate upper target for battery
+        # charging once the user has chosen to prioritize the EV over storage.
+        battery_charge_excess = battery_charge_power - battery_reserve_power
+        if battery_charge_excess <= self._deadband_power:
+            return target_current
+
+        extra_current = ceil(battery_charge_excess / watts_per_amp)
+        battery_target_current = min(
+            self._max_current,
+            last_current + max(extra_current, 1),
+        )
+        if battery_target_current > target_current:
+            self._current_limit_reason = "battery_charge_target"
+            return battery_target_current
+        return target_current
+
+    def _apply_residual_export_recovery(self, target_current: int) -> int:
+        reference_current = self._get_reference_current()
+        if reference_current is None:
+            return target_current
+        if not self._track_residual_export():
+            return target_current
+
+        recovered_current = min(
+            self._max_current,
+            reference_current + self._increase_step,
+        )
+        if recovered_current > target_current:
+            self._reset_residual_export()
+            self._current_limit_reason = "residual_export_recovery"
+            return recovered_current
+        return target_current
+
+    def _get_reference_current(self) -> int | None:
+        """Return the best known wallbox current limit for ramp decisions."""
+        if self._restart_from_min_current:
+            return MIN_CHARGE_CURRENT
+        return self._reported_current_limit or self._last_current_command
+
+    def _should_restart_from_min_current(self) -> bool:
+        """Return True until Prism has acknowledged a 6A restart after low surplus."""
+        if not self._restart_from_min_current:
+            return False
+
+        if self._reported_current_limit is not None:
+            if self._reported_current_limit <= MIN_CHARGE_CURRENT:
+                self._restart_from_min_current = False
+                return False
+            return True
+
+        if self._last_current_command == MIN_CHARGE_CURRENT:
+            self._restart_from_min_current = False
+            return False
+
+        return True
+
+    def _track_grid_error(self) -> None:
+        """Update import/export diagnostics relative to the configured buffer."""
+        assert self._grid_power is not None
+        grid_error = self._grid_power + self._target_export_power
+        self._deadband_active = abs(grid_error) <= self._deadband_power
+        self._unused_export_power = max(-grid_error - self._deadband_power, 0)
+        self._excess_import_power = max(grid_error - self._deadband_power, 0)
+
+    def _track_residual_export(self) -> bool:
+        """Return True once unused export has stayed available long enough."""
+        if self._residual_export_power <= 0:
+            self._residual_export_remaining = 0
+            return False
+
+        if self._unused_export_power < self._residual_export_power:
+            self._reset_residual_export()
+            return False
+
+        if self._residual_export_delay <= 0:
+            self._residual_export_remaining = 0
+            return True
+
+        now = utcnow()
+        if self._residual_export_since is None:
+            self._residual_export_since = now
+            self._residual_export_remaining = self._residual_export_delay
+            return False
+
+        elapsed = (now - self._residual_export_since).total_seconds()
+        self._residual_export_remaining = max(
+            self._residual_export_delay - int(elapsed), 0
+        )
+        return elapsed >= self._residual_export_delay
+
+    def _limit_current_increase(
+        self, target_current: int, last_current: int, watts_per_amp: float
+    ) -> int:
+        self._ramp_direction = "up"
+        step = self._get_proportional_increase_step(watts_per_amp)
+        if self._increase_interval <= 0:
+            self._last_current_increase = utcnow()
+            limited_current = min(target_current, last_current + step)
+            self._ramp_limited = limited_current != target_current
+            self._current_limit_reason = (
+                "ramp_up_limited" if self._ramp_limited else "target_current"
+            )
+            return limited_current
+
+        now = utcnow()
+        if self._last_current_increase is not None:
+            elapsed = (now - self._last_current_increase).total_seconds()
+            if elapsed < self._increase_interval:
+                self._ramp_limited = True
+                self._current_limit_reason = "ramp_up_wait"
+                return last_current
+
+        self._last_current_increase = now
+        limited_current = min(target_current, last_current + step)
+        self._ramp_limited = limited_current != target_current
+        self._current_limit_reason = (
+            "ramp_up_limited" if self._ramp_limited else "target_current"
+        )
+        return limited_current
+
+    def _get_proportional_increase_step(self, watts_per_amp: float) -> int:
+        """Scale upward corrections with export, bounded by configured steps."""
+        if watts_per_amp <= 0:
+            return self._increase_step
+        proportional_step = int(self._unused_export_power // watts_per_amp)
+        return max(self._increase_step, min(proportional_step, self._decrease_step))
+
+    def _get_proportional_decrease_step(self, watts_per_amp: float) -> int:
+        """Scale downward corrections with import so house loads win quickly."""
+        if watts_per_amp <= 0:
+            return self._decrease_step
+        proportional_step = int(self._excess_import_power // watts_per_amp) + 1
+        return max(self._decrease_step, proportional_step)
+
+    def _get_start_delay_remaining(self) -> int:
+        if self._start_delay_seconds <= 0:
+            return 0
+
+        now = utcnow()
+        if self._surplus_since is None:
+            self._surplus_since = now
+            return self._start_delay_seconds
+
+        elapsed = int((now - self._surplus_since).total_seconds())
+        return max(self._start_delay_seconds - elapsed, 0)
+
+    def _schedule_start_delay(self, delay_remaining: int) -> None:
+        if self._start_delay_trigger is not None:
+            return
+        self._start_delay_trigger = async_call_later(
+            self.hass, min(delay_remaining, 1), self._start_delay_elapsed
+        )
+
+    @callback
+    def _start_delay_elapsed(self, *_: datetime) -> None:
+        self._start_delay_trigger = None
+        self.hass.async_create_task(self._async_update_balance())
+
+    def _reset_start_delay(self) -> None:
+        self._surplus_since = None
+        self._cancel_start_delay()
+
+    def _reset_residual_export(self) -> None:
+        self._residual_export_since = None
+        self._residual_export_remaining = 0
+
+    def _reset_current_diagnostics(self) -> None:
+        self._raw_target_current = None
+        self._unused_export_power = 0
+        self._excess_import_power = 0
+        self._residual_export_remaining = 0
+        self._deadband_active = False
+        self._ramp_limited = False
+        self._ramp_direction = "none"
+        self._current_limit_reason = "target_current"
+
+    def _cancel_start_delay(self) -> None:
+        if self._start_delay_trigger is not None:
+            self._start_delay_trigger()
+            self._start_delay_trigger = None
+
+    def _update_solar_balance_state(
+        self,
+        status: str,
+        surplus_current: float | None,
+        available_power: float | None,
+        target_power: float | None,
+        start_delay_remaining: int | None,
+        battery_power: float | None = None,
+        battery_charge_power: float | None = None,
+        battery_discharge_power: float | None = None,
+        battery_power_used: float | None = None,
+        battery_reserve_power: float | None = None,
+        battery_reserve_shortfall_power: float | None = None,
+        surplus_source: str | None = None,
+        raw_target_current: float | None = None,
+        target_current: float | None = None,
+        current_limit_reason: str | None = None,
+        decision_reason: str | None = None,
+        theoretical_target_current: float | None = None,
+        missing_data_reason: str | None = None,
+    ) -> None:
+        state = SolarBalanceState(
+            status=status,
+            surplus_current=surplus_current,
+            available_power=available_power,
+            target_power=target_power,
+            start_delay_remaining=start_delay_remaining,
+            grid_power=self._grid_power,
+            ev_power=self._ev_power,
+            solar_power=self._solar_power,
+            home_load_power=(
+                self._effective_home_load_power
+                if self._effective_home_load_power is not None
+                else self._home_load_power
+            ),
+            battery_power=battery_power,
+            battery_charge_power=battery_charge_power,
+            battery_discharge_power=battery_discharge_power,
+            battery_power_used=battery_power_used,
+            battery_max_charge_power=self._battery_max_charge_power,
+            battery_soc=self._battery_soc,
+            battery_reserve_power=battery_reserve_power,
+            battery_reserve_shortfall_power=battery_reserve_shortfall_power,
+            surplus_source=surplus_source,
+            target_export_power=self._target_export_power,
+            deadband_power=self._deadband_power,
+            raw_target_current=raw_target_current,
+            target_current=target_current,
+            theoretical_target_current=theoretical_target_current,
+            reported_current_limit=self._reported_current_limit,
+            unused_export_power=self._unused_export_power,
+            excess_import_power=self._excess_import_power,
+            residual_export_remaining=self._residual_export_remaining,
+            deadband_active=self._deadband_active,
+            ramp_limited=self._ramp_limited,
+            ramp_direction=self._ramp_direction,
+            current_limit_reason=current_limit_reason,
+            decision_reason=decision_reason,
+            missing_data_reason=missing_data_reason,
+            dry_run=self._dry_run,
+        )
+        state.decision_summary = describe_solar_balance_state(
+            state, self.hass.config.language
+        )
+        self._entry_data.solar_balance_states[self._port] = state
+        async_dispatcher_send(
+            self.hass,
+            get_solar_balance_signal(self._entry_data.serial, self._port),
+            state,
+        )
+
+    @property
+    def _has_required_values(self) -> bool:
+        if (
+            self._grid_power is None
+            or self._ev_power is None
+            or self._battery_power is None
+        ):
+            return False
+        if self._solar_production_sensor and self._home_load_sensor:
+            return self._solar_power is not None and self._home_load_power is not None
+        return True
+
+    @property
+    def _is_externally_paused(self) -> bool:
+        if self._reported_mode == MODE_AUTOLIMIT:
+            return False
+        if self._last_mode_command == MODE_PAUSED and (
+            self._reported_mode == MODE_PAUSED
+            or self._reported_state in (STATE_PAUSE, "pause")
+        ):
+            return False
+        return self._reported_mode == MODE_PAUSED or self._reported_state in (
+            STATE_PAUSE,
+            "pause",
+        )
+
+    @property
+    def _is_solar_control_mode(self) -> bool:
+        return self._reported_mode in (MODE_SOLAR, MODE_AUTOLIMIT)
+
+    def _get_missing_data_reason(self) -> str:
+        if self._grid_power is None:
+            return "grid_power"
+        if self._ev_power is None:
+            return "ev_power"
+        if self._battery_power is None:
+            return "battery_power"
+        if self._solar_production_sensor and self._solar_power is None:
+            return "solar_production_power"
+        if self._home_load_sensor and self._home_load_power is None:
+            return "home_load_power"
+        return "unknown"
+
+    async def _async_publish_current(self, current: int) -> None:
+        now = utcnow()
+        recently_published = (
+            self._last_current_publish is not None
+            and (now - self._last_current_publish).total_seconds()
+            < CURRENT_REPUBLISH_INTERVAL
+        )
+        if self._last_current_command == current and (
+            self._reported_current_limit == current or recently_published
+        ):
+            return
+        if self._dry_run:
+            self._last_current_command = current
+            self._last_current_publish = now
+            _LOGGER.info(
+                "Solar balance dry run: would publish current %sA to Prism port %s",
+                current,
+                self._port,
+            )
+            return
+        self._last_current_command = current
+        self._last_current_publish = now
+        await mqtt.async_publish(
+            self.hass,
+            f"{self._base_topic}{self._port}/command/set_current_limit",
+            current,
+        )
+
+    async def _async_publish_mode(self, mode: str) -> None:
+        if self._last_mode_command == mode and self._reported_mode in (None, mode):
+            return
+        if self._dry_run:
+            self._last_mode_command = mode
+            _LOGGER.info(
+                "Solar balance dry run: would publish mode %s to Prism port %s",
+                mode,
+                self._port,
+            )
+            return
+        self._last_mode_command = mode
+        await mqtt.async_publish(
+            self.hass,
+            f"{self._base_topic}{self._port}/command/set_mode",
+            mode,
+        )
+
+
+SWITCHES: tuple[PrismSwitchEntityDescription, ...] = (
+    PrismSwitchEntityDescription(
+        key="solar_battery_balance_{}",
+        entity_category=EntityCategory.CONFIG,
+        has_entity_name=True,
+        translation_key="solar_battery_balance",
+    ),
+)

--- a/homeassistant/components/silla_prism/touch_events.py
+++ b/homeassistant/components/silla_prism/touch_events.py
@@ -1,0 +1,42 @@
+"""Helpers for parsing Prism touch event MQTT payloads."""
+
+import re
+from typing import Any
+
+_INTEGER_RE = re.compile(r"-?\d+")
+_TEXT_SEQUENCES = {
+    "single": (1,),
+    "singolo": (1,),
+    "double": (2,),
+    "doppio": (2,),
+    "long": (3,),
+    "lungo": (3,),
+    "pressione_lunga": (3,),
+}
+
+
+def normalize_touch_payload(payload: Any) -> tuple[int, ...] | None:
+    """Return a normalized touch event sequence from a Prism MQTT payload."""
+    if payload is None:
+        return None
+    if isinstance(payload, bytes):
+        payload = payload.decode(errors="ignore")
+    text = str(payload).strip().strip('"').strip("'")
+    if not text:
+        return None
+
+    normalized_text = text.lower().replace("-", "_").replace(" ", "_")
+    for marker, sequence in _TEXT_SEQUENCES.items():
+        if marker in normalized_text:
+            return sequence
+
+    values = tuple(int(match) for match in _INTEGER_RE.findall(text))
+    return values or None
+
+
+def touch_payload_matches(
+    payload: Any, accepted_sequences: tuple[tuple[int, ...], ...]
+) -> bool:
+    """Return True when a Prism touch payload matches one accepted event shape."""
+    sequence = normalize_touch_payload(payload)
+    return sequence in accepted_sequences if sequence is not None else False

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6601,7 +6601,6 @@
       "iot_class": "cloud_push"
     },
     "silla_prism": {
-      "name": "Silla Prism",
       "integration_type": "device",
       "config_flow": true,
       "iot_class": "local_push"
@@ -8769,6 +8768,7 @@
     "schedule",
     "season",
     "shopping_list",
+    "silla_prism",
     "statistics",
     "sun",
     "switch_as_x",

--- a/tests/components/silla_prism/__init__.py
+++ b/tests/components/silla_prism/__init__.py
@@ -15,6 +15,8 @@ async def setup_integration(hass: HomeAssistant, entry: MockConfigEntry) -> None
 
 async def fire_burst(hass: HomeAssistant) -> None:
     """Publish the retained status burst captured from a real Prism."""
+    await hass.async_block_till_done()
     for topic, payload in RETAINED_BURST:
         async_fire_mqtt_message(hass, topic, payload)
+    await hass.async_block_till_done()
     await hass.async_block_till_done()

--- a/tests/components/silla_prism/snapshots/test_sensor.ambr
+++ b/tests/components/silla_prism/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_sensors[sensor.silla_prism_current-entry]
+# name: test_sensors[sensor.prism_session_time-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -15,7 +15,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.silla_prism_current',
+    'entity_id': 'sensor.prism_session_time',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,160 +23,41 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Current',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 2,
-      }),
-      'sensor.private': dict({
-        'suggested_unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
-    'original_icon': None,
-    'original_name': 'Current',
-    'platform': 'silla_prism',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'prism_current',
-    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-  })
-# ---
-# name: test_sensors[sensor.silla_prism_current-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Silla Prism Current',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.silla_prism_current',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '8.0',
-  })
-# ---
-# name: test_sensors[sensor.silla_prism_error-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
-        'none',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.silla_prism_error',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Error',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
-    'original_icon': None,
-    'original_name': 'Error',
-    'platform': 'silla_prism',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'error',
-    'unique_id': 'prism_error',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[sensor.silla_prism_error-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Silla Prism Error',
-      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
-        'none',
-      ]),
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.silla_prism_error',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'none',
-  })
-# ---
-# name: test_sensors[sensor.silla_prism_grid_power-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.silla_prism_grid_power',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Grid power',
+    'object_id_base': 'Session time',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
     'original_icon': None,
-    'original_name': 'Grid power',
+    'original_name': 'Session time',
     'platform': 'silla_prism',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'grid_power',
-    'unique_id': 'prism_grid_power',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    'translation_key': 'session_time',
+    'unique_id': 'prism_session_time_001',
+    'unit_of_measurement': <UnitOfTime.SECONDS: 's'>,
   })
 # ---
-# name: test_sensors[sensor.silla_prism_grid_power-state]
+# name: test_sensors[sensor.prism_session_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Silla Prism Grid power',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Prism Session time',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.WATT: 'W'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.SECONDS: 's'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.silla_prism_grid_power',
+    'entity_id': 'sensor.prism_session_time',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2800.0',
+    'state': '16030',
   })
 # ---
-# name: test_sensors[sensor.silla_prism_pilot_current-entry]
+# name: test_sensors[sensor.prism_car_requested_by_car-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -191,8 +72,8 @@
     'device_id': <ANY>,
     'disabled_by': None,
     'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.silla_prism_pilot_current',
+    'entity_category': None,
+    'entity_id': 'sensor.prism_car_requested_by_car',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -200,41 +81,41 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Pilot current',
+    'object_id_base': 'Car requested by car',
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 2,
+        'suggested_display_precision': 0,
       }),
     }),
     'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
     'original_icon': None,
-    'original_name': 'Pilot current',
+    'original_name': 'Car requested by car',
     'platform': 'silla_prism',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'pilot',
-    'unique_id': 'prism_pilot',
+    'translation_key': 'output_car_current',
+    'unique_id': 'prism_output_car_current_001',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
-# name: test_sensors[sensor.silla_prism_pilot_current-state]
+# name: test_sensors[sensor.prism_car_requested_by_car-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Silla Prism Pilot current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Prism Car requested by car',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.silla_prism_pilot_current',
+    'entity_id': 'sensor.prism_car_requested_by_car',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '6.0',
   })
 # ---
-# name: test_sensors[sensor.silla_prism_power-entry]
+# name: test_sensors[sensor.prism_cpu_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -250,7 +131,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.silla_prism_power',
+    'entity_id': 'sensor.prism_cpu_temperature',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -258,41 +139,169 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Power',
+    'object_id_base': 'CPU temperature',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
     'original_icon': None,
-    'original_name': 'Power',
+    'original_name': 'CPU temperature',
     'platform': 'silla_prism',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'prism_power',
-    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+    'translation_key': 'core_temperature',
+    'unique_id': 'prism_core_temperature_001',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensors[sensor.silla_prism_power-state]
+# name: test_sensors[sensor.prism_cpu_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Silla Prism Power',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Prism CPU temperature',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.WATT: 'W'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.silla_prism_power',
+    'entity_id': 'sensor.prism_cpu_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '1760.0',
+    'state': '35',
   })
 # ---
-# name: test_sensors[sensor.silla_prism_session_energy-entry]
+# name: test_sensors[sensor.prism_current_limited_by_user-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.prism_current_limited_by_user',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current limited by user',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current limited by user',
+    'platform': 'silla_prism',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_set_by_user',
+    'unique_id': 'prism_current_set_by_user_001',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensors[sensor.prism_current_limited_by_user-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Prism Current limited by user',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.prism_current_limited_by_user',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '6',
+  })
+# ---
+# name: test_sensors[sensor.prism_current_port_output_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'solar',
+        'normal',
+        'paused',
+        'hybrid',
+        'suspended',
+        'unknown',
+        'autolimit',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.prism_current_port_output_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current port output mode',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Current port output mode',
+    'platform': 'silla_prism',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_port_mode',
+    'unique_id': 'prism_current_port_mode_001',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.prism_current_port_output_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Prism Current port output mode',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'solar',
+        'normal',
+        'paused',
+        'hybrid',
+        'suspended',
+        'unknown',
+        'autolimit',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.prism_current_port_output_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'normal',
+  })
+# ---
+# name: test_sensors[sensor.prism_energy_provided_in_last_session-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -308,7 +317,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.silla_prism_session_energy',
+    'entity_id': 'sensor.prism_energy_provided_in_last_session',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -316,7 +325,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Session energy',
+    'object_id_base': 'Energy provided in last session',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -324,96 +333,40 @@
     }),
     'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
     'original_icon': None,
-    'original_name': 'Session energy',
+    'original_name': 'Energy provided in last session',
     'platform': 'silla_prism',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'session_energy',
-    'unique_id': 'prism_session_energy',
+    'translation_key': 'session_output_energy',
+    'unique_id': 'prism_session_output_energy_001',
     'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
   })
 # ---
-# name: test_sensors[sensor.silla_prism_session_energy-state]
+# name: test_sensors[sensor.prism_energy_provided_in_last_session-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Silla Prism Session energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Prism Energy provided in last session',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.WATT_HOUR: 'Wh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.silla_prism_session_energy',
+    'entity_id': 'sensor.prism_energy_provided_in_last_session',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '3900.0',
+    'state': '3900',
   })
 # ---
-# name: test_sensors[sensor.silla_prism_session_start-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.silla_prism_session_start',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Session start',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': None,
-    'original_name': 'Session start',
-    'platform': 'silla_prism',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'session_start',
-    'unique_id': 'prism_session_start',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[sensor.silla_prism_session_start-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Silla Prism Session start',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.silla_prism_session_start',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2025-12-31T19:32:50+00:00',
-  })
-# ---
-# name: test_sensors[sensor.silla_prism_status-entry]
+# name: test_sensors[sensor.prism_output_current-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
     ]),
     'area_id': None,
     'capabilities': dict({
-      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
-        'idle',
-        'waiting',
-        'charging',
-        'paused',
-      ]),
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -422,7 +375,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.silla_prism_status',
+    'entity_id': 'sensor.prism_output_current',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -430,42 +383,41 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Status',
+    'object_id_base': 'Output current',
     'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
     }),
-    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
     'original_icon': None,
-    'original_name': 'Status',
+    'original_name': 'Output current',
     'platform': 'silla_prism',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'status',
-    'unique_id': 'prism_status',
-    'unit_of_measurement': None,
+    'translation_key': 'output_current',
+    'unique_id': 'prism_output_current_001',
+    'unit_of_measurement': <UnitOfElectricCurrent.MILLIAMPERE: 'mA'>,
   })
 # ---
-# name: test_sensors[sensor.silla_prism_status-state]
+# name: test_sensors[sensor.prism_output_current-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Silla Prism Status',
-      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
-        'idle',
-        'waiting',
-        'charging',
-        'paused',
-      ]),
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Prism Output current',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.MILLIAMPERE: 'mA'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.silla_prism_status',
+    'entity_id': 'sensor.prism_output_current',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'idle',
+    'state': '8000',
   })
 # ---
-# name: test_sensors[sensor.silla_prism_temperature-entry]
+# name: test_sensors[sensor.prism_power_from_utility-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -480,8 +432,8 @@
     'device_id': <ANY>,
     'disabled_by': None,
     'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.silla_prism_temperature',
+    'entity_category': None,
+    'entity_id': 'sensor.prism_power_from_utility',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -489,41 +441,157 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Temperature',
+    'object_id_base': 'Power from utility',
     'options': dict({
       'sensor': dict({
-        'suggested_display_precision': 1,
+        'suggested_display_precision': 0,
       }),
     }),
-    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
     'original_icon': None,
-    'original_name': 'Temperature',
+    'original_name': 'Power from utility',
     'platform': 'silla_prism',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'prism_temperature',
-    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    'translation_key': 'input_grid_power',
+    'unique_id': 'prism_input_grid_power_001',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
   })
 # ---
-# name: test_sensors[sensor.silla_prism_temperature-state]
+# name: test_sensors[sensor.prism_power_from_utility-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Silla Prism Temperature',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Prism Power from utility',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.WATT: 'W'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.silla_prism_temperature',
+    'entity_id': 'sensor.prism_power_from_utility',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '35.0',
+    'state': '2800',
   })
 # ---
-# name: test_sensors[sensor.silla_prism_total_energy-entry]
+# name: test_sensors[sensor.prism_power_grid_voltage-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.prism_power_grid_voltage',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power grid voltage',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_icon': None,
+    'original_name': 'Power grid voltage',
+    'platform': 'silla_prism',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'power_grid_voltage',
+    'unique_id': 'prism_power_grid_voltage_001',
+    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+  })
+# ---
+# name: test_sensors[sensor.prism_power_grid_voltage-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Prism Power grid voltage',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.prism_power_grid_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '236.0',
+  })
+# ---
+# name: test_sensors[sensor.prism_power_provided_to_car-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.prism_power_provided_to_car',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power provided to car',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Power provided to car',
+    'platform': 'silla_prism',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'output_power',
+    'unique_id': 'prism_output_power_001',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensors[sensor.prism_power_provided_to_car-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Prism Power provided to car',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.prism_power_provided_to_car',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1760.0',
+  })
+# ---
+# name: test_sensors[sensor.prism_total_energy-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -539,7 +607,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.silla_prism_total_energy',
+    'entity_id': 'sensor.prism_total_energy',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -560,35 +628,40 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'total_energy',
-    'unique_id': 'prism_total_energy',
+    'translation_key': 'total_output_energy',
+    'unique_id': 'prism_total_output_energy_001',
     'unit_of_measurement': <UnitOfEnergy.WATT_HOUR: 'Wh'>,
   })
 # ---
-# name: test_sensors[sensor.silla_prism_total_energy-state]
+# name: test_sensors[sensor.prism_total_energy-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Silla Prism Total energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Prism Total energy',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.WATT_HOUR: 'Wh'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.silla_prism_total_energy',
+    'entity_id': 'sensor.prism_total_energy',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '719800.0',
+    'state': '719800',
   })
 # ---
-# name: test_sensors[sensor.silla_prism_voltage-entry]
+# name: test_sensors[sensor.prism_wallbox_current_state-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
     ]),
     'area_id': None,
     'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'idle',
+        'waiting',
+        'charging',
+        'pause',
+      ]),
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -596,8 +669,8 @@
     'device_id': <ANY>,
     'disabled_by': None,
     'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.silla_prism_voltage',
+    'entity_category': None,
+    'entity_id': 'sensor.prism_wallbox_current_state',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -605,37 +678,38 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Voltage',
+    'object_id_base': 'Wallbox current state',
     'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 0,
-      }),
     }),
-    'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
-    'original_name': 'Voltage',
+    'original_name': 'Wallbox current state',
     'platform': 'silla_prism',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'prism_voltage',
-    'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    'translation_key': 'current_state',
+    'unique_id': 'prism_current_state_001',
+    'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[sensor.silla_prism_voltage-state]
+# name: test_sensors[sensor.prism_wallbox_current_state-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'voltage',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Silla Prism Voltage',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricPotential.VOLT: 'V'>,
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Prism Wallbox current state',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'idle',
+        'waiting',
+        'charging',
+        'pause',
+      ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.silla_prism_voltage',
+    'entity_id': 'sensor.prism_wallbox_current_state',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '236.0',
+    'state': 'idle',
   })
 # ---

--- a/tests/components/silla_prism/test_init.py
+++ b/tests/components/silla_prism/test_init.py
@@ -29,9 +29,12 @@ async def test_setup_and_unload(
     )
     assert device is not None
 
-    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    entry_id = mock_config_entry.entry_id
+    assert await hass.config_entries.async_unload(entry_id)
     await hass.async_block_till_done()
-    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+    entry = hass.config_entries.async_get_entry(entry_id)
+    assert entry is not None
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_setup_mqtt_unavailable(

--- a/tests/components/silla_prism/test_sensor.py
+++ b/tests/components/silla_prism/test_sensor.py
@@ -1,12 +1,14 @@
 """Test the Silla Prism sensors."""
 
 from datetime import timedelta
+from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.components.silla_prism.const import DOMAIN
+from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -15,12 +17,17 @@ from . import fire_burst, setup_integration
 from tests.common import MockConfigEntry, async_fire_mqtt_message, snapshot_platform
 from tests.typing import MqttMockHAClient
 
-ERROR_ENTITY_ID = "sensor.silla_prism_error"
 ERROR_TOPIC = "prism/1/error"
-POWER_ENTITY_ID = "sensor.silla_prism_power"
 POWER_TOPIC = "prism/1/w"
-SESSION_START_ENTITY_ID = "sensor.silla_prism_session_start"
 SESSION_TIME_TOPIC = "prism/1/session_time"
+
+
+def _entity_id(
+    entity_registry: er.EntityRegistry, platform: Platform, unique_id: str
+) -> str:
+    entity_id = entity_registry.async_get_entity_id(platform, DOMAIN, unique_id)
+    assert entity_id is not None
+    return entity_id
 
 
 async def test_sensors(
@@ -33,80 +40,98 @@ async def test_sensors(
 ) -> None:
     """Test the sensors."""
     freezer.move_to("2026-01-01 00:00:00+00:00")
-    await setup_integration(hass, mock_config_entry)
+    with patch("homeassistant.components.silla_prism.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
     await fire_burst(hass)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
 @pytest.mark.usefixtures("mqtt_mock")
-async def test_undocumented_error_code(
+async def test_error_status(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    caplog: pytest.LogCaptureFixture,
+    entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test that an error code outside the documented ones reads as unknown."""
+    """Test that Prism error values update the problem binary sensor."""
     await setup_integration(hass, mock_config_entry)
     await fire_burst(hass)
 
     async_fire_mqtt_message(hass, ERROR_TOPIC, "12")
     await hass.async_block_till_done()
-
-    assert hass.states.get(ERROR_ENTITY_ID).state == STATE_UNKNOWN
-    assert caplog.text.count("Unknown error code: 12") == 1
-
-    async_fire_mqtt_message(hass, ERROR_TOPIC, "12")
     await hass.async_block_till_done()
 
-    assert caplog.text.count("Unknown error code: 12") == 1
+    error_entity_id = _entity_id(
+        entity_registry, Platform.BINARY_SENSOR, "prism_error_001"
+    )
+    state = hass.states.get(error_entity_id)
+    assert state is not None
+    assert state.state == STATE_ON
 
     async_fire_mqtt_message(hass, ERROR_TOPIC, "0")
     async_fire_mqtt_message(hass, POWER_TOPIC, "2000.0")
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
-    assert hass.states.get(ERROR_ENTITY_ID).state == "none"
-    assert hass.states.get(POWER_ENTITY_ID).state == "2000.0"
+    power_entity_id = _entity_id(
+        entity_registry, Platform.SENSOR, "prism_output_power_001"
+    )
+    state = hass.states.get(error_entity_id)
+    assert state is not None
+    assert state.state == STATE_OFF
+    state = hass.states.get(power_entity_id)
+    assert state is not None
+    assert state.state == "2000.0"
 
 
 @pytest.mark.usefixtures("mqtt_mock")
-@pytest.mark.parametrize(
-    ("elapsed", "expected"),
-    [
-        pytest.param("16089", "2025-12-31T19:32:50+00:00", id="jitter_ignored"),
-        pytest.param("16150", "2025-12-31T19:31:50+00:00", id="new_session_tracked"),
-    ],
-)
-async def test_session_start_deviation(
+@pytest.mark.parametrize("elapsed", ["16089", "16150"])
+async def test_session_time_updates(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
     freezer: FrozenDateTimeFactory,
     elapsed: str,
-    expected: str,
 ) -> None:
-    """Test the session start absorbs jitter but follows a real change."""
+    """Test the session time sensor follows Prism session_time payloads."""
     freezer.move_to("2026-01-01 00:00:00+00:00")
     await setup_integration(hass, mock_config_entry)
     await fire_burst(hass)
 
-    assert hass.states.get(SESSION_START_ENTITY_ID).state == "2025-12-31T19:32:50+00:00"
+    session_time_entity_id = _entity_id(
+        entity_registry, Platform.SENSOR, "prism_session_time_001"
+    )
+    state = hass.states.get(session_time_entity_id)
+    assert state is not None
+    assert state.state == "16030"
 
     freezer.tick(timedelta(seconds=60))
     async_fire_mqtt_message(hass, SESSION_TIME_TOPIC, elapsed)
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
-    assert hass.states.get(SESSION_START_ENTITY_ID).state == expected
+    state = hass.states.get(session_time_entity_id)
+    assert state is not None
+    assert state.state == elapsed
 
 
 @pytest.mark.usefixtures("mqtt_mock")
-async def test_session_start_without_session(
+async def test_session_time_without_session(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test that no running session reads as unknown."""
+    """Test that no running session reads as zero seconds."""
     await setup_integration(hass, mock_config_entry)
     await fire_burst(hass)
 
     async_fire_mqtt_message(hass, SESSION_TIME_TOPIC, "0")
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
-    assert hass.states.get(SESSION_START_ENTITY_ID).state == STATE_UNKNOWN
+    session_time_entity_id = _entity_id(
+        entity_registry, Platform.SENSOR, "prism_session_time_001"
+    )
+    state = hass.states.get(session_time_entity_id)
+    assert state is not None
+    assert state.state == "0"

--- a/tests/components/silla_prism/test_solar_balance.py
+++ b/tests/components/silla_prism/test_solar_balance.py
@@ -1,0 +1,264 @@
+"""Unit tests for pure solar balancing helpers."""
+
+from homeassistant.components.silla_prism.solar_balance import (
+    SOLAR_BALANCE_CHARGING_SURPLUS,
+    SOLAR_BALANCE_DISABLED,
+    SOLAR_BALANCE_EXTERNAL_PAUSED,
+    SOLAR_BALANCE_WAITING_BATTERY_DATA,
+    SOLAR_BALANCE_WAITING_DATA,
+    SOLAR_BALANCE_WAITING_SOLAR_MODE,
+    SURPLUS_SOURCE_PRISM_GRID_BATTERY,
+    SURPLUS_SOURCE_SOLAR_HOME_LOAD,
+    SolarBalanceState,
+    calculate_available_power,
+    describe_solar_balance_state,
+    get_battery_reserve_power,
+    normalize_battery_power,
+)
+
+
+def test_home_load_including_ev_is_corrected() -> None:
+    """Test total home load can exclude EV power."""
+    result = calculate_available_power(
+        ev_power=2600,
+        grid_power=0,
+        battery_charge_available=0,
+        battery_reserve_shortfall=0,
+        battery_power_to_exclude=0,
+        use_battery_charge=False,
+        solar_power=1300,
+        home_load_power=3400,
+        home_load_includes_ev=True,
+    )
+
+    assert result.source == SURPLUS_SOURCE_SOLAR_HOME_LOAD
+    assert result.effective_home_load_power == 800
+    assert result.available_power == 500
+
+
+def test_zero_solar_and_battery_discharge_are_not_surplus() -> None:
+    """Test zero PV production does not become surplus."""
+    result = calculate_available_power(
+        ev_power=2660,
+        grid_power=-3,
+        battery_charge_available=0,
+        battery_reserve_shortfall=0,
+        battery_power_to_exclude=3607,
+        use_battery_charge=True,
+        solar_power=0,
+        home_load_power=755,
+        home_load_includes_ev=False,
+    )
+
+    assert result.source == SURPLUS_SOURCE_SOLAR_HOME_LOAD
+    assert result.available_power == -755
+
+
+def test_negative_solar_sensor_is_not_treated_as_production() -> None:
+    """Test negative PV readings are clamped out of production."""
+    result = calculate_available_power(
+        ev_power=0,
+        grid_power=0,
+        battery_charge_available=0,
+        battery_reserve_shortfall=0,
+        battery_power_to_exclude=0,
+        use_battery_charge=False,
+        solar_power=-1200,
+        home_load_power=400,
+    )
+
+    assert result.source == SURPLUS_SOURCE_SOLAR_HOME_LOAD
+    assert result.available_power == -400
+
+
+def test_fallback_subtracts_grid_import_and_battery_discharge() -> None:
+    """Test fallback surplus calculation subtracts import and battery discharge."""
+    result = calculate_available_power(
+        ev_power=2000,
+        grid_power=300,
+        battery_charge_available=0,
+        battery_reserve_shortfall=0,
+        battery_power_to_exclude=600,
+        use_battery_charge=False,
+    )
+
+    assert result.source == SURPLUS_SOURCE_PRISM_GRID_BATTERY
+    assert result.available_power == 1100
+
+
+def test_battery_reserve_shortfall_reduces_direct_solar_surplus() -> None:
+    """Test reserve shortfall keeps power for the home battery."""
+    result = calculate_available_power(
+        ev_power=1790,
+        grid_power=0,
+        battery_charge_available=0,
+        battery_reserve_shortfall=837,
+        battery_power_to_exclude=0,
+        use_battery_charge=False,
+        solar_power=2652,
+        home_load_power=534,
+    )
+
+    assert result.source == SURPLUS_SOURCE_SOLAR_HOME_LOAD
+    assert result.available_power == 1281
+
+
+def test_battery_reserve_tracks_soc_thresholds() -> None:
+    """Test battery reserve changes with SOC thresholds."""
+    assert get_battery_reserve_power(None, 2700, 40, 80, 1500, 1000) == 2700
+    assert get_battery_reserve_power(60, 2700, 40, 80, 1500, 1000) == 1500
+    assert get_battery_reserve_power(85, 2700, 40, 80, 1500, 1000) == 1000
+    assert get_battery_reserve_power(96, 2700, 40, 80, 1500, 1000) == 0
+
+
+def test_battery_charge_above_reserve_can_become_surplus() -> None:
+    """Test excess battery charge power can be reused by EV charging."""
+    breakdown = normalize_battery_power(
+        battery_power=-2200,
+        battery_discharge_positive=True,
+        battery_reserve_power=1500,
+        use_battery_charge=True,
+    )
+
+    assert breakdown.charge_power == 2200
+    assert breakdown.discharge_power == 0
+    assert breakdown.charge_available_above_reserve == 700
+    assert breakdown.power_to_exclude == -700
+
+
+def test_battery_discharge_positive_setting_is_respected() -> None:
+    """Test inverted battery sign convention."""
+    breakdown = normalize_battery_power(
+        battery_power=-500,
+        battery_discharge_positive=False,
+        battery_reserve_power=1500,
+        use_battery_charge=True,
+    )
+
+    assert breakdown.normalized_power == 500
+    assert breakdown.discharge_power == 500
+    assert breakdown.power_to_exclude == 500
+
+
+def test_decision_summary_explains_low_surplus_hold() -> None:
+    """Test English low-surplus summary."""
+    summary = describe_solar_balance_state(
+        SolarBalanceState(
+            status=SOLAR_BALANCE_CHARGING_SURPLUS,
+            available_power=-755,
+            target_current=6,
+            current_limit_reason="low_surplus_hold_6a",
+        )
+    )
+
+    assert "Holding 6A" in summary
+    assert "-755W" in summary
+    assert "Constraint" in summary
+
+
+def test_decision_summary_uses_italian_when_requested() -> None:
+    """Test Italian decision summary."""
+    summary = describe_solar_balance_state(
+        SolarBalanceState(
+            available_power=-755,
+            target_current=6,
+            current_limit_reason="low_surplus_hold_6a",
+        ),
+        "it",
+    )
+
+    assert "Mantengo 6A" in summary
+    assert "surplus calcolato" in summary
+    assert "Vincolo" in summary
+
+
+def test_decision_summary_explains_dry_run() -> None:
+    """Test dry-run summary."""
+    summary = describe_solar_balance_state(
+        SolarBalanceState(
+            status=SOLAR_BALANCE_CHARGING_SURPLUS,
+            available_power=2800,
+            target_current=12,
+            current_limit_reason="target_current",
+            dry_run=True,
+        )
+    )
+
+    assert "Dry run" in summary
+    assert "would request 12A" in summary
+    assert "no MQTT command is sent" in summary
+
+
+def test_decision_summary_reports_next_stable_surplus_release() -> None:
+    """Test stable-surplus countdown summary."""
+    summary = describe_solar_balance_state(
+        SolarBalanceState(
+            target_current=6,
+            start_delay_remaining=42,
+            current_limit_reason="waiting_stable_surplus",
+        )
+    )
+
+    assert "Waiting 42s" in summary
+    assert "Next release in 42s" in summary
+
+
+def test_decision_summary_reports_theoretical_pause_target() -> None:
+    """Test theoretical target while externally paused."""
+    summary = describe_solar_balance_state(
+        SolarBalanceState(
+            status=SOLAR_BALANCE_EXTERNAL_PAUSED,
+            current_limit_reason="external_pause",
+            theoretical_target_current=10,
+        )
+    )
+
+    assert "Theoretical target 10A" in summary
+
+
+def test_decision_summary_reports_waiting_solar_mode() -> None:
+    """Test waiting-for-solar-mode summary."""
+    summary = describe_solar_balance_state(
+        SolarBalanceState(
+            status=SOLAR_BALANCE_WAITING_SOLAR_MODE,
+            current_limit_reason="waiting_solar_mode",
+            theoretical_target_current=10,
+        )
+    )
+
+    assert "not in solar mode" in summary
+
+
+def test_decision_summary_reports_restart_from_minimum() -> None:
+    """Test restart summary starts from minimum current."""
+    summary = describe_solar_balance_state(
+        SolarBalanceState(
+            status=SOLAR_BALANCE_CHARGING_SURPLUS,
+            target_current=6,
+            current_limit_reason="restart_min_current",
+            reported_current_limit=32,
+        )
+    )
+
+    assert "Restarting from 6A" in summary
+    assert "old current limit" in summary
+
+
+def test_decision_summary_handles_disabled_and_waiting_data() -> None:
+    """Test simple waiting and disabled summaries."""
+    assert (
+        describe_solar_balance_state(SolarBalanceState(status=SOLAR_BALANCE_DISABLED))
+        == "Solar balancing is disabled."
+    )
+    assert (
+        describe_solar_balance_state(
+            SolarBalanceState(status=SOLAR_BALANCE_WAITING_DATA)
+        )
+        == "Waiting for required sensor data."
+    )
+    assert (
+        describe_solar_balance_state(
+            SolarBalanceState(status=SOLAR_BALANCE_WAITING_BATTERY_DATA)
+        )
+        == "Waiting for battery power data."
+    )

--- a/tests/components/silla_prism/test_switch.py
+++ b/tests/components/silla_prism/test_switch.py
@@ -1,0 +1,196 @@
+"""Test the Silla Prism switches."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.silla_prism.const import (
+    CONF_BATTERY_MAX_CHARGE_POWER,
+    CONF_BATTERY_POWER_SENSOR,
+    CONF_HOME_LOAD_POWER_SENSOR,
+    CONF_SOLAR_BALANCE_DRY_RUN,
+    CONF_SOLAR_BALANCE_START_DELAY,
+    CONF_SOLAR_BATTERY_BALANCE,
+    CONF_SOLAR_PRODUCTION_POWER_SENSOR,
+    DOMAIN,
+)
+from homeassistant.components.silla_prism.solar_balance import (
+    SOLAR_BALANCE_CHARGING_SURPLUS,
+    SOLAR_BALANCE_PAUSED_LOW_SURPLUS,
+    SOLAR_BALANCE_WAITING_DATA,
+    SOLAR_BALANCE_WAITING_SOLAR_MODE,
+)
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+from .const import BASE_TOPIC
+
+from tests.common import MockConfigEntry, async_fire_mqtt_message
+from tests.typing import MqttMockHAClient
+
+BATTERY_SENSOR = "sensor.home_battery_power"
+SOLAR_SENSOR = "sensor.solar_production_power"
+HOME_LOAD_SENSOR = "sensor.home_load_power"
+SWITCH_UNIQUE_ID = "prism_solar_battery_balance_001"
+
+
+def _entity_id(
+    entity_registry: er.EntityRegistry, platform: Platform, unique_id: str
+) -> str:
+    entity_id = entity_registry.async_get_entity_id(platform, DOMAIN, unique_id)
+    assert entity_id is not None
+    return entity_id
+
+
+def _solar_balance_config_entry(hass: HomeAssistant, **data: object) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Silla Prism",
+        unique_id=BASE_TOPIC,
+        data={
+            "topic": BASE_TOPIC,
+            CONF_SOLAR_BATTERY_BALANCE: True,
+            CONF_BATTERY_POWER_SENSOR: BATTERY_SENSOR,
+            CONF_SOLAR_PRODUCTION_POWER_SENSOR: SOLAR_SENSOR,
+            CONF_HOME_LOAD_POWER_SENSOR: HOME_LOAD_SENSOR,
+            CONF_BATTERY_MAX_CHARGE_POWER: 0,
+            CONF_SOLAR_BALANCE_START_DELAY: 0,
+            **data,
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def _setup_solar_balance(
+    hass: HomeAssistant, entry: MockConfigEntry, entity_registry: er.EntityRegistry
+) -> str:
+    with patch("homeassistant.components.silla_prism.PLATFORMS", [Platform.SWITCH]):
+        await setup_integration(hass, entry)
+    return _entity_id(entity_registry, Platform.SWITCH, SWITCH_UNIQUE_ID)
+
+
+async def _fire_balance_inputs(
+    hass: HomeAssistant,
+    *,
+    grid_power: str = "-3000",
+    ev_power: str = "0",
+    current_limit: str = "32",
+    voltage: str = "230",
+    mode: str = "1",
+) -> None:
+    async_fire_mqtt_message(hass, "prism/energy_data/power_grid", grid_power)
+    async_fire_mqtt_message(hass, "prism/1/w", ev_power)
+    async_fire_mqtt_message(hass, "prism/1/pilot", current_limit)
+    async_fire_mqtt_message(hass, "prism/1/volt", voltage)
+    async_fire_mqtt_message(hass, "prism/1/mode", mode)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+
+@pytest.mark.usefixtures("mqtt_mock")
+async def test_solar_balance_only_commands_in_solar_mode(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the balancer waits when Prism is not in solar control mode."""
+    entry = _solar_balance_config_entry(hass)
+    hass.states.async_set(BATTERY_SENSOR, "0")
+    hass.states.async_set(SOLAR_SENSOR, "3500")
+    hass.states.async_set(HOME_LOAD_SENSOR, "500")
+    await _setup_solar_balance(hass, entry, entity_registry)
+
+    mqtt_mock.async_publish.reset_mock()
+    await _fire_balance_inputs(hass, mode="2")
+
+    state = entry.runtime_data.solar_balance_states[1]
+    assert state.status == SOLAR_BALANCE_WAITING_SOLAR_MODE
+    assert state.theoretical_target_current == 12
+    mqtt_mock.async_publish.assert_not_called()
+
+    await _fire_balance_inputs(hass, mode="1")
+
+    state = entry.runtime_data.solar_balance_states[1]
+    assert state.status == SOLAR_BALANCE_CHARGING_SURPLUS
+    assert state.raw_target_current == 12
+    assert state.target_current == 29
+    assert tuple(call.args[:2] for call in mqtt_mock.async_publish.call_args_list) == (
+        ("prism/1/command/set_current_limit", "29"),
+        ("prism/1/command/set_mode", "1"),
+    )
+
+
+@pytest.mark.usefixtures("mqtt_mock")
+async def test_solar_balance_low_surplus_pauses_and_restarts_from_minimum(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test low surplus pauses charging and the next recovery starts at 6A."""
+    entry = _solar_balance_config_entry(hass)
+    hass.states.async_set(BATTERY_SENSOR, "0")
+    hass.states.async_set(SOLAR_SENSOR, "900")
+    hass.states.async_set(HOME_LOAD_SENSOR, "500")
+    await _setup_solar_balance(hass, entry, entity_registry)
+
+    mqtt_mock.async_publish.reset_mock()
+    await _fire_balance_inputs(hass, grid_power="1000")
+
+    state = entry.runtime_data.solar_balance_states[1]
+    assert state.status == SOLAR_BALANCE_PAUSED_LOW_SURPLUS
+    assert state.target_current == 0
+    assert tuple(call.args[:2] for call in mqtt_mock.async_publish.call_args_list) == (
+        ("prism/1/command/set_current_limit", "6"),
+        ("prism/1/command/set_mode", "3"),
+    )
+
+    mqtt_mock.async_publish.reset_mock()
+    hass.states.async_set(SOLAR_SENSOR, "5000")
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    state = entry.runtime_data.solar_balance_states[1]
+    assert state.status == SOLAR_BALANCE_CHARGING_SURPLUS
+    assert state.target_current == 6
+    assert tuple(call.args[:2] for call in mqtt_mock.async_publish.call_args_list) == (
+        ("prism/1/command/set_mode", "1"),
+    )
+
+
+@pytest.mark.usefixtures("mqtt_mock")
+async def test_solar_balance_turn_off_does_not_force_normal_mode(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test disabling the balancer does not publish an unrestricted mode."""
+    entry = _solar_balance_config_entry(hass)
+    switch_entity_id = await _setup_solar_balance(hass, entry, entity_registry)
+
+    mqtt_mock.async_publish.reset_mock()
+    switch_entity = hass.data[Platform.SWITCH].get_entity(switch_entity_id)
+    assert switch_entity is not None
+    await switch_entity.async_turn_off()
+
+    mqtt_mock.async_publish.assert_not_called()
+
+
+@pytest.mark.usefixtures("mqtt_mock")
+async def test_solar_balance_reports_missing_direct_sensor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test missing configured direct sensors are reported specifically."""
+    entry = _solar_balance_config_entry(hass, **{CONF_SOLAR_BALANCE_DRY_RUN: True})
+    hass.states.async_set(BATTERY_SENSOR, "0")
+    hass.states.async_set(SOLAR_SENSOR, "3500")
+    await _setup_solar_balance(hass, entry, entity_registry)
+
+    await _fire_balance_inputs(hass)
+
+    state = entry.runtime_data.solar_balance_states[1]
+    assert state.status == SOLAR_BALANCE_WAITING_DATA
+    assert state.missing_data_reason == "home_load_power"

--- a/tests/components/silla_prism/test_touch_events.py
+++ b/tests/components/silla_prism/test_touch_events.py
@@ -1,0 +1,37 @@
+"""Unit tests for Prism touch event parsing."""
+
+from homeassistant.components.silla_prism.touch_events import (
+    normalize_touch_payload,
+    touch_payload_matches,
+)
+
+
+def test_parses_comma_and_json_like_sequences() -> None:
+    """Test numeric touch payload sequences."""
+    assert normalize_touch_payload("1") == (1,)
+    assert normalize_touch_payload("1,1") == (1, 1)
+    assert normalize_touch_payload("[1, 1]") == (1, 1)
+
+
+def test_parses_textual_events() -> None:
+    """Test textual touch payload aliases."""
+    assert normalize_touch_payload("single") == (1,)
+    assert normalize_touch_payload("double_touch") == (2,)
+    assert normalize_touch_payload("pressione lunga") == (3,)
+
+
+def test_double_accepts_repeated_touch_and_numeric_code() -> None:
+    """Test double touch accepts firmware payload variants."""
+    accepted = ((1, 1), (2,))
+
+    assert touch_payload_matches("1,1", accepted)
+    assert touch_payload_matches("2", accepted)
+    assert touch_payload_matches("double", accepted)
+    assert not touch_payload_matches("1", accepted)
+
+
+def test_ignores_empty_or_unknown_payloads() -> None:
+    """Test empty and unknown payloads are ignored."""
+    assert normalize_touch_payload("") is None
+    assert normalize_touch_payload(None) is None
+    assert not touch_payload_matches("knock", ((1,),))


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

Update the Silla Prism integration with the full EVSE control surface currently used by the custom integration, including current limit controls, port mode selection, touch event binary sensors, virtual diagnostics, and solar battery balancing.

The solar balancing feature is intentionally included because it is the main user-facing value of the integration for PV/home-battery installations. It adjusts the Prism current only while the wallbox is in solar mode, pauses charging when surplus is below the Type 2 minimum, and restarts from 6A after a low-surplus pause.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47879
- Link to developer documentation pull request:
- Link to frontend pull request:

This branch ports the local v0.9.24 custom integration behavior into the existing Core integration. It keeps the existing Core manifest metadata, documentation URL, MQTT discovery topic, and pysillaprism dependency metadata.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

No dependency version is changed in this PR.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

## Local verification

- `/tmp/ha-core-silla-venv/bin/ruff check homeassistant/components/silla_prism tests/components/silla_prism` passed.
- `/tmp/ha-core-silla-venv/bin/ruff format homeassistant/components/silla_prism tests/components/silla_prism` passed.
- `/tmp/ha-core-silla-venv/bin/mypy --follow-imports=silent homeassistant/components/silla_prism tests/components/silla_prism/test_config_flow.py tests/components/silla_prism/test_init.py tests/components/silla_prism/test_sensor.py tests/components/silla_prism/test_touch_events.py tests/components/silla_prism/test_solar_balance.py tests/components/silla_prism/test_switch.py` passed.
- `PATH=/tmp/ha-core-silla-venv/bin:$PATH /tmp/ha-core-silla-venv/bin/python -m script.hassfest --integration-path homeassistant/components/silla_prism` passed.
- `python3 -m compileall -q homeassistant/components/silla_prism tests/components/silla_prism` passed.
- `git diff --check` passed.
- `/tmp/ha-core-silla-venv/bin/pytest -q tests/components/silla_prism/test_solar_balance.py tests/components/silla_prism/test_touch_events.py` passed.
- `/tmp/ha-core-silla-venv/bin/pytest -q tests/components/silla_prism/test_switch.py` had 4 test bodies pass locally, then failed during teardown because this temporary checkout lacks generated Core service translations for `mqtt.services.dump` / `switch.services.turn_off`. The same integration tests pass in GitHub CI where generated translations are available.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
