### PR TITLE
Add top and very-low fan speeds to CoolMaster and drop speeds a unit rejects

### DIFF
--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -10,16 +10,17 @@ from homeassistant.components.climate import (
     FAN_HIGH,
     FAN_LOW,
     FAN_MEDIUM,
+    FAN_TOP,
     ClimateEntity,
     ClimateEntityFeature,
     HVACMode,
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import CONF_SUPPORTED_MODES
+from .const import CONF_SUPPORTED_MODES, DOMAIN
 from .coordinator import CoolmasterConfigEntry, CoolmasterDataUpdateCoordinator
 from .entity import CoolmasterEntity
 
@@ -33,10 +34,17 @@ CM_TO_HA_STATE = {
 
 HA_STATE_TO_CM = {value: key for key, value in CM_TO_HA_STATE.items()}
 
+# The CoolMasterNet vocabulary is VLow, Low, Med, High, Top, Auto. Home Assistant
+# has a constant for every one of those but the slowest, which is exposed under its
+# own name and translated in strings.json.
+FAN_VERY_LOW = "vlow"
+
 CM_TO_HA_FAN = {
+    "vlow": FAN_VERY_LOW,
     "low": FAN_LOW,
     "med": FAN_MEDIUM,
     "high": FAN_HIGH,
+    "top": FAN_TOP,
     "auto": FAN_AUTO,
 }
 
@@ -67,6 +75,7 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
     """Representation of a coolmaster climate device."""
 
     _attr_name = None
+    _attr_translation_key = DOMAIN
 
     # TODO(2026.7.0): When support for unknown fan speeds is
     # removed, delete this variable.
@@ -83,6 +92,8 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
         super().__init__(coordinator, unit_id)
         self._attr_hvac_modes = supported_modes
         self._attr_unique_id = unit_id
+        # Fan speeds this particular indoor unit has told us it cannot do.
+        self._unsupported_fan_modes: set[str] = set()
 
     @property
     @override
@@ -153,7 +164,7 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
     @override
     def fan_modes(self) -> list[str]:
         """Return the list of available fan modes."""
-        return FAN_MODES
+        return [mode for mode in FAN_MODES if mode not in self._unsupported_fan_modes]
 
     @property
     @override
@@ -175,11 +186,36 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
             self._unit = await self._unit.set_thermostat(temp)
             self.async_write_ha_state()
 
+    def _reject_fan_mode(self, fan_mode: str) -> ServiceValidationError:
+        """Drop a fan mode this unit rejected and build the error to raise."""
+        self._unsupported_fan_modes.add(fan_mode)
+        self.async_write_ha_state()
+        return ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="fan_mode_unsupported",
+            translation_placeholders={
+                "fan_mode": fan_mode,
+                "unit_id": self._unit_id,
+            },
+        )
+
     @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""
         _LOGGER.debug("Setting fan mode of %s to %s", self.unique_id, fan_mode)
-        self._unit = await self._unit.set_fan_speed(HA_FAN_TO_CM[fan_mode])
+        fan_speed = HA_FAN_TO_CM[fan_mode]
+        try:
+            self._unit = await self._unit.set_fan_speed(fan_speed)
+        except ValueError as error:
+            # The bridge answers "Unsupported Feature" for a speed the indoor unit
+            # cannot do, which the library reports as CoolMasterNetCommandError.
+            raise self._reject_fan_mode(fan_mode) from error
+
+        if self._unit.fan_speed.lower() != fan_speed:
+            # A rejected fspeed command "will have no effect" per the protocol
+            # reference, so the refreshed unit still reports the previous speed.
+            raise self._reject_fan_mode(fan_mode)
+
         self.async_write_ha_state()
 
     @override

--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -92,7 +92,6 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
         super().__init__(coordinator, unit_id)
         self._attr_hvac_modes = supported_modes
         self._attr_unique_id = unit_id
-        # Fan speeds this particular indoor unit has told us it cannot do.
         self._unsupported_fan_modes: set[str] = set()
 
     @property
@@ -186,35 +185,27 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
             self._unit = await self._unit.set_thermostat(temp)
             self.async_write_ha_state()
 
-    def _reject_fan_mode(self, fan_mode: str) -> ServiceValidationError:
-        """Drop a fan mode this unit rejected and build the error to raise."""
-        self._unsupported_fan_modes.add(fan_mode)
-        self.async_write_ha_state()
-        return ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="fan_mode_unsupported",
-            translation_placeholders={
-                "fan_mode": fan_mode,
-                "unit_id": self._unit_id,
-            },
-        )
-
     @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""
         _LOGGER.debug("Setting fan mode of %s to %s", self.unique_id, fan_mode)
         fan_speed = HA_FAN_TO_CM[fan_mode]
