### PR TITLE
Fix stale Sonos media position after track changes and transport transitions

### DIFF
--- a/homeassistant/components/sonos/media.py
+++ b/homeassistant/components/sonos/media.py
@@ -84,6 +84,7 @@ class SonosMedia:
         self.position: int | None = None
         self.position_updated_at: datetime.datetime | None = None
         self._position_settle_unsub: Callable[[], None] | None = None
+        self._newest_poll_at: datetime.datetime | None = None
 
     def clear(self) -> None:
         """Clear basic media info."""
@@ -272,14 +273,12 @@ class SonosMedia:
         polled_at: datetime.datetime | None = None,
     ) -> None:
         """Update state when playing music tracks."""
-        if (
-            polled_at is not None
-            and self.position_updated_at is not None
-            and polled_at < self.position_updated_at
-        ):
-            # An overlapping poll finished out of order; a newer result has
-            # already been written.
-            return
+        if polled_at is not None:
+            if self._newest_poll_at is not None and polled_at < self._newest_poll_at:
+                # An overlapping poll finished out of order; a newer result
+                # has already been processed (whether or not it was written).
+                return
+            self._newest_poll_at = polled_at
 
         duration = position_info.get(DURATION_SECONDS)
         current_position = position_info.get(POSITION_SECONDS)

--- a/homeassistant/components/sonos/media.py
+++ b/homeassistant/components/sonos/media.py
@@ -179,9 +179,10 @@ class SonosMedia:
         audio_source = self.soco.music_source_from_uri(track_uri)
 
         self.set_basic_track_info(update_position=state_changed or track_changed)
-        if track_changed:
+        if state_changed or track_changed:
             # The poll above can race the transition and return the previous
-            # track's clock; re-poll once the transition has settled so a
+            # track's clock — or, on a resume, a transient 0:00 while the
+            # stream rebuffers; re-poll once the transition has settled so a
             # stale snapshot cannot stick.
             self.hass.loop.call_soon_threadsafe(self._async_schedule_settle_poll)
 

--- a/homeassistant/components/sonos/media.py
+++ b/homeassistant/components/sonos/media.py
@@ -1,6 +1,8 @@
 """Support for media metadata handling."""
 
+from collections.abc import Callable
 import datetime
