### PR TITLE
Bump python-hotspring to 2.1.0 (hotfix)

### DIFF
--- a/homeassistant/components/hotspring/manifest.json
+++ b/homeassistant/components/hotspring/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "loggers": ["hotspring"],
   "quality_scale": "platinum",
-  "requirements": ["python-hotspring==2.0.1"],
+  "requirements": ["python-hotspring==2.1.0"],
   "zeroconf": [
     {
       "name": "watkins_spa*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2735,7 +2735,7 @@ python-homeassistant-analytics==0.9.0
 python-homewizard-energy==10.2.0
 
 # homeassistant.components.hotspring
-python-hotspring==2.0.1
+python-hotspring==2.1.0
 
 # homeassistant.components.hp_ilo
 python-hpilo==4.4.3


### PR DESCRIPTION
## Proposed change

Bumps `python-hotspring` to version 2.1.0 (hotfix).

This is a hotfix intended for the 2026.9.1 patch release. Right now, Home Assistant swaps constantly between the Spa Network Adapter (SNA) and Home Network Adapter (HNA) via Zeroconf discovery because both devices share the same rootTopic/MAC identifier. When polling the SNA, all telemetry data is missing/empty, causing entities to become unavailable and fail updates. Version 2.1.0 properly identifies and rejects SNA devices so only the HNA is configured.

A follow up PR will make the changes to reject SNA from being added in Home Assistant. It should be a hot fix because Home Assistant zeroconf will switch between both devices at random since the devices report the same mac address (since they share the same root topic).

- **Changelog**: https://github.com/Moustachauve/python-hotspring/releases/tag/v2.1.0
- **Diff**: https://github.com/Moustachauve/python-hotspring/compare/v2.0.1...v2.1.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
