### PR TITLE
Fix todo item triggers after config entry reload

### DIFF
--- a/homeassistant/components/todo/trigger.py
+++ b/homeassistant/components/todo/trigger.py
@@ -10,11 +10,24 @@ from typing import TYPE_CHECKING, cast, override
 
 import voluptuous as vol
 
-from homeassistant.const import ATTR_ENTITY_ID, CONF_OPTIONS, CONF_TARGET
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback, split_entity_id
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_OPTIONS,
+    CONF_TARGET,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    Event,
+    EventStateChangedData,
+    HomeAssistant,
+    callback,
+    split_entity_id,
+)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.target import TargetEntityChangeTracker, TargetSelection
 from homeassistant.helpers.trigger import (
     Trigger,
@@ -79,6 +92,7 @@ class ItemChangeListener(TargetEntityChangeTracker):
 
         self._pending_listener_task: asyncio.Task[None] | None = None
         self._unsubscribe_listeners: list[CALLBACK_TYPE] = []
+        self._state_change_unsub: CALLBACK_TYPE | None = None
 
     @override
     @callback
@@ -114,6 +128,27 @@ class ItemChangeListener(TargetEntityChangeTracker):
             )
             self._unsubscribe_listeners.append(unsub)
 
+        if self._state_change_unsub:
+            self._state_change_unsub()
+            self._state_change_unsub = None
+        if tracked_entities:
+            self._state_change_unsub = async_track_state_change_event(
+                self._hass, tracked_entities, self._async_todo_entity_state_changed
+            )
+
+    @callback
+    def _async_todo_entity_state_changed(
+        self, event: Event[EventStateChangedData]
+    ) -> None:
+        """Config entry reload recreates the entity without a registry change."""
+        new_state = event.data["new_state"]
+        old_state = event.data["old_state"]
+        if new_state is None or new_state.state == STATE_UNAVAILABLE:
+            return
+        if old_state is not None and old_state.state != STATE_UNAVAILABLE:
+            return
+        self._handle_entities_update(self._referenced_entities())
+
     @override
     @callback
     def _unsubscribe(self) -> None:
@@ -122,6 +157,9 @@ class ItemChangeListener(TargetEntityChangeTracker):
         if self._pending_listener_task:
             self._pending_listener_task.cancel()
             self._pending_listener_task = None
+        if self._state_change_unsub:
+            self._state_change_unsub()
+            self._state_change_unsub = None
         for unsub in self._unsubscribe_listeners:
             unsub()
 

--- a/homeassistant/components/todo/trigger.py
+++ b/homeassistant/components/todo/trigger.py
@@ -140,7 +140,11 @@ class ItemChangeListener(TargetEntityChangeTracker):
     def _async_todo_entity_state_changed(
         self, event: Event[EventStateChangedData]
     ) -> None:
-        """Config entry reload recreates the entity without a registry change."""
+        """Handle entities becoming available.
+        
+        This is required so that when the config entry is reloaded,
+        we start listening on the newly created classes.
+        """
         new_state = event.data["new_state"]
         old_state = event.data["old_state"]
         if new_state is None or new_state.state == STATE_UNAVAILABLE:

--- a/homeassistant/components/todo/trigger.py
+++ b/homeassistant/components/todo/trigger.py
@@ -141,7 +141,7 @@ class ItemChangeListener(TargetEntityChangeTracker):
         self, event: Event[EventStateChangedData]
     ) -> None:
         """Handle entities becoming available.
-        
+
         This is required so that when the config entry is reloaded,
         we start listening on the newly created classes.
         """

--- a/tests/components/todo/test_trigger.py
+++ b/tests/components/todo/test_trigger.py
@@ -12,6 +12,7 @@ from homeassistant.components.todo import (
     TodoListEntityFeature,
 )
 from homeassistant.components.todo.const import ATTR_ITEM, ATTR_STATUS, TodoServices
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_AREA_ID,
     ATTR_DEVICE_ID,