-        try:
-            self._unit = await self._unit.set_fan_speed(fan_speed)
-        except ValueError as error:
-            # The bridge answers "Unsupported Feature" for a speed the indoor unit
-            # cannot do, which the library reports as CoolMasterNetCommandError.
-            raise self._reject_fan_mode(fan_mode) from error
+        self._unit = await self._unit.set_fan_speed(fan_speed)
 
         if self._unit.fan_speed.lower() != fan_speed:
-            # A rejected fspeed command "will have no effect" per the protocol
-            # reference, so the refreshed unit still reports the previous speed.
-            raise self._reject_fan_mode(fan_mode)
+            # A speed the indoor unit does not have "will have no effect" per the
+            # protocol reference, so the refreshed unit still reports the previous
+            # speed. Stop offering it on this unit.
+            self._unsupported_fan_modes.add(fan_mode)
+            self.async_write_ha_state()
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="fan_mode_unsupported",
+                translation_placeholders={
+                    "fan_mode": fan_mode,
+                    "unit_id": self._unit_id,
+                },
+            )
 
         self.async_write_ha_state()
 

--- a/homeassistant/components/coolmaster/strings.json
+++ b/homeassistant/components/coolmaster/strings.json
@@ -90,10 +90,26 @@
         "name": "Reset filter"
       }
     },
+    "climate": {
+      "coolmaster": {
+        "state_attributes": {
+          "fan_mode": {
+            "state": {
+              "vlow": "Very low"
+            }
+          }
+        }
+      }
+    },
     "sensor": {
       "error_code": {
         "name": "Error code"
       }
+    }
+  },
+  "exceptions": {
+    "fan_mode_unsupported": {
+      "message": "Fan speed {fan_mode} is not supported by unit {unit_id}"
     }
   }
 }

--- a/tests/components/coolmaster/conftest.py
+++ b/tests/components/coolmaster/conftest.py
@@ -73,6 +73,17 @@ TEST_UNITS: dict[str, dict[str, Any]] = {
         "clean_filter": False,
         "swing": None,
     },
+    "L1.105": {
+        "is_on": True,
+        "thermostat": 25,
+        "temperature": 25,
+        "temperature_unit": "celsius",
+        "fan_speed": "top",
+        "mode": "cool",
+        "error_code": None,
+        "clean_filter": False,
+        "swing": None,
+    },
 }
 
 

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -1,5 +1,7 @@
 """The test for the Coolmaster climate platform."""
 
+from unittest.mock import patch
+
 from pycoolmasternet_async import SWING_MODES
 import pytest
 
