### PR TITLE
Fix Fibaro FGD212 dimmers not detected as dimmable lights

### DIFF
--- a/homeassistant/components/fibaro/light.py
+++ b/homeassistant/components/fibaro/light.py
@@ -79,10 +79,13 @@ class FibaroLight(FibaroEntity, LightEntity):
             or "RGBW" in fibaro_device.type
             or "rgbw" in fibaro_device.type
         )
-        supports_dimming = (
-            fibaro_device.has_interface("levelChange")
-            or fibaro_device.type == "com.fibaro.multilevelSwitch"
-        ) and "setValue" in fibaro_device.actions
+        supports_dimming = fibaro_device.has_interface("levelChange") or (
+            (
+                fibaro_device.base_type == "com.fibaro.multilevelSwitch"
+                or fibaro_device.type == "com.fibaro.multilevelSwitch"
+            )
+            and "setValue" in fibaro_device.actions
+        )
 
         if supports_color and supports_white_v:
             self._attr_supported_color_modes = {ColorMode.RGBW}

--- a/tests/components/fibaro/conftest.py
+++ b/tests/components/fibaro/conftest.py
@@ -173,6 +173,40 @@ def mock_light() -> Mock:
 
 
 @pytest.fixture
+def mock_fgd212_light() -> Mock:
+    """Fixture for an FGD212 dimmer without setValue in actions."""
+    light = Mock()
+    light.fibaro_id = 116
+    light.parent_fibaro_id = 113
+    light.name = "8 Spots"
+    light.room_id = 1
+    light.dead = False
+    light.visible = True
+    light.enabled = True
+    light.type = "com.fibaro.FGD212"
+    light.base_type = "com.fibaro.multilevelSwitch"
+    light.properties = {"manufacturer": "", "isLight": True}
+    light.actions = {
+        "configureFavoritePositions": 1,
+        "setAutoOff": 0,
+        "setFavoritePosition": 1,
+    }
+    light.supported_features = {}
+    light.has_interface.side_effect = lambda name: name == "levelChange"
+    light.raw_data = {
+        "fibaro_id": 116,
+        "name": "8 Spots",
+        "interfaces": ["levelChange", "light"],
+        "properties": {"value": 50},
+    }
+    value_mock = Mock()
+    value_mock.has_value = True
+    value_mock.int_value.return_value = 50
+    light.value = value_mock
+    return light
+
+
+@pytest.fixture
 def mock_zigbee_light() -> Mock:
     """Fixture for a dimmmable zigbee light."""
     light = Mock()

--- a/tests/components/fibaro/test_light.py
+++ b/tests/components/fibaro/test_light.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import Mock, patch
 
-from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    DOMAIN as LIGHT_DOMAIN,
+    ColorMode,
+)
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -55,6 +59,29 @@ async def test_light_brightness(
         # Assert
         state = hass.states.get("light.room_1_test_light_3")
         assert state.attributes["brightness"] == 51
+        assert state.state == "on"
+
+
+async def test_fgd212_light_brightness_without_setvalue_action(
+    hass: HomeAssistant,
+    mock_fibaro_client: Mock,
+    mock_config_entry: MockConfigEntry,
+    mock_fgd212_light: Mock,
+    mock_room: Mock,
+) -> None:
+    """Test FGD212 dimmers with levelChange but no setValue action."""
+
+    # Arrange
+    mock_fibaro_client.read_rooms.return_value = [mock_room]
+    mock_fibaro_client.read_devices.return_value = [mock_fgd212_light]
+
+    with patch("homeassistant.components.fibaro.PLATFORMS", [Platform.LIGHT]):
+        # Act
+        await init_integration(hass, mock_config_entry)
+        # Assert
+        state = hass.states.get("light.room_1_8_spots_116")
+        assert state.attributes[ATTR_BRIGHTNESS] == 128
+        assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
         assert state.state == "on"
 
 

--- a/tests/components/fibaro/test_light.py
+++ b/tests/components/fibaro/test_light.py
@@ -80,7 +80,7 @@ async def test_fgd212_light_brightness_without_setvalue_action(
         await init_integration(hass, mock_config_entry)
         # Assert
         state = hass.states.get("light.room_1_8_spots_116")
-        assert state.attributes[ATTR_BRIGHTNESS] == 128
+        assert state.attributes[ATTR_BRIGHTNESS] == 127
         assert state.attributes["color_mode"] == ColorMode.BRIGHTNESS
         assert state.state == "on"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After having problems for a long time I got this fixed with help from Cursor. Have had this fix working for a few months now.

This fixes Fibaro dimmers (and similar multilevel switches) being imported as on/off lights instead of dimmable lights.

Modern Fibaro Home Center devices expose dimmers with `base_type` `com.fibaro.multilevelSwitch` and a `levelChange` interface, but often omit `setValue` from the device actions dict. The previous logic required both `levelChange`/`multilevelSwitch` type **and** `setValue` in actions, causing dimmers to fall back to `ColorMode.ONOFF`.

This change:
- Trusts the `levelChange` interface alone for dimming support
- Also checks `base_type` for `com.fibaro.multilevelSwitch` (not just `type`)
- Keeps the legacy fallback requiring `setValue` in actions for older devices
- Adds a regression test for an FGD212 device without `setValue` in actions

Reopens the change from closed/stale PR #173567 against current `dev`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #173567
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
