### PR TITLE
Use Opower's import/export registers for grid statistics

### DIFF
--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -332,8 +332,17 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
 
                 cost_state = max(0, cost_read.provided_cost)
                 compensation_state = max(0, -cost_read.provided_cost)
-                consumption_state = max(0, cost_read.consumption)
-                return_state = max(0, -cost_read.consumption)
+                # Prefer the meter's own import and export registers when the
+                # utility publishes them. Splitting the net consumption on its
+                # sign undercounts both directions on a net-metered site,
+                # because an interval that is net-export can still contain real
+                # import (and vice versa).
+                if cost_read.imported is not None and cost_read.exported is not None:
+                    consumption_state = cost_read.imported
+                    return_state = cost_read.exported
+                else:
+                    consumption_state = max(0, cost_read.consumption)
+                    return_state = max(0, -cost_read.consumption)
 
                 cost_sum += cost_state
                 compensation_sum += compensation_state

--- a/tests/components/opower/test_coordinator.py
+++ b/tests/components/opower/test_coordinator.py
@@ -142,6 +142,134 @@ async def test_coordinator_subsequent_run(
     assert stats == snapshot
 
 
+async def test_coordinator_uses_import_export_registers(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_opower_api: AsyncMock,
+) -> None:
+    """Test the meter's own import/export registers are preferred over the net.
+
+    An interval that is net-export can still contain real grid import, so
+    splitting the net on its sign undercounts both directions. When the utility
+    publishes the registers we use them verbatim.
+    """
+    mock_opower_api.async_get_cost_reads.return_value = [
+        # Net export, but 0.25 kWh really was taken from the grid in that hour.
+        CostRead(
+            start_time=dt_util.as_utc(datetime(2023, 1, 1, 8)),
+            end_time=dt_util.as_utc(datetime(2023, 1, 1, 9)),
+            consumption=-3.9,
+            provided_cost=-1.2,
+            imported=0.25,
+            exported=4.15,
+        ),
+        # Net import, with a little export in the same hour.
+        CostRead(
+            start_time=dt_util.as_utc(datetime(2023, 1, 1, 9)),
+            end_time=dt_util.as_utc(datetime(2023, 1, 1, 10)),
+            consumption=1.5,
+            provided_cost=0.5,
+            imported=1.75,
+            exported=0.25,
+        ),
+    ]
+
+    coordinator = OpowerCoordinator(hass, mock_config_entry)
+    await coordinator._async_update_data()
+    await async_wait_recording_done(hass)
+
+    stats = await hass.async_add_executor_job(
+        statistics_during_period,
+        hass,
+        dt_util.utc_from_timestamp(0),
+        None,
+        {
+            "opower:pge_elec_111111_energy_consumption",
+            "opower:pge_elec_111111_energy_return",
+        },
+        "hour",
+        None,
+        {"state", "sum"},
+    )
+
+    consumption = stats["opower:pge_elec_111111_energy_consumption"]
+    grid_return = stats["opower:pge_elec_111111_energy_return"]
+    # Sign splitting would have recorded 0 and 1.5 for consumption
+    # and 3.9 and 0 for return.
+    assert [s["state"] for s in consumption] == [0.25, 1.75]
+    assert [s["sum"] for s in consumption] == [0.25, 2.0]
+    assert [s["state"] for s in grid_return] == [4.15, 0.25]
+    assert [s["sum"] for s in grid_return] == [4.15, 4.4]
+
+
+async def test_coordinator_falls_back_to_sign_split(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_opower_api: AsyncMock,
+) -> None:
+    """Test reads without registers still split the net on its sign.
+
+    Utilities that do not publish the registers leave both fields None, and even
+    those that do can leave gaps (PG&E publishes none for the hours around a DST
+    transition), so both paths have to coexist within a single update.
+    """
+    mock_opower_api.async_get_cost_reads.return_value = [
+        CostRead(
+            start_time=dt_util.as_utc(datetime(2023, 1, 1, 8)),
+            end_time=dt_util.as_utc(datetime(2023, 1, 1, 9)),
+            consumption=-3.9,
+            provided_cost=-1.2,
+        ),
+        CostRead(
+            start_time=dt_util.as_utc(datetime(2023, 1, 1, 9)),
+            end_time=dt_util.as_utc(datetime(2023, 1, 1, 10)),
+            consumption=1.5,
+            provided_cost=0.5,
+            imported=1.75,
+            exported=0.25,
+        ),
+        # Only one of the two registers came back; not enough to use either.
+        CostRead(
+            start_time=dt_util.as_utc(datetime(2023, 1, 1, 10)),
+            end_time=dt_util.as_utc(datetime(2023, 1, 1, 11)),
+            consumption=2.0,
+            provided_cost=0.7,
+            imported=2.0,
+        ),
+    ]
+
+    coordinator = OpowerCoordinator(hass, mock_config_entry)
+    await coordinator._async_update_data()
+    await async_wait_recording_done(hass)
+
+    stats = await hass.async_add_executor_job(
+        statistics_during_period,
+        hass,
+        dt_util.utc_from_timestamp(0),
+        None,
+        {
+            "opower:pge_elec_111111_energy_consumption",
+            "opower:pge_elec_111111_energy_return",
+        },
+        "hour",
+        None,
+        {"state", "sum"},
+    )
+
+    assert [s["state"] for s in stats["opower:pge_elec_111111_energy_consumption"]] == [
+        0.0,
+        1.75,
+        2.0,
+    ]
+    assert [s["state"] for s in stats["opower:pge_elec_111111_energy_return"]] == [
+        3.9,
+        0.25,
+        0.0,
+    ]
+
+
 async def test_coordinator_subsequent_run_no_energy_data(
     recorder_mock: Recorder,
     hass: HomeAssistant,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prefer the new CostRead.imported/.exported over splitting the net consumption on its sign.

Deriving grid-in and grid-out from the sign of the net is systematically low on a net-metered site: an interval that is net-export can still contain real import. Measured on a PG&E NEM2 account over July 2026, the hourly sign split reports 197.20 kWh of grid import where the meter's own register recorded 219.67 kWh, 10% low. The daily statistics are worse, because nearly every summer day is net-export as a whole: the daily sign split reports 0.00 kWh of import for that same month. Summed over a billing period the registers reproduce the paper statement's Imports/Exports lines exactly.

Reads without both registers keep the old sign split, so utilities that do not publish them are unaffected, as are the bill-level statistics older than three years, which the registers are not served for.

No migration: the coordinator already re-requests and rewrites the last 30 days on every update, so recent statistics pick up the register values on their own. Older statistics keep the values they were written with. Each hour's state stays individually correct, so the running sum has no step change.

Cost and compensation still come from the sign of the net, so an hour that is net-export can now report real import in the consumption statistic alongside a compensation figure. That is intended: each statistic is as accurate as its own source allows.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
