### PR TITLE
Split Teslemetry local-control abort into two reasons

### DIFF
--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -219,14 +219,20 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             for subentry in entry.subentries.values()
             if subentry.subentry_type == SUBENTRY_TYPE_ENERGY_SITE
         }
-        available = {
-            str(energy_data.id): energy_data
+        local_control_sites = [
+            energy_data
             for energy_data in entry.runtime_data.energysites
             if energy_data.can_local_control
-            and str(energy_data.id) not in added_site_ids
+        ]
+        available = {
+            str(energy_data.id): energy_data
+            for energy_data in local_control_sites
+            if str(energy_data.id) not in added_site_ids
         }
         if not available:
-            return self.async_abort(reason="no_energy_sites")
+            return self.async_abort(
+                reason="all_sites_added" if local_control_sites else "no_powerwall"
+            )
 
         if user_input is not None:
             energy_data = available[user_input[CONF_SITE_ID]]

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -52,7 +52,7 @@
         "all_sites_added": "Every energy site with a Powerwall on your Teslemetry account has already been added for local control.",
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
         "entry_not_loaded": "The Teslemetry account must be loaded before setting up local control. Try again once it has finished loading.",
-        "no_powerwall": "Local control requires a Powerwall, and no energy site on your Teslemetry account has one."
+        "no_powerwall": "Local control requires a Powerwall, and no energy site with one is currently accessible on your Teslemetry account."
       },
       "entry_type": "Energy site",
       "error": {

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -49,9 +49,10 @@
   "config_subentries": {
     "energy_site": {
       "abort": {
+        "all_sites_added": "Every energy site with a Powerwall on your Teslemetry account has already been added for local control.",
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
         "entry_not_loaded": "The Teslemetry account must be loaded before setting up local control. Try again once it has finished loading.",
-        "no_energy_sites": "No energy sites on your Teslemetry account are available for local control. This may be because they lack a Powerwall or have already been added."
+        "no_powerwall": "Local control requires a Powerwall, and no energy site on your Teslemetry account has one."
       },
       "entry_type": "Energy site",
       "error": {

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -49,7 +49,7 @@
   "config_subentries": {
     "energy_site": {
       "abort": {
-        "all_sites_added": "Every energy site with a Powerwall on your Teslemetry account has already been added for local control.",
+        "all_sites_added": "Every accessible energy site with a Powerwall on your Teslemetry account has already been added for local control.",
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
         "entry_not_loaded": "The Teslemetry account must be loaded before setting up local control. Try again once it has finished loading.",
         "no_powerwall": "Local control requires a Powerwall, and no energy site with one is currently accessible on your Teslemetry account."

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -1047,7 +1047,53 @@ async def test_add_flow_aborts_when_all_sites_added(hass: HomeAssistant) -> None
     )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "no_energy_sites"
+    assert result["reason"] == "all_sites_added"
+
+
+async def test_add_flow_aborts_when_no_powerwall(hass: HomeAssistant) -> None:
+    """The add flow aborts when the account has no Powerwall-capable site."""
+    products = deepcopy(PRODUCTS)
+    products["response"] = [
+        product
+        for product in products["response"]
+        if product.get("energy_site_id") != SITE_ID
+    ]
+    products["response"].append(
+        {
+            "energy_site_id": WALL_CONNECTOR_SITE_ID,
+            "site_name": "Wall Connector Site",
+            "components": {
+                "battery": False,
+                "solar": False,
+                "grid": True,
+                "wall_connectors": [{"device_id": "wc-1", "din": "WC-DIN-1"}],
+            },
+        }
+    )
+    metadata = deepcopy(METADATA)
+    del metadata["energy_sites"][str(SITE_ID)]
+    metadata["energy_sites"][str(WALL_CONNECTOR_SITE_ID)] = {
+        "access": True,
+        "name": "Wall Connector Site",
+    }
+
+    entry = mock_config_entry()
+    entry.add_to_hass(hass)
+    with (
+        patch("tesla_fleet_api.teslemetry.Teslemetry.products", return_value=products),
+        patch("tesla_fleet_api.teslemetry.Teslemetry.metadata", return_value=metadata),
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.subentries.async_init(
+        (entry.entry_id, SUBENTRY_TYPE_ENERGY_SITE),
+        context={"source": "user"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_powerwall"
 
 
 @pytest.mark.usefixtures("mock_rsa_key")


### PR DESCRIPTION
## Breaking change


## Proposed change

The energy-site subentry flow aborts with one reason whether every Powerwall site is already added or the account has no Powerwall at all, so a solar-only customer is told they've already added everything they never had. Pick the reason from whether any local-control site exists.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
