### PR TITLE
Add Flo Detect last water-event sensors

### DIFF
--- a/homeassistant/components/flo/coordinator.py
+++ b/homeassistant/components/flo/coordinator.py
@@ -49,6 +49,7 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
         self._manufacturer: str = "Flo by Moen"
         self._device_information: dict[str, Any] = {}
         self._water_usage: dict[str, Any] = {}
+        self._events: dict[str, Any] = {}
         super().__init__(
             hass,
             LOGGER,
@@ -65,6 +66,8 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
                 await self.send_presence_ping()
                 await self._update_device()
                 await self._update_consumption_data()
+                if self.device_type != "puck_oem":
+                    await self._update_flodetect_events()
                 self._failure_count = 0
         except (RequestError, TimeoutError, JSONDecodeError) as error:
             self._failure_count += 1
@@ -157,6 +160,14 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
     def consumption_today(self) -> float:
         """Return the current consumption for today in gallons."""
         return self._water_usage["aggregations"]["sumTotalGallonsConsumed"]
+
+    @property
+    def last_water_event(self) -> dict[str, Any] | None:
+        """Return the most recent Flo Detect water-flow event, if any."""
+        items = self._events.get("items") or []
+        if not items:
+            return None
+        return items[0]
 
     @property
     def firmware_version(self) -> str:
@@ -253,3 +264,10 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
             device_mac_address=self.mac_address,
         )
         LOGGER.debug("Updated Flo consumption data: %s", self._water_usage)
+
+    async def _update_flodetect_events(self) -> None:
+        """Update Flo Detect water-flow events from the API."""
+        self._events = await self.api_client.flodetect.get_events(
+            self.mac_address, limit=20
+        )
+        LOGGER.debug("Updated Flo Detect events: %s", self._events)

--- a/homeassistant/components/flo/coordinator.py
+++ b/homeassistant/components/flo/coordinator.py
@@ -19,6 +19,14 @@ from .const import DOMAIN, LOGGER
 type FloConfigEntry = ConfigEntry[FloRuntimeData]
 
 
+def _event_sort_key(event: dict[str, Any]) -> datetime:
+    """Return a comparable timestamp for a Flo Detect event."""
+    parsed = dt_util.parse_datetime(
+        event.get("endTime") or event.get("startTime") or ""
+    )
+    return parsed or dt_util.utc_from_timestamp(0)
+
+
 @dataclass
 class FloRuntimeData:
     """Flo runtime data."""
@@ -167,7 +175,7 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
         items = self._events.get("items") or []
         if not items:
             return None
-        return items[0]
+        return max(items, key=_event_sort_key)
 
     @property
     def firmware_version(self) -> str:

--- a/homeassistant/components/flo/coordinator.py
+++ b/homeassistant/components/flo/coordinator.py
@@ -21,9 +21,7 @@ type FloConfigEntry = ConfigEntry[FloRuntimeData]
 
 def _event_sort_key(event: dict[str, Any]) -> datetime:
     """Return a comparable timestamp for a Flo Detect event."""
-    parsed = dt_util.parse_datetime(
-        event.get("endTime") or event.get("startTime") or ""
-    )
+    parsed = dt_util.parse_datetime(event.get("endAt") or event.get("startAt") or "")
     return parsed or dt_util.utc_from_timestamp(0)
 
 
@@ -172,10 +170,10 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
     @property
     def last_water_event(self) -> dict[str, Any] | None:
         """Return the most recent Flo Detect water-flow event, if any."""
-        items = self._events.get("items") or []
-        if not items:
+        events = self.api_client.flodetect.parse_events(self._events)
+        if not events:
             return None
-        return max(items, key=_event_sort_key)
+        return max(events, key=_event_sort_key)
 
     @property
     def firmware_version(self) -> str:

--- a/homeassistant/components/flo/coordinator.py
+++ b/homeassistant/components/flo/coordinator.py
@@ -19,12 +19,6 @@ from .const import DOMAIN, LOGGER
 type FloConfigEntry = ConfigEntry[FloRuntimeData]
 
 
