### PR TITLE
Reject Hot Spring Spa Network Adapter (SNA) in config flow (hotfix)

### DIFF
--- a/homeassistant/components/hotspring/config_flow.py
+++ b/homeassistant/components/hotspring/config_flow.py
@@ -3,7 +3,13 @@
 from collections.abc import Mapping
 from typing import Any, override
 
-from hotspring import HotSpring, HotSpringConnectionError, HotSpringError, Spa
+from hotspring import (
+    HotSpring,
+    HotSpringConnectionError,
+    HotSpringError,
+    HotSpringSNADetectedError,
+    Spa,
+)
 import voluptuous as vol
 
 from homeassistant.config_entries import (
@@ -52,6 +58,8 @@ class HotSpringConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 spa = await validate_input(self.hass, user_input)
+            except HotSpringSNADetectedError:
+                errors["base"] = "sna_device"
             except HotSpringConnectionError, HotSpringError:
                 errors["base"] = "cannot_connect"
             else:
@@ -101,6 +109,8 @@ class HotSpringConfigFlow(ConfigFlow, domain=DOMAIN):
             self.discovered_spa = await validate_input(
                 self.hass, {CONF_HOST: discovery_info.host}
             )
+        except HotSpringSNADetectedError:
+            return self.async_abort(reason="sna_device")
         except HotSpringConnectionError, HotSpringError:
             return self.async_abort(reason="cannot_connect")
 

--- a/homeassistant/components/hotspring/strings.json
+++ b/homeassistant/components/hotspring/strings.json
@@ -4,10 +4,12 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "sna_device": "The discovered device is a Spa Network Adapter (SNA). Only the Home Network Adapter (HNA) can be configured.",
       "unique_id_mismatch": "The MAC address does not match the configured device. Please ensure you reconfigure against the same device."
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "sna_device": "The entered address belongs to the Spa Network Adapter (SNA). Please enter the IP address or hostname of your Home Network Adapter (HNA) instead."
     },
     "step": {
       "user": {

--- a/tests/components/hotspring/test_config_flow.py
+++ b/tests/components/hotspring/test_config_flow.py
@@ -4,7 +4,12 @@ import dataclasses
 from ipaddress import ip_address
 from unittest.mock import MagicMock
 
-from hotspring import HotSpringConnectionError, HotSpringError, Spa
+from hotspring import (
+    HotSpringConnectionError,
+    HotSpringError,
+    HotSpringSNADetectedError,
+    Spa,
+)
 import pytest
 
 from homeassistant.components.hotspring.const import DOMAIN
@@ -69,14 +74,21 @@ async def test_user_device_exists_abort(
 
 
 @pytest.mark.parametrize(
-    "exception",
-    [HotSpringConnectionError, HotSpringError],
+    ("exception", "error_key"),
+    [
+        (HotSpringConnectionError, "cannot_connect"),
+        (HotSpringError, "cannot_connect"),
+        (HotSpringSNADetectedError, "sna_device"),
+    ],
 )
 @pytest.mark.usefixtures("mock_setup_entry")
-async def test_form_cannot_connect(
-    hass: HomeAssistant, mock_hotspring: MagicMock, exception: type[Exception]
+async def test_form_errors(
+    hass: HomeAssistant,
+    mock_hotspring: MagicMock,
+    exception: type[Exception],
+    error_key: str,
 ) -> None:
-    """Test we show user form on Hot Spring connection error and recover."""
+    """Test we show user form on error and recover."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
@@ -92,7 +104,7 @@ async def test_form_cannot_connect(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
-    assert result["errors"] == {"base": "cannot_connect"}
+    assert result["errors"] == {"base": error_key}
 
     mock_hotspring.update.side_effect = None
     result = await hass.config_entries.flow.async_configure(
@@ -158,13 +170,20 @@ async def test_full_zeroconf_flow_implementation(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "exception",
-    [HotSpringConnectionError, HotSpringError],
+    ("exception", "reason"),
+    [
+        (HotSpringConnectionError, "cannot_connect"),
+        (HotSpringError, "cannot_connect"),
+        (HotSpringSNADetectedError, "sna_device"),
+    ],
 )
-async def test_zeroconf_connection_error(
-    hass: HomeAssistant, mock_hotspring: MagicMock, exception: type[Exception]
+async def test_zeroconf_error(
+    hass: HomeAssistant,
+    mock_hotspring: MagicMock,
+    exception: type[Exception],
+    reason: str,
 ) -> None:
-    """Test we abort zeroconf flow on Hot Spring connection error."""
+    """Test we abort zeroconf flow on Hot Spring error."""
     mock_hotspring.update.side_effect = exception
 
     result = await hass.config_entries.flow.async_init(
@@ -174,7 +193,7 @@ async def test_zeroconf_connection_error(
     )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "cannot_connect"
+    assert result["reason"] == reason
 
 
 @pytest.mark.usefixtures("mock_hotspring")


### PR DESCRIPTION
## Proposed change

Hotfix intended for the 2026.9.1 patch release (follow-up to #181256).

Hot Spring Spas use two network adapters: the **Home Network Adapter (HNA)**, which serves spa telemetry, and the **Spa Network Adapter (SNA)**, which wirelessly links the spa motherboard to the HNA.

Both adapters advertise the same mDNS service (`watkins_spa*._ws._tcp.local.`) and share the same `rootTopic`. Previously, discovering an SNA via Zeroconf would overwrite the config entry's host with the SNA's IP, which does not provide telemetry and caused entities to flap between available and unavailable.

Using `HotSpringSNADetectedError` from `python-hotspring==2.1.0` (bumped in #181256), this PR:
- Aborts Zeroconf discovery if an SNA is discovered instead of updating the configured host.
- Displays a clear error during manual user/reconfigure flow if an SNA address is entered.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #181256
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
