### PR TITLE
Add glass break device class for binary_sensor

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -55,6 +55,9 @@ class BinarySensorDeviceClass(StrEnum):
     # On means gas detected, Off means no gas (clear)
     GAS = "gas"
 
+    # On means glass break detected, Off means no glass break (clear)
+    GLASS_BREAK = "glass_break"
+
     # On means hot, Off means normal
     HEAT = "heat"
 

--- a/homeassistant/components/binary_sensor/device_condition.py
+++ b/homeassistant/components/binary_sensor/device_condition.py
@@ -37,6 +37,8 @@ CONF_IS_CONNECTED = "is_connected"
 CONF_IS_NOT_CONNECTED = "is_not_connected"
 CONF_IS_GAS = "is_gas"
 CONF_IS_NO_GAS = "is_no_gas"
+CONF_IS_GLASS_BREAK = "is_glass_break"
+CONF_IS_NO_GLASS_BREAK = "is_no_glass_break"
 CONF_IS_HOT = "is_hot"
 CONF_IS_NOT_HOT = "is_not_hot"
 CONF_IS_LIGHT = "is_light"
@@ -83,6 +85,7 @@ IS_ON = [
     CONF_IS_COLD,
     CONF_IS_CONNECTED,
     CONF_IS_GAS,
+    CONF_IS_GLASS_BREAK,
     CONF_IS_HOT,
     CONF_IS_LIGHT,
     CONF_IS_NOT_LOCKED,
@@ -123,6 +126,7 @@ IS_OFF = [
     CONF_IS_NOT_UNSAFE,
     CONF_IS_NO_CO,
     CONF_IS_NO_GAS,
+    CONF_IS_NO_GLASS_BREAK,
     CONF_IS_NO_LIGHT,
     CONF_IS_NO_MOTION,
     CONF_IS_NO_PROBLEM,
@@ -166,6 +170,10 @@ ENTITY_CONDITIONS = {
     BinarySensorDeviceClass.GAS: [
         {CONF_TYPE: CONF_IS_GAS},
         {CONF_TYPE: CONF_IS_NO_GAS},
+    ],
+    BinarySensorDeviceClass.GLASS_BREAK: [
+        {CONF_TYPE: CONF_IS_GLASS_BREAK},
+        {CONF_TYPE: CONF_IS_NO_GLASS_BREAK},
     ],
     BinarySensorDeviceClass.HEAT: [
         {CONF_TYPE: CONF_IS_HOT},

--- a/homeassistant/components/binary_sensor/device_trigger.py
+++ b/homeassistant/components/binary_sensor/device_trigger.py
@@ -31,6 +31,8 @@ CONF_CONNECTED = "connected"
 CONF_NOT_CONNECTED = "not_connected"
 CONF_GAS = "gas"
 CONF_NO_GAS = "no_gas"
+CONF_GLASS_BREAK = "glass_break"
+CONF_NO_GLASS_BREAK = "no_glass_break"
 CONF_HOT = "hot"
 CONF_NOT_HOT = "not_hot"
 CONF_LIGHT = "light"
@@ -103,6 +105,10 @@ ENTITY_TRIGGERS = {
     BinarySensorDeviceClass.GAS: [
         {CONF_TYPE: CONF_GAS},
         {CONF_TYPE: CONF_NO_GAS},
+    ],
+    BinarySensorDeviceClass.GLASS_BREAK: [
+        {CONF_TYPE: CONF_GLASS_BREAK},
+        {CONF_TYPE: CONF_NO_GLASS_BREAK},
     ],
     BinarySensorDeviceClass.HEAT: [
         {CONF_TYPE: CONF_HOT},

--- a/homeassistant/components/binary_sensor/icons.json
+++ b/homeassistant/components/binary_sensor/icons.json
@@ -54,6 +54,9 @@
         "on": "mdi:alert-circle"
       }
     },
+    "glass_break": {
+      "default": "mdi:glass-fragile"
+    },
     "heat": {
       "default": "mdi:thermometer",
       "state": {

--- a/homeassistant/components/binary_sensor/strings.json
+++ b/homeassistant/components/binary_sensor/strings.json
@@ -7,6 +7,7 @@
       "is_cold": "{entity_name} is cold",
       "is_connected": "{entity_name} is connected",
       "is_gas": "{entity_name} is detecting gas",
+      "is_glass_break": "{entity_name} is detecting glass break",
       "is_hot": "{entity_name} is hot",
       "is_light": "{entity_name} is detecting light",
       "is_locked": "{entity_name} is locked",
@@ -15,6 +16,7 @@
       "is_moving": "{entity_name} is moving",
       "is_no_co": "{entity_name} is not detecting carbon monoxide",
       "is_no_gas": "{entity_name} is not detecting gas",
+      "is_no_glass_break": "{entity_name} is not detecting glass break",
       "is_no_light": "{entity_name} is not detecting light",
       "is_no_motion": "{entity_name} is not detecting motion",
       "is_no_problem": "{entity_name} is not detecting problem",
@@ -64,6 +66,7 @@
       "cold": "{entity_name} became cold",
       "connected": "{entity_name} connected",
       "gas": "{entity_name} started detecting gas",
+      "glass_break": "{entity_name} detected glass break",
       "hot": "{entity_name} became hot",
       "light": "{entity_name} started detecting light",
       "locked": "{entity_name} locked",
@@ -72,6 +75,7 @@
       "moving": "{entity_name} started moving",
       "no_co": "{entity_name} stopped detecting carbon monoxide",
       "no_gas": "{entity_name} stopped detecting gas",
+      "no_glass_break": "{entity_name} stopped detecting glass break",
       "no_light": "{entity_name} stopped detecting light",
       "no_motion": "{entity_name} stopped detecting motion",
       "no_problem": "{entity_name} stopped detecting problem",
@@ -174,6 +178,13 @@
       "state": {
         "off": "Clear",
         "on": "Detected"
+      }
+    },
+    "glass_break": {
+      "name": "Glass break",
+      "state": {
+        "off": "Clear",
+        "on": "Glass break detected"
       }
     },
     "heat": {

--- a/homeassistant/generated/device_classes.json
+++ b/homeassistant/generated/device_classes.json
@@ -8,6 +8,7 @@
     "door",
     "garage_door",
     "gas",
+    "glass_break",
     "heat",
     "light",
     "lock",

--- a/tests/components/binary_sensor/test_init.py
+++ b/tests/components/binary_sensor/test_init.py
@@ -6,6 +6,9 @@ from unittest import mock
 import pytest
 
 from homeassistant.components import binary_sensor
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.binary_sensor.device_condition import ENTITY_CONDITIONS
+from homeassistant.components.binary_sensor.device_trigger import ENTITY_TRIGGERS
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory, Platform
 from homeassistant.core import HomeAssistant
@@ -196,3 +199,68 @@ async def test_entity_category_config_raises_error(
         "Entity binary_sensor.test2 cannot be added as the"
         " entity category is set to config" in caplog.text
     )
+
+
+def test_glass_break_device_class() -> None:
+    """Test glass break device class enum value and automation mappings."""
+    assert BinarySensorDeviceClass.GLASS_BREAK == "glass_break"
+    assert BinarySensorDeviceClass.GLASS_BREAK in ENTITY_CONDITIONS
+    assert BinarySensorDeviceClass.GLASS_BREAK in ENTITY_TRIGGERS
+    conditions = ENTITY_CONDITIONS[BinarySensorDeviceClass.GLASS_BREAK]
+    assert len(conditions) == 2
+    condition_types = {c["type"] for c in conditions}
+    assert condition_types == {"is_glass_break", "is_no_glass_break"}
+    triggers = ENTITY_TRIGGERS[BinarySensorDeviceClass.GLASS_BREAK]
+    assert len(triggers) == 2
+    trigger_types = {t["type"] for t in triggers}
+    assert trigger_types == {"glass_break", "no_glass_break"}
+
+
+async def test_glass_break_entity_state(hass: HomeAssistant) -> None:
+    """Test a glass break binary sensor reports the correct state and attributes."""
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(
+            config_entry, [Platform.BINARY_SENSOR]
+        )
+        return True
+
+    mock_platform(hass, f"{TEST_DOMAIN}.config_flow")
+    mock_integration(
+        hass,
+        MockModule(
+            TEST_DOMAIN,
+            async_setup_entry=async_setup_entry_init,
+        ),
+    )
+
+    entity = binary_sensor.BinarySensorEntity()
+    entity.entity_id = "binary_sensor.glass_break_1"
+    entity._attr_device_class = BinarySensorDeviceClass.GLASS_BREAK
+    entity._attr_is_on = True
+
+    async def async_setup_entry_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddConfigEntryEntitiesCallback,
+    ) -> None:
+        """Set up test binary_sensor platform via config entry."""
+        async_add_entities([entity])
+
+    mock_platform(
+        hass,
+        f"{TEST_DOMAIN}.{binary_sensor.DOMAIN}",
+        MockPlatform(async_setup_entry=async_setup_entry_platform),
+    )
+
+    config_entry = MockConfigEntry(domain=TEST_DOMAIN)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.glass_break_1")
+    assert state.state == STATE_ON
+    assert state.attributes["device_class"] == "glass_break"

--- a/tests/components/binary_sensor/test_init.py
+++ b/tests/components/binary_sensor/test_init.py
@@ -7,8 +7,6 @@ import pytest
 
 from homeassistant.components import binary_sensor
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
-from homeassistant.components.binary_sensor.device_condition import ENTITY_CONDITIONS
-from homeassistant.components.binary_sensor.device_trigger import ENTITY_TRIGGERS
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory, Platform
 from homeassistant.core import HomeAssistant
@@ -199,21 +197,6 @@ async def test_entity_category_config_raises_error(
         "Entity binary_sensor.test2 cannot be added as the"
         " entity category is set to config" in caplog.text
     )
-
-
-def test_glass_break_device_class() -> None:
-    """Test glass break device class enum value and automation mappings."""
-    assert BinarySensorDeviceClass.GLASS_BREAK == "glass_break"
-    assert BinarySensorDeviceClass.GLASS_BREAK in ENTITY_CONDITIONS
-    assert BinarySensorDeviceClass.GLASS_BREAK in ENTITY_TRIGGERS
-    conditions = ENTITY_CONDITIONS[BinarySensorDeviceClass.GLASS_BREAK]
-    assert len(conditions) == 2
-    condition_types = {c["type"] for c in conditions}
-    assert condition_types == {"is_glass_break", "is_no_glass_break"}
-    triggers = ENTITY_TRIGGERS[BinarySensorDeviceClass.GLASS_BREAK]
-    assert len(triggers) == 2
-    trigger_types = {t["type"] for t in triggers}
-    assert trigger_types == {"glass_break", "no_glass_break"}
 
 
 async def test_glass_break_entity_state(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a dedicated `glass_break` binary sensor device class so that glass-break detectors can be represented with a specific device class instead of generic safety, sound, problem, or vibration.

The device class uses `Clear` and `Glass break detected` states with the `mdi:glass-fragile` icon. It also provides semantic device conditions and triggers.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/discussions/1455
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47902
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3335
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53989

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging the code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr