### PR TITLE
Fix Openhome players becoming unavailable between polls

### DIFF
--- a/homeassistant/components/openhome/__init__.py
+++ b/homeassistant/components/openhome/__init__.py
@@ -2,15 +2,15 @@
 
 import logging
 
-import aiohttp
-from async_upnp_client.client import UpnpError
 from openhomedevice.device import Device
+from openhomedevice.exceptions import OpenhomeError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
@@ -37,11 +37,11 @@ async def async_setup_entry(
     """Set up the configuration config entry."""
     _LOGGER.debug("Setting up config entry: %s", config_entry.unique_id)
 
-    device = await hass.async_add_executor_job(Device, config_entry.data[CONF_HOST])
+    device = Device(config_entry.data[CONF_HOST], session=async_get_clientsession(hass))
 
     try:
         await device.init()
-    except (TimeoutError, aiohttp.ClientError, UpnpError) as exc:
+    except OpenhomeError as exc:
         raise ConfigEntryNotReady from exc
 
     _LOGGER.debug("Initialised device: %s", device.uuid())

--- a/homeassistant/components/openhome/manifest.json
+++ b/homeassistant/components/openhome/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["async_upnp_client", "openhomedevice"],
-  "requirements": ["openhomedevice==2.2.0"],
+  "requirements": ["openhomedevice==2.5"],
   "ssdp": [
     {
       "st": "urn:av-openhome-org:service:Product:1"

--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -5,8 +5,7 @@ import functools
 import logging
 from typing import Any, Concatenate, override
 
-import aiohttp
-from async_upnp_client.client import UpnpError
+from openhomedevice.exceptions import OpenhomeError
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
@@ -58,7 +57,7 @@ type _ReturnFuncType[_T, **_P, _R] = Callable[
 def catch_request_errors[_OpenhomeDeviceT: OpenhomeDevice, **_P, _R]() -> Callable[
     [_FuncType[_OpenhomeDeviceT, _P, _R]], _ReturnFuncType[_OpenhomeDeviceT, _P, _R]
 ]:
-    """Catch TimeoutError, aiohttp.ClientError, UpnpError errors."""
+    """Catch OpenhomeError errors."""
 
     def call_wrapper(
         func: _FuncType[_OpenhomeDeviceT, _P, _R],
@@ -69,11 +68,11 @@ def catch_request_errors[_OpenhomeDeviceT: OpenhomeDevice, **_P, _R]() -> Callab
         async def wrapper(
             self: _OpenhomeDeviceT, *args: _P.args, **kwargs: _P.kwargs
         ) -> _R | None:
-            """Catch TimeoutError, aiohttp.ClientError, UpnpError errors."""
+            """Catch OpenhomeError errors."""
             try:
                 return await func(self, *args, **kwargs)
-            except TimeoutError, aiohttp.ClientError, UpnpError:
-                _LOGGER.error("Error during call %s", func.__name__)
+            except OpenhomeError as err:
+                _LOGGER.error("Error during call %s: %s", func.__name__, err)
             return None
 
         return wrapper
@@ -169,7 +168,9 @@ class OpenhomeDevice(MediaPlayerEntity):
                 self._attr_state = MediaPlayerState.PLAYING
 
             self._attr_available = True
-        except TimeoutError, aiohttp.ClientError, UpnpError:
+        except OpenhomeError as err:
+            if self._attr_available:
+                _LOGGER.warning("Error updating %s: %s", self.entity_id, err)
             self._attr_available = False
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
@@ -263,7 +264,7 @@ class OpenhomeDevice(MediaPlayerEntity):
                 await self._device.invoke_pin(pin)
             else:
                 _LOGGER.error("Pins service not supported")
-        except UpnpError:
+        except OpenhomeError:
             _LOGGER.error("Error invoking pin %s", pin)
 
     # pylint: disable-next=home-assistant-action-swallowed-exception

--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -264,8 +264,8 @@ class OpenhomeDevice(MediaPlayerEntity):
                 await self._device.invoke_pin(pin)
             else:
                 _LOGGER.error("Pins service not supported")
-        except OpenhomeError:
-            _LOGGER.error("Error invoking pin %s", pin)
+        except OpenhomeError as err:
+            _LOGGER.error("Error invoking pin %s: %s", pin, err)
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()

--- a/homeassistant/components/openhome/update.py
+++ b/homeassistant/components/openhome/update.py
@@ -3,8 +3,7 @@
 import logging
 from typing import Any, override
 
-import aiohttp
-from async_upnp_client.client import UpnpError
+from openhomedevice.exceptions import OpenhomeError
 
 from homeassistant.components.update import (
     UpdateDeviceClass,
@@ -92,7 +91,7 @@ class OpenhomeUpdateEntity(UpdateEntity):
         try:
             if self.latest_version:
                 await self._device.update_firmware()
-        except (TimeoutError, aiohttp.ClientError, UpnpError) as err:
+        except OpenhomeError as err:
             raise HomeAssistantError(
                 f"Error updating {self._device.device.friendly_name}: {err}"
             ) from err

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1824,7 +1824,7 @@ openai==2.45.0
 openerz-api==0.3.0
 
 # homeassistant.components.openhome
-openhomedevice==2.2.0
+openhomedevice==2.5
 
 # homeassistant.components.openrgb
 openrgb-python==0.3.6

--- a/tests/components/openhome/test_init.py
+++ b/tests/components/openhome/test_init.py
@@ -1,0 +1,37 @@
+"""Tests for the Openhome integration setup."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.openhome.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from tests.common import MockConfigEntry
+
+HOST = "http://localhost"
+
+
+async def test_device_uses_shared_session(hass: HomeAssistant) -> None:
+    """Test the device is given Home Assistant's shared aiohttp session.
+
+    Without the session the library falls back to a requester that opens a new
+    session per request and never retries, so a single timed out call drops the
+    whole poll and marks the device unavailable.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: HOST}, unique_id="uuid")
+    entry.add_to_hass(hass)
+
+    with (
+        patch("homeassistant.components.openhome.PLATFORMS", []),
+        patch("homeassistant.components.openhome.Device", MagicMock()) as mock_device,
+    ):
+        mock_device.return_value.init = AsyncMock()
+        mock_device.return_value.uuid = MagicMock(return_value="uuid")
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    mock_device.assert_called_once_with(HOST, session=async_get_clientsession(hass))

--- a/tests/components/openhome/test_init.py
+++ b/tests/components/openhome/test_init.py
@@ -14,12 +14,7 @@ HOST = "http://localhost"
 
 
 async def test_device_uses_shared_session(hass: HomeAssistant) -> None:
-    """Test the device is given Home Assistant's shared aiohttp session.
-
-    Without the session the library falls back to a requester that opens a new
-    session per request and never retries, so a single timed out call drops the
-    whole poll and marks the device unavailable.
-    """
+    """Test the device is given Home Assistant's shared aiohttp session."""
     entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: HOST}, unique_id="uuid")
     entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Bump the upstream library openhomedevice to 2.5, use shared client and log all errors. 

The main fix here is in https://github.com/bazwilliams/openhomedevice/releases/tag/2.5

There are other changes included in that library in including a metadata escaping fix and support for songcast (not used by this integration) detailed in https://github.com/bazwilliams/openhomedevice/compare/2.2...2.5

Problem: 
async_update makes nine UPnP calls per poll during a ten second scan interval within a single try/except. Any failure marks the entity unavailable until the next successful poll.

openhomedevice 2.2 used async_upnp_client's AiohttpRequester, which applies a five second timeout per request and never retries. All nine calls share one try/except, so a single timed out call aborts the whole poll and the device is marked unavailable until the next poll recovers it around five seconds later. 

openhomedevice 2.5 can be given Home Assistant's shared aiohttp session. Passing a session makes it use async_upnp_client's AiohttpSessionRequester rather than AiohttpRequester, and that retries a failed request up to three times. UpnpConnectionTimeoutError subclasses aiohttp.ClientConnectionError, so the timeouts above are retried. openhomedevice 2.5 also translates async_upnp_client and aiohttp errors into its own exception hierarchy, so we can catch `OpenhomeError` instead, and the integration now logs the error rather than discarding it. 

init test added to assert that the shared aiohttp session is used

Fixes https://github.com/home-assistant/core/issues/175964

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/175964
- This PR is related to issue: https://github.com/home-assistant/core/issues/175964
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