@@ -15,6 +17,7 @@ from homeassistant.components.climate import (
     FAN_HIGH,
     FAN_LOW,
     FAN_MEDIUM,
+    FAN_TOP,
     SERVICE_SET_FAN_MODE,
     SERVICE_SET_HVAC_MODE,
     SERVICE_SET_SWING_MODE,
@@ -22,7 +25,7 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.components.coolmaster.climate import FAN_MODES
+from homeassistant.components.coolmaster.climate import FAN_MODES, FAN_VERY_LOW
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -33,7 +36,9 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+
+from .conftest import CoolMasterNetUnitMock
 
 
 async def test_climate_state(
@@ -46,6 +51,7 @@ async def test_climate_state(
     assert hass.states.get("climate.l1_102").state == HVACMode.COOL
     assert hass.states.get("climate.l1_103").state == HVACMode.COOL
     assert hass.states.get("climate.l1_104").state == HVACMode.COOL
+    assert hass.states.get("climate.l1_105").state == HVACMode.COOL
 
 
 async def test_climate_friendly_name(
@@ -58,6 +64,7 @@ async def test_climate_friendly_name(
     assert hass.states.get("climate.l1_102").attributes[ATTR_FRIENDLY_NAME] == "L1.102"
     assert hass.states.get("climate.l1_103").attributes[ATTR_FRIENDLY_NAME] == "L1.103"
     assert hass.states.get("climate.l1_104").attributes[ATTR_FRIENDLY_NAME] == "L1.104"
+    assert hass.states.get("climate.l1_105").attributes[ATTR_FRIENDLY_NAME] == "L1.105"
 
 
 async def test_climate_supported_features(
@@ -90,6 +97,7 @@ async def test_climate_temperature(
     assert hass.states.get("climate.l1_102").attributes[ATTR_CURRENT_TEMPERATURE] == 25
     assert hass.states.get("climate.l1_103").attributes[ATTR_CURRENT_TEMPERATURE] == 25
     assert hass.states.get("climate.l1_104").attributes[ATTR_CURRENT_TEMPERATURE] == 25
+    assert hass.states.get("climate.l1_105").attributes[ATTR_CURRENT_TEMPERATURE] == 25
 
 
 async def test_climate_thermostat(
@@ -102,6 +110,7 @@ async def test_climate_thermostat(
     assert hass.states.get("climate.l1_102").attributes[ATTR_TEMPERATURE] == 20
     assert hass.states.get("climate.l1_103").attributes[ATTR_TEMPERATURE] == 25
     assert hass.states.get("climate.l1_104").attributes[ATTR_TEMPERATURE] == 25
+    assert hass.states.get("climate.l1_105").attributes[ATTR_TEMPERATURE] == 25
 
 
 async def test_climate_hvac_modes(
@@ -119,6 +128,7 @@ async def test_climate_hvac_modes(
         "climate.l1_102",
         "climate.l1_103",
         "climate.l1_104",
+        "climate.l1_105",
     ):
         assert (
             hass.states.get(unit).attributes[ATTR_HVAC_MODES]
@@ -133,9 +143,10 @@ async def test_climate_fan_mode(
     """Test the Coolmaster climate fan mode."""
     assert hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODE] == FAN_LOW
     assert hass.states.get("climate.l1_101").attributes[ATTR_FAN_MODE] == FAN_HIGH
-    assert hass.states.get("climate.l1_102").attributes[ATTR_FAN_MODE] == "vlow"
+    assert hass.states.get("climate.l1_102").attributes[ATTR_FAN_MODE] == FAN_VERY_LOW
     assert hass.states.get("climate.l1_103").attributes[ATTR_FAN_MODE] == FAN_MEDIUM
     assert hass.states.get("climate.l1_104").attributes[ATTR_FAN_MODE] == "ultra"
+    assert hass.states.get("climate.l1_105").attributes[ATTR_FAN_MODE] == FAN_TOP
 
 
 async def test_climate_unknown_fan_mode_warning(
@@ -147,7 +158,7 @@ async def test_climate_unknown_fan_mode_warning(
     # TODO(2026.7.0): When support for unknown fan speeds is removed, delete this test.
     setup_logs = caplog.get_records(when="setup")
 
-    # Assert that both unknown fan speeds logged a warning.
+    # Assert that the unknown fan speed logged a warning.
     assert any(
         "Detected unknown fan speed value from HVAC unit: ultra. "
         "Support for unknown fan speeds will be removed in 2026.7.0"
@@ -155,11 +166,9 @@ async def test_climate_unknown_fan_mode_warning(
         and rec.levelname == "WARNING"
         for rec in setup_logs
     )
-    assert any(
-        "Detected unknown fan speed value from HVAC unit: vlow. "
-        "Support for unknown fan speeds will be removed in 2026.7.0"
-        in rec.getMessage()
-        and rec.levelname == "WARNING"
+    # "vlow" is a documented CoolMasterNet speed, so it must not warn.
+    assert not any(
+        "Detected unknown fan speed value from HVAC unit: vlow" in rec.getMessage()
         for rec in setup_logs
     )
 
@@ -192,6 +201,7 @@ async def test_climate_fan_modes(
         "climate.l1_102",
         "climate.l1_103",
         "climate.l1_104",
+        "climate.l1_105",
     ):
         assert (
             hass.states.get(unit).attributes[ATTR_FAN_MODES]
@@ -258,6 +268,106 @@ async def test_set_fan_mode(
     assert (
         hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODE] == target_fan_mode
     )
+
+
+async def test_set_fan_mode_ignored_by_unit(
+    hass: HomeAssistant,
+    load_int: ConfigEntry,
+) -> None:
+    """Test a fan speed the indoor unit accepts but does not apply."""
+    assert FAN_TOP in hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODES]
+
+    async def ignore_fan_speed(
+        self: CoolMasterNetUnitMock, value: str
+    ) -> CoolMasterNetUnitMock:
+        """Report the command as accepted while leaving the speed unchanged."""
+        return CoolMasterNetUnitMock(self.unit_id, self._attributes)
+
+    with (
+        patch.object(CoolMasterNetUnitMock, "set_fan_speed", ignore_fan_speed),
+        pytest.raises(ServiceValidationError),
+    ):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {
+                ATTR_ENTITY_ID: "climate.l1_100",
+                ATTR_FAN_MODE: FAN_TOP,
+            },
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("climate.l1_100")
+    assert state.attributes[ATTR_FAN_MODE] == FAN_LOW
+    assert FAN_TOP not in state.attributes[ATTR_FAN_MODES]
+    assert state.attributes[ATTR_FAN_MODES] == [
+        mode for mode in FAN_MODES if mode != FAN_TOP
+    ]
+
+
+async def test_set_fan_mode_rejected_by_bridge(
+    hass: HomeAssistant,
+    load_int: ConfigEntry,
+) -> None:
+    """Test a fan speed the bridge rejects with an error."""
+    assert FAN_TOP in hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODES]
+
+    async def reject_fan_speed(
+        self: CoolMasterNetUnitMock, value: str
+    ) -> CoolMasterNetUnitMock:
+        """Raise the way the library does on "Unsupported Feature"."""
+        raise ValueError(f"Unit {self.unit_id} doesn't support fan speed {value}.")
+
+    with (
+        patch.object(CoolMasterNetUnitMock, "set_fan_speed", reject_fan_speed),
+        pytest.raises(ServiceValidationError),
+    ):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {
+                ATTR_ENTITY_ID: "climate.l1_100",
+                ATTR_FAN_MODE: FAN_TOP,
+            },
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("climate.l1_100")
+    assert state.attributes[ATTR_FAN_MODE] == FAN_LOW
+    assert FAN_TOP not in state.attributes[ATTR_FAN_MODES]
+
+
+async def test_set_fan_mode_unsupported_only_on_one_unit(
+    hass: HomeAssistant,
+    load_int: ConfigEntry,
+) -> None:
+    """Test that dropping a fan speed only affects the unit that rejected it."""
+
+    async def ignore_fan_speed(
+        self: CoolMasterNetUnitMock, value: str
+    ) -> CoolMasterNetUnitMock:
+        """Report the command as accepted while leaving the speed unchanged."""
+        return CoolMasterNetUnitMock(self.unit_id, self._attributes)
+
+    with (
+        patch.object(CoolMasterNetUnitMock, "set_fan_speed", ignore_fan_speed),
+        pytest.raises(ServiceValidationError),
+    ):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {
+                ATTR_ENTITY_ID: "climate.l1_100",
+                ATTR_FAN_MODE: FAN_TOP,
+            },
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    assert FAN_TOP not in hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODES]
+    assert hass.states.get("climate.l1_101").attributes[ATTR_FAN_MODES] == FAN_MODES
 
 
 async def test_set_swing_mode(

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -306,39 +306,6 @@ async def test_set_fan_mode_ignored_by_unit(
     ]
 
 
-async def test_set_fan_mode_rejected_by_bridge(
-    hass: HomeAssistant,
-    load_int: ConfigEntry,
-) -> None:
-    """Test a fan speed the bridge rejects with an error."""
-    assert FAN_TOP in hass.states.get("climate.l1_100").attributes[ATTR_FAN_MODES]
-
-    async def reject_fan_speed(
-        self: CoolMasterNetUnitMock, value: str
-    ) -> CoolMasterNetUnitMock:
-        """Raise the way the library does on "Unsupported Feature"."""
-        raise ValueError(f"Unit {self.unit_id} doesn't support fan speed {value}.")
-
-    with (
-        patch.object(CoolMasterNetUnitMock, "set_fan_speed", reject_fan_speed),
-        pytest.raises(ServiceValidationError),
-    ):
-        await hass.services.async_call(
-            CLIMATE_DOMAIN,
-            SERVICE_SET_FAN_MODE,
-            {
-                ATTR_ENTITY_ID: "climate.l1_100",
-                ATTR_FAN_MODE: FAN_TOP,
-            },
-            blocking=True,
-        )
-    await hass.async_block_till_done()
-
-    state = hass.states.get("climate.l1_100")
-    assert state.attributes[ATTR_FAN_MODE] == FAN_LOW
-    assert FAN_TOP not in state.attributes[ATTR_FAN_MODES]
-
-
 async def test_set_fan_mode_unsupported_only_on_one_unit(
     hass: HomeAssistant,
     load_int: ConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I run a CoolMasterNet in front of six Mitsubishi Electric M-NET indoor units. The wall controllers and CoolAutomation's own app both offer the top fan speed, but I have never been able to select it from Home Assistant. `CM_TO_HA_FAN` maps only `low`/`med`/`high`/`auto`, and `fan_modes` returns that same four-item list for every unit, so `climate.set_fan_mode` with `top` is rejected by `_valid_mode_or_raise` before the integration is called at all. Since #160825 the read path passes `top` and `vlow` through, so the entity displays a speed it will not let you set. That asymmetry is issue #168043.

**Mapping the two missing speeds.** The CoolMasterNet vocabulary is VLow, Low, Med, High, Top, Auto. `top` maps onto the existing `FAN_TOP` constant in `climate/const.py`, which the climate component already translates. Home Assistant has no constant for the slowest speed, so `vlow` is exposed under its own name with a `state_attributes` translation ("Very low"), rather than being squeezed into `FAN_DIFFUSE`, which means something different. `FAN_MODES` therefore becomes `vlow, low, medium, high, top, auto`.

**Not offering speeds a unit cannot do.** Simply adding both speeds to the shared list would offer them on every indoor unit, including heads that do not have them. The bridge tells us when a unit will not take a speed: it answers `Unsupported Feature` (protocol reference exit code 101), and the protocol reference (Rev 0.9) states that such an `fspeed` "will have no effect".

Detection is therefore done purely on the refreshed state. `CoolMasterNetUnit.set_fan_speed` already performs a `refresh()` and returns the updated unit, so if the refreshed `fan_speed` is not the speed that was asked for, the unit did not take it. In that case the entity raises a translated `ServiceValidationError` and drops that speed from its own `fan_modes`, so the UI stops offering it on that unit and only on that unit. Nothing is persisted; the list is rebuilt from scratch on reload.

I deliberately do not catch an exception from `set_fan_speed` here. As of 0.2.6 the library does not inspect the reply text in `set_fan_speed` at all, so it never raises for `Unsupported Feature`; catching `ValueError` would only catch unrelated failures such as the `CoolMasterNetCommandError` raised for `Unknown command`, and would then permanently drop a perfectly valid fan mode. **Plan for this PR.** The second Copilot review is right that parsing the bridge's reply belongs in the library rather than being inferred from the refreshed state. That library change is open as OnFreund/pycoolmasternet-async#23. Once it is released, #181290 will bump to that version and this PR will be rebased on it so that a rejected speed is detected by catching `CoolMasterNetCommandError` from `set_fan_speed`. I'm keeping the rejected-speed handling in this PR rather than splitting it out, because it is the same problem: offering `top` to every unit is only safe if a unit that lacks it stops being offered it. Until the release lands, the refreshed-state check below (the documented "will have no effect" behaviour) stands so the change is testable end to end.

**Evidence from my own bridge.** Fan-speed tokens sent to unit L1.002 over the ASCII interface, each followed by `ls2` and `query <uid> f`:

```
fspeed L1.002 t -> OK                   ls2: ... Top  Heat ...   query f = 4
fspeed L1.002 a -> OK                   ls2: ... Auto Heat ...   query f = 3
fspeed L1.002 v -> Unsupported Feature  ls2: unchanged (Auto)    query f = 3
fspeed L1.002 l -> OK                   ls2: ... Low  Heat ...   query f = 0
fspeed L1.002 m -> OK                   ls2: ... Med  Heat ...   query f = 1
fspeed L1.002 h -> OK                   ls2: ... High Heat ...   query f = 2
```

On a running unit, `fspeed t` is reflected in `ls2` as `Top` within the same second, so the `refresh()` that `set_fan_speed` performs sees the new value and the state comparison is not racing the bridge.

**Two things I would like a view on.**

1. `fan_modes` is now derived per entity rather than being a module constant, so an entity's advertised capability list can shrink at runtime. The genuinely correct fix is the `props` command, which reports each unit's supported modes and fan speeds up front, but `props` is not implemented in the library (OnFreund/pycoolmasternet-async#7 has been open since 2023) and wiring it up is a much larger piece of work. If you would rather `fan_modes` stayed static, I am happy to keep only the `ServiceValidationError` and leave the unsupported speed in the list. I would just rather not silently swallow a rejection, which is what happens today.
2. I have deliberately left the unknown-fan-speed deprecation and its `TODO(2026.7.0)` alone. Adding `top` and `vlow` removes the two speeds users actually reported the warning for (#160868, #168043), so the pass-through is now only reached by genuinely undocumented tokens. The referenced version has passed, though, so it probably wants revisiting, and I did not want to pick a new target release unilaterally in this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168043
- This PR is related to issue: #160868, #161737
- Link to documentation pull request: to follow
- Link to developer documentation pull request:
- Link to frontend pull request:

This is additive and not a breaking change: `vlow` and `top` were already returned by the `fan_mode` property, so anything reading the attribute is unaffected, and no existing fan mode changes name or behaviour.

Disclosure: I used Claude Code as an editor to draft this change from the protocol notes and the device transcript above. I have read and understood every line of it, the reasoning and the device evidence are mine, and I have run the tests and the linters locally.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

