### PR TITLE
Add Spin EV Charger integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -556,6 +556,7 @@ homeassistant.components.sonarr.*
 homeassistant.components.spaceapi.*
 homeassistant.components.specialized_turbo.*
 homeassistant.components.speedtestdotnet.*
+homeassistant.components.spinev.*
 homeassistant.components.spotify.*
 homeassistant.components.sql.*
 homeassistant.components.squeezebox.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1774,6 +1774,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/specialized_turbo/ @JamieMagee
 /homeassistant/components/speedtestdotnet/ @rohankapoorcom @engrbm87
 /tests/components/speedtestdotnet/ @rohankapoorcom @engrbm87
+/homeassistant/components/spinev/ @Dr-Blank
+/tests/components/spinev/ @Dr-Blank
 /homeassistant/components/splunk/ @Bre77
 /tests/components/splunk/ @Bre77
 /homeassistant/components/spotify/ @frenck @joostlek

--- a/homeassistant/components/spinev/__init__.py
+++ b/homeassistant/components/spinev/__init__.py
@@ -1,0 +1,30 @@
+"""The Spin EV Charger integration."""
+
+from homeassistant.core import HomeAssistant
+
+from .const import PLATFORMS
+from .coordinator import SpinEvConfigEntry, SpinEvCoordinator
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: SpinEvConfigEntry) -> bool:
+    """Set up a charger from a config entry."""
+    coordinator = SpinEvCoordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: SpinEvConfigEntry) -> bool:
+    """Unload a config entry and hand the charger back."""
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    await entry.runtime_data.async_release()
+    return unloaded
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: SpinEvConfigEntry) -> None:
+    """Reload the entry so a changed connection mode takes effect."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/spinev/__init__.py
+++ b/homeassistant/components/spinev/__init__.py
@@ -9,6 +9,7 @@ from .coordinator import SpinEvConfigEntry, SpinEvCoordinator
 async def async_setup_entry(hass: HomeAssistant, entry: SpinEvConfigEntry) -> bool:
     """Set up a charger from a config entry."""
     coordinator = SpinEvCoordinator(hass, entry)
+    entry.async_on_unload(coordinator.async_release)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
 
@@ -19,10 +20,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: SpinEvConfigEntry) -> bo
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: SpinEvConfigEntry) -> bool:
-    """Unload a config entry and hand the charger back."""
-    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    await entry.runtime_data.async_release()
-    return unloaded
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: SpinEvConfigEntry) -> None:

--- a/homeassistant/components/spinev/config_flow.py
+++ b/homeassistant/components/spinev/config_flow.py
@@ -181,7 +181,9 @@ class SpinEvConfigFlow(ConfigFlow, domain=DOMAIN):
         if ble_device is None:
             return False
 
-        charger = SpinEvCharger(ble_device, client_class=HaBleakClientWrapper)
+        charger = SpinEvCharger(
+            ble_device, client_class=HaBleakClientWrapper, max_attempts=1
+        )
         try:
             async with charger:
                 await charger.async_get_state_value()

--- a/homeassistant/components/spinev/config_flow.py
+++ b/homeassistant/components/spinev/config_flow.py
@@ -1,0 +1,200 @@
+"""Config flow for the Spin EV Charger integration."""
+
+import logging
+import re
+from typing import Any, override
+
+from habluetooth import HaBleakClientWrapper
+from spinev_ble import ADVERTISED_NAME_PATTERN, SpinEvCharger, SpinEvError
+import voluptuous as vol
+
+from homeassistant.components import bluetooth
+from homeassistant.components.bluetooth import (
+    BluetoothServiceInfoBleak,
+    async_discovered_service_info,
+)
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
+
+from .const import (
+    CONF_CONNECTION_MODE,
+    CONF_SERIAL,
+    DEFAULT_CONNECTION_MODE,
+    DOMAIN,
+    ConnectionMode,
+)
+from .coordinator import SpinEvConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_CONNECTION_MODE): SelectSelector(
+            SelectSelectorConfig(
+                options=[mode.value for mode in ConnectionMode],
+                mode=SelectSelectorMode.LIST,
+                translation_key=CONF_CONNECTION_MODE,
+            )
+        )
+    }
+)
+
+
+def serial_from_name(name: str | None) -> str | None:
+    """Return the serial from an advertised name, or None if it is not one.
+
+    The service UUID the charger advertises is a generic serial over BLE
+    tunnel used by many unrelated devices, so the name is what actually tells
+    a charger apart from them.
+    """
+    if name is None or not re.match(ADVERTISED_NAME_PATTERN, name):
+        return None
+    return name.strip().split("_")[0]
+
+
+class SpinEvOptionsFlow(OptionsFlow):
+    """Handle the options for a charger."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Choose how the charger's single Bluetooth slot is used."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(
+                OPTIONS_SCHEMA,
+                {
+                    CONF_CONNECTION_MODE: self.config_entry.options.get(
+                        CONF_CONNECTION_MODE, DEFAULT_CONNECTION_MODE
+                    )
+                },
+            ),
+        )
+
+
+class SpinEvConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Spin EV Charger."""
+
+    VERSION = 1
+
+    _address: str
+    _serial: str
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._discovered: dict[str, str] = {}
+
+    @staticmethod
+    @callback
+    @override
+    def async_get_options_flow(config_entry: SpinEvConfigEntry) -> SpinEvOptionsFlow:
+        """Return the options flow."""
+        return SpinEvOptionsFlow()
+
+    @override
+    async def async_step_bluetooth(
+        self, discovery_info: BluetoothServiceInfoBleak
+    ) -> ConfigFlowResult:
+        """Handle a charger discovered over Bluetooth."""
+        serial = serial_from_name(discovery_info.name)
+        if serial is None:
+            return self.async_abort(reason="not_supported")
+
+        await self.async_set_unique_id(discovery_info.address)
+        self._abort_if_unique_id_configured()
+
+        self._address = discovery_info.address
+        self._serial = serial
+        self.context["title_placeholders"] = {"name": serial}
+
+        return await self.async_step_bluetooth_confirm()
+
+    async def async_step_bluetooth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm a discovered charger."""
+        if user_input is not None:
+            if await self._async_charger_answers(self._address, self._serial):
+                return self._async_create(self._address, self._serial)
+            # There is nothing to correct on a confirm step, so a charger that
+            # will not answer ends the flow rather than looping on itself.
+            return self.async_abort(reason="cannot_connect")
+
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="bluetooth_confirm",
+            description_placeholders={"name": self._serial},
+        )
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Pick a charger from the ones already seen."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            address = user_input[CONF_ADDRESS]
+            serial = self._discovered[address]
+            await self.async_set_unique_id(address, raise_on_progress=False)
+            self._abort_if_unique_id_configured()
+            if await self._async_charger_answers(address, serial):
+                return self._async_create(address, serial)
+            errors["base"] = "cannot_connect"
+        else:
+            # The charger only answers a connectable scan, and a passive-only
+            # adapter will not have it in range yet on the first pass.
+            await bluetooth.async_request_active_scan(self.hass)
+
+            current = self._async_current_ids(include_ignore=False)
+            for info in async_discovered_service_info(self.hass, connectable=True):
+                if info.address in current:
+                    continue
+                if (found := serial_from_name(info.name)) is not None:
+                    self._discovered[info.address] = found
+
+            if not self._discovered:
+                return self.async_abort(reason="no_devices_found")
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_ADDRESS): vol.In(self._discovered)}
+            ),
+            errors=errors,
+        )
+
+    async def _async_charger_answers(self, address: str, serial: str) -> bool:
+        """Return True if the charger is in range and replies to a read."""
+        ble_device = bluetooth.async_ble_device_from_address(
+            self.hass, address, connectable=True
+        )
+        if ble_device is None:
+            return False
+
+        charger = SpinEvCharger(ble_device, client_class=HaBleakClientWrapper)
+        try:
+            async with charger:
+                await charger.async_get_state_value()
+        except SpinEvError as err:
+            _LOGGER.debug("Could not reach charger %s: %s", serial, err)
+            return False
+        return True
+
+    @callback
+    def _async_create(self, address: str, serial: str) -> ConfigFlowResult:
+        """Store the charger."""
+        return self.async_create_entry(
+            title=serial,
+            data={CONF_ADDRESS: address, CONF_SERIAL: serial},
+            options={CONF_CONNECTION_MODE: DEFAULT_CONNECTION_MODE},
+        )

--- a/homeassistant/components/spinev/const.py
+++ b/homeassistant/components/spinev/const.py
@@ -1,0 +1,36 @@
+"""Constants for the Spin EV Charger integration."""
+
+from datetime import timedelta
+from enum import StrEnum
+from typing import Final
+
+from homeassistant.const import Platform
+
+DOMAIN: Final = "spinev"
+
+MANUFACTURER: Final = "Exicom"
+MODEL: Final = "Spin"
+
+PLATFORMS: Final = [Platform.SENSOR]
+
+CONF_CONNECTION_MODE: Final = "connection_mode"
+CONF_SERIAL: Final = "serial"
+
+
+class ConnectionMode(StrEnum):
+    """What the integration does with the charger's one Bluetooth slot."""
+
+    PER_POLL = "per_poll"
+    """Give the slot back between polls, so the phone app can still reach it."""
+
+    PERSISTENT = "persistent"
+    """Hold the slot, which locks every other client out, phone app included."""
+
+
+DEFAULT_CONNECTION_MODE: Final = ConnectionMode.PER_POLL
+
+#: Poll interval while a vehicle is charging, so power stays current.
+CHARGING_INTERVAL: Final = timedelta(seconds=60)
+#: Poll interval while idle. Kept long so the charger's single Bluetooth slot
+#: is left free for the phone app for long stretches.
+IDLE_INTERVAL: Final = timedelta(seconds=300)

--- a/homeassistant/components/spinev/const.py
+++ b/homeassistant/components/spinev/const.py
@@ -24,7 +24,7 @@ class ConnectionMode(StrEnum):
     """Give the slot back between polls, so the phone app can still reach it."""
 
     PERSISTENT = "persistent"
-    """Hold the slot, which locks every other client out, phone app included."""
+    """Keep the slot claimed, shutting other clients out while the link holds."""
 
 
 DEFAULT_CONNECTION_MODE: Final = ConnectionMode.PER_POLL

--- a/homeassistant/components/spinev/coordinator.py
+++ b/homeassistant/components/spinev/coordinator.py
@@ -1,0 +1,132 @@
+"""Coordinator for the Spin EV Charger integration."""
+
+import logging
+from typing import override
+
+from bleak.backends.device import BLEDevice
+from bleak_retry_connector import close_stale_connections_by_address
+from habluetooth import HaBleakClientWrapper
+from spinev_ble import ChargerStatus, SpinEvCharger, SpinEvError
+
+from homeassistant.components import bluetooth
+from homeassistant.components.bluetooth import BluetoothReachabilityIntent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import (
+    CHARGING_INTERVAL,
+    CONF_CONNECTION_MODE,
+    DEFAULT_CONNECTION_MODE,
+    DOMAIN,
+    IDLE_INTERVAL,
+    ConnectionMode,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+type SpinEvConfigEntry = ConfigEntry[SpinEvCoordinator]
+
+
+class SpinEvCoordinator(DataUpdateCoordinator[ChargerStatus]):
+    """Poll one charger over Bluetooth.
+
+    The charger accepts a single Bluetooth client at a time, which makes the
+    link itself the thing to decide about. Holding it keeps every other client
+    out, the phone app included, which is what an owner who does not want the
+    charger reachable from the street wants. Giving it back between polls
+    leaves the app usable. The choice is per config entry.
+
+    The poll interval also adapts to what the charger is doing: short while a
+    vehicle is charging so power stays current, long while idle so a link that
+    is handed back leaves the app long uncontested stretches.
+    """
+
+    config_entry: SpinEvConfigEntry
+
+    def __init__(self, hass: HomeAssistant, entry: SpinEvConfigEntry) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=DOMAIN,
+            update_interval=CHARGING_INTERVAL,
+        )
+        self.address: str = entry.data[CONF_ADDRESS]
+        self._keep_connected = (
+            entry.options.get(CONF_CONNECTION_MODE, DEFAULT_CONNECTION_MODE)
+            == ConnectionMode.PERSISTENT
+        )
+        self._charger: SpinEvCharger | None = None
+
+    @override
+    async def _async_setup(self) -> None:
+        """Clear a link left behind by a previous run."""
+        await close_stale_connections_by_address(self.address)
+
+    @override
+    async def _async_update_data(self) -> ChargerStatus:
+        """Read a full status snapshot."""
+        charger = await self._async_charger()
+        try:
+            await charger.async_connect()
+            status = await charger.async_get_status()
+        except SpinEvError as err:
+            await self.async_release()
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_read",
+                translation_placeholders={"error": str(err)},
+            ) from err
+        finally:
+            if not self._keep_connected:
+                await self.async_release()
+
+        # A suspended session can resume without a command, so it is polled at
+        # the charging rate rather than the idle one.
+        session_open = status.state is not None and (
+            status.state.is_charging or status.state.is_suspended
+        )
+        self.update_interval = CHARGING_INTERVAL if session_open else IDLE_INTERVAL
+        return status
+
+    async def async_release(self) -> None:
+        """Drop the link so another client can reach the charger."""
+        charger, self._charger = self._charger, None
+        if charger is not None:
+            await charger.async_disconnect()
+
+    async def _async_charger(self) -> SpinEvCharger:
+        """Return a client, rebuilding it against a fresh device if needed."""
+        if self._charger is not None:
+            if self._charger.is_connected:
+                return self._charger
+            # A held link the charger dropped leaves a client that will not
+            # reconnect, so it is replaced rather than reused.
+            await self.async_release()
+
+        self._charger = SpinEvCharger(
+            self._async_ble_device(), client_class=HaBleakClientWrapper
+        )
+        return self._charger
+
+    @callback
+    def _async_ble_device(self) -> BLEDevice:
+        """Look the charger up in the Bluetooth manager."""
+        ble_device = bluetooth.async_ble_device_from_address(
+            self.hass, self.address, connectable=True
+        )
+        if ble_device is None:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="device_not_found",
+                translation_placeholders={
+                    "address": self.address,
+                    "reason": bluetooth.async_address_reachability_diagnostics(
+                        self.hass, self.address, BluetoothReachabilityIntent.CONNECTION
+                    ),
+                },
+            )
+        return ble_device

--- a/homeassistant/components/spinev/coordinator.py
+++ b/homeassistant/components/spinev/coordinator.py
@@ -33,10 +33,11 @@ class SpinEvCoordinator(DataUpdateCoordinator[ChargerStatus]):
     """Poll one charger over Bluetooth.
 
     The charger accepts a single Bluetooth client at a time, which makes the
-    link itself the thing to decide about. Holding it keeps every other client
-    out, the phone app included, which is what an owner who does not want the
-    charger reachable from the street wants. Giving it back between polls
-    leaves the app usable. The choice is per config entry.
+    link itself the thing to decide about. Holding it keeps other clients out,
+    the phone app included, for as long as the link lasts, which is what an
+    owner who does not want the charger reachable from the street wants.
+    Giving it back between polls leaves the app usable. The choice is per
+    config entry.
 
     The poll interval also adapts to what the charger is doing: short while a
     vehicle is charging so power stays current, long while idle so a link that

--- a/homeassistant/components/spinev/entity.py
+++ b/homeassistant/components/spinev/entity.py
@@ -1,0 +1,34 @@
+"""Base entity for the Spin EV Charger integration."""
+
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CONF_SERIAL, MANUFACTURER, MODEL
+from .coordinator import SpinEvCoordinator
+
+
+class SpinEvEntity(CoordinatorEntity[SpinEvCoordinator]):
+    """An entity backed by a charger status snapshot."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self, coordinator: SpinEvCoordinator, description: EntityDescription
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+
+        address = coordinator.address
+        serial = coordinator.config_entry.data[CONF_SERIAL]
+
+        self._attr_unique_id = f"{address}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, address)},
+            manufacturer=MANUFACTURER,
+            model=MODEL,
+            name=coordinator.config_entry.title,
+            serial_number=serial,
+            sw_version=coordinator.data.firmware_version,
+        )

--- a/homeassistant/components/spinev/icons.json
+++ b/homeassistant/components/spinev/icons.json
@@ -1,0 +1,9 @@
+{
+  "entity": {
+    "sensor": {
+      "state": {
+        "default": "mdi:ev-station"
+      }
+    }
+  }
+}

--- a/homeassistant/components/spinev/manifest.json
+++ b/homeassistant/components/spinev/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_polling",
   "loggers": ["spinev_ble"],
   "quality_scale": "bronze",
-  "requirements": ["spinev-ble[bleak]==0.2.0"]
+  "requirements": ["spinev-ble[bleak]==0.3.0"]
 }

--- a/homeassistant/components/spinev/manifest.json
+++ b/homeassistant/components/spinev/manifest.json
@@ -1,0 +1,19 @@
+{
+  "domain": "spinev",
+  "name": "Spin EV Charger",
+  "bluetooth": [
+    {
+      "connectable": true,
+      "service_uuid": "49535343-fe7d-4ae5-8fa9-9fafd205e455"
+    }
+  ],
+  "codeowners": ["@Dr-Blank"],
+  "config_flow": true,
+  "dependencies": ["bluetooth_adapters"],
+  "documentation": "https://www.home-assistant.io/integrations/spinev",
+  "integration_type": "device",
+  "iot_class": "local_polling",
+  "loggers": ["spinev_ble"],
+  "quality_scale": "bronze",
+  "requirements": ["spinev-ble[bleak]==0.2.0"]
+}

--- a/homeassistant/components/spinev/quality_scale.yaml
+++ b/homeassistant/components/spinev/quality_scale.yaml
@@ -1,0 +1,99 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: The integration does not register custom actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: The integration does not register custom actions.
+  docs-conditions:
+    status: exempt
+    comment: The integration does not register conditions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: The integration does not register triggers.
+  entity-event-setup:
+    status: exempt
+    comment: Entities receive their updates through the shared coordinator.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: The integration only reads from the charger.
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters:
+    status: exempt
+    comment: Setup is discovery driven and takes no parameters.
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: |
+      The charger has no credential the integration holds. It accepts commands
+      from any client that wins its single Bluetooth slot.
+  test-coverage: done
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: |
+      The Bluetooth address is the unique ID and does not change, and the
+      charger advertises nothing else that setup stores.
+  discovery: done
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: todo
+  docs-troubleshooting: done
+  docs-use-cases: todo
+  dynamic-devices:
+    status: exempt
+    comment: A config entry is one charger and never gains child devices.
+  entity-category:
+    status: exempt
+    comment: Every entity is primary state rather than configuration or diagnostics.
+  entity-device-class: done
+  entity-disabled-by-default:
+    status: exempt
+    comment: Every entity the integration creates is useful by default.
+  entity-translations: done
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow:
+    status: exempt
+    comment: |
+      The entry stores only the Bluetooth address, which is the unique ID and
+      cannot be reconfigured.
+  repair-issues:
+    status: exempt
+    comment: Nothing the integration detects needs user repair.
+  stale-devices:
+    status: exempt
+    comment: A config entry is one charger; removing the entry removes it.
+
+  # Platinum
+  async-dependency: done
+  inject-websession:
+    status: exempt
+    comment: The integration talks Bluetooth and opens no web session.
+  strict-typing: done

