### PR TITLE
Add switch support for Tuya ggq devices

### DIFF
--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -263,6 +263,10 @@ SWITCHES: dict[DeviceCategory, tuple[SwitchEntityDescription, ...]] = {
     ),
     DeviceCategory.GGQ: (
         SwitchEntityDescription(
+            key=DPCode.SWITCH,
+            translation_key="switch",
+        ),
+        SwitchEntityDescription(
             key=DPCode.SWITCH_1,
             translation_key="indexed_switch",
             translation_placeholders={"index": "1"},

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -2189,6 +2189,36 @@
     'via_device_id': None,
   })
 # ---
+# name: test_device_registry[anmj1w0gnz2avbauqgg]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tuya',
+        'anmj1w0gnz2avbauqgg',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Tuya',
+    'model': 'WiFi Watering Pump',
+    'model_id': 'uabva2zng0w1jmna',
+    'name': 'WiFi Watering Pump',
+    'name_by_user': None,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
 # name: test_device_registry[ao3z3oeyvepe8o3xqdt]
   DeviceRegistryEntrySnapshot({
     'area_id': None,
@@ -3263,6 +3293,36 @@
     'model': 'DOLCECLIMA 10 HP WIFI (unsupported)',
     'model_id': 'jevroj5aguwdbs2e',
     'name': 'DOLCECLIMA 10 HP WIFI',
+    'name_by_user': None,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_device_registry[eikafwrmuhdvizruqzktk]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tuya',
+        'eikafwrmuhdvizruqzktk',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Tuya',
+    'model': 'VITAL+ (unsupported)',
+    'model_id': 'urzivdhumrwfakie',
+    'name': 'VITAL+',
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,
@@ -8060,7 +8120,7 @@
     'labels': set({
     }),
     'manufacturer': 'Tuya',
-    'model': 'GIEX Watering Timer (unsupported)',
+    'model': 'GIEX Watering Timer',
     'model_id': '7ytb3h8u',
     'name': 'GIEX Watering Timer',
     'name_by_user': None,
@@ -8213,36 +8273,6 @@
     'model': 'WiFi Temperature & Humidity Sensor',
     'model_id': 'yqiqbaldtr0i7mru',
     'name': 'WiFi Temperature & Humidity Sensor',
-    'name_by_user': None,
-    'serial_number': None,
-    'sw_version': None,
-    'via_device_id': None,
-  })
-# ---
-# name: test_device_registry[eikafwrmuhdvizruqzktk]
-  DeviceRegistryEntrySnapshot({
-    'area_id': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'configuration_url': None,
-    'connections': set({
-    }),
-    'disabled_by': None,
-    'entry_type': None,
-    'hw_version': None,
-    'id': <ANY>,
-    'identifiers': set({
-      tuple(
-        'tuya',
-        'eikafwrmuhdvizruqzktk',
-      ),
-    }),
-    'labels': set({
-    }),
-    'manufacturer': 'Tuya',
-    'model': 'VITAL+ (unsupported)',
-    'model_id': 'urzivdhumrwfakie',
-    'name': 'VITAL+',
     'name_by_user': None,
     'serial_number': None,
     'sw_version': None,


### PR DESCRIPTION
## Breaking change


## Proposed change

Add support for the standard `switch` datapoint for Tuya devices in the `ggq` category.

A WiFi Watering Pump using the `ggq` category exposes its primary on/off control as the standard Boolean `switch` datapoint in both the Tuya Standard Instruction Set and Standard Status Set.

Home Assistant currently maps `switch_1` through `switch_8` for `DeviceCategory.GGQ`, but not the standard `switch` datapoint. As a result, the primary switch of devices using this datapoint is not exposed.

This change adds `DPCode.SWITCH` to the existing `DeviceCategory.GGQ` switch mapping.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Device details:
- Device category: `ggq`
- Tested device: WiFi Watering Pump
- Tuya product ID: `uabva2zng0w1jmna`
- Tuya Standard Instruction Set: `switch` (Boolean)
- Tuya Standard Status Set: `switch` (Boolean)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr