### PR TITLE
Add demand binary sensor and hvac_action to CoolMaster

### DIFF
--- a/homeassistant/components/coolmaster/binary_sensor.py
+++ b/homeassistant/components/coolmaster/binary_sensor.py
@@ -23,7 +23,9 @@ async def async_setup_entry(
     """Set up the CoolMasterNet binary_sensor platform."""
     coordinator = config_entry.runtime_data
     async_add_entities(
-        CoolmasterCleanFilter(coordinator, unit_id) for unit_id in coordinator.data
+        entity_class(coordinator, unit_id)
+        for unit_id in coordinator.data
+        for entity_class in (CoolmasterCleanFilter, CoolmasterDemand)
     )
 
 
@@ -42,3 +44,19 @@ class CoolmasterCleanFilter(CoolmasterEntity, BinarySensorEntity):
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
         return self._unit.clean_filter
+
+
+class CoolmasterDemand(CoolmasterEntity, BinarySensorEntity):
+    """Representation of a unit's demand (true means calling for heating or cooling)."""
+
+    entity_description = BinarySensorEntityDescription(
+        key="demand",
+        translation_key="demand",
+        device_class=BinarySensorDeviceClass.RUNNING,
+    )
+
+    @property
+    @override
+    def is_on(self) -> bool | None:
+        """Return true if the unit is calling for heating or cooling."""
+        return self._unit.demand

--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -156,12 +156,13 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
             return HVACAction.IDLE
         if mode == "auto":
             # The bridge does not say which way a unit in automatic mode is
-            # working, so compare the room temperature against the set point.
-            return (
-                HVACAction.COOLING
-                if self._unit.temperature > self._unit.thermostat
-                else HVACAction.HEATING
-            )
+            # working, so infer it from the room temperature against the set
+            # point, and stay unknown when there is nothing to tell them apart.
+            if self._unit.temperature > self._unit.thermostat:
+                return HVACAction.COOLING
+            if self._unit.temperature < self._unit.thermostat:
+                return HVACAction.HEATING
+            return None
         return CM_TO_HA_ACTION[mode]
 
     @property

--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -145,8 +145,6 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
 
         mode = self._unit.mode
         if mode == "fan":
-            # In fan only mode the fan runs for as long as the unit is on and the
-            # unit never calls for heating or cooling.
             return HVACAction.FAN
 
         if (demand := self._unit.demand) is None:

--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -12,6 +12,7 @@ from homeassistant.components.climate import (
     FAN_MEDIUM,
     ClimateEntity,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
@@ -32,6 +33,12 @@ CM_TO_HA_STATE = {
 }
 
 HA_STATE_TO_CM = {value: key for key, value in CM_TO_HA_STATE.items()}
+
+CM_TO_HA_ACTION = {
+    "heat": HVACAction.HEATING,
+    "cool": HVACAction.COOLING,
+    "dry": HVACAction.DRYING,
+}
 
 CM_TO_HA_FAN = {
     "low": FAN_LOW,
@@ -128,6 +135,34 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
             return HVACMode.OFF
 
         return CM_TO_HA_STATE[mode]
+
+    @property
+    @override
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current running action."""
+        if not self._unit.is_on:
+            return HVACAction.OFF
+
+        mode = self._unit.mode
+        if mode == "fan":
+            # In fan only mode the fan runs for as long as the unit is on and the
+            # unit never calls for heating or cooling.
+            return HVACAction.FAN
+
+        if (demand := self._unit.demand) is None:
+            # Bridges that only speak the legacy status format omit demand.
+            return None
+        if not demand:
+            return HVACAction.IDLE
+        if mode == "auto":
+            # The bridge does not say which way a unit in automatic mode is
+            # working, so compare the room temperature against the set point.
+            return (
+                HVACAction.COOLING
+                if self._unit.temperature > self._unit.thermostat
+                else HVACAction.HEATING
+            )
+        return CM_TO_HA_ACTION[mode]
 
     @property
     @override

--- a/homeassistant/components/coolmaster/strings.json
+++ b/homeassistant/components/coolmaster/strings.json
@@ -83,6 +83,9 @@
     "binary_sensor": {
       "clean_filter": {
         "name": "Clean filter"
+      },
+      "demand": {
+        "name": "Demand"
       }
     },
     "button": {

--- a/tests/components/coolmaster/conftest.py
+++ b/tests/components/coolmaster/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for the Coolmaster integration."""
 
 import copy
+from functools import partial
 from typing import Any
 from unittest.mock import patch
 
@@ -82,9 +83,18 @@ TEST_UNITS: dict[str, dict[str, Any]] = {
 
 
 @pytest.fixture
-def unit_count():
+def units(request: pytest.FixtureRequest) -> dict[str, dict[str, Any]]:
+    """Fixture for the units the mocked bridge reports.
+
+    Parametrise indirectly to have the bridge report units in a given state.
+    """
+    return getattr(request, "param", TEST_UNITS)
+
+
+@pytest.fixture
+def unit_count(units: dict[str, dict[str, Any]]) -> int:
     """Fixture to expose the number of pre-defined units."""
-    return len(TEST_UNITS)
+    return len(units)
 
 
 class CoolMasterNetUnitMock:
@@ -138,9 +148,14 @@ class CoolMasterNetUnitMock:
 class CoolMasterNetMock:
     """Mock for CoolMasterNet."""
 
-    def __init__(self, *_args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *_args: Any,
+        units: dict[str, dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Initialize the CoolMasterNetMock."""
-        self._units = copy.deepcopy(TEST_UNITS)
+        self._units = copy.deepcopy(TEST_UNITS if units is None else units)
 
     async def info(self) -> dict[str, Any]:
         """Return info about the bridge device."""
@@ -203,7 +218,9 @@ class CoolMasterNetEmptyStatusMock:
 
 @pytest.fixture
 async def load_int(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    units: dict[str, dict[str, Any]],
 ) -> MockConfigEntry:
     """Set up the Coolmaster integration in Home Assistant."""
     config_entry = MockConfigEntry(
@@ -219,7 +236,7 @@ async def load_int(
 
     with patch(
         "homeassistant.components.coolmaster.CoolMasterNet",
-        new=CoolMasterNetMock,
+        new=partial(CoolMasterNetMock, units=units),
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/coolmaster/conftest.py
+++ b/tests/components/coolmaster/conftest.py
@@ -26,6 +26,7 @@ TEST_UNITS: dict[str, dict[str, Any]] = {
         "fan_speed": "low",
         "mode": "cool",
         "error_code": None,
+        "demand": False,
         "clean_filter": False,
         "swing": None,
     },
@@ -37,6 +38,7 @@ TEST_UNITS: dict[str, dict[str, Any]] = {
         "fan_speed": "high",
         "mode": "heat",
         "error_code": "Err1",
+        "demand": True,
         "clean_filter": True,
         "swing": "horizontal",
     },
@@ -48,6 +50,7 @@ TEST_UNITS: dict[str, dict[str, Any]] = {
         "fan_speed": "vlow",
         "mode": "cool",
         "error_code": None,
+        "demand": False,
         "clean_filter": False,
         "swing": None,
     },
@@ -59,6 +62,7 @@ TEST_UNITS: dict[str, dict[str, Any]] = {
         "fan_speed": "Med",  # Test case insensitivity for fan speed
         "mode": "cool",
         "error_code": None,
+        "demand": True,
         "clean_filter": False,
         "swing": None,
     },
@@ -70,6 +74,7 @@ TEST_UNITS: dict[str, dict[str, Any]] = {
         "fan_speed": "ULTRA",  # Test unknown fan speed handling
         "mode": "cool",
         "error_code": None,
+        "demand": None,  # Test a bridge that does not report demand
         "clean_filter": False,
         "swing": None,
     },

--- a/tests/components/coolmaster/test_binary_sensor.py
+++ b/tests/components/coolmaster/test_binary_sensor.py
@@ -1,13 +1,27 @@
 """The test for the Coolmaster binary sensor platform."""
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
 
-async def test_binary_sensor(
+async def test_clean_filter(
     hass: HomeAssistant,
     load_int: ConfigEntry,
 ) -> None:
-    """Test the Coolmaster binary sensor."""
-    assert hass.states.get("binary_sensor.l1_100_clean_filter").state == "off"
-    assert hass.states.get("binary_sensor.l1_101_clean_filter").state == "on"
+    """Test the Coolmaster clean filter binary sensor."""
+    assert hass.states.get("binary_sensor.l1_100_clean_filter").state == STATE_OFF
+    assert hass.states.get("binary_sensor.l1_101_clean_filter").state == STATE_ON
+
+
+async def test_demand(
+    hass: HomeAssistant,
+    load_int: ConfigEntry,
+) -> None:
+    """Test the Coolmaster demand binary sensor."""
+    assert hass.states.get("binary_sensor.l1_100_demand").state == STATE_OFF
+    assert hass.states.get("binary_sensor.l1_101_demand").state == STATE_ON
+    assert hass.states.get("binary_sensor.l1_102_demand").state == STATE_OFF
+    assert hass.states.get("binary_sensor.l1_103_demand").state == STATE_ON
+    # The legacy status format does not report demand at all.
+    assert hass.states.get("binary_sensor.l1_104_demand").state == STATE_UNKNOWN

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -1,5 +1,7 @@
 """The test for the Coolmaster climate platform."""
 
+from typing import Any
+
 from pycoolmasternet_async import SWING_MODES
 import pytest
 
@@ -36,7 +38,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_component import async_update_entity
+
+from .conftest import TEST_UNITS
 
 
 async def test_climate_state(
@@ -153,37 +156,39 @@ async def test_climate_hvac_action(
     assert ATTR_HVAC_ACTION not in hass.states.get("climate.l1_104").attributes
 
 
+def only_unit(**overrides: Any) -> dict[str, dict[str, Any]]:
+    """Build a single unit table based on L1.102, which is on and set to 20."""
+    return {"L1.102": {**TEST_UNITS["L1.102"], **overrides}}
+
+
 @pytest.mark.parametrize(
-    ("mode", "demand", "temperature", "expected"),
+    ("units", "expected"),
     [
         # In fan only mode the fan runs whenever the unit is on.
-        ("fan", False, 25, HVACAction.FAN),
-        ("dry", True, 25, HVACAction.DRYING),
-        ("dry", False, 25, HVACAction.IDLE),
+        (only_unit(mode="fan", demand=False), HVACAction.FAN),
+        (only_unit(mode="dry", demand=True), HVACAction.DRYING),
+        (only_unit(mode="dry", demand=False), HVACAction.IDLE),
         # A unit in automatic mode does not say which way it is working, so the
-        # room temperature is compared against the set point of 20.
-        ("auto", True, 25, HVACAction.COOLING),
-        ("auto", True, 15, HVACAction.HEATING),
+        # room temperature is compared against the set point of 20, and the
+        # action stays unknown when the two are equal.
+        (only_unit(mode="auto", demand=True, temperature=25), HVACAction.COOLING),
+        (only_unit(mode="auto", demand=True, temperature=15), HVACAction.HEATING),
+        (only_unit(mode="auto", demand=True, temperature=20), None),
     ],
+    indirect=["units"],
 )
 async def test_climate_hvac_action_derived_modes(
     hass: HomeAssistant,
     load_int: ConfigEntry,
-    mode: str,
-    demand: bool,
-    temperature: float,
-    expected: HVACAction,
+    expected: HVACAction | None,
 ) -> None:
     """Test the hvac action for modes no fixture unit reports."""
-    unit = load_int.runtime_data._coolmaster._units["L1.102"]
-    unit["mode"] = mode
-    unit["demand"] = demand
-    unit["temperature"] = temperature
+    attributes = hass.states.get("climate.l1_102").attributes
 
-    await async_update_entity(hass, "climate.l1_102")
-    await hass.async_block_till_done()
-
-    assert hass.states.get("climate.l1_102").attributes[ATTR_HVAC_ACTION] == expected
+    if expected is None:
+        assert ATTR_HVAC_ACTION not in attributes
+    else:
+        assert attributes[ATTR_HVAC_ACTION] == expected
 
 
 async def test_climate_fan_mode(

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -7,6 +7,7 @@ from homeassistant.components.climate import (
     ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
     ATTR_FAN_MODES,
+    ATTR_HVAC_ACTION,
     ATTR_HVAC_MODE,
     ATTR_HVAC_MODES,
     ATTR_SWING_MODE,
@@ -20,6 +21,7 @@ from homeassistant.components.climate import (
     SERVICE_SET_SWING_MODE,
     SERVICE_SET_TEMPERATURE,
     ClimateEntityFeature,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.components.coolmaster.climate import FAN_MODES
@@ -124,6 +126,60 @@ async def test_climate_hvac_modes(
             hass.states.get(unit).attributes[ATTR_HVAC_MODES]
             == hass.states.get("climate.l1_100").attributes[ATTR_HVAC_MODES]
         )
+
+
+async def test_climate_hvac_action(
+    hass: HomeAssistant,
+    load_int: ConfigEntry,
+) -> None:
+    """Test the Coolmaster climate hvac action."""
+    assert (
+        hass.states.get("climate.l1_100").attributes[ATTR_HVAC_ACTION] == HVACAction.OFF
+    )
+    assert (
+        hass.states.get("climate.l1_101").attributes[ATTR_HVAC_ACTION]
+        == HVACAction.HEATING
+    )
+    assert (
+        hass.states.get("climate.l1_102").attributes[ATTR_HVAC_ACTION]
+        == HVACAction.IDLE
+    )
+    assert (
+        hass.states.get("climate.l1_103").attributes[ATTR_HVAC_ACTION]
+        == HVACAction.COOLING
+    )
+    # The legacy status format does not report demand, so the action is unknown.
+    assert ATTR_HVAC_ACTION not in hass.states.get("climate.l1_104").attributes
+
+
+@pytest.mark.parametrize(
+    ("mode", "demand", "temperature", "expected"),
+    [
+        # In fan only mode the fan runs whenever the unit is on.
+        ("fan", False, 25, HVACAction.FAN),
+        ("dry", True, 25, HVACAction.DRYING),
+        ("dry", False, 25, HVACAction.IDLE),
+        # A unit in automatic mode does not say which way it is working, so the
+        # room temperature is compared against the set point of 20.
+        ("auto", True, 25, HVACAction.COOLING),
+        ("auto", True, 15, HVACAction.HEATING),
+    ],
+)
+async def test_climate_hvac_action_derived_modes(
+    hass: HomeAssistant,
+    load_int: ConfigEntry,
+    mode: str,
+    demand: bool,
+    temperature: float,
+    expected: HVACAction,
+) -> None:
+    """Test the hvac action for modes no fixture unit reports."""
+    entity = hass.data[CLIMATE_DOMAIN].get_entity("climate.l1_102")
+    entity._unit.mode = mode
+    entity._unit.demand = demand
+    entity._unit.temperature = temperature
+
+    assert entity.hvac_action == expected
 
 
 async def test_climate_fan_mode(

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -36,6 +36,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_component import async_update_entity
 
 
 async def test_climate_state(
@@ -174,12 +175,15 @@ async def test_climate_hvac_action_derived_modes(
     expected: HVACAction,
 ) -> None:
     """Test the hvac action for modes no fixture unit reports."""
-    entity = hass.data[CLIMATE_DOMAIN].get_entity("climate.l1_102")
-    entity._unit.mode = mode
-    entity._unit.demand = demand
-    entity._unit.temperature = temperature
+    unit = load_int.runtime_data._coolmaster._units["L1.102"]
+    unit["mode"] = mode
+    unit["demand"] = demand
+    unit["temperature"] = temperature
 
-    assert entity.hvac_action == expected
+    await async_update_entity(hass, "climate.l1_102")
+    await hass.async_block_till_done()
+
+    assert hass.states.get("climate.l1_102").attributes[ATTR_HVAC_ACTION] == expected
 
 
 async def test_climate_fan_mode(

--- a/tests/components/coolmaster/test_climate.py
+++ b/tests/components/coolmaster/test_climate.py
@@ -185,10 +185,8 @@ async def test_climate_hvac_action_derived_modes(
     """Test the hvac action for modes no fixture unit reports."""
     attributes = hass.states.get("climate.l1_102").attributes
 
-    if expected is None:
-        assert ATTR_HVAC_ACTION not in attributes
-    else:
-        assert attributes[ATTR_HVAC_ACTION] == expected
+    # The attribute is dropped entirely when hvac_action is None.
+    assert attributes.get(ATTR_HVAC_ACTION) == expected
 
 
 async def test_climate_fan_mode(

--- a/tests/components/coolmaster/test_init.py
+++ b/tests/components/coolmaster/test_init.py
@@ -13,8 +13,8 @@ async def test_load_entry(
     hass: HomeAssistant, load_int: ConfigEntry, unit_count: int
 ) -> None:
     """Test Coolmaster initial load."""
-    # 4 units times 4 entities (climate, binary_sensor, sensor, button).
-    assert hass.states.async_entity_ids_count() == unit_count * 4
+    # Every unit has five entities: climate, two binary sensors, sensor, button.
+    assert hass.states.async_entity_ids_count() == unit_count * 5
     assert load_int.state is ConfigEntryState.LOADED
 
 


### PR DESCRIPTION
> **Status: on hold, not ready for review.** Testing this on my own bridge (CoolMasterNet fw 1.4.3, one Mitsubishi Electric M-NET line, `L1: ME`) shows the `ls2` demand column is present but never set on that line: with a unit in Heat and the set point raised 6.5 °C above room temperature for six minutes, the room warmed 2 °C while the column read `0` at every sample. CoolAutomation's documentation only lists a Mitsubishi thermo-ON signal (`TH_ON`) among the "PRO" indoor objects, which are not enabled on my bridge, so on ME lines the standard flag seems to have no source. As written this PR would report "Demand: off" and `hvac_action: idle` on such systems while they are actually heating, which is worse than reporting nothing. I've asked CoolAutomation whether Demand State is supported on ME lines and whether it depends on PRO. Until that's answered, and the library can tell HA which units genuinely report demand, this stays a draft.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The CoolMasterNet reports a per-unit demand flag in the last field of `ls2`. It is the bridge's "thermo ON" signal: true when the indoor unit is actually calling for heating or cooling, false when it is switched on but satisfied. pycoolmasternet-async 0.2.6 exposes it as `CoolMasterNetUnit.demand`, and nothing in Home Assistant reads it yet, so today there is no way to tell a unit that is working from one that is merely powered.

This adds two things:

* **A `demand` binary sensor** per unit, device class `running`. On my six-unit installation this is the closest thing the hardware offers to a runtime signal — the bridge is a control gateway and reports no power or energy at all — so it is what you would use to build duty-cycle or runtime statistics.
* **`hvac_action` on the climate entity**, derived from the same flag. Off when the unit is off; `fan` in fan-only mode, where the fan runs for as long as the unit is on and demand never applies; otherwise `heating`, `cooling` or `drying` when demand is true and `idle` when it is false.

Two cases worth calling out:

* Bridges that only answer the legacy eight-field `stat2` format have no demand field. The library reports that as `None`, and both the binary sensor and `hvac_action` stay unknown rather than claiming the unit is idle. There is a fixture unit and a test for this.
* A unit in the bridge's `auto` mode does not tell us which way it is currently working, and `HVACAction` has no equivalent value. When such a unit is calling, the room temperature is compared against the set point: above it gives `cooling`, below it gives `heating`, and when the two are equal there is nothing to infer a direction from, so the action stays unknown rather than guessing. That is a heuristic rather than a reading, so I have kept it to that one branch and commented it. If you would prefer `hvac_action` to be unknown in automatic mode altogether, say so and I will change it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 

This needs pycoolmasternet-async 0.2.6 for `unit.demand`, which landed in #181290, so this branch is now rebased on `dev` and contains only its own commits.
- Link to documentation pull request: home-assistant/home-assistant.io#47898
- Link to developer documentation pull request: 
- Link to frontend pull request: 

This is additive: one new entity per unit and one new attribute on an existing entity. No existing entity or attribute changes.

Disclosure: I used Claude Code as an editor to draft this change. I have read and understood every line of it, the design decisions above are mine, and I have run the tests and the linters locally.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

