### PR TITLE
Expose writable myUplink 0/1 points as switches

### DIFF
--- a/homeassistant/components/myuplink/helpers.py
+++ b/homeassistant/components/myuplink/helpers.py
@@ -29,19 +29,20 @@ def find_matching_platform(
     if (
         device_point.writable
         and not device_point.enum_values
-        and device_point.raw.get("minValue") == 0
-        and device_point.raw.get("maxValue") == 1
-        and device_point.raw.get("stepValue") == 1
-        and not device_point.raw.get("unit")
+        and device_point.min_value == 0
+        and device_point.max_value == 1
+        and device_point.step_value == 1
+        and not device_point.parameter_unit
     ):
         return Platform.SWITCH
 
-    has_numeric_range = (
-        device_point.raw.get("minValue") is not None
-        and device_point.raw.get("maxValue") is not None
+    has_numeric_range = isinstance(device_point.min_value, int | float) and isinstance(
+        device_point.max_value, int | float
     )
 
-    if (description and description.native_unit_of_measurement == "DM") or has_numeric_range:
+    if (
+        description and description.native_unit_of_measurement == "DM"
+    ) or has_numeric_range:
         if device_point.writable:
             return Platform.NUMBER
         return Platform.SENSOR

--- a/homeassistant/components/myuplink/helpers.py
+++ b/homeassistant/components/myuplink/helpers.py
@@ -26,9 +26,24 @@ def find_matching_platform(
     if len(device_point.enum_values) > 0 and device_point.writable:
         return Platform.SELECT
 
-    if (description and description.native_unit_of_measurement == "DM") or (
-        device_point.raw["maxValue"] and device_point.raw["minValue"]
-    ):
+    is_bool_range = (
+        device_point.raw.get("minValue") == 0
+        and device_point.raw.get("maxValue") == 1
+        and device_point.raw.get("stepValue") == 1
+        and not device_point.raw.get("unit")
+    )
+    
+    if is_bool_range:
+        if device_point.writable:
+            return Platform.SWITCH
+        return Platform.BINARY_SENSOR
+
+    has_numeric_range = (
+        device_point.raw.get("minValue") is not None
+        and device_point.raw.get("maxValue") is not None
+    )
+
+    if (description and description.native_unit_of_measurement == "DM") or has_numeric_range:
         if device_point.writable:
             return Platform.NUMBER
         return Platform.SENSOR

--- a/homeassistant/components/myuplink/helpers.py
+++ b/homeassistant/components/myuplink/helpers.py
@@ -26,17 +26,15 @@ def find_matching_platform(
     if len(device_point.enum_values) > 0 and device_point.writable:
         return Platform.SELECT
 
-    is_bool_range = (
-        device_point.raw.get("minValue") == 0
+    if (
+        device_point.writable
+        and not device_point.enum_values
+        and device_point.raw.get("minValue") == 0
         and device_point.raw.get("maxValue") == 1
         and device_point.raw.get("stepValue") == 1
         and not device_point.raw.get("unit")
-    )
-    
-    if is_bool_range:
-        if device_point.writable:
-            return Platform.SWITCH
-        return Platform.BINARY_SENSOR
+    ):
+        return Platform.SWITCH
 
     has_numeric_range = (
         device_point.raw.get("minValue") is not None

--- a/tests/components/myuplink/test_helpers.py
+++ b/tests/components/myuplink/test_helpers.py
@@ -1,0 +1,40 @@
+"""Tests for myUplink helpers."""
+
+from myuplink import DevicePoint
+import pytest
+
+from homeassistant.components.myuplink.helpers import find_matching_platform
+from homeassistant.const import Platform
+
+
+@pytest.mark.parametrize(
+    ("writable", "minimum", "maximum", "step", "unit", "expected_platform"),
+    [
+        pytest.param(True, 0, 1, 1, "", Platform.SWITCH, id="writable_boolean"),
+        pytest.param(True, 0, 1, 1, "EB101", Platform.NUMBER, id="unit"),
+        pytest.param(False, 0, 1, 1, "", Platform.SENSOR, id="read_only"),
+        pytest.param(True, 0, 10, 1, "", Platform.NUMBER, id="numeric_range"),
+        pytest.param(True, "", "", 1, "", Platform.SENSOR, id="invalid_range"),
+    ],
+)
+def test_find_matching_platform(
+    writable: bool,
+    minimum: int | str,
+    maximum: int | str,
+    step: int,
+    unit: str,
+    expected_platform: Platform,
+) -> None:
+    """Test finding the matching platform for a device point."""
+    device_point = DevicePoint(
+        {
+            "enumValues": [],
+            "writable": writable,
+            "minValue": minimum,
+            "maxValue": maximum,
+            "stepValue": step,
+            "parameterUnit": unit,
+        }
+    )
+
+    assert find_matching_platform(device_point) is expected_platform


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Some writable myUplink device points that represent on/off values may now be exposed as switch entities instead of sensor entities.

For example, NIBE night cooling can change from `sensor.smo_40_night_cooling` to `switch.smo_40_night_cooling` when the myUplink API reports it as a writable 0/1 point.

If you used one of these entities in automations, scripts, templates, or dashboards, update the entity ID to the new switch entity. This change makes these device points controllable from Home Assistant instead of exposing them as read-only sensors.

## Proposed change

This fixes a bug where a writable boolean API endpoint is only interpreted as a sensor in HA.

Treat numeric device points with minValue 0, maxValue 1, and stepValue 1 as boolean-like points when no enum values are provided. This allows writable points such as NIBE night cooling to be exposed as switches instead of read-only sensors.

Also treat zero min/max values as valid numeric bounds when detecting number entities by adding "is not None". (Problem before was that 0 is not true)

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #181275 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
