### PR TITLE
Revert orjson to 3.11.9

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -48,7 +48,7 @@ Jinja2==3.1.6
 lru-dict==1.4.1
 mutagen==1.48.1
 openai==2.45.0
-orjson==3.12.0
+orjson==3.11.9
 packaging>=23.1
 paho-mqtt==2.1.0
 Pillow==12.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,10 @@ dependencies = [
   "Pillow==12.3.0",
   "propcache==0.5.2",
   "pyOpenSSL==26.2.0",
-  "orjson==3.12.0",
+  # Do not bump orjson until the very aggressive buffer resizing
+  # introduced in 3.12.0 which causes memory use to ballooon have
+  # been adjusted or we have a workaround
+  "orjson==3.11.9",
   "packaging>=23.1",
   "psutil-home-assistant==0.0.1",
   "python-slugify==8.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,9 @@ dependencies = [
   "Pillow==12.3.0",
   "propcache==0.5.2",
   "pyOpenSSL==26.2.0",
-  # Do not bump orjson until the very aggressive buffer resizing
-  # introduced in 3.12.0 which causes memory use to ballooon have
-  # been adjusted or we have a workaround
+  # Do not bump orjson until the very aggressive buffer resizing introduced in
+  # 3.12.0, which causes memory use to balloon, has been adjusted or a workaround
+  # is available.
   "orjson==3.11.9",
   "packaging>=23.1",
   "psutil-home-assistant==0.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ infrared-protocols==10.0.0
 Jinja2==3.1.6
 lru-dict==1.4.1
 mutagen==1.48.1
-orjson==3.12.0
+orjson==3.11.9
 packaging>=23.1
 Pillow==12.3.0
 probatio==0.11.4

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -891,7 +891,7 @@ async def test_loading_corrupt_core_file(
         assert issue_entry.translation_placeholders["storage_key"] == storage_key
         assert issue_entry.issue_domain == HOMEASSISTANT_DOMAIN
         assert (
-            "unexpected character, expected a JSON value: line 1 column 1 (char 0)"
+            "unexpected character: line 1 column 1 (char 0)"
             in issue_entry.translation_placeholders["error"]
         )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Revert orjson to 3.11.9

#### Background

In orjson commit c2a6e8ff7b89 "JsonWriter, iterators" (2026-08-14), src/serialize/writer/byteswriter.rs changed BUFFER_LENGTH from 1024 → 4096 - size_of::<PyBytesObject>(), and added aggressive per-container pre-reservation (reserve_map = 2*(64 + num_items*(bytes_per_item+16)), reserve_array similar).

This causes the size of JSON fragments which we persist in memory to greatly increase, which is causing at least some of the issues reported in https://github.com/home-assistant/core/issues/181120

orjson does not trim its buffers, instead finish() (CPython path) does:
```
self.append_and_terminate(append);
crate::ffi::Py_SET_SIZE(self.bytes.cast::<PyVarObject>(), usize_to_isize(self.len)); // (1)
self.resize(self.len);                                                              // (2)
```
where `resize(len)` calls `_PyBytes_Resize(&self.bytes, len)`.

Step (1) sets the object's ob_size to self.len. Then in step (2), CPython's _PyBytes_Resize reads oldsize = Py_SIZE(v) — which is now already len — hits its if (oldsize == newsize) return 0; early-return, and never reallocs. So the physical buffer stays at cap (the initial BUFFER_LENGTH or a grown power-of-two). The resize call is dead.

It's not clear to me if this is a bug or intentional to not take the penalty of a realloc.

If it's a bug, it would be nice to get it fixed. If it's intentional, it would be very useful to get a variant of `dumps` which trims its buffer.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
