### PR TITLE
Add HassSetBrightnessRelative intent for lights

### DIFF
--- a/homeassistant/components/light/intent.py
+++ b/homeassistant/components/light/intent.py
@@ -1,24 +1,38 @@
 """Intents for the light integration."""
 
 import logging
+from typing import override
 
 import voluptuous as vol
 
-from homeassistant.const import SERVICE_TURN_ON
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, intent
 from homeassistant.util import color as color_util
 
-from . import ATTR_BRIGHTNESS_PCT, ATTR_COLOR_TEMP_KELVIN, ATTR_RGB_COLOR
+from . import (
+    ATTR_BRIGHTNESS_PCT,
+    ATTR_BRIGHTNESS_STEP_PCT,
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_RGB_COLOR,
+    ATTR_SUPPORTED_COLOR_MODES,
+    brightness_supported,
+)
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 INTENT_SET = "HassLightSet"
+INTENT_SET_BRIGHTNESS_RELATIVE = "HassSetBrightnessRelative"
+
+# Used when the sentence only says "up"/"down" without an amount.
+DEFAULT_BRIGHTNESS_STEP_PCT = 10
 
 
 async def async_setup_intents(hass: HomeAssistant) -> None:
     """Set up the light intents."""
+    intent.async_register(hass, SetBrightnessRelativeHandler())
     intent.async_register(
         hass,
         intent.ServiceIntentHandler(
@@ -49,3 +63,95 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
             platforms={DOMAIN},
         ),
     )
+
+
+class SetBrightnessRelativeHandler(intent.IntentHandler):
+    """Handler for increasing or decreasing the brightness of a light."""
+
+    description = "Increases or decreases the brightness of a light"
+
+    intent_type = INTENT_SET_BRIGHTNESS_RELATIVE
+    slot_schema = {
+        vol.Required("brightness_step"): vol.Any(
+            "up",
+            "down",
+            vol.All(vol.Coerce(int), vol.Range(min=-100, max=100)),
+        ),
+        # Optional name/area/floor slots handled by intent matcher
+        vol.Optional("name"): cv.string,
+        vol.Optional("area"): cv.string,
+        vol.Optional("floor"): cv.string,
+        vol.Optional("preferred_area_id"): cv.string,
+        vol.Optional("preferred_floor_id"): cv.string,
+    }
+    platforms = {DOMAIN}
+
+    @override
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
+        """Handle the intent."""
+        hass = intent_obj.hass
+        slots = self.async_validate_slots(intent_obj.slots)
+
+        brightness_step = slots["brightness_step"]["value"]
+        if brightness_step == "up":
+            brightness_step = DEFAULT_BRIGHTNESS_STEP_PCT
+        elif brightness_step == "down":
+            brightness_step = -DEFAULT_BRIGHTNESS_STEP_PCT
+
+        match_constraints = intent.MatchTargetsConstraints(
+            name=slots.get("name", {}).get("value"),
+            area_name=slots.get("area", {}).get("value"),
+            floor_name=slots.get("floor", {}).get("value"),
+            domains={DOMAIN},
+            assistant=intent_obj.assistant,
+        )
+        match_preferences = intent.MatchTargetsPreferences(
+            area_id=slots.get("preferred_area_id", {}).get("value"),
+            floor_id=slots.get("preferred_floor_id", {}).get("value"),
+        )
+        match_result = intent.async_match_targets(
+            hass, match_constraints, match_preferences
+        )
+        if not match_result.is_match:
+            raise intent.MatchFailedError(
+                result=match_result,
+                constraints=match_constraints,
+                preferences=match_preferences,
+            )
+
+        match_result.states = [
+            state
+            for state in match_result.states
+            if brightness_supported(state.attributes.get(ATTR_SUPPORTED_COLOR_MODES))
+        ]
+        if not match_result.states:
+            raise intent.MatchFailedError(
+                result=intent.MatchTargetsResult(
+                    is_match=False, no_match_reason=intent.MatchFailedReason.FEATURE
+                ),
+                constraints=match_constraints,
+                preferences=match_preferences,
+            )
+
+        try:
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_TURN_ON,
+                {
+                    ATTR_ENTITY_ID: [state.entity_id for state in match_result.states],
+                    ATTR_BRIGHTNESS_STEP_PCT: brightness_step,
+                },
+                blocking=True,
+                context=intent_obj.context,
+            )
+        except HomeAssistantError as err:
+            _LOGGER.error("Error setting relative brightness: %s", err)
+            raise intent.IntentHandleError(
+                f"Error setting relative brightness: {err}"
+            ) from err
+
+        response = intent_obj.create_response()
+        response.async_set_states(
+            [hass.states.get(state.entity_id) or state for state in match_result.states]
+        )
+        return response