+import logging
 from typing import Any
 
 from soco.core import (
@@ -14,9 +16,10 @@ from soco.core import (
 from soco.data_structures import DidlAudioBroadcast, DidlPlaylistContainer
 from soco.music_library import MusicLibrary
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.config_validation import time_period_str
 from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.event import async_call_later
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -28,7 +31,10 @@ from .const import (
     SOURCE_SPOTIFY_CONNECT,
     SOURCE_TV,
 )
+from .exception import SonosUpdateError
 from .helpers import soco_error
+
+_LOGGER = logging.getLogger(__name__)
 
 LINEIN_SOURCES = (MUSIC_SRC_TV, MUSIC_SRC_LINE_IN)
 SOURCE_MAPPING = {
@@ -40,6 +46,9 @@ SOURCE_MAPPING = {
 UNAVAILABLE_VALUES = {"", "NOT_IMPLEMENTED", None}
 DURATION_SECONDS = "duration_in_s"
 POSITION_SECONDS = "position_in_s"
+# A track transition can briefly report the previous track's clock; re-poll
+# the position once the transition has settled.
+POSITION_SETTLE_DELAY = 2
 
 
 def _timespan_secs(timespan: str | None) -> int | None:
@@ -74,9 +83,7 @@ class SonosMedia:
 
         self.position: int | None = None
         self.position_updated_at: datetime.datetime | None = None
-        # When the last position poll was requested; a position is only as
-        # fresh as the moment it was asked for.
-        self._position_polled_at: datetime.datetime | None = None
+        self._position_settle_unsub: Callable[[], None] | None = None
 
     def clear(self) -> None:
         """Clear basic media info."""
@@ -103,15 +110,20 @@ class SonosMedia:
         return self.soco.music_library
 
     @soco_error()
-    def poll_track_info(self) -> dict[str, Any]:
-        """Poll the speaker for current track info, add converted position values."""
-        # Capture the request time first: stamping the position at write time
-        # would let a delayed response masquerade as current.
-        self._position_polled_at = dt_util.utcnow()
+    def poll_track_info(self) -> tuple[dict[str, Any], datetime.datetime]:
+        """Poll the speaker for current track info, add converted position values.
+
+        Also returns the time the poll was requested: a position is only as
+        fresh as the moment it was asked for, and overlapping polls each need
+        their own request time.
+
+        :raises SonosUpdateError: when the speaker cannot be reached.
+        """
+        polled_at = dt_util.utcnow()
         track_info: dict[str, Any] = self.soco.get_current_track_info()
         track_info[DURATION_SECONDS] = _timespan_secs(track_info.get("duration"))
         track_info[POSITION_SECONDS] = _timespan_secs(track_info.get("position"))
-        return track_info
+        return track_info, polled_at
 
     def write_media_player_states(self) -> None:
         """Send a signal to media player(s) to write new states."""
@@ -121,7 +133,7 @@ class SonosMedia:
         """Query the speaker to update media metadata and position info."""
         self.clear()
 
-        track_info = self.poll_track_info()
+        track_info, polled_at = self.poll_track_info()
         if not track_info["uri"]:
             return
         self.uri = track_info["uri"]
@@ -144,7 +156,9 @@ class SonosMedia:
         if playlist_position > 0:
             self.queue_position = playlist_position
 
-        self.update_media_position(track_info, force_update=update_position)
+        self.update_media_position(
+            track_info, force_update=update_position, polled_at=polled_at
+        )
 
     def update_media_from_event(self, evars: dict[str, Any]) -> None:
         """Update information about currently playing media using an event payload."""
@@ -165,6 +179,11 @@ class SonosMedia:
         audio_source = self.soco.music_source_from_uri(track_uri)
 
         self.set_basic_track_info(update_position=state_changed or track_changed)
+        if track_changed:
+            # The poll above can race the transition and return the previous
+            # track's clock; re-poll once the transition has settled so a
+            # stale snapshot cannot stick.
+            self.hass.loop.call_soon_threadsafe(self._async_schedule_settle_poll)
 
         if ct_md := evars["current_track_meta_data"]:
             if not self.image_url:
@@ -194,6 +213,40 @@ class SonosMedia:
 
         self.write_media_player_states()
 
+    @callback
+    def _async_schedule_settle_poll(self) -> None:
+        """(Re)schedule the one-shot position poll after a track change."""
+        self.async_cancel_settle_poll()
+        self._position_settle_unsub = async_call_later(
+            self.hass, POSITION_SETTLE_DELAY, self._async_settle_poll
+        )
+
+    @callback
+    def async_cancel_settle_poll(self) -> None:
+        """Cancel a pending settle poll."""
+        if self._position_settle_unsub is not None:
+            self._position_settle_unsub()
+            self._position_settle_unsub = None
+
+    async def _async_settle_poll(self, _now: datetime.datetime) -> None:
+        """Refresh the position once a track transition has settled."""
+        self._position_settle_unsub = None
+        await self.hass.async_add_executor_job(self._settle_position)
+
+    def _settle_position(self) -> None:
+        """Poll and write the settled position."""
+        try:
+            track_info, polled_at = self.poll_track_info()
+        except SonosUpdateError as err:
+            _LOGGER.debug("Could not poll settled position: %s", err)
+            return
+        audio_source = self.soco.music_source_from_uri(track_info["uri"])
+        if audio_source in LINEIN_SOURCES:
+            # Line-in/TV positions are deliberately cleared, never tracked.
+            return
+        self.update_media_position(track_info, force_update=True, polled_at=polled_at)
+        self.write_media_player_states()
+
     @soco_error()
     def poll_media(self) -> None:
         """Poll information about currently playing media."""
@@ -212,9 +265,21 @@ class SonosMedia:
         self.write_media_player_states()
 
     def update_media_position(
-        self, position_info: dict[str, int], force_update: bool = False
+        self,
+        position_info: dict[str, int],
+        force_update: bool = False,
+        polled_at: datetime.datetime | None = None,
     ) -> None:
         """Update state when playing music tracks."""
+        if (
+            polled_at is not None
+            and self.position_updated_at is not None
+            and polled_at < self.position_updated_at
+        ):
+            # An overlapping poll finished out of order; a newer result has
+            # already been written.
+            return
+
         duration = position_info.get(DURATION_SECONDS)
         current_position = position_info.get(POSITION_SECONDS)
 
@@ -247,4 +312,4 @@ class SonosMedia:
             self.clear_position()
         elif should_update:
             self.position = current_position
-            self.position_updated_at = self._position_polled_at or dt_util.utcnow()
+            self.position_updated_at = polled_at or dt_util.utcnow()

--- a/homeassistant/components/sonos/media.py
+++ b/homeassistant/components/sonos/media.py
@@ -74,6 +74,9 @@ class SonosMedia:
 
         self.position: int | None = None
         self.position_updated_at: datetime.datetime | None = None
+        # When the last position poll was requested; a position is only as
+        # fresh as the moment it was asked for.
+        self._position_polled_at: datetime.datetime | None = None
 
     def clear(self) -> None:
         """Clear basic media info."""
@@ -102,6 +105,9 @@ class SonosMedia:
     @soco_error()
     def poll_track_info(self) -> dict[str, Any]:
         """Poll the speaker for current track info, add converted position values."""
+        # Capture the request time first: stamping the position at write time
+        # would let a delayed response masquerade as current.
+        self._position_polled_at = dt_util.utcnow()
         track_info: dict[str, Any] = self.soco.get_current_track_info()
         track_info[DURATION_SECONDS] = _timespan_secs(track_info.get("duration"))
         track_info[POSITION_SECONDS] = _timespan_secs(track_info.get("position"))
@@ -144,14 +150,21 @@ class SonosMedia:
         """Update information about currently playing media using an event payload."""
         new_status = evars["transport_state"]
         state_changed = new_status != self.playback_status
+        # A track change without a transport state change (e.g. a skip or an
+        # auto-advance while playing) must also force a position update: the
+        # position jump heuristic can mistake a mid-transition position
+        # snapshot for the previous track's clock and leave a stale position
+        # stamped as current.
+        current_track_uri = evars["current_track_uri"]
+        track_changed = bool(current_track_uri) and current_track_uri != self.uri
 
         self.play_mode = evars["current_play_mode"]
         self.playback_status = new_status
 
-        track_uri = evars["enqueued_transport_uri"] or evars["current_track_uri"]
+        track_uri = evars["enqueued_transport_uri"] or current_track_uri
         audio_source = self.soco.music_source_from_uri(track_uri)
 
-        self.set_basic_track_info(update_position=state_changed)
+        self.set_basic_track_info(update_position=state_changed or track_changed)
 
         if ct_md := evars["current_track_meta_data"]:
             if not self.image_url:
@@ -234,4 +247,4 @@ class SonosMedia:
             self.clear_position()
         elif should_update:
             self.position = current_position
-            self.position_updated_at = dt_util.utcnow()
+            self.position_updated_at = self._position_polled_at or dt_util.utcnow()

--- a/homeassistant/components/sonos/media.py
+++ b/homeassistant/components/sonos/media.py
@@ -84,6 +84,9 @@ class SonosMedia:
         self.position: int | None = None
         self.position_updated_at: datetime.datetime | None = None
         self._position_settle_unsub: Callable[[], None] | None = None
+        # Bumped by async_cancel_settle_poll so a schedule queued from an
+        # in-flight executor job cannot re-arm the timer after cancellation.
+        self._settle_generation = 0
         self._newest_poll_at: datetime.datetime | None = None
 
     def clear(self) -> None:
@@ -185,7 +188,9 @@ class SonosMedia:
             # track's clock — or, on a resume, a transient 0:00 while the
             # stream rebuffers; re-poll once the transition has settled so a
             # stale snapshot cannot stick.
-            self.hass.loop.call_soon_threadsafe(self._async_schedule_settle_poll)
+            self.hass.loop.call_soon_threadsafe(
+                self._async_schedule_settle_poll, self._settle_generation
+            )
 
         if ct_md := evars["current_track_meta_data"]:
             if not self.image_url:
@@ -216,16 +221,21 @@ class SonosMedia:
         self.write_media_player_states()
 
     @callback
-    def _async_schedule_settle_poll(self) -> None:
-        """(Re)schedule the one-shot position poll after a track change."""
-        self.async_cancel_settle_poll()
+    def _async_schedule_settle_poll(self, generation: int) -> None:
+        """(Re)schedule the one-shot position poll after a transition."""
+        if generation != self._settle_generation:
+            # Cancelled (unload or offline) after this schedule was queued.
+            return
+        if self._position_settle_unsub is not None:
+            self._position_settle_unsub()
         self._position_settle_unsub = async_call_later(
             self.hass, POSITION_SETTLE_DELAY, self._async_settle_poll
         )
 
     @callback
     def async_cancel_settle_poll(self) -> None:
-        """Cancel a pending settle poll."""
+        """Cancel a pending settle poll and drop any queued (re)schedules."""
+        self._settle_generation += 1
         if self._position_settle_unsub is not None:
             self._position_settle_unsub()
             self._position_settle_unsub = None

--- a/homeassistant/components/sonos/media.py
+++ b/homeassistant/components/sonos/media.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable
 import datetime
 import logging
+import threading
 from typing import Any
 
 from soco.core import (
@@ -88,6 +89,8 @@ class SonosMedia:
         # in-flight executor job cannot re-arm the timer after cancellation.
         self._settle_generation = 0
         self._newest_poll_at: datetime.datetime | None = None
+        # Serializes applying poll results from concurrent executor jobs.
+        self._poll_lock = threading.Lock()
 
     def clear(self) -> None:
         """Clear basic media info."""
@@ -107,6 +110,15 @@ class SonosMedia:
         """Clear the position attributes."""
         self.position = None
         self.position_updated_at = None
+
+    @property
+    def settle_generation(self) -> int:
+        """Return the current settle-poll generation.
+
+        Captured on the event loop when an event's executor job is submitted,
+        so a cancellation always invalidates work queued before it.
+        """
+        return self._settle_generation
 
     @property
     def library(self) -> MusicLibrary:
@@ -135,37 +147,48 @@ class SonosMedia:
 
     def set_basic_track_info(self, update_position: bool = False) -> None:
         """Query the speaker to update media metadata and position info."""
-        self.clear()
-
         track_info, polled_at = self.poll_track_info()
-        if not track_info["uri"]:
-            return
-        self.uri = track_info["uri"]
-
-        audio_source = self.soco.music_source_from_uri(self.uri)
-        if source := SOURCE_MAPPING.get(audio_source):
-            self.source_name = source
-            if audio_source in LINEIN_SOURCES:
-                self.clear_position()
-                self.title = source
+        with self._poll_lock:
+            if self._newest_poll_at is not None and polled_at < self._newest_poll_at:
+                # An overlapping poll finished out of order; a newer result
+                # has already been applied. Discard the whole result so stale
+                # metadata cannot be restored alongside a guarded position.
                 return
+            self.clear()
+            if not track_info["uri"]:
+                return
+            self.uri = track_info["uri"]
 
-        self.artist = track_info.get("artist")
-        self.album_name = track_info.get("album")
-        title = track_info.get("title") or ""
-        self.title = title.strip() or None
-        self.image_url = track_info.get("album_art")
+            audio_source = self.soco.music_source_from_uri(self.uri)
+            if source := SOURCE_MAPPING.get(audio_source):
+                self.source_name = source
+                if audio_source in LINEIN_SOURCES:
+                    self.clear_position()
+                    self.title = source
+                    return
 
-        playlist_position = int(track_info.get("playlist_position", -1))
-        if playlist_position > 0:
-            self.queue_position = playlist_position
+            self.artist = track_info.get("artist")
+            self.album_name = track_info.get("album")
+            title = track_info.get("title") or ""
+            self.title = title.strip() or None
+            self.image_url = track_info.get("album_art")
 
-        self.update_media_position(
-            track_info, force_update=update_position, polled_at=polled_at
-        )
+            playlist_position = int(track_info.get("playlist_position", -1))
+            if playlist_position > 0:
+                self.queue_position = playlist_position
 
-    def update_media_from_event(self, evars: dict[str, Any]) -> None:
-        """Update information about currently playing media using an event payload."""
+            self.update_media_position(
+                track_info, force_update=update_position, polled_at=polled_at
+            )
+
+    def update_media_from_event(
+        self, evars: dict[str, Any], settle_generation: int
+    ) -> None:
+        """Update information about currently playing media using an event payload.
+
+        settle_generation must be captured on the event loop when this job is
+        submitted, so cancellations during the blocking poll are honored.
+        """
         new_status = evars["transport_state"]
         state_changed = new_status != self.playback_status
         # A track change without a transport state change (e.g. a skip or an
@@ -189,7 +212,7 @@ class SonosMedia:
             # stream rebuffers; re-poll once the transition has settled so a
             # stale snapshot cannot stick.
             self.hass.loop.call_soon_threadsafe(
-                self._async_schedule_settle_poll, self._settle_generation
+                self._async_schedule_settle_poll, settle_generation
             )
 
         if ct_md := evars["current_track_meta_data"]:
@@ -256,7 +279,10 @@ class SonosMedia:
         if audio_source in LINEIN_SOURCES:
             # Line-in/TV positions are deliberately cleared, never tracked.
             return
-        self.update_media_position(track_info, force_update=True, polled_at=polled_at)
+        with self._poll_lock:
+            self.update_media_position(
+                track_info, force_update=True, polled_at=polled_at
+            )
         self.write_media_player_states()
 
     @soco_error()

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -457,6 +457,8 @@ class SonosSpeaker:
             self._poll_timer()
             self._poll_timer = None
 
+        self.media.async_cancel_settle_poll()
+
     @callback
     def async_renew_failed(self, exception: Exception) -> None:
         """Handle a failed subscription renewal."""
@@ -732,6 +734,8 @@ class SonosSpeaker:
         if self._poll_timer:
             self._poll_timer()
             self._poll_timer = None
+
+        self.media.async_cancel_settle_poll()
 
         await self.async_unsubscribe()
 

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -593,7 +593,9 @@ class SonosSpeaker:
 
         self.event_stats.process(event)
         self.hass.async_add_executor_job(
-            self.media.update_media_from_event, event.variables
+            self.media.update_media_from_event,
+            event.variables,
+            self.media.settle_generation,
         )
 
     @callback

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -95,7 +95,7 @@ from homeassistant.util import dt as dt_util
 
 from .conftest import MockMusicServiceItem, MockSoCo, SoCoMockFactory, SonosMockEvent
 
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.fixture(autouse=True)
@@ -1870,6 +1870,54 @@ async def test_position_settles_after_resume(
         state = hass.states.get(entity_id)
         assert state.attributes[ATTR_MEDIA_POSITION] == 44
         assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == dt_util.utcnow()
+
+
+@pytest.mark.freeze_time("2024-01-01T12:00:00Z")
+async def test_out_of_order_poll_result_discarded(
+    hass: HomeAssistant,
+    soco: MockSoCo,
+    async_autosetup_sonos,
+    media_event: SonosMockEvent,
+    current_track_info: dict[str, Any],
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test a poll result older than the newest processed one is discarded."""
+    entity_id = "media_player.zone_a"
+    soco.get_current_track_info.return_value = current_track_info
+    soco.avTransport.subscribe.return_value.callback(media_event)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    # Consume the initial settle poll.
+    with freeze_time("2024-01-01T12:00:02Z"):
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done(wait_background_tasks=True)
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_MEDIA_POSITION] == 42
+    updated_at = state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT]
+
+    media = list(config_entry.runtime_data.discovered.values())[0].media
+    # A newer poll whose position matches the extrapolation writes nothing
+    # but must still advance the ordering watermark.
+    newer = dict(current_track_info)
+    newer["duration_in_s"] = 156
+    newer["position_in_s"] = 44
+    media.update_media_position(
+        newer,
+        polled_at=dt_util.utcnow() + datetime.timedelta(seconds=2),
+    )
+    # A slower, older poll finishing afterwards must be discarded even though
+    # nothing was written since its request time.
+    stale = dict(current_track_info)
+    stale["duration_in_s"] = 156
+    stale["position_in_s"] = 3
+    media.update_media_position(
+        stale,
+        force_update=True,
+        polled_at=dt_util.utcnow() + datetime.timedelta(seconds=1),
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_MEDIA_POSITION] == 42
+    assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == updated_at
 
 
 @pytest.mark.parametrize(

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1872,6 +1872,61 @@ async def test_position_settles_after_resume(
         assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == dt_util.utcnow()
 
 
+@pytest.mark.freeze_time("2024-01-01T12:00:00Z")
+async def test_out_of_order_poll_does_not_restore_metadata(
+    hass: HomeAssistant,
+    soco: MockSoCo,
+    async_autosetup_sonos,
+    media_event: SonosMockEvent,
+    current_track_info: dict[str, Any],
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test a stale poll is discarded whole, metadata included."""
+    entity_id = "media_player.zone_a"
+    soco.get_current_track_info.return_value = current_track_info
+    soco.avTransport.subscribe.return_value.callback(media_event)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    with freeze_time("2024-01-01T12:00:02Z"):
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done(wait_background_tasks=True)
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_MEDIA_TITLE] == "Something"
+
+    media = list(config_entry.runtime_data.discovered.values())[0].media
+    # A newer poll has been applied while a slower one was still in flight.
+    media._newest_poll_at = dt_util.utcnow() + datetime.timedelta(seconds=5)
+    stale_info = dict(current_track_info)
+    stale_info["title"] = "Stale Old Title"
+    stale_info["position"] = "00:00:03"
+    soco.get_current_track_info.return_value = stale_info
+    media.set_basic_track_info(update_position=True)
+    # The stale result must not restore old metadata nor touch the position.
+    assert media.title == "Something"
+    assert media.position == 42
+
+
+async def test_event_with_stale_generation_does_not_arm_settle(
+    hass: HomeAssistant,
+    soco: MockSoCo,
+    async_autosetup_sonos,
+    media_event: SonosMockEvent,
+    current_track_info: dict[str, Any],
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test an event job submitted before cancellation cannot arm the timer."""
+    media = list(config_entry.runtime_data.discovered.values())[0].media
+    soco.get_current_track_info.return_value = current_track_info
+    # The generation is captured at submission; cancellation runs while the
+    # job's blocking poll is still in flight.
+    stale_generation = media.settle_generation
+    media.async_cancel_settle_poll()
+    await hass.async_add_executor_job(
+        media.update_media_from_event, media_event.variables, stale_generation
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert media._position_settle_unsub is None
+
+
 async def test_settle_poll_not_rearmed_after_cancellation(
     hass: HomeAssistant,
     soco: MockSoCo,

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1824,6 +1824,54 @@ async def test_settle_poll_failure_keeps_last_position(
     assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == updated_at
 
 
+@pytest.mark.freeze_time("2024-01-01T12:00:00Z")
+async def test_position_settles_after_resume(
+    hass: HomeAssistant,
+    soco: MockSoCo,
+    async_autosetup_sonos,
+    media_event: SonosMockEvent,
+    current_track_info: dict[str, Any],
+) -> None:
+    """Test a transient 0:00 reported during a resume is settled to the truth."""
+    entity_id = "media_player.zone_a"
+    soco.get_current_track_info.return_value = current_track_info
+    soco.avTransport.subscribe.return_value.callback(media_event)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    # Consume the initial settle poll.
+    with freeze_time("2024-01-01T12:00:02Z"):
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Resume: while the stream rebuffers the speaker briefly reports 0:00,
+    # which the forced state-change poll captures.
+    resuming_track_info = current_track_info.copy()
+    resuming_track_info["position"] = "00:00:00"
+    soco.get_current_track_info.return_value = resuming_track_info
+    paused_event = SonosMockEvent(soco, soco.avTransport, media_event.variables.copy())
+    paused_event.variables["transport_state"] = "PAUSED_PLAYBACK"
+    with freeze_time("2024-01-01T12:00:10Z"):
+        soco.avTransport.subscribe.return_value.callback(paused_event)
+        await hass.async_block_till_done(wait_background_tasks=True)
+    playing_event = SonosMockEvent(soco, soco.avTransport, media_event.variables.copy())
+    with freeze_time("2024-01-01T12:00:12Z"):
+        soco.avTransport.subscribe.return_value.callback(playing_event)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        state = hass.states.get(entity_id)
+        assert state.attributes[ATTR_MEDIA_POSITION] == 0
+
+    # Once the transition settles, the speaker reports the real clock again
+    # and the settle poll repairs the entity.
+    settled_track_info = current_track_info.copy()
+    settled_track_info["position"] = "00:00:44"
+    soco.get_current_track_info.return_value = settled_track_info
+    with freeze_time("2024-01-01T12:00:14Z"):
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done(wait_background_tasks=True)
+        state = hass.states.get(entity_id)
+        assert state.attributes[ATTR_MEDIA_POSITION] == 44
+        assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == dt_util.utcnow()
+
+
 @pytest.mark.parametrize(
     ("track_info", "event_variables"),
     [

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1872,6 +1872,26 @@ async def test_position_settles_after_resume(
         assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == dt_util.utcnow()
 
 
+async def test_settle_poll_not_rearmed_after_cancellation(
+    hass: HomeAssistant,
+    soco: MockSoCo,
+    async_autosetup_sonos,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test a schedule queued before cancellation cannot re-arm the timer."""
+    media = list(config_entry.runtime_data.discovered.values())[0].media
+    # An executor job captures the generation, then teardown cancels before
+    # the queued schedule reaches the event loop.
+    stale_generation = media._settle_generation
+    media.async_cancel_settle_poll()
+    media._async_schedule_settle_poll(stale_generation)
+    assert media._position_settle_unsub is None
+    # A schedule queued after the cancellation is honored again.
+    media._async_schedule_settle_poll(media._settle_generation)
+    assert media._position_settle_unsub is not None
+    media.async_cancel_settle_poll()
+
+
 @pytest.mark.freeze_time("2024-01-01T12:00:00Z")
 async def test_out_of_order_poll_result_discarded(
     hass: HomeAssistant,

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1703,6 +1703,59 @@ async def test_position_updates(
         assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == dt_util.utcnow()
 
 
+@pytest.mark.freeze_time("2024-01-01T12:00:00Z")
+async def test_position_updated_on_track_change_while_playing(
+    hass: HomeAssistant,
+    soco: MockSoCo,
+    async_autosetup_sonos,
+    media_event: SonosMockEvent,
+    current_track_info: dict[str, Any],
+) -> None:
+    """Test a track change without a transport state change refreshes position.
+
+    A skip or auto-advance keeps the transport state PLAYING. The position
+    must still be force-updated: the poll triggered by the event can return a
+    mid-transition snapshot still carrying the previous track's clock, which
+    the position jump heuristic alone would discard, leaving a stale position
+    and timestamp on the entity.
+    """
+    entity_id = "media_player.zone_a"
+    sub_callback = soco.avTransport.subscribe.return_value.callback
+
+    soco.get_current_track_info.return_value = current_track_info
+    sub_callback(media_event)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_MEDIA_POSITION] == 42
+    updated_at = state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT]
+
+    # Skip to the next track while PLAYING: same transport state, new track
+    # uri. The mid-transition poll reports the new track's metadata but a
+    # position snapshot matching the previous track's extrapolated clock,
+    # which the jump heuristic alone would discard as unchanged.
+    new_track_info = current_track_info.copy()
+    new_track_info["uri"] = (
+        "x-file-cifs://192.168.42.10/music/The%20Beatles/Abbey%20Road/04%20Oh%21%20Darling.mp3"
+    )
+    new_track_info["title"] = "Oh! Darling"
+    new_track_info["position"] = "00:00:43"
+    soco.get_current_track_info.return_value = new_track_info
+    new_media_event = SonosMockEvent(
+        soco, soco.avTransport, media_event.variables.copy()
+    )
+    new_media_event.variables["current_track_uri"] = new_track_info["uri"]
+    with freeze_time("2024-01-01T12:00:01Z"):
+        sub_callback(new_media_event)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        state = hass.states.get(entity_id)
+        assert state.attributes[ATTR_MEDIA_TITLE] == "Oh! Darling"
+        # The reported clock matches the old track's extrapolation, but the
+        # track changed, so the position must be written and re-stamped fresh.
+        assert state.attributes[ATTR_MEDIA_POSITION] == 43
+        assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == dt_util.utcnow()
+        assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] > updated_at
+
+
 @pytest.mark.parametrize(
     ("track_info", "event_variables"),
     [

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1711,14 +1711,7 @@ async def test_position_updated_on_track_change_while_playing(
     media_event: SonosMockEvent,
     current_track_info: dict[str, Any],
 ) -> None:
-    """Test a track change without a transport state change refreshes position.
-
-    A skip or auto-advance keeps the transport state PLAYING. The position
-    must still be force-updated: the poll triggered by the event can return a
-    mid-transition snapshot still carrying the previous track's clock, which
-    the position jump heuristic alone would discard, leaving a stale position
-    and timestamp on the entity.
-    """
+    """Test a track change without a transport state change refreshes position."""
     entity_id = "media_player.zone_a"
     sub_callback = soco.avTransport.subscribe.return_value.callback
 

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1,11 +1,13 @@
 """Tests for the Sonos Media Player platform."""
 
 from collections.abc import Generator
+import datetime
 import logging
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 from freezegun import freeze_time
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from soco.data_structures import (
     DidlAudioBroadcast,
@@ -13,7 +15,7 @@ from soco.data_structures import (
     DidlPlaylistContainer,
     SearchResult,
 )
-from soco.exceptions import SoCoUPnPException
+from soco.exceptions import SoCoException, SoCoUPnPException
 from sonos_websocket.exception import SonosWebsocketError
 from syrupy.assertion import SnapshotAssertion
 
@@ -92,6 +94,8 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from .conftest import MockMusicServiceItem, MockSoCo, SoCoMockFactory, SonosMockEvent
+
+from tests.common import async_fire_time_changed
 
 
 @pytest.fixture(autouse=True)
@@ -1747,6 +1751,77 @@ async def test_position_updated_on_track_change_while_playing(
         assert state.attributes[ATTR_MEDIA_POSITION] == 43
         assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == dt_util.utcnow()
         assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] > updated_at
+
+    # A settle poll corrects any snapshot that raced the transition once the
+    # track change has settled.
+    settled_track_info = new_track_info.copy()
+    settled_track_info["position"] = "00:00:02"
+    soco.get_current_track_info.return_value = settled_track_info
+    with freeze_time("2024-01-01T12:00:03Z"):
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done(wait_background_tasks=True)
+        state = hass.states.get(entity_id)
+        assert state.attributes[ATTR_MEDIA_POSITION] == 2
+        assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == dt_util.utcnow()
+
+
+async def test_position_stamped_with_poll_request_time(
+    hass: HomeAssistant,
+    soco: MockSoCo,
+    async_autosetup_sonos,
+    media_event: SonosMockEvent,
+    current_track_info: dict[str, Any],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a delayed poll response is stamped with the poll request time."""
+    entity_id = "media_player.zone_a"
+    request_time = dt_util.utcnow()
+
+    def delayed_track_info():
+        # The speaker takes 5 seconds to answer the poll.
+        freezer.tick(datetime.timedelta(seconds=5))
+        return current_track_info
+
+    soco.get_current_track_info.side_effect = delayed_track_info
+    soco.avTransport.subscribe.return_value.callback(media_event)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_MEDIA_POSITION] == 42
+    # The position was true when the poll was requested, not when the delayed
+    # response was written.
+    assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == request_time
+
+    # Let the scheduled settle poll fire so no timer lingers.
+    freezer.tick(datetime.timedelta(seconds=5))
+    async_fire_time_changed(hass, dt_util.utcnow())
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+
+@pytest.mark.freeze_time("2024-01-01T12:00:00Z")
+async def test_settle_poll_failure_keeps_last_position(
+    hass: HomeAssistant,
+    soco: MockSoCo,
+    async_autosetup_sonos,
+    media_event: SonosMockEvent,
+    current_track_info: dict[str, Any],
+) -> None:
+    """Test a failing settle poll leaves the last written position in place."""
+    entity_id = "media_player.zone_a"
+    soco.get_current_track_info.return_value = current_track_info
+    soco.avTransport.subscribe.return_value.callback(media_event)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_MEDIA_POSITION] == 42
+    updated_at = state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT]
+
+    # The speaker becomes unreachable before the settle poll fires.
+    soco.get_current_track_info.side_effect = SoCoException("connection lost")
+    with freeze_time("2024-01-01T12:00:02Z"):
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done(wait_background_tasks=True)
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_MEDIA_POSITION] == 42
+    assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == updated_at
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

On a track change that leaves the transport state unchanged — every skip or auto-advance while playing — `update_media_from_event` never forces a position update, leaving it to the >1.5 s jump heuristic. The poll fired at event time can return a mid-transition snapshot still carrying the previous track's clock, which the heuristic judges "unchanged" and discards; since position is not carried in UPnP events and evented mode never re-polls, the entity's `media_position` stays stale until the next track boundary. A delayed follow-up snapshot can then be written with `position_updated_at` stamped at write time, presenting an already-stale position as fresh.

The same window also corrupts resumes: while a Spotify Connect stream rebuffers after `play`, the speaker briefly reports `0:00`, which the forced state-change poll captures and keeps (reproduced live: entity pinned at 0 while the speaker resumed at 0:00:44).

Three changes:
1. `update_media_from_event` now also forces a position update when the event's `current_track_uri` differs from the currently tracked URI.
2. `position_updated_at` is stamped from when the position poll was *requested* rather than when the result is written (per-poll, so overlapping polls each carry their own request time), and an out-of-order older result is discarded.
3. Any transport transition (track change or state change) schedules a debounced settle poll 2 s later that re-reads and force-writes the position once the transition has settled — so no transition-window snapshot can stick. The timer is cancelled on speaker shutdown/offline, skips line-in/TV sources, and tolerates an unreachable speaker.

Observed in the wild as a frozen progress bar after every Spotify Connect skip (full diagnosis in the linked issue). Verified on the reporting household's production system (2026.7.4, S2 soundbar, Spotify Connect): with this patch applied, live REST-API sampling shows `media_position` reset with a sub-second-fresh `media_position_updated_at` within ~0.3 s of both speaker-initiated and app-initiated skips, where unpatched code left the stamp 20+ seconds stale.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181315
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