--- a/homeassistant/components/spinev/sensor.py
+++ b/homeassistant/components/spinev/sensor.py
@@ -1,0 +1,101 @@
+"""Sensors for the Spin EV Charger integration."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import override
+
+from spinev_ble import ChargerState, ChargerStatus
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import UnitOfElectricCurrent, UnitOfEnergy, UnitOfPower
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import StateType
+
+from .coordinator import SpinEvConfigEntry
+from .entity import SpinEvEntity
+
+PARALLEL_UPDATES = 0
+
+STATE_OPTIONS = [state.name.lower() for state in ChargerState]
+
+
+@dataclass(frozen=True, kw_only=True)
+class SpinEvSensorEntityDescription(SensorEntityDescription):
+    """Describes a Spin EV sensor."""
+
+    value_fn: Callable[[ChargerStatus], StateType]
+
+
+SENSORS: tuple[SpinEvSensorEntityDescription, ...] = (
+    SpinEvSensorEntityDescription(
+        key="state",
+        translation_key="state",
+        device_class=SensorDeviceClass.ENUM,
+        options=STATE_OPTIONS,
+        value_fn=lambda status: status.state.name.lower() if status.state else None,
+    ),
+    SpinEvSensorEntityDescription(
+        key="power",
+        device_class=SensorDeviceClass.POWER,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+        value_fn=lambda status: status.power_w,
+    ),
+    SpinEvSensorEntityDescription(
+        key="current",
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        value_fn=lambda status: status.current_a,
+    ),
+    SpinEvSensorEntityDescription(
+        key="session_energy",
+        translation_key="session_energy",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda status: status.session_energy_kwh,
+    ),
+    SpinEvSensorEntityDescription(
+        key="lifetime_energy",
+        translation_key="lifetime_energy",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+        value_fn=lambda status: status.lifetime_energy_kwh,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SpinEvConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the charger sensors."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        SpinEvSensor(coordinator, description) for description in SENSORS
+    )
+
+
+class SpinEvSensor(SpinEvEntity, SensorEntity):
+    """A value read from the charger."""
+
+    entity_description: SpinEvSensorEntityDescription
+
+    @property
+    @override
+    def native_value(self) -> StateType:
+        """Return the value reported by the charger."""
+        return self.entity_description.value_fn(self.coordinator.data)

--- a/homeassistant/components/spinev/strings.json
+++ b/homeassistant/components/spinev/strings.json
@@ -1,0 +1,81 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:component::spinev::config::error::cannot_connect%]",
+      "no_devices_found": "No Spin EV charger was found over Bluetooth. Check that the charger is powered on, that no phone app is connected to it, and that Home Assistant has a Bluetooth adapter or an ESPHome Bluetooth proxy in range of the charger.",
+      "not_supported": "This Bluetooth device is not a Spin EV charger."
+    },
+    "error": {
+      "cannot_connect": "Failed to connect. The charger accepts one Bluetooth client at a time, so close the phone app and try again."
+    },
+    "flow_title": "{name}",
+    "step": {
+      "bluetooth_confirm": {
+        "description": "[%key:component::bluetooth::config::step::bluetooth_confirm::description%]"
+      },
+      "user": {
+        "data": {
+          "address": "[%key:common::config_flow::data::device%]"
+        },
+        "data_description": {
+          "address": "The chargers discovered over Bluetooth, listed by serial number."
+        },
+        "description": "[%key:component::bluetooth::config::step::user::description%]"
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "lifetime_energy": {
+        "name": "Lifetime energy"
+      },
+      "session_energy": {
+        "name": "Session energy"
+      },
+      "state": {
+        "name": "State",
+        "state": {
+          "available": "Available",
+          "booting": "Starting up",
+          "charging": "Charging",
+          "ev_suspended": "Paused by vehicle",
+          "evse_suspended": "Paused by charger",
+          "fault": "Fault",
+          "finishing": "Finishing",
+          "idle": "Idle",
+          "starting": "Starting",
+          "unavailable": "Unavailable"
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "cannot_read": {
+      "message": "Could not read the charger: {error}"
+    },
+    "device_not_found": {
+      "message": "Could not find the charger with address {address}. {reason}"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "connection_mode": "Bluetooth connection"
+        },
+        "data_description": {
+          "connection_mode": "The charger accepts one Bluetooth client at a time. Stay connected holds that slot for Home Assistant, so nobody else in range can reach the charger, and polling is faster and fails less often. Reconnect each poll gives the slot up between polls, so the phone app stays usable."
+        }
+      }
+    }
+  },
+  "selector": {
+    "connection_mode": {
+      "options": {
+        "per_poll": "Reconnect each poll",
+        "persistent": "Stay connected"
+      }
+    }
+  }
+}

--- a/homeassistant/components/spinev/strings.json
+++ b/homeassistant/components/spinev/strings.json
@@ -7,7 +7,7 @@
       "not_supported": "This Bluetooth device is not a Spin EV charger."
     },
     "error": {
-      "cannot_connect": "Failed to connect. The charger accepts one Bluetooth client at a time, so close the phone app and try again."
+      "cannot_connect": "Failed to connect. Check that the charger is powered on and in Bluetooth range, and that no phone app is connected to it, since it accepts one Bluetooth client at a time."
     },
     "flow_title": "{name}",
     "step": {
@@ -65,7 +65,7 @@
           "connection_mode": "Bluetooth connection"
         },
         "data_description": {
-          "connection_mode": "The charger accepts one Bluetooth client at a time. Stay connected holds that slot for Home Assistant, so nobody else in range can reach the charger, and polling is faster and fails less often. Reconnect each poll gives the slot up between polls, so the phone app stays usable."
+          "connection_mode": "The charger accepts one Bluetooth client at a time. Stay connected keeps that slot claimed for Home Assistant, which makes polling faster and less likely to fail, and keeps other clients out for as long as the link holds. Reconnect each poll gives the slot up between polls, so the phone app stays usable."
         }
       }
     }

--- a/homeassistant/generated/bluetooth.py
+++ b/homeassistant/generated/bluetooth.py
@@ -1089,6 +1089,11 @@ BLUETOOTH: Final[list[dict[str, bool | str | int | list[int]]]] = [
         "local_name": "SPECIALIZED*",
     },
     {
+        "connectable": True,
+        "domain": "spinev",
+        "service_uuid": "49535343-fe7d-4ae5-8fa9-9fafd205e455",
+    },
+    {
         "connectable": False,
         "domain": "switchbot",
         "service_data_uuid": "00000d00-0000-1000-8000-00805f9b34fb",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -750,6 +750,7 @@ FLOWS = {
         "soundtouch",
         "specialized_turbo",
         "speedtestdotnet",
+        "spinev",
         "splunk",
         "spotify",
         "sql",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -6966,6 +6966,12 @@
       "config_flow": true,
       "iot_class": "cloud_polling"
     },
+    "spinev": {
+      "name": "Spin EV Charger",
+      "integration_type": "device",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "splunk": {
       "name": "Splunk",
       "integration_type": "service",

--- a/mypy.ini
+++ b/mypy.ini
@@ -5318,6 +5318,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.spinev.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.spotify.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3147,7 +3147,7 @@ specialized-turbo[cloud]==0.8.2
 speedtest-cli==2.1.3
 
 # homeassistant.components.spinev
-spinev-ble[bleak]==0.2.0
+spinev-ble[bleak]==0.3.0
 
 # homeassistant.components.spotify
 spotifyaio==2.0.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3146,6 +3146,9 @@ specialized-turbo[cloud]==0.8.2
 # homeassistant.components.speedtestdotnet
 speedtest-cli==2.1.3
 
+# homeassistant.components.spinev
+spinev-ble[bleak]==0.2.0
+
 # homeassistant.components.spotify
 spotifyaio==2.0.2
 

--- a/tests/components/spinev/__init__.py
+++ b/tests/components/spinev/__init__.py
@@ -1,0 +1,12 @@
+"""Tests for the Spin EV Charger integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Set the integration up from a config entry."""
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/spinev/conftest.py
+++ b/tests/components/spinev/conftest.py
@@ -1,0 +1,123 @@
+"""Fixtures for the Spin EV Charger tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bleak.backends.device import BLEDevice
+import pytest
+
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.components.spinev.const import DOMAIN
+
+from .const import (
+    ADDRESS,
+    ADVERTISED_NAME,
+    ENTRY_DATA,
+    ENTRY_OPTIONS,
+    SERIAL,
+    SERVICE_UUID,
+    STATUS,
+)
+
+from tests.common import MockConfigEntry
+from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
+
+
+@pytest.fixture
+def ble_device() -> BLEDevice:
+    """Return the charger as the Bluetooth manager reports it."""
+    return generate_ble_device(address=ADDRESS, name=ADVERTISED_NAME)
+
+
+@pytest.fixture
+def service_info(ble_device: BLEDevice) -> BluetoothServiceInfoBleak:
+    """Return a discovery payload for the charger."""
+    return BluetoothServiceInfoBleak(
+        name=ADVERTISED_NAME,
+        address=ADDRESS,
+        rssi=-60,
+        manufacturer_data={},
+        service_data={},
+        service_uuids=[SERVICE_UUID],
+        source="local",
+        device=ble_device,
+        advertisement=generate_advertisement_data(
+            local_name=ADVERTISED_NAME,
+            manufacturer_data={},
+            service_data={},
+            service_uuids=[SERVICE_UUID],
+        ),
+        connectable=True,
+        time=0,
+        tx_power=-127,
+    )
+
+
+@pytest.fixture
+def mock_charger() -> Generator[AsyncMock]:
+    """Patch SpinEvCharger everywhere it is constructed."""
+    charger = AsyncMock()
+    charger.async_get_status.return_value = STATUS
+    charger.async_get_state_value.return_value = 4
+    charger.__aenter__.return_value = charger
+    charger.is_connected = True
+
+    with (
+        patch(
+            "homeassistant.components.spinev.coordinator.SpinEvCharger",
+            return_value=charger,
+        ),
+        patch(
+            "homeassistant.components.spinev.config_flow.SpinEvCharger",
+            return_value=charger,
+        ),
+    ):
+        yield charger
+
+
+@pytest.fixture(autouse=True)
+def mock_ble_device(
+    enable_bluetooth: None, ble_device: BLEDevice
+) -> Generator[MagicMock]:
+    """Make the Bluetooth manager resolve the charger's address."""
+    # Both modules import the bluetooth component itself, so one patch of the
+    # lookup covers the coordinator and the config flow alike.
+    with (
+        patch(
+            "homeassistant.components.bluetooth.async_ble_device_from_address",
+            return_value=ble_device,
+        ) as mock_lookup,
+        patch(
+            "homeassistant.components.spinev.coordinator.close_stale_connections_by_address"
+        ),
+        patch(
+            "homeassistant.components.bluetooth.async_address_reachability_diagnostics",
+            return_value="No Bluetooth adapter or proxy is in range of it.",
+        ),
+        patch(
+            "homeassistant.components.bluetooth.async_request_active_scan",
+            new_callable=AsyncMock,
+        ),
+    ):
+        yield mock_lookup
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a config entry for the charger."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=SERIAL,
+        unique_id=ADDRESS,
+        data=ENTRY_DATA,
+        options=ENTRY_OPTIONS,
+    )
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Stop the entry a flow creates from setting the integration up."""
+    with patch(
+        "homeassistant.components.spinev.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry

--- a/tests/components/spinev/const.py
+++ b/tests/components/spinev/const.py
@@ -1,0 +1,51 @@
+"""Shared constants for the Spin EV Charger tests."""
+
+from spinev_ble import ChargerState, ChargerStatus
+
+from homeassistant.components.spinev.const import (
+    CONF_CONNECTION_MODE,
+    CONF_SERIAL,
+    DEFAULT_CONNECTION_MODE,
+)
+from homeassistant.const import CONF_ADDRESS
+
+ADDRESS = "AA:BB:CC:DD:EE:FF"
+SERIAL = "123456789012"
+#: The charger advertises its serial with a leading space and an address suffix.
+ADVERTISED_NAME = f" {SERIAL}_EEFF"
+SERVICE_UUID = "49535343-fe7d-4ae5-8fa9-9fafd205e455"
+
+ENTRY_DATA = {CONF_ADDRESS: ADDRESS, CONF_SERIAL: SERIAL}
+ENTRY_OPTIONS = {CONF_CONNECTION_MODE: DEFAULT_CONNECTION_MODE}
+
+STATE_SENSOR = "sensor.123456789012_state"
+
+STATUS = ChargerStatus(
+    state=ChargerState.CHARGING,
+    state_value=4,
+    power_w=7360.0,
+    voltage_v=230.0,
+    current_a=32.0,
+    current_limit_a=32.0,
+    session_energy_kwh=12.5,
+    session_seconds=3600,
+    lifetime_energy_kwh=1234.5,
+    lifetime_seconds=360000,
+    firmware_version="35.24.4.32",
+    alarms=(),
+)
+
+IDLE_STATUS = ChargerStatus(
+    state=ChargerState.IDLE,
+    state_value=2,
+    power_w=0.0,
+    voltage_v=230.0,
+    current_a=0.0,
+    current_limit_a=32.0,
+    session_energy_kwh=0.0,
+    session_seconds=0,
+    lifetime_energy_kwh=1234.5,
+    lifetime_seconds=360000,
+    firmware_version="35.24.4.32",
+    alarms=(),
+)

--- a/tests/components/spinev/snapshots/test_sensor.ambr
+++ b/tests/components/spinev/snapshots/test_sensor.ambr
@@ -1,0 +1,309 @@
+# serializer version: 1
+# name: test_sensors[sensor.123456789012_current-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.123456789012_current',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+    'original_icon': None,
+    'original_name': 'Current',
+    'platform': 'spinev',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'AA:BB:CC:DD:EE:FF_current',
+    'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+  })
+# ---
+# name: test_sensors[sensor.123456789012_current-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'current',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: '123456789012 Current',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.123456789012_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '32.0',
+  })
+# ---
+# name: test_sensors[sensor.123456789012_lifetime_energy-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.123456789012_lifetime_energy',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Lifetime energy',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Lifetime energy',
+    'platform': 'spinev',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lifetime_energy',
+    'unique_id': 'AA:BB:CC:DD:EE:FF_lifetime_energy',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_sensors[sensor.123456789012_lifetime_energy-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: '123456789012 Lifetime energy',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.123456789012_lifetime_energy',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1234.5',
+  })
+# ---
+# name: test_sensors[sensor.123456789012_power-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.123456789012_power',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Power',
+    'platform': 'spinev',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'AA:BB:CC:DD:EE:FF_power',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_sensors[sensor.123456789012_power-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: '123456789012 Power',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.123456789012_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '7360.0',
+  })
+# ---
+# name: test_sensors[sensor.123456789012_session_energy-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.123456789012_session_energy',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Session energy',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+    'original_icon': None,
+    'original_name': 'Session energy',
+    'platform': 'spinev',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'session_energy',
+    'unique_id': 'AA:BB:CC:DD:EE:FF_session_energy',
+    'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+  })
+# ---
+# name: test_sensors[sensor.123456789012_session_energy-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: '123456789012 Session energy',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.123456789012_session_energy',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '12.5',
+  })
+# ---
+# name: test_sensors[sensor.123456789012_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'available',
+        'idle',
+        'starting',
+        'charging',
+        'fault',
+        'finishing',
+        'evse_suspended',
+        'ev_suspended',
+        'booting',
+        'unavailable',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.123456789012_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'State',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'State',
+    'platform': 'spinev',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'state',
+    'unique_id': 'AA:BB:CC:DD:EE:FF_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.123456789012_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: '123456789012 State',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'available',
+        'idle',
+        'starting',
+        'charging',
+        'fault',
+        'finishing',
+        'evse_suspended',
+        'ev_suspended',
+        'booting',
+        'unavailable',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.123456789012_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'charging',
+  })
+# ---

--- a/tests/components/spinev/test_config_flow.py
+++ b/tests/components/spinev/test_config_flow.py
@@ -1,0 +1,228 @@
+"""Tests for the Spin EV Charger config flow."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from spinev_ble import SpinEvError
+
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
+from homeassistant.components.spinev.const import (
+    CONF_CONNECTION_MODE,
+    DEFAULT_CONNECTION_MODE,
+    DOMAIN,
+    ConnectionMode,
+)
+from homeassistant.config_entries import SOURCE_BLUETOOTH, SOURCE_USER
+from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .const import ADDRESS, ENTRY_DATA, ENTRY_OPTIONS, SERIAL
+
+from tests.common import MockConfigEntry
+
+
+@contextmanager
+def patch_discovered(
+    service_infos: list[BluetoothServiceInfoBleak],
+) -> Iterator[None]:
+    """Pretend the Bluetooth manager has seen exactly these devices."""
+    with patch(
+        "homeassistant.components.spinev.config_flow.async_discovered_service_info",
+        return_value=service_infos,
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("mock_charger", "mock_setup_entry")
+async def test_bluetooth_discovery(
+    hass: HomeAssistant, service_info: BluetoothServiceInfoBleak
+) -> None:
+    """A discovered charger is confirmed and stored."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_BLUETOOTH}, data=service_info
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+    assert result["description_placeholders"] == {"name": SERIAL}
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == SERIAL
+    assert result["data"] == ENTRY_DATA
+    assert result["options"] == ENTRY_OPTIONS
+    assert result["result"].unique_id == ADDRESS
+
+
+@pytest.mark.usefixtures("mock_charger")
+async def test_discovery_of_another_device_on_the_same_service_uuid(
+    hass: HomeAssistant, service_info: BluetoothServiceInfoBleak
+) -> None:
+    """The advertised service UUID is generic, so the name is what decides."""
+    service_info.name = "Some other serial-over-BLE gadget"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_BLUETOOTH}, data=service_info
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "not_supported"
+
+
+@pytest.mark.usefixtures("mock_charger")
+async def test_discovery_of_a_configured_charger(
+    hass: HomeAssistant,
+    service_info: BluetoothServiceInfoBleak,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A charger that is already set up is not offered again."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_BLUETOOTH}, data=service_info
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_discovery_when_the_charger_does_not_answer(
+    hass: HomeAssistant,
+    service_info: BluetoothServiceInfoBleak,
+    mock_charger: AsyncMock,
+) -> None:
+    """A charger held by the phone app cannot be set up yet."""
+    mock_charger.async_get_state_value.side_effect = SpinEvError("busy")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_BLUETOOTH}, data=service_info
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+@pytest.mark.usefixtures("mock_charger")
+async def test_discovery_when_the_charger_is_out_of_range(
+    hass: HomeAssistant,
+    service_info: BluetoothServiceInfoBleak,
+    mock_ble_device: MagicMock,
+) -> None:
+    """An address the Bluetooth manager no longer resolves cannot be set up."""
+    mock_ble_device.return_value = None
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_BLUETOOTH}, data=service_info
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+@pytest.mark.usefixtures("mock_charger", "mock_setup_entry")
+async def test_user_flow(
+    hass: HomeAssistant, service_info: BluetoothServiceInfoBleak
+) -> None:
+    """A charger already seen by the Bluetooth manager can be picked by hand."""
+    with patch_discovered([service_info]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_ADDRESS: ADDRESS}
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == SERIAL
+    assert result["data"] == ENTRY_DATA
+
+
+@pytest.mark.usefixtures("mock_charger")
+async def test_user_flow_with_nothing_to_offer(hass: HomeAssistant) -> None:
+    """Nothing recognisable in range means there is nothing to configure."""
+    with patch_discovered([]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"
+
+
+@pytest.mark.usefixtures("mock_charger")
+async def test_user_flow_skips_configured_chargers(
+    hass: HomeAssistant,
+    service_info: BluetoothServiceInfoBleak,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A charger that is already set up is not offered in the picker."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch_discovered([service_info]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_user_flow_when_the_charger_does_not_answer(
+    hass: HomeAssistant,
+    service_info: BluetoothServiceInfoBleak,
+    mock_charger: AsyncMock,
+) -> None:
+    """The picker comes back with an error so the charger can be tried again."""
+    mock_charger.async_get_state_value.side_effect = SpinEvError("busy")
+
+    with patch_discovered([service_info]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_ADDRESS: ADDRESS}
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"] == {"base": "cannot_connect"}
+
+        mock_charger.async_get_state_value.side_effect = None
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_ADDRESS: ADDRESS}
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == SERIAL
+
+
+@pytest.mark.usefixtures("mock_charger")
+async def test_options_flow(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """The charger's single Bluetooth slot can be held open instead."""
+    mock_config_entry.add_to_hass(hass)
+    assert mock_config_entry.options[CONF_CONNECTION_MODE] == DEFAULT_CONNECTION_MODE
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {CONF_CONNECTION_MODE: ConnectionMode.PERSISTENT}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert mock_config_entry.options[CONF_CONNECTION_MODE] == ConnectionMode.PERSISTENT

--- a/tests/components/spinev/test_init.py
+++ b/tests/components/spinev/test_init.py
@@ -118,6 +118,21 @@ async def test_a_persistent_connection_is_held(
     mock_charger.async_disconnect.assert_not_awaited()
 
 
+async def test_a_held_link_is_released_on_unload(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_charger: AsyncMock
+) -> None:
+    """Unloading hands the charger back even when the link was being held."""
+    await setup_persistent(hass, mock_config_entry)
+
+    mock_charger.async_disconnect.assert_not_awaited()
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+    mock_charger.async_disconnect.assert_awaited()
+
+
 async def test_a_held_link_that_drops_is_rebuilt(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/spinev/test_init.py
+++ b/tests/components/spinev/test_init.py
@@ -1,0 +1,199 @@
+"""Tests for setting the Spin EV Charger integration up and polling it."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from spinev_ble import ChargerStatus, SpinEvError
+
+from homeassistant.components.spinev.const import (
+    CHARGING_INTERVAL,
+    CONF_CONNECTION_MODE,
+    IDLE_INTERVAL,
+    ConnectionMode,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+from .const import IDLE_STATUS, STATE_SENSOR, STATUS
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def setup_persistent(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Set the integration up with the charger's Bluetooth slot held open."""
+    entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        entry,
+        options={**entry.options, CONF_CONNECTION_MODE: ConnectionMode.PERSISTENT},
+    )
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.usefixtures("mock_charger")
+async def test_setup_and_unload(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """The entry loads, then unloads cleanly."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.usefixtures("mock_charger")
+async def test_setup_retries_when_the_charger_is_not_seen(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_ble_device: MagicMock,
+) -> None:
+    """An address the Bluetooth manager cannot resolve is a retry, not a failure."""
+    mock_ble_device.return_value = None
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_retries_when_the_first_read_fails(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_charger: AsyncMock
+) -> None:
+    """A charger that does not answer on setup is a retry, not a failure."""
+    mock_charger.async_get_status.side_effect = SpinEvError("no reply")
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        pytest.param(STATUS, CHARGING_INTERVAL, id="charging"),
+        pytest.param(IDLE_STATUS, IDLE_INTERVAL, id="idle"),
+    ],
+)
+async def test_the_poll_interval_follows_the_session(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: AsyncMock,
+    status: ChargerStatus,
+    expected: timedelta,
+) -> None:
+    """Polling is fast during a session and slow while idle."""
+    mock_charger.async_get_status.return_value = status
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.runtime_data.update_interval == expected
+
+
+async def test_a_per_poll_connection_is_released(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_charger: AsyncMock
+) -> None:
+    """The default mode hands the charger back so the phone app can reach it."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_charger.async_disconnect.assert_awaited()
+
+
+async def test_a_persistent_connection_is_held(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_charger: AsyncMock
+) -> None:
+    """Holding the charger's only Bluetooth slot keeps everyone else out."""
+    await setup_persistent(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    mock_charger.async_disconnect.assert_not_awaited()
+
+
+async def test_a_held_link_that_drops_is_rebuilt(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """In persistent mode the client outlives a poll, so a dead one is replaced."""
+    await setup_persistent(hass, mock_config_entry)
+
+    mock_charger.is_connected = False
+    freezer.tick(CHARGING_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    mock_charger.async_disconnect.assert_awaited()
+    assert hass.states.get(STATE_SENSOR).state == "charging"
+
+
+async def test_a_changed_connection_mode_takes_effect(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The mode is read when the coordinator is built, so it needs a reload."""
+    await setup_integration(hass, mock_config_entry)
+
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        options={
+            **mock_config_entry.options,
+            CONF_CONNECTION_MODE: ConnectionMode.PERSISTENT,
+        },
+    )
+    await hass.async_block_till_done()
+
+    mock_charger.async_disconnect.reset_mock()
+    freezer.tick(CHARGING_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    mock_charger.async_disconnect.assert_not_awaited()
+
+
+async def test_a_failed_poll_makes_entities_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_charger: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A charger that stops answering is reported as unavailable, not stale."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get(STATE_SENSOR).state != STATE_UNAVAILABLE
+
+    mock_charger.async_get_status.side_effect = SpinEvError("gone")
+    freezer.tick(CHARGING_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(STATE_SENSOR).state == STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("mock_charger")
+async def test_a_poll_fails_when_the_charger_goes_out_of_range(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_ble_device: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """An address the Bluetooth manager stops resolving fails the poll."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_ble_device.return_value = None
+    freezer.tick(CHARGING_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(STATE_SENSOR).state == STATE_UNAVAILABLE

--- a/tests/components/spinev/test_sensor.py
+++ b/tests/components/spinev/test_sensor.py
@@ -1,0 +1,24 @@
+"""Snapshot tests for the Spin EV Charger sensors."""
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("mock_charger")
+async def test_sensors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """The sensor platform registers the entities it is expected to."""
+    await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a new integration for Exicom Spin EV chargers, which talk over Bluetooth LE
through the [`spinev-ble`](https://pypi.org/project/spinev-ble/) library.

This first pull request is read only. It sets up one charger per config entry
and adds five sensors: state, power, current, session energy and lifetime
energy. Binary sensors, diagnostics, and the write path (switch, number,
button) are deliberately left out and will follow in separate pull requests, so
this one can be reviewed as setup and polling only.

Two things worth knowing before reviewing:

**The Bluetooth matcher is a service UUID only.**
`49535343-fe7d-4ae5-8fa9-9fafd205e455` is the generic Microchip/ISSC
transparent UART service, which is shared with many unrelated devices. A
`local_name` matcher cannot narrow it: wildcards are not allowed in the first
three characters of a `local_name` pattern, and the charger advertises twelve
arbitrary digits followed by `_XXXX`. `async_step_bluetooth` therefore aborts
with `not_supported` when the advertised name does not match, so no flow is
ever shown for another vendor's device. `iron_os` and `iseo_argo_ble` use the
same approach.

**The connection mode option is not a polling interval.** The charger accepts a
single Bluetooth client at a time, so the option chooses whether Home Assistant
holds that slot. Holding it locks every other client out, including the vendor
phone app, which is what an owner who does not want the charger reachable from
the street wants; handing it back between polls keeps the app usable. The poll
interval itself is not configurable: it is 60 seconds while a session is open
and 300 seconds while idle. The option is in this pull request rather than a
later one because it decides the coordinator's connect and release lifecycle
rather than sitting on top of it.

Tests cover both modes, and the integration is at 100% coverage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47891
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