--- a/homeassistant/components/light/intent.py
+++ b/homeassistant/components/light/intent.py
@@ -98,8 +98,13 @@ class SetBrightnessRelativeHandler(intent.IntentHandler):
         elif brightness_step == "down":
             brightness_step = -DEFAULT_BRIGHTNESS_STEP_PCT
 
+        entity_name: str | None = slots.get("name", {}).get("value")
+        if entity_name == "all":
+            # Don't match on name if targeting all entities
+            entity_name = None
+
         match_constraints = intent.MatchTargetsConstraints(
-            name=slots.get("name", {}).get("value"),
+            name=entity_name,
             area_name=slots.get("area", {}).get("value"),
             floor_name=slots.get("floor", {}).get("value"),
             domains={DOMAIN},
@@ -109,25 +114,33 @@ class SetBrightnessRelativeHandler(intent.IntentHandler):
             area_id=slots.get("preferred_area_id", {}).get("value"),
             floor_id=slots.get("preferred_floor_id", {}).get("value"),
         )
-        match_result = intent.async_match_targets(
-            hass, match_constraints, match_preferences
-        )
-        if not match_result.is_match:
-            raise intent.MatchFailedError(
-                result=match_result,
-                constraints=match_constraints,
-                preferences=match_preferences,
-            )
 
-        match_result.states = [
+        # Only dimmable lights are candidates, so that a light which cannot be
+        # dimmed does not make an otherwise unambiguous name ambiguous.
+        # An empty candidate list would be treated as "match against all states".
+        brightness_states = [
             state
-            for state in match_result.states
+            for state in hass.states.async_all(DOMAIN)
             if brightness_supported(state.attributes.get(ATTR_SUPPORTED_COLOR_MODES))
         ]
-        if not match_result.states:
+        match_result = (
+            intent.async_match_targets(
+                hass, match_constraints, match_preferences, brightness_states
+            )
+            if brightness_states
+            else intent.MatchTargetsResult(False, intent.MatchFailedReason.FEATURE)
+        )
+
+        if not match_result.is_match:
+            # Report a feature failure when lights matched but none can be dimmed
+            unfiltered_result = intent.async_match_targets(
+                hass, match_constraints, match_preferences
+            )
             raise intent.MatchFailedError(
-                result=intent.MatchTargetsResult(
-                    is_match=False, no_match_reason=intent.MatchFailedReason.FEATURE
+                result=(
+                    intent.MatchTargetsResult(False, intent.MatchFailedReason.FEATURE)
+                    if unfiltered_result.is_match
+                    else unfiltered_result
                 ),
                 constraints=match_constraints,
                 preferences=match_preferences,
@@ -150,7 +163,37 @@ class SetBrightnessRelativeHandler(intent.IntentHandler):
                 f"Error setting relative brightness: {err}"
             ) from err
 
+        success_results: list[intent.IntentResponseTarget] = []
+        if match_result.floors:
+            success_results.extend(
+                intent.IntentResponseTarget(
+                    type=intent.IntentResponseTargetType.FLOOR,
+                    name=floor.name,
+                    id=floor.floor_id,
+                )
+                for floor in match_result.floors
+            )
+        elif match_result.areas:
+            success_results.extend(
+                intent.IntentResponseTarget(
+                    type=intent.IntentResponseTargetType.AREA,
+                    name=area.name,
+                    id=area.id,
+                )
+                for area in match_result.areas
+            )
+
+        success_results.extend(
+            intent.IntentResponseTarget(
+                type=intent.IntentResponseTargetType.ENTITY,
+                name=state.name,
+                id=state.entity_id,
+            )
+            for state in match_result.states
+        )
+
         response = intent_obj.create_response()
+        response.async_set_results(success_results=success_results)
         response.async_set_states(
             [hass.states.get(state.entity_id) or state for state in match_result.states]
         )

--- a/homeassistant/components/light/llm.py
+++ b/homeassistant/components/light/llm.py
@@ -7,10 +7,10 @@ from homeassistant.helpers import intent
 from homeassistant.helpers.llm import LLM_API_ASSIST, IntentTool, LLMContext, Tool
 
 from .const import DOMAIN
-from .intent import INTENT_SET
+from .intent import INTENT_SET, INTENT_SET_BRIGHTNESS_RELATIVE
 
 # Intents owned by this integration that are exposed as LLM tools.
-LLM_INTENTS = (INTENT_SET,)
+LLM_INTENTS = (INTENT_SET, INTENT_SET_BRIGHTNESS_RELATIVE)
 
 
 @callback

--- a/tests/components/light/test_intent.py
+++ b/tests/components/light/test_intent.py
@@ -6,9 +6,15 @@ from homeassistant.components import light
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES, ColorMode, intent
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_OFF, STATE_ON
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import area_registry as ar, entity_registry as er
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import (
+    area_registry as ar,
+    entity_registry as er,
+    floor_registry as fr,
+)
 from homeassistant.helpers.intent import (
+    IntentHandleError,
     IntentResponseTargetType,
     MatchFailedError,
     MatchFailedReason,
@@ -395,3 +401,63 @@ async def test_intent_set_brightness_relative_response_targets(
             "id": entry.entity_id,
         },
     ]
+
+
+async def test_intent_set_brightness_relative_floor_response_targets(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+    floor_registry: fr.FloorRegistry,
+) -> None:
+    """Test the response reports the floor when a floor is targeted."""
+    ground = floor_registry.async_create("Ground")
+    kitchen = area_registry.async_create("Kitchen")
+    area_registry.async_update(kitchen.id, floor_id=ground.floor_id)
+    entry = entity_registry.async_get_or_create("light", "test", "l1")
+    entity_registry.async_update_entity(entry.entity_id, area_id=kitchen.id)
+    hass.states.async_set(entry.entity_id, "on", DIMMABLE_ATTRIBUTES)
+
+    async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
+    await intent.async_setup_intents(hass)
+
+    response = await async_handle(
+        hass,
+        "test",
+        intent.INTENT_SET_BRIGHTNESS_RELATIVE,
+        {"floor": {"value": "Ground"}, "brightness_step": {"value": "up"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.as_dict()["data"]["success"] == [
+        {
+            "type": IntentResponseTargetType.FLOOR,
+            "name": "Ground",
+            "id": ground.floor_id,
+        },
+        {
+            "type": IntentResponseTargetType.ENTITY,
+            "name": "test l1",
+            "id": entry.entity_id,
+        },
+    ]
+
+
+async def test_intent_set_brightness_relative_service_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test a failing turn_on call is reported as an intent handling error."""
+    hass.states.async_set("light.test", "on", DIMMABLE_ATTRIBUTES)
+
+    async def raise_error(call: ServiceCall) -> None:
+        raise HomeAssistantError("Boom")
+
+    hass.services.async_register(light.DOMAIN, light.SERVICE_TURN_ON, raise_error)
+    await intent.async_setup_intents(hass)
+
+    with pytest.raises(IntentHandleError):
+        await async_handle(
+            hass,
+            "test",
+            intent.INTENT_SET_BRIGHTNESS_RELATIVE,
+            {"name": {"value": "test"}, "brightness_step": {"value": "up"}},
+        )

--- a/tests/components/light/test_intent.py
+++ b/tests/components/light/test_intent.py
@@ -9,6 +9,7 @@ from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_OFF, STAT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar, entity_registry as er
 from homeassistant.helpers.intent import (
+    IntentResponseTargetType,
     MatchFailedError,
     MatchFailedReason,
     async_handle,
@@ -288,3 +289,109 @@ async def test_intent_set_brightness_relative_skips_onoff_lights(
 
     assert err.value.result.no_match_reason == MatchFailedReason.FEATURE
     assert not calls
+
+
+async def test_intent_set_brightness_relative_unknown_name(
+    hass: HomeAssistant,
+) -> None:
+    """Test a name that matches no light is reported as a name failure."""
+    hass.states.async_set("light.test", "on", DIMMABLE_ATTRIBUTES)
+    await intent.async_setup_intents(hass)
+
+    with pytest.raises(MatchFailedError) as err:
+        await async_handle(
+            hass,
+            "test",
+            intent.INTENT_SET_BRIGHTNESS_RELATIVE,
+            {"name": {"value": "does not exist"}, "brightness_step": {"value": "up"}},
+        )
+
+    assert err.value.result.no_match_reason == MatchFailedReason.NAME
+
+
+async def test_intent_set_brightness_relative_duplicate_name(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a shared name is unambiguous when only one light can be dimmed."""
+    dimmable = entity_registry.async_get_or_create(
+        "light", "test", "l1", suggested_object_id="dimmable"
+    )
+    onoff = entity_registry.async_get_or_create(
+        "light", "test", "l2", suggested_object_id="onoff"
+    )
+    for entry in (dimmable, onoff):
+        entity_registry.async_update_entity(entry.entity_id, name="Lamp")
+    hass.states.async_set(dimmable.entity_id, "on", DIMMABLE_ATTRIBUTES)
+    hass.states.async_set(
+        onoff.entity_id, "on", {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.ONOFF]}
+    )
+
+    calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
+    await intent.async_setup_intents(hass)
+
+    await async_handle(
+        hass,
+        "test",
+        intent.INTENT_SET_BRIGHTNESS_RELATIVE,
+        {"name": {"value": "Lamp"}, "brightness_step": {"value": "up"}},
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].data.get(ATTR_ENTITY_ID) == [dimmable.entity_id]
+
+
+async def test_intent_set_brightness_relative_all(hass: HomeAssistant) -> None:
+    """Test the reserved "all" name targets every light."""
+    hass.states.async_set("light.one", "on", DIMMABLE_ATTRIBUTES)
+    hass.states.async_set("light.two", "on", DIMMABLE_ATTRIBUTES)
+    calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
+    await intent.async_setup_intents(hass)
+
+    await async_handle(
+        hass,
+        "test",
+        intent.INTENT_SET_BRIGHTNESS_RELATIVE,
+        {"name": {"value": "all"}, "brightness_step": {"value": "up"}},
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].data.get(ATTR_ENTITY_ID) == ["light.one", "light.two"]
+
+
+async def test_intent_set_brightness_relative_response_targets(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the response reports the adjusted lights as successful targets."""
+    kitchen = area_registry.async_create("Kitchen")
+    entry = entity_registry.async_get_or_create("light", "test", "l1")
+    entity_registry.async_update_entity(entry.entity_id, area_id=kitchen.id)
+    hass.states.async_set(entry.entity_id, "on", DIMMABLE_ATTRIBUTES)
+
+    async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
+    await intent.async_setup_intents(hass)
+
+    response = await async_handle(
+        hass,
+        "test",
+        intent.INTENT_SET_BRIGHTNESS_RELATIVE,
+        {"area": {"value": "Kitchen"}, "brightness_step": {"value": "up"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.as_dict()["data"]["success"] == [
+        {
+            "type": IntentResponseTargetType.AREA,
+            "name": "Kitchen",
+            "id": kitchen.id,
+        },
+        {
+            "type": IntentResponseTargetType.ENTITY,
+            "name": "test l1",
+            "id": entry.entity_id,
+        },
+    ]

--- a/tests/components/light/test_intent.py
+++ b/tests/components/light/test_intent.py
@@ -5,15 +5,22 @@ import pytest
 from homeassistant.components import light
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES, ColorMode, intent
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar, entity_registry as er
-from homeassistant.helpers.intent import MatchFailedError, async_handle
+from homeassistant.helpers.intent import (
+    MatchFailedError,
+    MatchFailedReason,
+    async_handle,
+)
 from homeassistant.setup import async_setup_component
 
-from tests.common import async_mock_service
+from .common import MockLight
+
+from tests.common import async_mock_service, setup_test_component_platform
 
 ASSISTANT = "conversation"
+DIMMABLE_ATTRIBUTES = {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.BRIGHTNESS]}
 
 
 async def test_intent_set_color(hass: HomeAssistant) -> None:
@@ -171,4 +178,113 @@ async def test_intent_set_without_name_or_area_all_unexposed(
             assistant=ASSISTANT,
         )
 
+    assert not calls
+
+
+@pytest.mark.parametrize(
+    ("brightness_step", "expected_step_pct"),
+    [
+        pytest.param("up", 10, id="up"),
+        pytest.param("down", -10, id="down"),
+        pytest.param(25, 25, id="increase_by_amount"),
+        pytest.param(-25, -25, id="decrease_by_amount"),
+    ],
+)
+async def test_intent_set_brightness_relative(
+    hass: HomeAssistant, brightness_step: str | int, expected_step_pct: int
+) -> None:
+    """Test increasing and decreasing the brightness of a light by name."""
+    hass.states.async_set("light.test", "on", DIMMABLE_ATTRIBUTES)
+    calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
+    await intent.async_setup_intents(hass)
+
+    await async_handle(
+        hass,
+        "test",
+        intent.INTENT_SET_BRIGHTNESS_RELATIVE,
+        {
+            "name": {"value": "test"},
+            "brightness_step": {"value": brightness_step},
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == light.DOMAIN
+    assert call.service == SERVICE_TURN_ON
+    assert call.data.get(ATTR_ENTITY_ID) == ["light.test"]
+    assert call.data.get(light.ATTR_BRIGHTNESS_STEP_PCT) == expected_step_pct
+
+
+async def test_intent_set_brightness_relative_includes_off_lights(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test lights that are off are adjusted too, coming up from zero brightness."""
+    kitchen = area_registry.async_create("Kitchen")
+    for unique_id, state in (("l1", "on"), ("l2", "off")):
+        entry = entity_registry.async_get_or_create("light", "test", unique_id)
+        entity_registry.async_update_entity(entry.entity_id, area_id=kitchen.id)
+        hass.states.async_set(entry.entity_id, state, DIMMABLE_ATTRIBUTES)
+
+    calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
+    await intent.async_setup_intents(hass)
+
+    await async_handle(
+        hass,
+        "test",
+        intent.INTENT_SET_BRIGHTNESS_RELATIVE,
+        {"area": {"value": "Kitchen"}, "brightness_step": {"value": 10}},
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].data.get(ATTR_ENTITY_ID) == ["light.test_l1", "light.test_l2"]
+    assert calls[0].data.get(light.ATTR_BRIGHTNESS_STEP_PCT) == 10
+
+
+async def test_intent_set_brightness_relative_from_off(hass: HomeAssistant) -> None:
+    """Test increasing brightness in a dark room brings the light up from zero."""
+    entity = MockLight("Test", STATE_OFF, {ColorMode.BRIGHTNESS})
+    setup_test_component_platform(hass, light.DOMAIN, [entity])
+    assert await async_setup_component(
+        hass, light.DOMAIN, {light.DOMAIN: {"platform": "test"}}
+    )
+    await hass.async_block_till_done()
+    await intent.async_setup_intents(hass)
+
+    await async_handle(
+        hass,
+        "test",
+        intent.INTENT_SET_BRIGHTNESS_RELATIVE,
+        {"name": {"value": "Test"}, "brightness_step": {"value": 10}},
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.test")
+    assert state.state == STATE_ON
+    assert state.attributes[light.ATTR_BRIGHTNESS] == round(255 * 0.1)
+
+
+async def test_intent_set_brightness_relative_skips_onoff_lights(
+    hass: HomeAssistant,
+) -> None:
+    """Test lights without brightness support are not adjusted."""
+    hass.states.async_set(
+        "light.test", "on", {ATTR_SUPPORTED_COLOR_MODES: [ColorMode.ONOFF]}
+    )
+    calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
+    await intent.async_setup_intents(hass)
+
+    with pytest.raises(MatchFailedError) as err:
+        await async_handle(
+            hass,
+            "test",
+            intent.INTENT_SET_BRIGHTNESS_RELATIVE,
+            {"name": {"value": "test"}, "brightness_step": {"value": "up"}},
+        )
+
+    assert err.value.result.no_match_reason == MatchFailedReason.FEATURE
     assert not calls

--- a/tests/components/light/test_llm.py
+++ b/tests/components/light/test_llm.py
@@ -1,5 +1,7 @@
 """Tests for the light LLM tools platform."""
 
+import dataclasses
+
 import pytest
 
 from homeassistant.components import llm as llm_component
@@ -60,3 +62,9 @@ async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
 async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
     """Test the platform returns None for an unsupported API."""
     assert light_llm.async_get_tools(hass, _llm_context(), "other") is None
+
+
+async def test_no_tools_without_assistant(hass: HomeAssistant) -> None:
+    """Test the platform returns None when the request has no assistant."""
+    llm_context = dataclasses.replace(_llm_context(), assistant=None)
+    assert light_llm.async_get_tools(hass, llm_context, "assist") is None

--- a/tests/components/light/test_llm.py
+++ b/tests/components/light/test_llm.py
@@ -42,14 +42,18 @@ async def _tool_names(hass: HomeAssistant) -> set[str]:
 
 
 async def test_intent_tool_exposed(hass: HomeAssistant) -> None:
-    """Test the intent tool is offered for an exposed light entity."""
-    assert "light__HassLightSet" in await _tool_names(hass)
+    """Test the intent tools are offered for an exposed light entity."""
+    tool_names = await _tool_names(hass)
+    assert "light__HassLightSet" in tool_names
+    assert "light__HassSetBrightnessRelative" in tool_names
 
 
 async def test_intent_tool_not_exposed(hass: HomeAssistant) -> None:
-    """Test the intent tool is hidden when no light entity is exposed."""
+    """Test the intent tools are hidden when no light entity is exposed."""
     async_expose_entity(hass, "conversation", ENTITY_ID, False)
-    assert "light__HassLightSet" not in await _tool_names(hass)
+    tool_names = await _tool_names(hass)
+    assert "light__HassLightSet" not in tool_names
+    assert "light__HassSetBrightnessRelative" not in tool_names
     assert light_llm.async_get_tools(hass, _llm_context(), "assist") is None
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a `HassSetBrightnessRelative` intent so lights can be brightened or dimmed by a relative amount ("make it brighter", "dim the lights", "increase the brightness by 20%"). Today `HassLightSet` can only set an absolute brightness percentage.

The intent is modelled directly on `HassSetVolumeRelative`. The required `brightness_step` slot accepts `"up"`, `"down"`, or a signed percentage from -100 to 100. `"up"`/`"down"` map to ±10% since lights have no per-entity step attribute to defer to. The value is passed to `light.turn_on` as `brightness_step_pct`, so the light component does the per-entity arithmetic and clamping, including turning the light off when the step reaches 0.

A few notes on the design:

- **Why a new intent rather than extending `HassLightSet`.** `HassLightSet` is a `ServiceIntentHandler`, i.e. a static slot-to-service-data mapping. It cannot express that `brightness` and `brightness_step` are mutually exclusive (sending both would fail inside `light.turn_on`'s `vol.Exclusive` group and surface as a generic service error), and it cannot filter out lights that don't support brightness. A single LLM tool carrying both an absolute 0-100 `brightness` and a relative -100..100 `brightness_step` is also easy for a model to confuse.
- **Lights that are off are included.** Stepping up from an off light brings it on at the step value, which is what "increase the brightness by 10%" means in a dark room.
- **Lights without brightness support are skipped**, so on/off-only lights don't report "brightness set" after a no-op. If none of the matched lights support brightness, the intent raises a match failure with `MatchFailedReason.FEATURE`.

The intent is registered as an LLM tool alongside `HassLightSet`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Sentences for the new intent still need to be added to the [intents](https://github.com/home-assistant/intents) repo before it is reachable from the default conversation agent. Until then it is available to LLM-based agents and via the intent API.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
