### PR TITLE
Add the air outlet, DHW and indoor unit sensors to WeHeat

### DIFF
--- a/homeassistant/components/weheat/icons.json
+++ b/homeassistant/components/weheat/icons.json
@@ -33,6 +33,9 @@
       "cop": {
         "default": "mdi:speedometer"
       },
+      "dhw_control_method": {
+        "default": "mdi:tune"
+      },
       "dhw_flow_volume": {
         "default": "mdi:pump"
       },
@@ -49,6 +52,9 @@
         "default": "mdi:flash"
       },
       "electricity_used_heating": {
+        "default": "mdi:flash"
+      },
+      "electricity_used_indoor_unit": {
         "default": "mdi:flash"
       },
       "energy_output": {

--- a/homeassistant/components/weheat/quality_scale.yaml
+++ b/homeassistant/components/weheat/quality_scale.yaml
@@ -74,7 +74,7 @@ rules:
     status: todo
     comment: |
       While unlikely to happen. Check if it is easily integrated.
-  entity-category: todo
+  entity-category: done
   entity-device-class: done
   entity-disabled-by-default: todo
   entity-translations: done

--- a/homeassistant/components/weheat/sensor.py
+++ b/homeassistant/components/weheat/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
+    EntityCategory,
     UnitOfEnergy,
     UnitOfPower,
     UnitOfTemperature,
@@ -47,6 +48,30 @@ class WeHeatSensorEntityDescription(SensorEntityDescription):
     """Describes Weheat sensor entity."""
 
     value_fn: Callable[[HeatPump], StateType]
+    # Whether the heat pump supports this sensor at all. Entities are only created
+    # during setup, so a sensor whose value_fn can return None on a heat pump that
+    # does support it would otherwise never appear once a value does arrive.
+    supported_fn: Callable[[HeatPump], bool] | None = None
+
+
+def _is_supported(
+    entity_description: WeHeatSensorEntityDescription, heat_pump: HeatPump
+) -> bool:
+    """Return whether the heat pump reports the value behind this sensor."""
+    if entity_description.supported_fn is not None:
+        return entity_description.supported_fn(heat_pump)
+    return entity_description.value_fn(heat_pump) is not None
+
+
+def _dhw_target_temperature(status: HeatPump) -> float | None:
+    """Return the DHW target temperature, if the heat pump has one.
+
+    A heat pump with DHW control off reports a target of zero, which is how it
+    says there is no target: zero is not a temperature it would ever aim for,
+    since that would freeze the vessel.
+    """
+    target = status.dhw_target_temperature
+    return target or None
 
 
 SENSORS = [
@@ -110,6 +135,15 @@ SENSORS = [
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=DISPLAY_PRECISION_WATER_TEMP,
         value_fn=lambda status: status.air_inlet_temperature,
+    ),
+    WeHeatSensorEntityDescription(
+        translation_key="air_outlet_temperature",
+        key="air_outlet_temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=DISPLAY_PRECISION_WATER_TEMP,
+        value_fn=lambda status: status.air_outlet_temperature,
     ),
     WeHeatSensorEntityDescription(
         translation_key="thermostat_water_setpoint",
@@ -203,6 +237,31 @@ DHW_SENSORS = [
         native_unit_of_measurement=UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR,
         value_fn=lambda status: status.dhw_flow_volume,
     ),
+    WeHeatSensorEntityDescription(
+        translation_key="dhw_target_temperature",
+        key="dhw_target_temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=DISPLAY_PRECISION_WATER_TEMP,
+        supported_fn=lambda status: status.dhw_target_temperature is not None,
+        value_fn=_dhw_target_temperature,
+    ),
+    WeHeatSensorEntityDescription(
+        translation_key="dhw_control_method",
+        key="dhw_control_method",
+        device_class=SensorDeviceClass.ENUM,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        options=[method.name.lower() for method in HeatPump.DhwControlMethod],
+        supported_fn=lambda status: status.dhw_control_method_code is not None,
+        value_fn=(
+            lambda status: (
+                status.dhw_control_method.name.lower()
+                if status.dhw_control_method is not None
+                else None
+            )
+        ),
+    ),
 ]
 
 ENERGY_SENSORS = [
@@ -213,6 +272,14 @@ ENERGY_SENSORS = [
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda status: status.energy_total,
+    ),
+    WeHeatSensorEntityDescription(
+        translation_key="electricity_used_indoor_unit",
+        key="electricity_used_indoor_unit",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda status: status.energy_in_indoor_unit,
     ),
     WeHeatSensorEntityDescription(
         translation_key="energy_output",
@@ -316,7 +383,7 @@ async def async_setup_entry(
                 entity_description,
             )
             for entity_description in SENSORS
-            if entity_description.value_fn(weheatdata.data_coordinator.data) is not None
+            if _is_supported(entity_description, weheatdata.data_coordinator.data)
         )
         if weheatdata.heat_pump_info.has_dhw:
             entities.extend(
@@ -326,8 +393,7 @@ async def async_setup_entry(
                     entity_description,
                 )
                 for entity_description in DHW_SENSORS
-                if entity_description.value_fn(weheatdata.data_coordinator.data)
-                is not None
+                if _is_supported(entity_description, weheatdata.data_coordinator.data)
             )
             entities.extend(
                 WeheatHeatPumpSensor(
@@ -336,8 +402,7 @@ async def async_setup_entry(
                     entity_description,
                 )
                 for entity_description in DHW_ENERGY_SENSORS
-                if entity_description.value_fn(weheatdata.energy_coordinator.data)
-                is not None
+                if _is_supported(entity_description, weheatdata.energy_coordinator.data)
             )
         entities.extend(
             WeheatHeatPumpSensor(
@@ -346,8 +411,7 @@ async def async_setup_entry(
                 entity_description,
             )
             for entity_description in ENERGY_SENSORS
-            if entity_description.value_fn(weheatdata.energy_coordinator.data)
-            is not None
+            if _is_supported(entity_description, weheatdata.energy_coordinator.data)
         )
 
     async_add_entities(entities)

--- a/homeassistant/components/weheat/sensor.py
+++ b/homeassistant/components/weheat/sensor.py
@@ -50,12 +50,6 @@ class WeHeatSensorEntityDescription(SensorEntityDescription):
     value_fn: Callable[[HeatPump], StateType]
 
 
-def _dhw_target_temperature(status: HeatPump) -> float | None:
-    """Return the DHW target temperature, which is zero when there is none."""
-    target = status.dhw_target_temperature
-    return target or None
-
-
 SENSORS = [
     WeHeatSensorEntityDescription(
         translation_key="power_output",
@@ -226,7 +220,8 @@ DHW_SENSORS = [
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=DISPLAY_PRECISION_WATER_TEMP,
-        value_fn=_dhw_target_temperature,
+        # A target of zero is how the heat pump says DHW control is off.
+        value_fn=lambda status: status.dhw_target_temperature or None,
     ),
     WeHeatSensorEntityDescription(
         translation_key="dhw_control_method",

--- a/homeassistant/components/weheat/sensor.py
+++ b/homeassistant/components/weheat/sensor.py
@@ -48,9 +48,7 @@ class WeHeatSensorEntityDescription(SensorEntityDescription):
     """Describes Weheat sensor entity."""
 
     value_fn: Callable[[HeatPump], StateType]
-    # Whether the heat pump supports this sensor at all. Entities are only created
-    # during setup, so a sensor whose value_fn can return None on a heat pump that
-    # does support it would otherwise never appear once a value does arrive.
+    # Entities are created only at setup, so a value_fn that can be None needs this.
     supported_fn: Callable[[HeatPump], bool] | None = None
 
 
@@ -64,12 +62,7 @@ def _is_supported(
 
 
 def _dhw_target_temperature(status: HeatPump) -> float | None:
-    """Return the DHW target temperature, if the heat pump has one.
-
-    A heat pump with DHW control off reports a target of zero, which is how it
-    says there is no target: zero is not a temperature it would ever aim for,
-    since that would freeze the vessel.
-    """
+    """Return the DHW target temperature, which is zero when there is none."""
     target = status.dhw_target_temperature
     return target or None
 

--- a/homeassistant/components/weheat/sensor.py
+++ b/homeassistant/components/weheat/sensor.py
@@ -48,17 +48,6 @@ class WeHeatSensorEntityDescription(SensorEntityDescription):
     """Describes Weheat sensor entity."""
 
     value_fn: Callable[[HeatPump], StateType]
-    # Entities are created only at setup, so a value_fn that can be None needs this.
-    supported_fn: Callable[[HeatPump], bool] | None = None
-
-
-def _is_supported(
-    entity_description: WeHeatSensorEntityDescription, heat_pump: HeatPump
-) -> bool:
-    """Return whether the heat pump reports the value behind this sensor."""
-    if entity_description.supported_fn is not None:
-        return entity_description.supported_fn(heat_pump)
-    return entity_description.value_fn(heat_pump) is not None
 
 
 def _dhw_target_temperature(status: HeatPump) -> float | None:
@@ -237,7 +226,6 @@ DHW_SENSORS = [
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=DISPLAY_PRECISION_WATER_TEMP,
-        supported_fn=lambda status: status.dhw_target_temperature is not None,
         value_fn=_dhw_target_temperature,
     ),
     WeHeatSensorEntityDescription(
@@ -246,7 +234,6 @@ DHW_SENSORS = [
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
         options=[method.name.lower() for method in HeatPump.DhwControlMethod],
-        supported_fn=lambda status: status.dhw_control_method_code is not None,
         value_fn=(
             lambda status: (
                 status.dhw_control_method.name.lower()
@@ -376,7 +363,7 @@ async def async_setup_entry(
                 entity_description,
             )
             for entity_description in SENSORS
-            if _is_supported(entity_description, weheatdata.data_coordinator.data)
+            if entity_description.value_fn(weheatdata.data_coordinator.data) is not None
         )
         if weheatdata.heat_pump_info.has_dhw:
             entities.extend(
@@ -386,7 +373,6 @@ async def async_setup_entry(
                     entity_description,
                 )
                 for entity_description in DHW_SENSORS
-                if _is_supported(entity_description, weheatdata.data_coordinator.data)
             )
             entities.extend(
                 WeheatHeatPumpSensor(
@@ -395,7 +381,6 @@ async def async_setup_entry(
                     entity_description,
                 )
                 for entity_description in DHW_ENERGY_SENSORS
-                if _is_supported(entity_description, weheatdata.energy_coordinator.data)
             )
         entities.extend(
             WeheatHeatPumpSensor(
@@ -404,7 +389,8 @@ async def async_setup_entry(
                 entity_description,
             )
             for entity_description in ENERGY_SENSORS
-            if _is_supported(entity_description, weheatdata.energy_coordinator.data)
+            if entity_description.value_fn(weheatdata.energy_coordinator.data)
+            is not None
         )
 
     async_add_entities(entities)

--- a/homeassistant/components/weheat/strings.json
+++ b/homeassistant/components/weheat/strings.json
@@ -48,6 +48,9 @@
       }
     },
     "sensor": {
+      "air_outlet_temperature": {
+        "name": "Air outlet temperature"
+      },
       "central_heating_flow_volume": {
         "name": "Central heating pump flow"
       },
@@ -66,8 +69,21 @@
       "dhw_bottom_temperature": {
         "name": "DHW bottom temperature"
       },
+      "dhw_control_method": {
+        "name": "DHW control method",
+        "state": {
+          "boost": "Boost",
+          "fixed": "Fixed setpoint",
+          "none": "None",
+          "schedule": "Schedule",
+          "weheat_intelligence": "Weheat Intelligence"
+        }
+      },
       "dhw_flow_volume": {
         "name": "DHW pump flow"
+      },
+      "dhw_target_temperature": {
+        "name": "DHW target temperature"
       },
       "dhw_top_temperature": {
         "name": "DHW top temperature"
@@ -86,6 +102,9 @@
       },
       "electricity_used_heating": {
         "name": "Electricity used heating"
+      },
+      "electricity_used_indoor_unit": {
+        "name": "Electricity used indoor unit"
       },
       "electricity_used_standby": {
         "name": "Electricity used standby"

--- a/tests/components/weheat/conftest.py
+++ b/tests/components/weheat/conftest.py
@@ -111,6 +111,7 @@ def mock_weheat_heat_pump_instance() -> MagicMock:
     mock_heat_pump_instance.water_outlet_temperature = 22
     mock_heat_pump_instance.water_house_in_temperature = 33
     mock_heat_pump_instance.air_inlet_temperature = 44
+    mock_heat_pump_instance.air_outlet_temperature = 50
     mock_heat_pump_instance.power_input = 55
     mock_heat_pump_instance.power_output = 66
     mock_heat_pump_instance.dhw_top_temperature = 77
@@ -126,6 +127,7 @@ def mock_weheat_heat_pump_instance() -> MagicMock:
     mock_heat_pump_instance.energy_in_cooling = 9000
     mock_heat_pump_instance.energy_in_standby = 684
     mock_heat_pump_instance.energy_total = 28689
+    mock_heat_pump_instance.energy_in_indoor_unit = 1042
     mock_heat_pump_instance.energy_out_heating = 10000
     mock_heat_pump_instance.energy_out_dhw = 6677
     mock_heat_pump_instance.energy_out_defrost = -1200
@@ -134,6 +136,9 @@ def mock_weheat_heat_pump_instance() -> MagicMock:
     mock_heat_pump_instance.compressor_rpm = 4500
     mock_heat_pump_instance.compressor_percentage = 100
     mock_heat_pump_instance.dhw_flow_volume = 1.12
+    mock_heat_pump_instance.dhw_target_temperature = 55
+    mock_heat_pump_instance.dhw_control_method = HeatPump.DhwControlMethod.FIXED
+    mock_heat_pump_instance.dhw_control_method_code = 1
     mock_heat_pump_instance.central_heating_flow_volume = 1.23
     mock_heat_pump_instance.indoor_unit_water_pump_state = False
     mock_heat_pump_instance.indoor_unit_auxiliary_pump_state = False

--- a/tests/components/weheat/snapshots/test_sensor.ambr
+++ b/tests/components/weheat/snapshots/test_sensor.ambr
@@ -77,6 +77,64 @@
     'state': 'heating',
   })
 # ---
+# name: test_all_entities[sensor.test_model_air_outlet_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_model_air_outlet_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Air outlet temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Air outlet temperature',
+    'platform': 'weheat',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'air_outlet_temperature',
+    'unique_id': '0000-1111-2222-3333_air_outlet_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_all_entities[sensor.test_model_air_outlet_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Model Air outlet temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_model_air_outlet_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '50',
+  })
+# ---
 # name: test_all_entities[sensor.test_model_central_heating_inlet_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -473,6 +531,72 @@
     'state': '88',
   })
 # ---
+# name: test_all_entities[sensor.test_model_dhw_control_method-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'none',
+        'fixed',
+        'schedule',
+        'weheat_intelligence',
+        'boost',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.test_model_dhw_control_method',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'DHW control method',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'DHW control method',
+    'platform': 'weheat',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dhw_control_method',
+    'unique_id': '0000-1111-2222-3333_dhw_control_method',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.test_model_dhw_control_method-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Model DHW control method',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'none',
+        'fixed',
+        'schedule',
+        'weheat_intelligence',
+        'boost',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_model_dhw_control_method',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'fixed',
+  })
+# ---
 # name: test_all_entities[sensor.test_model_dhw_pump_flow-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -529,6 +653,64 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '1.12',
+  })
+# ---
+# name: test_all_entities[sensor.test_model_dhw_target_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_model_dhw_target_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'DHW target temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'DHW target temperature',
+    'platform': 'weheat',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'dhw_target_temperature',
+    'unique_id': '0000-1111-2222-3333_dhw_target_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_all_entities[sensor.test_model_dhw_target_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Model DHW target temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_model_dhw_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '55',
   })
 # ---
 # name: test_all_entities[sensor.test_model_dhw_top_temperature-entry]
@@ -877,6 +1059,64 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '12345',
+  })
+# ---
+# name: test_all_entities[sensor.test_model_electricity_used_indoor_unit-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_model_electricity_used_indoor_unit',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Electricity used indoor unit',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Electricity used indoor unit',
+    'platform': 'weheat',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'electricity_used_indoor_unit',
+    'unique_id': '0000-1111-2222-3333_electricity_used_indoor_unit',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_all_entities[sensor.test_model_electricity_used_indoor_unit-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test Model Electricity used indoor unit',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_model_electricity_used_indoor_unit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1042',
   })
 # ---
 # name: test_all_entities[sensor.test_model_electricity_used_standby-entry]

--- a/tests/components/weheat/test_sensor.py
+++ b/tests/components/weheat/test_sensor.py
@@ -85,11 +85,7 @@ async def test_an_unknown_dhw_control_method_keeps_the_sensor(
     mock_weheat_heat_pump: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test a control method this library cannot name still gets a sensor.
-
-    The heat pump keeps reporting the raw method, so the sensor has to survive
-    the backend introducing one, ready to name it once the library knows it.
-    """
+    """Test a control method this library cannot name still gets a sensor."""
     mock_weheat_heat_pump.dhw_control_method = None
     mock_weheat_heat_pump.dhw_control_method_code = 99
 

--- a/tests/components/weheat/test_sensor.py
+++ b/tests/components/weheat/test_sensor.py
@@ -6,7 +6,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from weheat.abstractions.discovery import HeatPumpDiscovery
 
-from homeassistant.const import Platform
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -33,7 +33,7 @@ async def test_all_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.parametrize(("has_dhw", "nr_of_entities"), [(False, 23), (True, 28)])
+@pytest.mark.parametrize(("has_dhw", "nr_of_entities"), [(False, 25), (True, 32)])
 async def test_create_entities(
     hass: HomeAssistant,
     mock_weheat_discover: AsyncMock,
@@ -52,3 +52,50 @@ async def test_create_entities(
 
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == nr_of_entities
+
+
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        pytest.param(55, "55", id="a_target_it_aims_for"),
+        # DHW control off reports a target of zero, which is no target at all
+        pytest.param(0, STATE_UNKNOWN, id="dhw_control_off"),
+    ],
+)
+@pytest.mark.usefixtures("mock_weheat_discover")
+async def test_dhw_target_temperature(
+    hass: HomeAssistant,
+    mock_weheat_heat_pump: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    target: int,
+    expected: str,
+) -> None:
+    """Test the DHW target is only reported when the heat pump has one."""
+    mock_weheat_heat_pump.dhw_target_temperature = target
+
+    with patch("homeassistant.components.weheat.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get("sensor.test_model_dhw_target_temperature").state == expected
+
+
+@pytest.mark.usefixtures("mock_weheat_discover")
+async def test_an_unknown_dhw_control_method_keeps_the_sensor(
+    hass: HomeAssistant,
+    mock_weheat_heat_pump: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a control method this library cannot name still gets a sensor.
+
+    The heat pump keeps reporting the raw method, so the sensor has to survive
+    the backend introducing one, ready to name it once the library knows it.
+    """
+    mock_weheat_heat_pump.dhw_control_method = None
+    mock_weheat_heat_pump.dhw_control_method_code = 99
+
+    with patch("homeassistant.components.weheat.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    assert (
+        hass.states.get("sensor.test_model_dhw_control_method").state == STATE_UNKNOWN
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The heat pump reports four values the integration did not turn into entities: the air outlet temperature, the DHW target and control method, and the electricity the indoor unit used, which the overall electricity total leaves out.

Two of them need deciding whether the heat pump supports them at all, separately from the value itself, because entities are only created during setup. The DHW target is unset as a zero, which is how the heat pump says DHW control is off, and the control method has no name when the backend reports one this library version does not know yet. Probing the value alone would drop either sensor for good.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: Split from #180904
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/47884
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
