### PR TITLE
Allow empty motionEye usernames

### DIFF
--- a/homeassistant/components/motioneye/config_flow.py
+++ b/homeassistant/components/motioneye/config_flow.py
@@ -71,7 +71,7 @@ class MotionEyeConfigFlow(ConfigFlow, domain=DOMAIN):
                         **url_schema,
                         vol.Optional(
                             CONF_ADMIN_USERNAME,
-                            default=user_input.get(CONF_ADMIN_USERNAME),
+                            default=user_input.get(CONF_ADMIN_USERNAME, ""),
                         ): str,
                         vol.Optional(
                             CONF_ADMIN_PASSWORD,
@@ -79,7 +79,7 @@ class MotionEyeConfigFlow(ConfigFlow, domain=DOMAIN):
                         ): str,
                         vol.Optional(
                             CONF_SURVEILLANCE_USERNAME,
-                            default=user_input.get(CONF_SURVEILLANCE_USERNAME),
+                            default=user_input.get(CONF_SURVEILLANCE_USERNAME, ""),
                         ): str,
                         vol.Optional(
                             CONF_SURVEILLANCE_PASSWORD,

--- a/tests/components/motioneye/test_config_flow.py
+++ b/tests/components/motioneye/test_config_flow.py
@@ -7,6 +7,7 @@ from motioneye_client.client import (
     MotionEyeClientInvalidAuthError,
     MotionEyeClientRequestError,
 )
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.motioneye.const import (
@@ -30,7 +31,44 @@ from . import TEST_URL, create_mock_motioneye_client, create_mock_motioneye_conf
 from tests.common import MockConfigEntry
 
 
-async def test_user_success(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("user_input", "expected_data"),
+    [
+        pytest.param(
+            {
+                CONF_URL: TEST_URL,
+                CONF_ADMIN_USERNAME: "admin-username",
+                CONF_ADMIN_PASSWORD: "admin-password",
+                CONF_SURVEILLANCE_USERNAME: "surveillance-username",
+                CONF_SURVEILLANCE_PASSWORD: "surveillance-password",
+            },
+            {
+                CONF_URL: TEST_URL,
+                CONF_ADMIN_USERNAME: "admin-username",
+                CONF_ADMIN_PASSWORD: "admin-password",
+                CONF_SURVEILLANCE_USERNAME: "surveillance-username",
+                CONF_SURVEILLANCE_PASSWORD: "surveillance-password",
+            },
+            id="credentials",
+        ),
+        pytest.param(
+            {CONF_URL: TEST_URL},
+            {
+                CONF_URL: TEST_URL,
+                CONF_ADMIN_USERNAME: "",
+                CONF_ADMIN_PASSWORD: "",
+                CONF_SURVEILLANCE_USERNAME: "",
+                CONF_SURVEILLANCE_PASSWORD: "",
+            },
+            id="no_credentials",
+        ),
+    ],
+)
+async def test_user_success(
+    hass: HomeAssistant,
+    user_input: dict[str, str],
+    expected_data: dict[str, str],
+) -> None:
     """Test successful user flow."""
 
     result = await hass.config_entries.flow.async_init(
@@ -52,26 +90,13 @@ async def test_user_success(hass: HomeAssistant) -> None:
         ) as mock_setup_entry,
     ):
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_URL: TEST_URL,
-                CONF_ADMIN_USERNAME: "admin-username",
-                CONF_ADMIN_PASSWORD: "admin-password",
-                CONF_SURVEILLANCE_USERNAME: "surveillance-username",
-                CONF_SURVEILLANCE_PASSWORD: "surveillance-password",
-            },
+            result["flow_id"], user_input
         )
         await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"{TEST_URL}"
-    assert result["data"] == {
-        CONF_URL: TEST_URL,
-        CONF_ADMIN_USERNAME: "admin-username",
-        CONF_ADMIN_PASSWORD: "admin-password",
-        CONF_SURVEILLANCE_USERNAME: "surveillance-username",
-        CONF_SURVEILLANCE_PASSWORD: "surveillance-password",
-    }
+    assert result["data"] == expected_data
     assert len(mock_setup_entry.mock_calls) == 1
     assert mock_client.async_client_close.called
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Submitting the motionEye form without credentials failed with "expected str". Both username fields defaulted to `None` when nothing had been entered yet, and `None` does not pass the `str` validator. The two password fields were already fixed this way in #85407, the usernames were missed.

The same form is used for reauthentication, so an entry stored without those keys hit the identical error there.

This addresses the schema error from the linked issue only. The Argon2id signature mismatch reported alongside it lives in motionEye 0.44.0 and `motioneye-client`, so that issue stays open.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #181084
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
