### PR TITLE
Remove user-configurable polling interval from UpCloud

### DIFF
--- a/homeassistant/components/upcloud/__init__.py
+++ b/homeassistant/components/upcloud/__init__.py
@@ -1,44 +1,19 @@
 """Support for UpCloud."""
 
-from datetime import timedelta
 import logging
 
 import requests.exceptions
 import upcloud_api
 
-from homeassistant.const import (
-    CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
-    CONF_USERNAME,
-    Platform,
-)
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect,
-    async_dispatcher_send,
-)
 
-from .const import CONFIG_ENTRY_UPDATE_SIGNAL_TEMPLATE, DEFAULT_SCAN_INTERVAL
 from .coordinator import UpCloudConfigEntry, UpCloudDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SWITCH]
-
-
-def _config_entry_update_signal_name(config_entry: UpCloudConfigEntry) -> str:
-    """Get signal name for updates to a config entry."""
-    return CONFIG_ENTRY_UPDATE_SIGNAL_TEMPLATE.format(config_entry.unique_id)
-
-
-async def _async_signal_options_update(
-    hass: HomeAssistant, config_entry: UpCloudConfigEntry
-) -> None:
-    """Signal config entry options update."""
-    async_dispatcher_send(
-        hass, _config_entry_update_signal_name(config_entry), config_entry
-    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: UpCloudConfigEntry) -> bool:
@@ -57,15 +32,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: UpCloudConfigEntry) -> b
         _LOGGER.exception("Failed to connect")
         raise ConfigEntryNotReady from err
 
-    if entry.options.get(CONF_SCAN_INTERVAL):
-        update_interval = timedelta(seconds=entry.options[CONF_SCAN_INTERVAL])
-    else:
-        update_interval = DEFAULT_SCAN_INTERVAL
-
     coordinator = UpCloudDataUpdateCoordinator(
         hass,
         config_entry=entry,
-        update_interval=update_interval,
         cloud_manager=manager,
         username=entry.data[CONF_USERNAME],
     )
@@ -73,16 +42,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: UpCloudConfigEntry) -> b
 
     # Call the UpCloud API to refresh data
     await coordinator.async_config_entry_first_refresh()
-
-    # Listen to config entry updates
-    entry.async_on_unload(entry.add_update_listener(_async_signal_options_update))
-    entry.async_on_unload(
-        async_dispatcher_connect(
-            hass,
-            _config_entry_update_signal_name(entry),
-            coordinator.async_update_config,
-        )
-    )
 
     # Forward entry setup
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/upcloud/config_flow.py
+++ b/homeassistant/components/upcloud/config_flow.py
@@ -7,12 +7,11 @@ import requests.exceptions
 import upcloud_api
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
-from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
-from .coordinator import UpCloudConfigEntry
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,37 +82,3 @@ class UpCloudConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             errors=errors or {},
         )
-
-    @staticmethod
-    @callback
-    @override
-    def async_get_options_flow(
-        config_entry: UpCloudConfigEntry,
-    ) -> UpCloudOptionsFlow:
-        """Get options flow."""
-        return UpCloudOptionsFlow()
-
-
-class UpCloudOptionsFlow(OptionsFlow):
-    """UpCloud options flow."""
-
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle options flow."""
-
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
-
-        data_schema = vol.Schema(
-            {
-                # Polling interval is user-configurable, which is no longer allowed
-                # pylint: disable-next=home-assistant-config-flow-polling-field
-                vol.Optional(
-                    CONF_SCAN_INTERVAL,
-                    default=self.config_entry.options.get(CONF_SCAN_INTERVAL)
-                    or DEFAULT_SCAN_INTERVAL.total_seconds(),
-                ): vol.All(vol.Coerce(int), vol.Range(min=30)),
-            }
-        )
-        return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/homeassistant/components/upcloud/const.py
+++ b/homeassistant/components/upcloud/const.py
@@ -4,4 +4,3 @@ from datetime import timedelta
 
 DOMAIN = "upcloud"
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
-CONFIG_ENTRY_UPDATE_SIGNAL_TEMPLATE = f"{DOMAIN}_config_entry_update:{{}}"

--- a/homeassistant/components/upcloud/coordinator.py
+++ b/homeassistant/components/upcloud/coordinator.py
@@ -1,15 +1,15 @@
 """Coordinator for UpCloud."""
 
-from datetime import timedelta
 import logging
 from typing import override
 
 import upcloud_api
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DEFAULT_SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +28,6 @@ class UpCloudDataUpdateCoordinator(
         *,
         config_entry: UpCloudConfigEntry,
         cloud_manager: upcloud_api.CloudManager,
-        update_interval: timedelta,
         username: str,
     ) -> None:
         """Initialize coordinator."""
@@ -37,15 +36,9 @@ class UpCloudDataUpdateCoordinator(
             _LOGGER,
             config_entry=config_entry,
             name=f"{username}@UpCloud",
-            update_interval=update_interval,
+            update_interval=DEFAULT_SCAN_INTERVAL,
         )
         self.cloud_manager = cloud_manager
-
-    async def async_update_config(self, config_entry: UpCloudConfigEntry) -> None:
-        """Handle config update."""
-        self.update_interval = timedelta(
-            seconds=config_entry.options[CONF_SCAN_INTERVAL]
-        )
 
     @override
     async def _async_update_data(self) -> dict[str, upcloud_api.Server]:

--- a/homeassistant/components/upcloud/strings.json
+++ b/homeassistant/components/upcloud/strings.json
@@ -15,14 +15,5 @@
         }
       }
     }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "data": {
-          "scan_interval": "Update interval in seconds, minimum 30"
-        }
-      }
-    }
   }
 }

--- a/tests/components/upcloud/test_config_flow.py
+++ b/tests/components/upcloud/test_config_flow.py
@@ -1,7 +1,5 @@
 """Tests for the UpCloud config flow."""
 
-from unittest.mock import patch
-
 import requests.exceptions
 import requests_mock
 from requests_mock import ANY
@@ -9,7 +7,7 @@ from upcloud_api import UpCloudAPIError
 
 from homeassistant import config_entries
 from homeassistant.components.upcloud.const import DOMAIN
-from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -18,10 +16,6 @@ from tests.common import MockConfigEntry
 FIXTURE_USER_INPUT = {
     CONF_USERNAME: "user",
     CONF_PASSWORD: "pass",
-}
-
-FIXTURE_USER_INPUT_OPTIONS = {
-    CONF_SCAN_INTERVAL: "120",
 }
 
 
@@ -86,31 +80,6 @@ async def test_success(
     assert result["data"][CONF_PASSWORD] == FIXTURE_USER_INPUT[CONF_PASSWORD]
 
 
-async def test_options(hass: HomeAssistant) -> None:
-    """Test options produce expected data."""
-
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, data=FIXTURE_USER_INPUT, options=FIXTURE_USER_INPUT_OPTIONS
-    )
-    config_entry.add_to_hass(hass)
-
-    with patch("homeassistant.components.upcloud.async_setup_entry", return_value=True):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "init"
-
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input=FIXTURE_USER_INPUT_OPTIONS,
-    )
-    assert result["data"][CONF_SCAN_INTERVAL] == int(
-        FIXTURE_USER_INPUT_OPTIONS[CONF_SCAN_INTERVAL]
-    )
-
-
 async def test_already_configured(
     hass: HomeAssistant, requests_mock: requests_mock.Mocker
 ) -> None:
@@ -120,7 +89,6 @@ async def test_already_configured(
         domain=DOMAIN,
         unique_id=FIXTURE_USER_INPUT[CONF_USERNAME],
         data=FIXTURE_USER_INPUT,
-        options=FIXTURE_USER_INPUT_OPTIONS,
     )
     config_entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The configurable scan interval has been removed from the UpCloud integration. The integration now always polls every 60 seconds.

If you previously set a longer interval, polling will now be more frequent. For example, a 300 second interval becomes 60 seconds, which is a fivefold increase in API calls. If you need a different cadence, disable polling for the UpCloud entities (entity system options) and create an automation that calls `homeassistant.update_entity` on your schedule. Using `homeassistant.update_entity` alone is not enough while automatic polling is still enabled.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove the user-configurable polling interval from the UpCloud integration, per the [appropriate-polling](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/appropriate-polling) quality scale rule and [home-assistant/epics#45](https://github.com/home-assistant/epics/issues/45).

The coordinator now always polls every 60 seconds (`DEFAULT_SCAN_INTERVAL`). The options flow that exposed `scan_interval` is removed, along with the dispatcher path that updated the coordinator when that option changed. Existing config entries that still store `scan_interval` in options keep working; the stored value is ignored.

This follows the same approach as #175576.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please, be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168846
- This PR is related to issue: home-assistant/epics#45
- Link to documentation pull request: n/a (the UpCloud docs do not document the scan interval option)
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