@@ -31,11 +32,17 @@ from homeassistant.helpers import (
     floor_registry as fr,
     label_registry as lr,
 )
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.setup import async_setup_component
 
-from . import MockTodoListEntity, create_mock_platform
+from . import TEST_DOMAIN, MockTodoListEntity, create_mock_platform
 
-from tests.common import async_mock_service, mock_device_registry
+from tests.common import (
+    MockPlatform,
+    async_mock_service,
+    mock_device_registry,
+    mock_platform,
+)
 from tests.components.common import assert_trigger_options_supported
 
 TODO_ENTITY_ID1 = "todo.list_one"
@@ -470,6 +477,83 @@ async def test_new_entity_added_to_target_fires_triggers(
             {"platform": "todo.item_added", "entity_id": todo_entity_id3},
             {"platform": "todo.item_completed", "entity_id": todo_entity_id3},
             {"platform": "todo.item_removed", "entity_id": todo_entity_id3},
+        ],
+    )
+
+
+async def test_item_change_triggers_after_config_entry_reload(
+    hass: HomeAssistant,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test triggers still fire after the todo list's config entry is reloaded.
+
+    Reload recreates the entity object without changing the registry entry, so
+    the trigger must re-subscribe rather than keep the old object.
+    """
+    await _setup_automation(hass, {CONF_ENTITY_ID: TODO_ENTITY_ID1})
+
+    config_entry = hass.config_entries.async_entries(TEST_DOMAIN)[0]
+
+    async def async_setup_entry_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddConfigEntryEntitiesCallback,
+    ) -> None:
+        async_add_entities(
+            [
+                _make_entity(
+                    TODO_ENTITY_ID1,
+                    unique_id="list_one",
+                    items=[
+                        TodoItem(
+                            summary="existing_item",
+                            uid="existing_id",
+                            status=TodoItemStatus.NEEDS_ACTION,
+                        )
+                    ],
+                ),
+                _make_entity(TODO_ENTITY_ID2, unique_id="list_two"),
+            ]
+        )
+
+    mock_platform(
+        hass,
+        f"{TEST_DOMAIN}.{DOMAIN}",
+        MockPlatform(async_setup_entry=async_setup_entry_platform),
+    )
+    assert await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await _add_item(hass, TODO_ENTITY_ID1, "item_after_reload")
+    _assert_service_calls(
+        service_calls,
+        [{"platform": "todo.item_added", "entity_id": TODO_ENTITY_ID1}],
+    )
+    item_id = service_calls[0].data["item_ids"][0]
+    service_calls.clear()
+
+    await _complete_item(hass, TODO_ENTITY_ID1, item_id)
+    _assert_service_calls(
+        service_calls,
+        [
+            {
+                "platform": "todo.item_completed",
+                "entity_id": TODO_ENTITY_ID1,
+                "item_ids": [item_id],
+            }
+        ],
+    )
+    service_calls.clear()
+
+    await _remove_item(hass, TODO_ENTITY_ID1, item_id)
+    _assert_service_calls(
+        service_calls,
+        [
+            {
+                "platform": "todo.item_removed",
+                "entity_id": TODO_ENTITY_ID1,
+                "item_ids": [item_id],
+            }
         ],
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`todo.item_added`, `todo.item_completed`, and `todo.item_removed` subscribe to the entity *object* via `async_subscribe_updates`. Reloading the list's config entry tears that object down and creates a new one, but the entity registry entry is unchanged, so `TargetEntityChangeTracker` never restarts the listener.

The list itself keeps working — adding an item still updates the open-item count — but the automation trigger stays attached to the discarded object and goes silent until the automation is toggled.

This PR also listens for the tracked entity leaving `unavailable` and re-subscribes to the new object. A regression test reloads the mock todo platform (new instances, same unique ids) and checks that add / complete / remove still fire.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181242
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
