### PR TITLE
WeHeat - Diagnostics

### DIFF
--- a/homeassistant/components/weheat/diagnostics.py
+++ b/homeassistant/components/weheat/diagnostics.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 
 from .coordinator import WeheatConfigEntry
 
-TO_REDACT = {"heat_pump_id"}
+TO_REDACT = {"heat_pump_id", "uuid", "sn"}
 
 
 async def async_get_config_entry_diagnostics(
@@ -17,8 +17,7 @@ async def async_get_config_entry_diagnostics(
     return {
         "heat_pumps": [
             {
-                "model": weheatdata.heat_pump_info.model,
-                "has_dhw": weheatdata.heat_pump_info.has_dhw,
+                "info": async_redact_data(vars(weheatdata.heat_pump_info), TO_REDACT),
                 "logs": async_redact_data(
                     weheatdata.data_coordinator.data.raw_content or {}, TO_REDACT
                 ),

--- a/homeassistant/components/weheat/diagnostics.py
+++ b/homeassistant/components/weheat/diagnostics.py
@@ -1,0 +1,31 @@
+"""Diagnostics support for Weheat."""
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.core import HomeAssistant
+
+from .coordinator import WeheatConfigEntry
+
+TO_REDACT = {"heat_pump_id"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: WeheatConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    return {
+        "heat_pumps": [
+            {
+                "model": weheatdata.heat_pump_info.model,
+                "has_dhw": weheatdata.heat_pump_info.has_dhw,
+                "logs": async_redact_data(
+                    weheatdata.data_coordinator.data.raw_content or {}, TO_REDACT
+                ),
+                "energy": async_redact_data(
+                    weheatdata.energy_coordinator.data.raw_content or {}, TO_REDACT
+                ),
+            }
+            for weheatdata in entry.runtime_data
+        ]
+    }

--- a/homeassistant/components/weheat/quality_scale.yaml
+++ b/homeassistant/components/weheat/quality_scale.yaml
@@ -54,7 +54,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info:
     status: exempt
     comment: |

--- a/tests/components/weheat/conftest.py
+++ b/tests/components/weheat/conftest.py
@@ -140,6 +140,11 @@ def mock_weheat_heat_pump_instance() -> MagicMock:
     mock_heat_pump_instance.indoor_unit_dhw_valve_or_pump_state = None
     mock_heat_pump_instance.indoor_unit_gas_boiler_state = False
     mock_heat_pump_instance.indoor_unit_electric_heater_state = True
+    mock_heat_pump_instance.raw_content = {
+        "heat_pump_id": TEST_HP_UUID,
+        "t_water_in": 11,
+        "total_ein_heating": 12345,
+    }
 
     return mock_heat_pump_instance
 

--- a/tests/components/weheat/snapshots/test_diagnostics.ambr
+++ b/tests/components/weheat/snapshots/test_diagnostics.ambr
@@ -1,0 +1,19 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'heat_pumps': list([
+      dict({
+        'energy': dict({
+          'heat_pump_id': '**REDACTED**',
+          'total_ein_heating': 12345,
+        }),
+        'has_dhw': True,
+        'logs': dict({
+          'heat_pump_id': '**REDACTED**',
+          't_water_in': 11,
+        }),
+        'model': 'Test Model',
+      }),
+    ]),
+  })
+# ---

--- a/tests/components/weheat/snapshots/test_diagnostics.ambr
+++ b/tests/components/weheat/snapshots/test_diagnostics.ambr
@@ -5,14 +5,22 @@
       dict({
         'energy': dict({
           'heat_pump_id': '**REDACTED**',
+          't_water_in': 11,
           'total_ein_heating': 12345,
         }),
-        'has_dhw': True,
+        'info': dict({
+          'device_name': None,
+          'has_ch_boiler': False,
+          'has_dhw': True,
+          'model': 'Test Model',
+          'sn': '**REDACTED**',
+          'uuid': '**REDACTED**',
+        }),
         'logs': dict({
           'heat_pump_id': '**REDACTED**',
           't_water_in': 11,
+          'total_ein_heating': 12345,
         }),
-        'model': 'Test Model',
       }),
     ]),
   })

--- a/tests/components/weheat/test_diagnostics.py
+++ b/tests/components/weheat/test_diagnostics.py
@@ -1,42 +1,20 @@
 """Tests for the weheat diagnostics."""
 
-from collections.abc import Generator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
-from weheat.abstractions.heat_pump import HeatPump
 
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
-from .const import TEST_HP_UUID
 
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
 
-@pytest.fixture
-def mock_separate_heat_pumps() -> Generator[None]:
-    """Mock the two heat pump instances a config entry really builds.
-
-    Each coordinator builds its own, and the diagnostics read a different one
-    for the logs than for the energy, so they have to report different content
-    for the test to notice the wrong one being read.
-    """
-    logs, energy = (MagicMock(spec_set=HeatPump) for _ in range(2))
-    logs.raw_content = {"heat_pump_id": TEST_HP_UUID, "t_water_in": 11}
-    energy.raw_content = {"heat_pump_id": TEST_HP_UUID, "total_ein_heating": 12345}
-
-    with patch(
-        "homeassistant.components.weheat.coordinator.HeatPump",
-        side_effect=[logs, energy],
-    ):
-        yield
-
-
-@pytest.mark.usefixtures("mock_weheat_discover", "mock_separate_heat_pumps")
+@pytest.mark.usefixtures("mock_weheat_discover", "mock_weheat_heat_pump")
 async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -59,7 +37,7 @@ async def test_diagnostics_without_data(
     mock_config_entry: MockConfigEntry,
     mock_weheat_heat_pump: AsyncMock,
 ) -> None:
-    """Test that diagnostics are returned when the heat pump reported nothing yet."""
+    """Test the diagnostics of a heat pump that reported nothing yet."""
     mock_weheat_heat_pump.raw_content = None
 
     await setup_integration(hass, mock_config_entry)

--- a/tests/components/weheat/test_diagnostics.py
+++ b/tests/components/weheat/test_diagnostics.py
@@ -1,0 +1,72 @@
+"""Tests for the weheat diagnostics."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from weheat.abstractions.heat_pump import HeatPump
+
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+from .const import TEST_HP_UUID
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+@pytest.fixture
+def mock_separate_heat_pumps() -> Generator[None]:
+    """Mock the two heat pump instances a config entry really builds.
+
+    Each coordinator builds its own, and the diagnostics read a different one
+    for the logs than for the energy, so they have to report different content
+    for the test to notice the wrong one being read.
+    """
+    logs, energy = (MagicMock(spec_set=HeatPump) for _ in range(2))
+    logs.raw_content = {"heat_pump_id": TEST_HP_UUID, "t_water_in": 11}
+    energy.raw_content = {"heat_pump_id": TEST_HP_UUID, "total_ein_heating": 12345}
+
+    with patch(
+        "homeassistant.components.weheat.coordinator.HeatPump",
+        side_effect=[logs, energy],
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("mock_weheat_discover", "mock_separate_heat_pumps")
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the diagnostics of a config entry."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert (
+        await get_diagnostics_for_config_entry(hass, hass_client, mock_config_entry)
+        == snapshot
+    )
+
+
+@pytest.mark.usefixtures("mock_weheat_discover")
+async def test_diagnostics_without_data(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_weheat_heat_pump: AsyncMock,
+) -> None:
+    """Test that diagnostics are returned when the heat pump reported nothing yet."""
+    mock_weheat_heat_pump.raw_content = None
+
+    await setup_integration(hass, mock_config_entry)
+
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    assert diagnostics["heat_pumps"][0]["logs"] == {}
+    assert diagnostics["heat_pumps"][0]["energy"] == {}


### PR DESCRIPTION

## Proposed change
The heat pump reports far more than the integration turns into entities, so a diagnostics download gives everything the cloud returned for both coordinators, with the heat pump id redacted.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: Split from https://github.com/home-assistant/core/pull/180904
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
