### PR TITLE
Update Sonos media position immediately after a seek command

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -51,6 +51,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
+from homeassistant.util import dt as dt_util
 
 from . import media_browser
 from .const import (
@@ -485,6 +486,12 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
     def media_seek(self, position: float) -> None:
         """Send seek command."""
         self.coordinator.soco.seek(str(datetime.timedelta(seconds=int(position))))
+        # Sonos does not raise an event for position changes, so nothing else
+        # refreshes the entity after a seek; the commanded position is
+        # authoritative for the moment the command succeeded.
+        self.media.position = int(position)
+        self.media.position_updated_at = dt_util.utcnow()
+        self.media.write_media_player_states()
 
     @soco_error()
     @override

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -51,7 +51,6 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_call_later
-from homeassistant.util import dt as dt_util
 
 from . import media_browser
 from .const import (
@@ -486,16 +485,13 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
     def media_seek(self, position: float) -> None:
         """Send seek command."""
         # Capture the target before the blocking call: a topology change while
-        # seeking must not update a different coordinator's media.
+        # seeking must not poll a different coordinator's media.
         coordinator = self.coordinator
-        media = coordinator.media
         coordinator.soco.seek(str(datetime.timedelta(seconds=int(position))))
         # Sonos does not raise an event for position changes, so nothing else
-        # refreshes the entity after a seek; the commanded position is
-        # authoritative for the moment the command succeeded.
-        media.position = int(position)
-        media.position_updated_at = dt_util.utcnow()
-        media.write_media_player_states()
+        # refreshes the entity after a seek; poll the speaker for the updated
+        # transport information.
+        coordinator.media.poll_media()
 
     @soco_error()
     @override

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -485,13 +485,17 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
     @override
     def media_seek(self, position: float) -> None:
         """Send seek command."""
-        self.coordinator.soco.seek(str(datetime.timedelta(seconds=int(position))))
+        # Capture the target before the blocking call: a topology change while
+        # seeking must not update a different coordinator's media.
+        coordinator = self.coordinator
+        media = coordinator.media
+        coordinator.soco.seek(str(datetime.timedelta(seconds=int(position))))
         # Sonos does not raise an event for position changes, so nothing else
         # refreshes the entity after a seek; the commanded position is
         # authoritative for the moment the command succeeded.
-        self.media.position = int(position)
-        self.media.position_updated_at = dt_util.utcnow()
-        self.media.write_media_player_states()
+        media.position = int(position)
+        media.position_updated_at = dt_util.utcnow()
+        media.write_media_player_states()
 
     @soco_error()
     @override

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1728,6 +1728,7 @@ async def test_media_seek_updates_position(
             {ATTR_ENTITY_ID: entity_id, ATTR_MEDIA_SEEK_POSITION: 100},
             blocking=True,
         )
+        await hass.async_block_till_done()
         soco.seek.assert_called_once_with("0:01:40")
         state = hass.states.get(entity_id)
         # Sonos fires no event for a position change: the entity must reflect

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1721,6 +1721,13 @@ async def test_media_seek_updates_position(
     state = hass.states.get(entity_id)
     assert state.attributes[ATTR_MEDIA_POSITION] == 42
 
+    # The post-seek poll reads the updated transport information back.
+    sought_track_info = dict(current_track_info)
+    sought_track_info["position"] = "00:01:40"
+    soco.get_current_track_info.return_value = sought_track_info
+    soco.get_current_transport_info.return_value = {
+        "current_transport_state": "PLAYING"
+    }
     with freeze_time("2024-01-01T12:00:05Z"):
         await hass.services.async_call(
             MP_DOMAIN,
@@ -1732,7 +1739,7 @@ async def test_media_seek_updates_position(
         soco.seek.assert_called_once_with("0:01:40")
         state = hass.states.get(entity_id)
         # Sonos fires no event for a position change: the entity must reflect
-        # the commanded position immediately.
+        # the position polled back from the speaker after the seek.
         assert state.attributes[ATTR_MEDIA_POSITION] == 100
         assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == dt_util.utcnow()
 

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -33,11 +33,13 @@ from homeassistant.components.media_player import (
     ATTR_MEDIA_POSITION,
     ATTR_MEDIA_POSITION_UPDATED_AT,
     ATTR_MEDIA_REPEAT,
+    ATTR_MEDIA_SEEK_POSITION,
     ATTR_MEDIA_SHUFFLE,
     ATTR_MEDIA_TITLE,
     ATTR_MEDIA_VOLUME_LEVEL,
     DOMAIN as MP_DOMAIN,
     SERVICE_CLEAR_PLAYLIST,
+    SERVICE_MEDIA_SEEK,
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
     MediaPlayerEnqueue,
@@ -1700,6 +1702,37 @@ async def test_position_updates(
         await hass.async_block_till_done(wait_background_tasks=True)
         state = hass.states.get(entity_id)
         assert state.attributes[ATTR_MEDIA_POSITION] == 70
+        assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == dt_util.utcnow()
+
+
+@pytest.mark.freeze_time("2024-01-01T12:00:00Z")
+async def test_media_seek_updates_position(
+    hass: HomeAssistant,
+    soco: MockSoCo,
+    async_autosetup_sonos,
+    media_event: SonosMockEvent,
+    current_track_info: dict[str, Any],
+) -> None:
+    """Test that a seek updates the entity position without waiting for events."""
+    entity_id = "media_player.zone_a"
+    soco.get_current_track_info.return_value = current_track_info
+    soco.avTransport.subscribe.return_value.callback(media_event)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_MEDIA_POSITION] == 42
+
+    with freeze_time("2024-01-01T12:00:05Z"):
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_MEDIA_SEEK,
+            {ATTR_ENTITY_ID: entity_id, ATTR_MEDIA_SEEK_POSITION: 100},
+            blocking=True,
+        )
+        soco.seek.assert_called_once_with("0:01:40")
+        state = hass.states.get(entity_id)
+        # Sonos fires no event for a position change: the entity must reflect
+        # the commanded position immediately.
+        assert state.attributes[ATTR_MEDIA_POSITION] == 100
         assert state.attributes[ATTR_MEDIA_POSITION_UPDATED_AT] == dt_util.utcnow()
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Sonos speakers do not raise a UPnP event for position changes, so after `media_seek` nothing ever refreshes the entity's `media_position`: the seek takes effect on the speaker, but the entity keeps extrapolating from the pre-seek position until the next track boundary. To the user, dragging the progress bar appears to do nothing (the bar snaps back) even though playback audibly jumped.

This was reported as #128142 and closed unplanned. The fix is minimal: after a successful seek, write the commanded position — which is authoritative for the moment the command succeeded — with a fresh `media_position_updated_at`, and publish the state. If the seek raises, the `soco_error` decorator prevents the write.

Verified live on an S2 soundbar during a Spotify Connect session: `media_seek` to 45 s moved playback to 0:00:45 and the entity reflected `media_position: 45` with a fresh timestamp within 2 s, where unpatched code kept the stale pre-seek position indefinitely.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #128142
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