-def _event_sort_key(event: dict[str, Any]) -> datetime:
-    """Return a comparable timestamp for a Flo Detect event."""
-    parsed = dt_util.parse_datetime(event.get("endAt") or event.get("startAt") or "")
-    return parsed or dt_util.utc_from_timestamp(0)
-
-
 @dataclass
 class FloRuntimeData:
     """Flo runtime data."""
@@ -173,7 +167,12 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
         events = self.api_client.flodetect.parse_events(self._events)
         if not events:
             return None
-        return max(events, key=_event_sort_key)
+        return max(
+            events,
+            key=lambda event: dt_util.parse_datetime(
+                event.get("endAt") or event["startAt"], raise_on_error=True
+            ),
+        )
 
     @property
     def firmware_version(self) -> str:

--- a/homeassistant/components/flo/coordinator.py
+++ b/homeassistant/components/flo/coordinator.py
@@ -49,7 +49,7 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
         self._manufacturer: str = "Flo by Moen"
         self._device_information: dict[str, Any] = {}
         self._water_usage: dict[str, Any] = {}
-        self._events: dict[str, Any] = {}
+        self._last_water_event: dict[str, Any] | None = None
         super().__init__(
             hass,
             LOGGER,
@@ -164,15 +164,7 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
     @property
     def last_water_event(self) -> dict[str, Any] | None:
         """Return the most recent Flo Detect water-flow event, if any."""
-        events = self.api_client.flodetect.parse_events(self._events)
-        if not events:
-            return None
-        return max(
-            events,
-            key=lambda event: dt_util.parse_datetime(
-                event.get("endAt") or event["startAt"], raise_on_error=True
-            ),
-        )
+        return self._last_water_event
 
     @property
     def firmware_version(self) -> str:
@@ -272,7 +264,15 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _update_flodetect_events(self) -> None:
         """Update Flo Detect water-flow events from the API."""
-        self._events = await self.api_client.flodetect.get_events(
-            self.mac_address, limit=20
-        )
-        LOGGER.debug("Updated Flo Detect events: %s", self._events)
+        payload = await self.api_client.flodetect.get_events(self.mac_address, limit=20)
+        events = self.api_client.flodetect.parse_events(payload)
+        if events:
+            self._last_water_event = max(
+                events,
+                key=lambda event: dt_util.parse_datetime(
+                    event.get("endAt") or event["startAt"], raise_on_error=True
+                ),
+            )
+        else:
+            self._last_water_event = None
+        LOGGER.debug("Updated Flo Detect events: %s", payload)

--- a/homeassistant/components/flo/icons.json
+++ b/homeassistant/components/flo/icons.json
@@ -1,5 +1,13 @@
 {
   "entity": {
+    "sensor": {
+      "last_event_fixture": {
+        "default": "mdi:shower-head"
+      },
+      "last_event_usage": {
+        "default": "mdi:water"
+      }
+    },
     "switch": {
       "shutoff_valve": {
         "default": "mdi:valve-closed",

--- a/homeassistant/components/flo/sensor.py
+++ b/homeassistant/components/flo/sensor.py
@@ -1,6 +1,6 @@
 """Support for Flo Water Monitor sensors."""
 
-from typing import override
+from typing import Any, override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -42,6 +42,8 @@ async def async_setup_entry(
             entities.extend(
                 [
                     FloDailyUsageSensor(device),
+                    FloLastEventUsageSensor(device),
+                    FloLastEventFixtureSensor(device),
                     FloSystemModeSensor(device),
                     FloCurrentFlowRateSensor(device),
                     FloTemperatureSensor(device, True),
@@ -70,6 +72,62 @@ class FloDailyUsageSensor(FloEntity, SensorEntity):
         if self._device.consumption_today is None:
             return None
         return round(self._device.consumption_today, 1)
+
+
+class FloLastEventUsageSensor(FloEntity, SensorEntity):
+    """Monitors the most recent Flo Detect water-flow event."""
+
+    _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    _attr_device_class = SensorDeviceClass.WATER
+    _attr_translation_key = "last_event_usage"
+
+    def __init__(self, device):
+        """Initialize the last event usage sensor."""
+        super().__init__("last_event_usage", device)
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return gallons consumed in the last water-flow event."""
+        event = self._device.last_water_event
+        if event is None or event.get("gallonsConsumed") is None:
+            return None
+        return round(event["gallonsConsumed"], 1)
+
+    @property
+    @override
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return details of the last water-flow event."""
+        event = self._device.last_water_event
+        if event is None:
+            return {}
+        return {
+            "fixture_type": event.get("fixtureType"),
+            "duration_seconds": event.get("durationSeconds"),
+            "start_time": event.get("startTime"),
+            "end_time": event.get("endTime"),
+            "event_id": event.get("id"),
+        }
+
+
+class FloLastEventFixtureSensor(FloEntity, SensorEntity):
+    """Monitors the fixture type of the most recent Flo Detect event."""
+
+    _attr_translation_key = "last_event_fixture"
+
+    def __init__(self, device):
+        """Initialize the last event fixture sensor."""
+        super().__init__("last_event_fixture", device)
+
+    @property
+    @override
+    def native_value(self) -> str | None:
+        """Return the fixture type of the last water-flow event."""
+        event = self._device.last_water_event
+        if event is None:
+            return None
+        return event.get("fixtureType")
 
 
 class FloSystemModeSensor(FloEntity, SensorEntity):

--- a/homeassistant/components/flo/sensor.py
+++ b/homeassistant/components/flo/sensor.py
@@ -90,9 +90,9 @@ class FloLastEventUsageSensor(FloEntity, SensorEntity):
     def native_value(self) -> float | None:
         """Return gallons consumed in the last water-flow event."""
         event = self._device.last_water_event
-        if event is None or event.get("gallonsConsumed") is None:
+        if event is None or event.get("totalGal") is None:
             return None
-        return round(event["gallonsConsumed"], 1)
+        return round(event["totalGal"], 1)
 
     @property
     @override
@@ -101,11 +101,12 @@ class FloLastEventUsageSensor(FloEntity, SensorEntity):
         event = self._device.last_water_event
         if event is None:
             return {}
+        predicted = event.get("predicted") or {}
         return {
-            "fixture_type": event.get("fixtureType"),
-            "duration_seconds": event.get("durationSeconds"),
-            "start_time": event.get("startTime"),
-            "end_time": event.get("endTime"),
+            "fixture_type": predicted.get("displayText"),
+            "duration_seconds": event.get("duration"),
+            "start_time": event.get("startAt"),
+            "end_time": event.get("endAt"),
             "event_id": event.get("id"),
         }
 
@@ -126,7 +127,8 @@ class FloLastEventFixtureSensor(FloEntity, SensorEntity):
         event = self._device.last_water_event
         if event is None:
             return None
-        return event.get("fixtureType")
+        predicted = event.get("predicted") or {}
+        return predicted.get("displayText")
 
 
 class FloSystemModeSensor(FloEntity, SensorEntity):

--- a/homeassistant/components/flo/sensor.py
+++ b/homeassistant/components/flo/sensor.py
@@ -79,7 +79,6 @@ class FloLastEventUsageSensor(FloEntity, SensorEntity):
 
     _attr_native_unit_of_measurement = UnitOfVolume.GALLONS
     _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
-    _attr_device_class = SensorDeviceClass.WATER
     _attr_translation_key = "last_event_usage"
 
     def __init__(self, device):

--- a/homeassistant/components/flo/sensor.py
+++ b/homeassistant/components/flo/sensor.py
@@ -1,6 +1,7 @@
 """Support for Flo Water Monitor sensors."""
 
-from typing import Any, override
+from datetime import datetime
+from typing import override
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -11,11 +12,13 @@ from homeassistant.const import (
     PERCENTAGE,
     UnitOfPressure,
     UnitOfTemperature,
+    UnitOfTime,
     UnitOfVolume,
     UnitOfVolumeFlowRate,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .coordinator import FloConfigEntry
 from .entity import FloEntity
@@ -44,6 +47,9 @@ async def async_setup_entry(
                     FloDailyUsageSensor(device),
                     FloLastEventUsageSensor(device),
                     FloLastEventFixtureSensor(device),
+                    FloLastEventDurationSensor(device),
+                    FloLastEventStartSensor(device),
+                    FloLastEventEndSensor(device),
                     FloSystemModeSensor(device),
                     FloCurrentFlowRateSensor(device),
                     FloTemperatureSensor(device, True),
@@ -94,22 +100,6 @@ class FloLastEventUsageSensor(FloEntity, SensorEntity):
             return None
         return round(event["totalGal"], 1)
 
-    @property
-    @override
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return details of the last water-flow event."""
-        event = self._device.last_water_event
-        if event is None:
-            return {}
-        predicted = event.get("predicted") or {}
-        return {
-            "fixture_type": predicted.get("displayText"),
-            "duration_seconds": event.get("duration"),
-            "start_time": event.get("startAt"),
-            "end_time": event.get("endAt"),
-            "event_id": event.get("id"),
-        }
-
 
 class FloLastEventFixtureSensor(FloEntity, SensorEntity):
     """Monitors the fixture type of the most recent Flo Detect event."""
@@ -129,6 +119,68 @@ class FloLastEventFixtureSensor(FloEntity, SensorEntity):
             return None
         predicted = event.get("predicted") or {}
         return predicted.get("displayText")
+
+
+class FloLastEventDurationSensor(FloEntity, SensorEntity):
+    """Monitors the duration of the most recent Flo Detect event."""
+
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    _attr_translation_key = "last_event_duration"
+
+    def __init__(self, device):
+        """Initialize the last event duration sensor."""
+        super().__init__("last_event_duration", device)
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return the duration of the last water-flow event."""
+        event = self._device.last_water_event
+        if event is None or event.get("duration") is None:
+            return None
+        return event["duration"]
+
+
+class FloLastEventStartSensor(FloEntity, SensorEntity):
+    """Monitors the start time of the most recent Flo Detect event."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_translation_key = "last_event_start"
+
+    def __init__(self, device):
+        """Initialize the last event start sensor."""
+        super().__init__("last_event_start", device)
+
+    @property
+    @override
+    def native_value(self) -> datetime | None:
+        """Return the start time of the last water-flow event."""
+        event = self._device.last_water_event
+        if event is None or (start_at := event.get("startAt")) is None:
+            return None
+        return dt_util.parse_datetime(start_at)
+
+
+class FloLastEventEndSensor(FloEntity, SensorEntity):
+    """Monitors the end time of the most recent Flo Detect event."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_translation_key = "last_event_end"
+
+    def __init__(self, device):
+        """Initialize the last event end sensor."""
+        super().__init__("last_event_end", device)
+
+    @property
+    @override
+    def native_value(self) -> datetime | None:
+        """Return the end time of the last water-flow event."""
+        event = self._device.last_water_event
+        if event is None or (end_at := event.get("endAt")) is None:
+            return None
+        return dt_util.parse_datetime(end_at)
 
 
 class FloSystemModeSensor(FloEntity, SensorEntity):

--- a/homeassistant/components/flo/strings.json
+++ b/homeassistant/components/flo/strings.json
@@ -40,6 +40,12 @@
       "daily_consumption": {
         "name": "Today's water usage"
       },
+      "last_event_fixture": {
+        "name": "Last water event fixture"
+      },
+      "last_event_usage": {
+        "name": "Last water event"
+      },
       "water_pressure": {
         "name": "Water pressure"
       },

--- a/homeassistant/components/flo/strings.json
+++ b/homeassistant/components/flo/strings.json
@@ -40,8 +40,17 @@
       "daily_consumption": {
         "name": "Today's water usage"
       },
+      "last_event_duration": {
+        "name": "Last water event duration"
+      },
+      "last_event_end": {
+        "name": "Last water event end"
+      },
       "last_event_fixture": {
         "name": "Last water event fixture"
+      },
+      "last_event_start": {
+        "name": "Last water event start"
       },
       "last_event_usage": {
         "name": "Last water event"

--- a/tests/components/flo/conftest.py
+++ b/tests/components/flo/conftest.py
@@ -73,6 +73,13 @@ def aioclient_mock_fixture(aioclient_mock: AiohttpClientMocker) -> None:
         status=HTTPStatus.OK,
         headers={"Content-Type": CONTENT_TYPE_JSON},
     )
+    # Mocks Flo Detect events for flo.
+    aioclient_mock.get(
+        "https://api-gw.meetflo.com/api/v2/flodetect/events",
+        text=load_fixture("flo/flodetect_events_response.json"),
+        status=HTTPStatus.OK,
+        headers={"Content-Type": CONTENT_TYPE_JSON},
+    )
     # Mocks the location info for flo.
     aioclient_mock.get(
         "https://api-gw.meetflo.com/api/v2/locations/mmnnoopp",

--- a/tests/components/flo/fixtures/flodetect_events_response.json
+++ b/tests/components/flo/fixtures/flodetect_events_response.json
@@ -5,22 +5,33 @@
   },
   "items": [
     {
-      "id": "evt-002",
       "macAddress": "111111111111",
-      "startTime": "2026-07-12T09:41:10-04:00",
-      "endTime": "2026-07-12T09:48:22-04:00",
-      "gallonsConsumed": 14.8,
-      "durationSeconds": 432,
-      "fixtureType": "shower"
-    },
-    {
-      "id": "evt-001",
-      "macAddress": "111111111111",
-      "startTime": "2026-07-12T10:12:03-04:00",
-      "endTime": "2026-07-12T10:14:41-04:00",
-      "gallonsConsumed": 2.4,
-      "durationSeconds": 158,
-      "fixtureType": "faucet"
+      "events": [
+        {
+          "id": "evt-002",
+          "startAt": "2026-07-12T09:41:10-04:00",
+          "endAt": "2026-07-12T09:48:22-04:00",
+          "totalGal": 14.8,
+          "duration": 432,
+          "macAddress": "111111111111",
+          "predicted": {
+            "id": 101,
+            "displayText": "Shower"
+          }
+        },
+        {
+          "id": "evt-001",
+          "startAt": "2026-07-12T10:12:03-04:00",
+          "endAt": "2026-07-12T10:14:41-04:00",
+          "totalGal": 2.4,
+          "duration": 158,
+          "macAddress": "111111111111",
+          "predicted": {
+            "id": 300,
+            "displayText": "Faucet"
+          }
+        }
+      ]
     }
   ]
 }

--- a/tests/components/flo/fixtures/flodetect_events_response.json
+++ b/tests/components/flo/fixtures/flodetect_events_response.json
@@ -1,0 +1,26 @@
+{
+  "params": {
+    "macAddress": "111111111111",
+    "limit": "20"
+  },
+  "items": [
+    {
+      "id": "evt-001",
+      "macAddress": "111111111111",
+      "startTime": "2026-07-12T10:12:03-04:00",
+      "endTime": "2026-07-12T10:14:41-04:00",
+      "gallonsConsumed": 2.4,
+      "durationSeconds": 158,
+      "fixtureType": "faucet"
+    },
+    {
+      "id": "evt-002",
+      "macAddress": "111111111111",
+      "startTime": "2026-07-12T09:41:10-04:00",
+      "endTime": "2026-07-12T09:48:22-04:00",
+      "gallonsConsumed": 14.8,
+      "durationSeconds": 432,
+      "fixtureType": "shower"
+    }
+  ]
+}

--- a/tests/components/flo/fixtures/flodetect_events_response.json
+++ b/tests/components/flo/fixtures/flodetect_events_response.json
@@ -5,15 +5,6 @@
   },
   "items": [
     {
-      "id": "evt-001",
-      "macAddress": "111111111111",
-      "startTime": "2026-07-12T10:12:03-04:00",
-      "endTime": "2026-07-12T10:14:41-04:00",
-      "gallonsConsumed": 2.4,
-      "durationSeconds": 158,
-      "fixtureType": "faucet"
-    },
-    {
       "id": "evt-002",
       "macAddress": "111111111111",
       "startTime": "2026-07-12T09:41:10-04:00",
@@ -21,6 +12,15 @@
       "gallonsConsumed": 14.8,
       "durationSeconds": 432,
       "fixtureType": "shower"
+    },
+    {
+      "id": "evt-001",
+      "macAddress": "111111111111",
+      "startTime": "2026-07-12T10:12:03-04:00",
+      "endTime": "2026-07-12T10:14:41-04:00",
+      "gallonsConsumed": 2.4,
+      "durationSeconds": 158,
+      "fixtureType": "faucet"
     }
   ]
 }

--- a/tests/components/flo/test_device.py
+++ b/tests/components/flo/test_device.py
@@ -33,13 +33,20 @@ async def test_device(
     }
     assert consumption_macs == {"111111111111", "1a2b3c4d5e6f"}
 
+    event_macs = {
+        call[1].query.get("macAddress")
+        for call in aioclient_mock.mock_calls
+        if call[0] == "get" and call[1].path == "/api/v2/flodetect/events"
+    }
+    assert event_macs == {"111111111111"}
+
     call_count = aioclient_mock.call_count
 
     freezer.tick(timedelta(seconds=90))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == call_count + 6
+    assert aioclient_mock.call_count == call_count + 7
 
 
 @pytest.mark.usefixtures("aioclient_mock_fixture")

--- a/tests/components/flo/test_sensor.py
+++ b/tests/components/flo/test_sensor.py
@@ -119,4 +119,4 @@ async def test_manual_update_entity(
         {ATTR_ENTITY_ID: ["sensor.smart_water_shutoff_current_system_mode"]},
         blocking=True,
     )
-    assert aioclient_mock.call_count == call_count + 3
+    assert aioclient_mock.call_count == call_count + 4

--- a/tests/components/flo/test_sensor.py
+++ b/tests/components/flo/test_sensor.py
@@ -44,7 +44,7 @@ async def test_sensors(hass: HomeAssistant, config_entry: MockConfigEntry) -> No
     assert last_event is not None
     assert last_event.state == "2.4"
     assert last_event.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
-    assert last_event.attributes["fixture_type"] == "faucet"
+    assert last_event.attributes["fixture_type"] == "Faucet"
     assert last_event.attributes["duration_seconds"] == 158
     assert last_event.attributes["start_time"] == "2026-07-12T10:12:03-04:00"
     assert last_event.attributes["end_time"] == "2026-07-12T10:14:41-04:00"
@@ -52,7 +52,7 @@ async def test_sensors(hass: HomeAssistant, config_entry: MockConfigEntry) -> No
 
     assert (
         hass.states.get("sensor.smart_water_shutoff_last_water_event_fixture").state
-        == "faucet"
+        == "Faucet"
     )
 
     assert hass.states.get("sensor.smart_water_shutoff_water_flow_rate").state == "0"

--- a/tests/components/flo/test_sensor.py
+++ b/tests/components/flo/test_sensor.py
@@ -24,7 +24,7 @@ async def test_sensors(hass: HomeAssistant, config_entry: MockConfigEntry) -> No
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # we should have 5 entities for the valve
+    # we should have 7 entities for the valve
     assert (
         hass.states.get("sensor.smart_water_shutoff_current_system_mode").state
         == "home"
@@ -38,6 +38,21 @@ async def test_sensors(hass: HomeAssistant, config_entry: MockConfigEntry) -> No
             ATTR_STATE_CLASS
         ]
         == SensorStateClass.TOTAL_INCREASING
+    )
+
+    last_event = hass.states.get("sensor.smart_water_shutoff_last_water_event")
+    assert last_event is not None
+    assert last_event.state == "2.4"
+    assert last_event.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+    assert last_event.attributes["fixture_type"] == "faucet"
+    assert last_event.attributes["duration_seconds"] == 158
+    assert last_event.attributes["start_time"] == "2026-07-12T10:12:03-04:00"
+    assert last_event.attributes["end_time"] == "2026-07-12T10:14:41-04:00"
+    assert last_event.attributes["event_id"] == "evt-001"
+
+    assert (
+        hass.states.get("sensor.smart_water_shutoff_last_water_event_fixture").state
+        == "faucet"
     )
 
     assert hass.states.get("sensor.smart_water_shutoff_water_flow_rate").state == "0"

--- a/tests/components/flo/test_sensor.py
+++ b/tests/components/flo/test_sensor.py
@@ -6,8 +6,12 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HOMEASSISTANT_DOMAIN,
     SERVICE_UPDATE_ENTITY,
 )
-from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
@@ -24,7 +28,7 @@ async def test_sensors(hass: HomeAssistant, config_entry: MockConfigEntry) -> No
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    # we should have 7 entities for the valve
+    # we should have 10 entities for the valve
     assert (
         hass.states.get("sensor.smart_water_shutoff_current_system_mode").state
         == "home"
@@ -44,16 +48,35 @@ async def test_sensors(hass: HomeAssistant, config_entry: MockConfigEntry) -> No
     assert last_event is not None
     assert last_event.state == "2.4"
     assert last_event.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
-    assert last_event.attributes["fixture_type"] == "Faucet"
-    assert last_event.attributes["duration_seconds"] == 158
-    assert last_event.attributes["start_time"] == "2026-07-12T10:12:03-04:00"
-    assert last_event.attributes["end_time"] == "2026-07-12T10:14:41-04:00"
-    assert last_event.attributes["event_id"] == "evt-001"
 
     assert (
         hass.states.get("sensor.smart_water_shutoff_last_water_event_fixture").state
         == "Faucet"
     )
+
+    last_event_duration = hass.states.get(
+        "sensor.smart_water_shutoff_last_water_event_duration"
+    )
+    assert last_event_duration is not None
+    assert last_event_duration.state == "158"
+    assert (
+        last_event_duration.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.DURATION
+    )
+    assert (
+        last_event_duration.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+    )
+
+    last_event_start = hass.states.get(
+        "sensor.smart_water_shutoff_last_water_event_start"
+    )
+    assert last_event_start is not None
+    assert last_event_start.state == "2026-07-12T14:12:03+00:00"
+    assert last_event_start.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TIMESTAMP
+
+    last_event_end = hass.states.get("sensor.smart_water_shutoff_last_water_event_end")
+    assert last_event_end is not None
+    assert last_event_end.state == "2026-07-12T14:14:41+00:00"
+    assert last_event_end.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TIMESTAMP
 
     assert hass.states.get("sensor.smart_water_shutoff_water_flow_rate").state == "0"
     assert (

--- a/tests/components/flo/test_services.py
+++ b/tests/components/flo/test_services.py
@@ -33,7 +33,7 @@ async def test_services(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 8
+    assert aioclient_mock.call_count == 9
 
     await hass.services.async_call(
         DOMAIN,
@@ -42,7 +42,7 @@ async def test_services(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert aioclient_mock.call_count == 9
+    assert aioclient_mock.call_count == 10
 
     await hass.services.async_call(
         DOMAIN,
@@ -51,7 +51,7 @@ async def test_services(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert aioclient_mock.call_count == 10
+    assert aioclient_mock.call_count == 11
 
     await hass.services.async_call(
         DOMAIN,
@@ -60,7 +60,7 @@ async def test_services(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert aioclient_mock.call_count == 11
+    assert aioclient_mock.call_count == 12
 
     await hass.services.async_call(
         DOMAIN,
@@ -73,7 +73,7 @@ async def test_services(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert aioclient_mock.call_count == 12
+    assert aioclient_mock.call_count == 13
 
     # test calling with a string value to ensure it is converted to int
     await hass.services.async_call(
@@ -87,7 +87,7 @@ async def test_services(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert aioclient_mock.call_count == 13
+    assert aioclient_mock.call_count == 14
 
     # test calling with a non string -> int value and ensure exception is thrown
     with pytest.raises(MultipleInvalid):
@@ -101,4 +101,4 @@ async def test_services(
             },
             blocking=True,
         )
-    assert aioclient_mock.call_count == 13
+    assert aioclient_mock.call_count == 14


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add Flo Detect last-event sensors for shutoff valves.

`aioflo` 2026.9.3 exposes `GET /api/v2/flodetect/events`, which returns completed water uses (gallons, duration, fixture type) closer to real time than the daily consumption aggregate. This polls that endpoint on the existing 60s coordinator cycle and adds:

- **Last water event** — gallons from the newest completed event
- **Last water event fixture** — `faucet`, `shower`, etc.
- **Last water event duration** — length of that event in seconds
- **Last water event start** — start timestamp
- **Last water event end** — end timestamp

Leak detectors (`puck_oem`) are unchanged. **Today's water usage** still comes from `get_consumption_info` (with device MAC); events are not used as a daily total because they are completed uses only and are capped by `limit`.

Depends on #181246 (`aioflo==2026.9.3`).

Library diff: https://github.com/bachya/aioflo/compare/2021.11.0...2026.09.3
PyPI: https://pypi.org/project/aioflo/2026.9.3/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/bachya/aioflo/issues/72
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

