### PR TITLE
Handle Tradfri devices without a firmware version

### DIFF
--- a/homeassistant/components/tradfri/entity.py
+++ b/homeassistant/components/tradfri/entity.py
@@ -6,6 +6,7 @@ from functools import wraps
 from typing import Any, cast, override
 
 from pytradfri.command import Command
+from pytradfri.const import ATTR_DEVICE_FIRMWARE_VERSION
 from pytradfri.device import Device
 from pytradfri.error import RequestError
 
@@ -61,7 +62,7 @@ class TradfriBaseEntity(CoordinatorEntity[TradfriDeviceDataUpdateCoordinator]):
             manufacturer=info.manufacturer,
             model=info.model_number,
             name=self._device.name,
-            sw_version=info.firmware_version,
+            sw_version=info.raw.get(ATTR_DEVICE_FIRMWARE_VERSION),
             via_device_id=dr.async_get_device_id_by_identifier(
                 device_coordinator.hass,
                 (DOMAIN, gateway_id),

--- a/tests/components/tradfri/test_sensor.py
+++ b/tests/components/tradfri/test_sensor.py
@@ -1,9 +1,12 @@
 """Tradfri sensor platform tests."""
 
+import json
+
 import pytest
 from pytradfri.const import (
     ATTR_AIR_PURIFIER_AIR_QUALITY,
     ATTR_DEVICE_BATTERY,
+    ATTR_DEVICE_FIRMWARE_VERSION,
     ATTR_DEVICE_INFO,
     ATTR_REACHABLE_STATE,
     ROOT_AIR_PURIFIER,
@@ -27,7 +30,7 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import GATEWAY_ID
 from .common import CommandStore, setup_integration
@@ -39,6 +42,14 @@ from tests.common import MockConfigEntry, load_fixture
 def remote_control() -> str:
     """Return a remote control response."""
     return load_fixture("remote_control.json", DOMAIN)
+
+
+@pytest.fixture(scope="module")
+def remote_control_without_firmware(remote_control: str) -> str:
+    """Return a remote control response that reports no firmware version."""
+    device = json.loads(remote_control)
+    del device[ATTR_DEVICE_INFO][ATTR_DEVICE_FIRMWARE_VERSION]
+    return json.dumps(device)
 
 
 @pytest.mark.parametrize("device", ["remote_control"], indirect=True)
@@ -68,6 +79,26 @@ async def test_battery_sensor(
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfRatio.PERCENTAGE
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.BATTERY
     assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+
+
+@pytest.mark.parametrize("device", ["remote_control_without_firmware"], indirect=True)
+@pytest.mark.usefixtures("device")
+async def test_battery_sensor_without_firmware_version(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that a device that reports no firmware version still gets its sensor."""
+    entry = await setup_integration(hass)
+
+    state = hass.states.get("sensor.test_battery")
+    assert state
+    assert state.state == "87"
+
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{GATEWAY_ID}-65536"), entry.entry_id
+    )
+    assert device_entry
+    assert device_entry.sw_version is None
 
 
 @pytest.mark.parametrize("device", ["blind"], indirect=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

One remote that reported no firmware version took down the whole sensor platform. The library raises `KeyError` for a missing firmware field, and since every entity is built in a single setup pass, that one device removed all battery sensors.

The firmware version is now read as an optional value, so a device that does not report one simply has no software version.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181041
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
