### PR TITLE
Trim cached orjson fragments kept by registries

### DIFF
--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -14,7 +14,7 @@ from homeassistant.util.event_type import EventType
 from homeassistant.util.hass_dict import HassKey
 
 from . import device_registry as dr
-from .json import json_bytes, json_fragment
+from .json import cached_json_fragment, json_fragment
 from .normalized_name_base_registry import (
     NormalizedNameBaseRegistryEntry,
     NormalizedNameBaseRegistryItems,
@@ -87,22 +87,20 @@ class AreaEntry(NormalizedNameBaseRegistryEntry):
     @under_cached_property
     def json_fragment(self) -> json_fragment:
         """Return a JSON representation of this AreaEntry."""
-        return json_fragment(
-            json_bytes(
-                {
-                    "aliases": list(self.aliases),
-                    "area_id": self.id,
-                    "floor_id": self.floor_id,
-                    "humidity_entity_id": self.humidity_entity_id,
-                    "icon": self.icon,
-                    "labels": list(self.labels),
-                    "name": self.name,
-                    "picture": self.picture,
-                    "temperature_entity_id": self.temperature_entity_id,
-                    "created_at": self.created_at.timestamp(),
-                    "modified_at": self.modified_at.timestamp(),
-                }
-            )
+        return cached_json_fragment(
+            {
+                "aliases": list(self.aliases),
+                "area_id": self.id,
+                "floor_id": self.floor_id,
+                "humidity_entity_id": self.humidity_entity_id,
+                "icon": self.icon,
+                "labels": list(self.labels),
+                "name": self.name,
+                "picture": self.picture,
+                "temperature_entity_id": self.temperature_entity_id,
+                "created_at": self.created_at.timestamp(),
+                "modified_at": self.modified_at.timestamp(),
+            }
         )
 
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -52,7 +52,13 @@ from .frame import (
     get_integration_frame,
     report_usage,
 )
-from .json import JSON_DUMP, find_paths_unserializable_data, json_bytes, json_fragment
+from .json import (
+    JSON_DUMP,
+    cached_json_fragment,
+    find_paths_unserializable_data,
+    json_bytes,
+    json_fragment,
+)
 from .registry import BaseRegistry, BaseRegistryItems, RegistryIndexType
 from .typing import UNDEFINED, UndefinedType
 
@@ -564,39 +570,35 @@ class DeviceEntry(BaseDeviceEntry):
     @under_cached_property
     def as_storage_fragment(self) -> json_fragment:
         """Return a json fragment for storage."""
-        return json_fragment(
-            json_bytes(
-                {
-                    "area_id": self.area_id,
-                    "config_entry_id": self.config_entry_id,
-                    "config_subentry_id": self.config_subentry_id,
-                    "configuration_url": self.configuration_url,
-                    "connections": list(self.connections),
-                    "created_at": self.created_at,
-                    "disabled_by": self.disabled_by,
-                    "entry_type": self.entry_type,
-                    "hw_version": self.hw_version,
-                    "id": self.id,
-                    "identifiers": list(self.identifiers),
-                    "labels": list(self.labels),
-                    "composite_device_id": self.composite_device_id,
-                    "composite_primary_config_entry": (
-                        self.composite_primary_config_entry
-                    ),
-                    "split_at": self.split_at,
-                    "manufacturer": self.manufacturer,
-                    "model": self.model,
-                    "model_id": self.model_id,
-                    "modified_at": self.modified_at,
-                    "name_by_user": self.name_by_user,
-                    "name": self.name,
-                    "has_composite_identifiers": (self.has_composite_identifiers),
-                    "primary_config_entry": self.primary_config_entry,
-                    "serial_number": self.serial_number,
-                    "sw_version": self.sw_version,
-                    "via_device_id": self.via_device_id,
-                }
-            )
+        return cached_json_fragment(
+            {
+                "area_id": self.area_id,
+                "config_entry_id": self.config_entry_id,
+                "config_subentry_id": self.config_subentry_id,
+                "configuration_url": self.configuration_url,
+                "connections": list(self.connections),
+                "created_at": self.created_at,
+                "disabled_by": self.disabled_by,
+                "entry_type": self.entry_type,
+                "hw_version": self.hw_version,
+                "id": self.id,
+                "identifiers": list(self.identifiers),
+                "labels": list(self.labels),
+                "composite_device_id": self.composite_device_id,
+                "composite_primary_config_entry": self.composite_primary_config_entry,
+                "split_at": self.split_at,
+                "manufacturer": self.manufacturer,
+                "model": self.model,
+                "model_id": self.model_id,
+                "modified_at": self.modified_at,
+                "name_by_user": self.name_by_user,
+                "name": self.name,
+                "has_composite_identifiers": (self.has_composite_identifiers),
+                "primary_config_entry": self.primary_config_entry,
+                "serial_number": self.serial_number,
+                "sw_version": self.sw_version,
+                "via_device_id": self.via_device_id,
+            }
         )
 
     @property
@@ -686,23 +688,21 @@ class ChildDeviceEntry(BaseDeviceEntry):
     @under_cached_property
     def as_storage_fragment(self) -> json_fragment:
         """Return a json fragment for storage."""
-        return json_fragment(
-            json_bytes(
-                {
-                    "area_id": self.area_id,
-                    "config_entry_id": self.config_entry_id,
-                    "config_subentry_id": self.config_subentry_id,
-                    "created_at": self.created_at,
-                    "disabled_by": self.disabled_by,
-                    "id": self.id,
-                    "identifiers": list(self.identifiers),
-                    "labels": list(self.labels),
-                    "modified_at": self.modified_at,
-                    "name_by_user": self.name_by_user,
-                    "name": self.name,
-                    "parent_device_id": self.parent_device_id,
-                }
-            )
+        return cached_json_fragment(
+            {
+                "area_id": self.area_id,
+                "config_entry_id": self.config_entry_id,
+                "config_subentry_id": self.config_subentry_id,
+                "created_at": self.created_at,
+                "disabled_by": self.disabled_by,
+                "id": self.id,
+                "identifiers": list(self.identifiers),
+                "labels": list(self.labels),
+                "modified_at": self.modified_at,
+                "name_by_user": self.name_by_user,
+                "name": self.name,
+                "parent_device_id": self.parent_device_id,
+            }
         )
 
 
@@ -849,27 +849,25 @@ class DeletedDeviceEntry:
     @under_cached_property
     def as_storage_fragment(self) -> json_fragment:
         """Return a json fragment for storage."""
-        return json_fragment(
-            json_bytes(
-                {
-                    "area_id": self.area_id,
-                    "config_entry_id": self.config_entry_id,
-                    "config_subentry_id": self.config_subentry_id,
-                    "connections": list(self.connections),
-                    "created_at": self.created_at,
-                    "disabled_by": self.disabled_by
-                    if self.disabled_by is not UNDEFINED
-                    else None,
-                    "disabled_by_undefined": self.disabled_by is UNDEFINED,
-                    "identifiers": list(self.identifiers),
-                    "id": self.id,
-                    "labels": list(self.labels),
-                    "modified_at": self.modified_at,
-                    "name_by_user": self.name_by_user,
-                    "orphaned_timestamp": self.orphaned_timestamp,
-                    "domain": self.domain,
-                }
-            )
+        return cached_json_fragment(
+            {
+                "area_id": self.area_id,
+                "config_entry_id": self.config_entry_id,
+                "config_subentry_id": self.config_subentry_id,
+                "connections": list(self.connections),
+                "created_at": self.created_at,
+                "disabled_by": self.disabled_by
+                if self.disabled_by is not UNDEFINED
+                else None,
+                "disabled_by_undefined": self.disabled_by is UNDEFINED,
+                "identifiers": list(self.identifiers),
+                "id": self.id,
+                "labels": list(self.labels),
+                "modified_at": self.modified_at,
+                "name_by_user": self.name_by_user,
+                "orphaned_timestamp": self.orphaned_timestamp,
+                "domain": self.domain,
+            }
         )
 
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -54,9 +54,9 @@ from .frame import (
 )
 from .json import (
     JSON_DUMP,
+    cached_json_bytes,
     cached_json_fragment,
     find_paths_unserializable_data,
-    json_bytes,
     json_fragment,
 )
 from .registry import BaseRegistry, BaseRegistryItems, RegistryIndexType
@@ -441,7 +441,7 @@ class BaseDeviceEntry:
         """Return a cached JSON representation of the entry."""
         try:
             dict_repr = self.dict_repr
-            return json_bytes(dict_repr)
+            return cached_json_bytes(dict_repr)
         except ValueError, TypeError:
             _LOGGER.error(
                 "Unable to serialize entry %s to JSON. Bad data found at %s",

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -55,9 +55,9 @@ from .device_registry import (
 from .frame import ReportBehavior, report_usage
 from .json import (
     JSON_DUMP,
+    cached_json_bytes,
     cached_json_fragment,
     find_paths_unserializable_data,
-    json_bytes,
     json_fragment,
 )
 from .registry import BaseRegistry, BaseRegistryItems, RegistryIndexType
@@ -325,7 +325,9 @@ class RegistryEntry:
         """
         try:
             dict_repr = self._as_display_dict
-            json_repr: bytes | None = json_bytes(dict_repr) if dict_repr else None
+            json_repr: bytes | None = (
+                cached_json_bytes(dict_repr) if dict_repr else None
+            )
         except ValueError, TypeError:
             _LOGGER.error(
                 "Unable to serialize entry %s to JSON. Bad data found at %s",
@@ -392,7 +394,7 @@ class RegistryEntry:
         """Return a cached partial JSON representation of the entry."""
         try:
             dict_repr = self.as_partial_dict
-            return json_bytes(dict_repr)
+            return cached_json_bytes(dict_repr)
         except ValueError, TypeError:
             _LOGGER.error(
                 "Unable to serialize entry %s to JSON. Bad data found at %s",

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -53,7 +53,13 @@ from .device_registry import (
     EventDeviceRegistryUpdatedData,
 )
 from .frame import ReportBehavior, report_usage
-from .json import JSON_DUMP, find_paths_unserializable_data, json_bytes, json_fragment
+from .json import (
+    JSON_DUMP,
+    cached_json_fragment,
+    find_paths_unserializable_data,
+    json_bytes,
+    json_fragment,
+)
 from .registry import BaseRegistry, BaseRegistryItems, RegistryIndexType
 from .singleton import singleton
 from .typing import UNDEFINED, UndefinedType
@@ -400,43 +406,41 @@ class RegistryEntry:
     @under_cached_property
     def as_storage_fragment(self) -> json_fragment:
         """Return a json fragment for storage."""
-        return json_fragment(
-            json_bytes(
-                {
-                    "aliases": self.compat_aliases,
-                    "aliases_v2": _serialize_aliases(self.aliases),
-                    "area_id": self.area_id,
-                    "categories": self.categories,
-                    "capabilities": self.capabilities,
-                    "config_entry_id": self.config_entry_id,
-                    "config_subentry_id": self.config_subentry_id,
-                    "created_at": self.created_at,
-                    "device_class": self.device_class,
-                    "device_id": self.device_id,
-                    "disabled_by": self.disabled_by,
-                    "entity_category": self.entity_category,
-                    "entity_id": self.entity_id,
-                    "hidden_by": self.hidden_by,
-                    "icon": self.icon,
-                    "id": self.id,
-                    "has_entity_name": self.has_entity_name,
-                    "labels": list(self.labels),
-                    "modified_at": self.modified_at,
-                    "name": self.name,
-                    "object_id_base": self.object_id_base,
-                    "options": self.options,
-                    "original_device_class": self.original_device_class,
-                    "original_icon": self.original_icon,
-                    "original_name": self.original_name,
-                    "platform": self.platform,
-                    "suggested_object_id": self.suggested_object_id,
-                    "supported_features": self.supported_features,
-                    "translation_key": self.translation_key,
-                    "unique_id": self.unique_id,
-                    "previous_unique_id": self.previous_unique_id,
-                    "unit_of_measurement": self.unit_of_measurement,
-                }
-            )
+        return cached_json_fragment(
+            {
+                "aliases": self.compat_aliases,
+                "aliases_v2": _serialize_aliases(self.aliases),
+                "area_id": self.area_id,
+                "categories": self.categories,
+                "capabilities": self.capabilities,
+                "config_entry_id": self.config_entry_id,
+                "config_subentry_id": self.config_subentry_id,
+                "created_at": self.created_at,
+                "device_class": self.device_class,
+                "device_id": self.device_id,
+                "disabled_by": self.disabled_by,
+                "entity_category": self.entity_category,
+                "entity_id": self.entity_id,
+                "hidden_by": self.hidden_by,
+                "icon": self.icon,
+                "id": self.id,
+                "has_entity_name": self.has_entity_name,
+                "labels": list(self.labels),
+                "modified_at": self.modified_at,
+                "name": self.name,
+                "object_id_base": self.object_id_base,
+                "options": self.options,
+                "original_device_class": self.original_device_class,
+                "original_icon": self.original_icon,
+                "original_name": self.original_name,
+                "platform": self.platform,
+                "suggested_object_id": self.suggested_object_id,
+                "supported_features": self.supported_features,
+                "translation_key": self.translation_key,
+                "unique_id": self.unique_id,
+                "previous_unique_id": self.previous_unique_id,
+                "unit_of_measurement": self.unit_of_measurement,
+            }
         )
 
     @callback
@@ -738,38 +742,36 @@ class DeletedRegistryEntry:
     @under_cached_property
     def as_storage_fragment(self) -> json_fragment:
         """Return a json fragment for storage."""
-        return json_fragment(
-            json_bytes(
-                {
-                    "aliases": self.compat_aliases,
-                    "aliases_v2": _serialize_aliases(self.aliases),
-                    "area_id": self.area_id,
-                    "categories": self.categories,
-                    "config_entry_id": self.config_entry_id,
-                    "config_subentry_id": self.config_subentry_id,
-                    "created_at": self.created_at,
-                    "device_class": self.device_class,
-                    "disabled_by": self.disabled_by
-                    if self.disabled_by is not UNDEFINED
-                    else None,
-                    "disabled_by_undefined": self.disabled_by is UNDEFINED,
-                    "entity_id": self.entity_id,
-                    "hidden_by": self.hidden_by
-                    if self.hidden_by is not UNDEFINED
-                    else None,
-                    "hidden_by_undefined": self.hidden_by is UNDEFINED,
-                    "icon": self.icon,
-                    "id": self.id,
-                    "labels": list(self.labels),
-                    "modified_at": self.modified_at,
-                    "name": self.name,
-                    "options": self.options if self.options is not UNDEFINED else {},
-                    "options_undefined": self.options is UNDEFINED,
-                    "orphaned_timestamp": self.orphaned_timestamp,
-                    "platform": self.platform,
-                    "unique_id": self.unique_id,
-                }
-            )
+        return cached_json_fragment(
+            {
+                "aliases": self.compat_aliases,
+                "aliases_v2": _serialize_aliases(self.aliases),
+                "area_id": self.area_id,
+                "categories": self.categories,
+                "config_entry_id": self.config_entry_id,
+                "config_subentry_id": self.config_subentry_id,
+                "created_at": self.created_at,
+                "device_class": self.device_class,
+                "disabled_by": self.disabled_by
+                if self.disabled_by is not UNDEFINED
+                else None,
+                "disabled_by_undefined": self.disabled_by is UNDEFINED,
+                "entity_id": self.entity_id,
+                "hidden_by": self.hidden_by
+                if self.hidden_by is not UNDEFINED
+                else None,
+                "hidden_by_undefined": self.hidden_by is UNDEFINED,
+                "icon": self.icon,
+                "id": self.id,
+                "labels": list(self.labels),
+                "modified_at": self.modified_at,
+                "name": self.name,
+                "options": self.options if self.options is not UNDEFINED else {},
+                "options_undefined": self.options is UNDEFINED,
+                "orphaned_timestamp": self.orphaned_timestamp,
+                "platform": self.platform,
+                "unique_id": self.unique_id,
+            }
         )
 
 

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -116,6 +116,19 @@ def json_bytes_strip_null(data: Any) -> bytes:
 json_fragment = orjson.Fragment
 
 
+def cached_json_fragment(data: Any) -> orjson.Fragment:
+    """Return a json fragment right-sized for long-term caching.
+
+    orjson over-allocates the returned bytes buffer and does not shrink it (the
+    logical length is set but the allocation is rounded up to a power-of-two
+    floor), so a fragment cached for the lifetime of a long-lived object retains
+    several KiB of unused buffer per object. Copy the bytes to a right-sized
+    buffer before wrapping them, which matters when many such fragments are cached
+    at once (e.g. one per deleted device registry entry).
+    """
+    return orjson.Fragment(bytes(memoryview(json_bytes(data))))
+
+
 def json_dumps(data: Any) -> str:
     r"""Dump json string.
 

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -116,15 +116,23 @@ def json_bytes_strip_null(data: Any) -> bytes:
 json_fragment = orjson.Fragment
 
 
-def cached_json_fragment(data: Any) -> orjson.Fragment:
-    """Return a json fragment right-sized for long-term caching.
+def cached_json_bytes(data: Any) -> bytes:
+    """Return json bytes right-sized for long-term caching.
 
     orjson over-allocates the returned bytes buffer and does not shrink it: the
     logical length is set but the capacity is rounded up to a power of two (at
-    least a few KiB), so a fragment cached for the lifetime of a long-lived
-    object retains several KiB of unused buffer. Copy the bytes to a right-sized
-    buffer before wrapping them, which matters when many such fragments are
-    cached at once.
+    least a few KiB), so bytes cached for the lifetime of a long-lived object
+    retain several KiB of unused buffer.
+    """
+    # Drop orjson's over-allocated slack with help of a memoryview.
+    return bytes(memoryview(json_bytes(data)))
+
+
+def cached_json_fragment(data: Any) -> orjson.Fragment:
+    """Return a json fragment right-sized for long-term caching.
+
+    Wraps the same right-sized bytes as cached_json_bytes; the body is inlined
+    rather than calling it to avoid an extra function call on this hot path.
     """
     # Drop orjson's over-allocated slack with help of a memoryview.
     return orjson.Fragment(bytes(memoryview(json_bytes(data))))

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -119,13 +119,14 @@ json_fragment = orjson.Fragment
 def cached_json_fragment(data: Any) -> orjson.Fragment:
     """Return a json fragment right-sized for long-term caching.
 
-    orjson over-allocates the returned bytes buffer and does not shrink it (the
-    logical length is set but the allocation is rounded up to a power-of-two
-    floor), so a fragment cached for the lifetime of a long-lived object retains
-    several KiB of unused buffer per object. Copy the bytes to a right-sized
-    buffer before wrapping them, which matters when many such fragments are cached
-    at once (e.g. one per deleted device registry entry).
+    orjson over-allocates the returned bytes buffer and does not shrink it: the
+    logical length is set but the capacity is rounded up to a power of two (at
+    least a few KiB), so a fragment cached for the lifetime of a long-lived
+    object retains several KiB of unused buffer. Copy the bytes to a right-sized
+    buffer before wrapping them, which matters when many such fragments are
+    cached at once.
     """
+    # Drop orjson's over-allocated slack with help of a memoryview.
     return orjson.Fragment(bytes(memoryview(json_bytes(data))))
 
 

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -16,7 +16,9 @@ from homeassistant.core import Event, HomeAssistant, State
 from homeassistant.helpers.json import (
     ExtendedJSONEncoder,
     JSONEncoder as DefaultHASSJSONEncoder,
+    cached_json_fragment,
     find_paths_unserializable_data,
+    json_bytes,
     json_bytes_sorted,
     json_bytes_strip_null,
     json_dumps,
@@ -205,6 +207,19 @@ def test_json_fragments() -> None:
     assert (
         json_dumps([Fragment1(), Fragment2()])
         == '[{"inner":"fragment1"},{"inner":"fragment2"}]'
+    )
+
+
+def test_cached_json_fragment() -> None:
+    """Test cached_json_fragment serializes identically to a plain fragment."""
+    data = {"a": 1, "b": [1, 2, 3], "c": {"nested": True}, "d": None}
+
+    fragment = cached_json_fragment(data)
+    assert isinstance(fragment, json_fragment)
+    # The right-sized copy embeds the same bytes as the plain fragment path.
+    assert json_dumps([fragment]) == json_dumps([json_fragment(json_bytes(data))])
+    assert (
+        json_dumps([fragment]) == '[{"a":1,"b":[1,2,3],"c":{"nested":true},"d":null}]'
     )
 
 

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -19,6 +19,7 @@ from homeassistant.core import Event, HomeAssistant, State
 from homeassistant.helpers.json import (
     ExtendedJSONEncoder,
     JSONEncoder as DefaultHASSJSONEncoder,
+    cached_json_bytes,
     cached_json_fragment,
     find_paths_unserializable_data,
     json_bytes,
@@ -226,43 +227,56 @@ def test_cached_json_fragment() -> None:
     )
 
 
-def test_cached_json_fragment_trims_buffer() -> None:
-    """Test cached_json_fragment drops orjson's over-allocated buffer.
+def test_cached_json_bytes() -> None:
+    """Test cached_json_bytes serializes identically to json_bytes."""
+    data = {"a": 1, "b": [1, 2, 3], "c": {"nested": True}, "d": None}
+
+    assert cached_json_bytes(data) == json_bytes(data)
+    assert (
+        cached_json_bytes(data) == b'{"a":1,"b":[1,2,3],"c":{"nested":true},"d":null}'
+    )
+
+
+@pytest.mark.parametrize(
+    "cached_serializer",
+    [cached_json_bytes, cached_json_fragment],
+    ids=["cached_json_bytes", "cached_json_fragment"],
+)
+def test_cached_json_helpers_trim_buffer(
+    cached_serializer: Callable[[Any], object],
+) -> None:
+    """Test the cached_json_* helpers cache right-sized bytes, not orjson's slack.
 
     orjson.dumps returns bytes whose backing buffer is rounded up to a power of
-    two and not shrunk; cached_json_fragment copies them to a right-sized buffer.
-    Without that copy the cached fragment retains the full over-allocated buffer,
-    which is the memory regression this guards against.
+    two and not shrunk; the helpers copy them to a right-sized buffer. Without
+    that copy the cached value would retain the full over-allocated buffer
+    (several KiB even for a small payload), which is the memory regression this
+    guards against.
 
-    The over-allocation is invisible to normal object inspection: sys.getsizeof()
-    reports the logical length, not the backing buffer, and orjson.Fragment
-    exposes no way to reach the bytes it wraps. So the actual retained allocation
-    can only be observed via tracemalloc.
+    The waste is invisible to normal object inspection: sys.getsizeof() reports
+    the logical length, not the backing buffer, and orjson.Fragment exposes no way
+    to reach the bytes it wraps, so the retained allocation can only be observed
+    via tracemalloc.
     """
-    # A payload large enough that orjson's over-allocation is clearly visible.
     data = {f"key_{index}": "value" * 5 for index in range(40)}
     serialized_size = len(json_bytes(data))
 
-    def retained_bytes(make: Callable[[], object]) -> int:
-        gc.collect()
-        before, _ = tracemalloc.get_traced_memory()
-        obj = make()
-        gc.collect()  # free the transient over-allocated buffer, keep only `obj`
-        after, _ = tracemalloc.get_traced_memory()
-        assert obj is not None  # keep the fragment alive until measured
-        return after - before
-
     tracemalloc.start()
     try:
-        over_allocated = retained_bytes(lambda: json_fragment(json_bytes(data)))
-        right_sized = retained_bytes(lambda: cached_json_fragment(data))
+        # clear_traces resets the baseline to zero so pre-existing garbage from
+        # the test session is not counted; the transient over-allocated buffer is
+        # freed by refcounting before get_traced_memory, leaving only `cached`.
+        gc.collect()
+        tracemalloc.clear_traces()
+        cached = cached_serializer(data)
+        retained, _ = tracemalloc.get_traced_memory()
     finally:
         tracemalloc.stop()
 
-    # The plain fragment keeps orjson's oversized buffer; the trimmed one keeps
-    # roughly the serialized size.
-    assert over_allocated > serialized_size * 3
-    assert right_sized < serialized_size * 2
+    assert cached is not None  # keep alive until measured
+    # The cache holds ~the serialized size; without the copy it would hold
+    # orjson's oversized power-of-two buffer, which is far larger.
+    assert retained < serialized_size * 1.5
 
 
 def test_json_bytes_strip_null() -> None:

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -1,12 +1,15 @@
 """Test Home Assistant remote methods and classes."""
 
+from collections.abc import Callable
 import datetime
 from functools import partial
+import gc
 import json
 import math
 import os
 from pathlib import Path
 import time
+import tracemalloc
 from typing import Any, NamedTuple
 from unittest.mock import Mock, patch
 
@@ -221,6 +224,45 @@ def test_cached_json_fragment() -> None:
     assert (
         json_dumps([fragment]) == '[{"a":1,"b":[1,2,3],"c":{"nested":true},"d":null}]'
     )
+
+
+def test_cached_json_fragment_trims_buffer() -> None:
+    """Test cached_json_fragment drops orjson's over-allocated buffer.
+
+    orjson.dumps returns bytes whose backing buffer is rounded up to a power of
+    two and not shrunk; cached_json_fragment copies them to a right-sized buffer.
+    Without that copy the cached fragment retains the full over-allocated buffer,
+    which is the memory regression this guards against.
+
+    The over-allocation is invisible to normal object inspection: sys.getsizeof()
+    reports the logical length, not the backing buffer, and orjson.Fragment
+    exposes no way to reach the bytes it wraps. So the actual retained allocation
+    can only be observed via tracemalloc.
+    """
+    # A payload large enough that orjson's over-allocation is clearly visible.
+    data = {f"key_{index}": "value" * 5 for index in range(40)}
+    serialized_size = len(json_bytes(data))
+
+    def retained_bytes(make: Callable[[], object]) -> int:
+        gc.collect()
+        before, _ = tracemalloc.get_traced_memory()
+        obj = make()
+        gc.collect()  # free the transient over-allocated buffer, keep only `obj`
+        after, _ = tracemalloc.get_traced_memory()
+        assert obj is not None  # keep the fragment alive until measured
+        return after - before
+
+    tracemalloc.start()
+    try:
+        over_allocated = retained_bytes(lambda: json_fragment(json_bytes(data)))
+        right_sized = retained_bytes(lambda: cached_json_fragment(data))
+    finally:
+        tracemalloc.stop()
+
+    # The plain fragment keeps orjson's oversized buffer; the trimmed one keeps
+    # roughly the serialized size.
+    assert over_allocated > serialized_size * 3
+    assert right_sized < serialized_size * 2
 
 
 def test_json_bytes_strip_null() -> None:

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -220,7 +220,6 @@ def test_cached_json_fragment() -> None:
 
     fragment = cached_json_fragment(data)
     assert isinstance(fragment, json_fragment)
-    # The right-sized copy embeds the same bytes as the plain fragment path.
     assert json_dumps([fragment]) == json_dumps([json_fragment(json_bytes(data))])
     assert (
         json_dumps([fragment]) == '[{"a":1,"b":[1,2,3],"c":{"nested":true},"d":null}]'


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Trim cached orjson fragments

### Background:
2026.9.0 bumps orjson 3.11.9 → 3.12.0 change

orjson.dumps() in 3.12.0 changed the scheme in which buffers are allocated to be much more aggressive

<details> 
  <summary>  Details about the orjson buffer allocation scheme </summary>
buffer-allocation scheme for each version, from orjson src/serialize/writer/byteswriter.rs

Shared by both versions

- OVERALLOCATION = 64 constant.
- Growth algorithm (grow): keep doubling until it fits — while len >= cap: cap *= 2. So the buffer capacity is always floor × 2ᵏ.
- The "trim" is a no-op in both. finish() calls Py_SET_SIZE(bytes, len) before _PyBytes_Resize(bytes, len), and _PyBytes_Resize early-returns when oldsize == newsize. So the returned bytes keeps its full grown capacity — the logical length is set, but the backing allocation is never shrunk.

orjson 3.11.9

- Minimum / initial buffer: 1024 bytes.
- Reservation: reactive. The buffer grows on demand as bytes are written (reserve(len) checks headroom, grow doubles when exceeded). reserve_minimum just ensures 128 B (OVERALLOCATION×2) of headroom. There is no per-container size estimate.
- Net retained: smallest 1024·2ᵏ ≥ serialized_length. So roughly 1–2× the content, floored at 1024.
  - Measured: 91 B→1024, 561 B→1024, 1321 B→2048, 2891 B→4096, 5891 B→8192.

orjson 3.12.0 (the regression — commit c2a6e8ff7b89)

- Minimum / initial buffer: ~4096 bytes (BUFFER_LENGTH = 4096 - sizeof(PyBytesObject) usable, ~4096 allocated) — a 4× larger floor.
- Reservation: aggressive, upfront per container. Before serializing a dict/array it reserves from an element-count estimate:
  - array: 64 + num_items·(bytes_per_item + indent + 16)
  - map: 2·(64 + num_items·(bytes_per_item + indent + 16))

  (bytes_per_item is a per-value-type estimate from the container serializer; indent = 0 for compact output.) This pre-reservation triggers grow early, so capacity is driven by the estimate, not the actual length.
- Net retained: smallest 4096·2ᵏ ≥ max(4096, reserved_estimate). For a dict with many keys the estimate balloons well past the serialized size.
  - Measured: 91 B→4096, 561 B→16384, 1321 B→32768, 5891 B→131072. (The 561 B→16 KiB jump is the map pre-reservation, not the doubling.)
</details> 

This causes cached orjson storage fragments kept by the registries to grow very large because orjson doesn't trim returned buffers.
By trimming buffers which we want to keep, we keep the cached data at a minimum.

Example with a (pathological) device registry store shared by the author of https://github.com/home-assistant/core/issues/181120:

```
no trim, 3.12.0  ██████████████████████████████████████████  5767 MiB   ← the regression
no trim, 3.11.9  █████▎                                      768 MiB
  trim, either   ██▏                                         298 MiB   ← right-sized
serialized JSON  █▉                                          275 MiB   (theoretical floor)
```

### For follow-up PRs

We might want to adjust additional cached fragments in follow-up PRs.

#### High scale / hot path, these might be a bit risky to resize in Python for performance reasons

Site: State.as_dict_json (2042)
What's cached: over-allocated bytes, cached per State; consumed directly by websocket_api, api, restore_state
────────────────────────────────────────
Site: State.json_fragment (2047)
What's cached: wraps as_dict_json (shares its bytes)
────────────────────────────────────────
Site: Event.json_fragment (1438)
What's cached: fragment per Event
────────────────────────────────────────
Site: Context.json_fragment (1336)
What's cached: fragment per Context

#### Low scale / cold path

Site: config_entries.py:685
Property: ConfigEntry.as_json_fragment
(@cached_property)
Scale: dozens–hundreds, process-lifetime
────────────────────────────────────────
Site: config_entries.py:692
Property: ConfigEntry.as_storage_fragment
(@cached_property)
Scale: same
────────────────────────────────────────
Site: loader.py:801
Property: Integration.manifest_json_fragment
(@cached_property)
Scale: ~hundreds, process-lifetime
────────────────────────────────────────
Site: lovelace/dashboard.py:185
Property: LovelaceStorage._json_config (attr)
Scale: few dashboards
────────────────────────────────────────
Site: lovelace/dashboard.py:263
Property: LovelaceYAML._cache fragment (attr)
Scale: few


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/181120
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
