### PR TITLE
Leave Powerwall gateway host blank when discovery fails

### DIFF
--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -6,12 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast, override
 
 from aiohttp import ClientError
-from aiopowerwall import (
-    DEFAULT_GATEWAY_HOST,
-    PowerwallAuthenticationError,
-    PowerwallClient,
-    PowerwallError,
-)
+from aiopowerwall import PowerwallAuthenticationError, PowerwallClient, PowerwallError
 from tesla_fleet_api.const import (
     AuthorizedClientKeyType,
     AuthorizedClientState,
@@ -265,8 +260,11 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         try:
             self._discovered_host = await energy_site.find_gateway_address() or ""
         except (ClientError, TeslaFleetError) as err:
-            LOGGER.debug("Gateway address discovery failed: %s", err)
+            LOGGER.warning("Gateway address discovery failed: %s", err)
             self._discovered_host = ""
+        else:
+            if not self._discovered_host:
+                LOGGER.warning("Gateway address discovery returned no address")
 
         path = self.hass.config.path(POWERWALL_KEY_FILE)
         keyholder = Teslemetry(
@@ -412,9 +410,11 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             step_id="credentials",
             data_schema=vol.Schema(
                 {
+                    # Leave blank when discovery found nothing; defaulting to the
+                    # setup-AP address would misdirect a normally-connected gateway.
                     vol.Required(
                         CONF_HOST,
-                        default=self._discovered_host or DEFAULT_GATEWAY_HOST,
+                        default=self._discovered_host or vol.UNDEFINED,
                     ): str,
                     vol.Required(CONF_PASSWORD): str,
                 }

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -410,8 +410,6 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             step_id="credentials",
             data_schema=vol.Schema(
                 {
-                    # Leave blank when discovery found nothing; defaulting to the
-                    # setup-AP address would misdirect a normally-connected gateway.
                     vol.Required(
                         CONF_HOST,
                         default=self._discovered_host or vol.UNDEFINED,

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -70,6 +70,9 @@
             "host": "[%key:common::config_flow::data::host%]",
             "password": "[%key:common::config_flow::data::password%]"
           },
+          "data_description": {
+            "host": "If you are connected to your Powerwall's setup Wi-Fi network, enter 192.168.91.1."
+          },
           "description": "Enter your Powerwall system's local network address and its Wi-Fi password. Only the last 5 characters of the password are needed - find them on the QR label behind the front cover of your Powerwall 3, or behind the Backup Gateway door on Powerwall 2.",
           "title": "Connect to your Powerwall system"
         },

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -70,9 +70,6 @@
             "host": "[%key:common::config_flow::data::host%]",
             "password": "[%key:common::config_flow::data::password%]"
           },
-          "data_description": {
-            "host": "If you are connected to your Powerwall's setup Wi-Fi network, enter 192.168.91.1."
-          },
           "description": "Enter your Powerwall system's local network address and its Wi-Fi password. Only the last 5 characters of the password are needed - find them on the QR label behind the front cover of your Powerwall 3, or behind the Backup Gateway door on Powerwall 2.",
           "title": "Connect to your Powerwall system"
         },

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -9,7 +9,6 @@ from urllib.parse import parse_qs, urlparse
 
 from aiohttp import ClientConnectionError, ClientError
 from aiopowerwall import (
-    DEFAULT_GATEWAY_HOST,
     PowerwallAuthenticationError,
     PowerwallConnectionError,
     PowerwallFaultError,
@@ -25,6 +24,7 @@ from tesla_fleet_api.exceptions import (
     TeslaFleetError,
 )
 from tesla_fleet_api.teslemetry.energysite import AuthorizedClient, AuthorizedClients
+import voluptuous as vol
 
 from homeassistant.components.application_credentials import (
     ClientCredential,
@@ -838,6 +838,14 @@ def _credentials_host_default(result: SubentryFlowResult) -> str:
     raise AssertionError("CONF_HOST field not found in credentials schema")
 
 
+def _credentials_host_is_blank(result: SubentryFlowResult) -> bool:
+    """Return whether the CONF_HOST field carries no schema default (left blank)."""
+    for key in result["data_schema"].schema:
+        if key == CONF_HOST:
+            return key.default is vol.UNDEFINED
+    raise AssertionError("CONF_HOST field not found in credentials schema")
+
+
 @pytest.mark.usefixtures("mock_rsa_key")
 async def test_energy_subentry_pairing_requires_key_approval(
     hass: HomeAssistant,
@@ -1203,10 +1211,11 @@ async def test_add_flow_aborts_when_entry_not_loaded(hass: HomeAssistant) -> Non
 
 
 @pytest.mark.usefixtures("mock_rsa_key")
-async def test_gateway_discovery_failure_proceeds_without_host(
+async def test_gateway_discovery_failure_leaves_host_blank(
     hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A failed gateway-address discovery leaves the host default unset."""
+    """A failed gateway-address discovery leaves the host field blank and warns."""
     entry = await _setup_account_no_subentry(hass)
 
     with (
@@ -1225,7 +1234,42 @@ async def test_gateway_discovery_failure_proceeds_without_host(
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "credentials"
-    assert _credentials_host_default(result) == DEFAULT_GATEWAY_HOST
+    assert _credentials_host_is_blank(result)
+    assert any(
+        record.levelname == "WARNING" and "discovery failed" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_gateway_discovery_empty_leaves_host_blank(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Discovery returning no address (without raising) leaves the host blank and warns."""
+    entry = await _setup_account_no_subentry(hass)
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_gateway_address",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(
+                return_value=_own_key_clients(AuthorizedClientState.VERIFIED)
+            ),
+        ),
+    ):
+        result = await _start_add_flow_select_site(hass, entry)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+    assert _credentials_host_is_blank(result)
+    assert any(
+        record.levelname == "WARNING" and "no address" in record.message
+        for record in caplog.records
+    )
 
 
 @pytest.mark.usefixtures("mock_rsa_key")

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -1213,9 +1213,8 @@ async def test_add_flow_aborts_when_entry_not_loaded(hass: HomeAssistant) -> Non
 @pytest.mark.usefixtures("mock_rsa_key")
 async def test_gateway_discovery_failure_leaves_host_blank(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A failed gateway-address discovery leaves the host field blank and warns."""
+    """A failed gateway-address discovery leaves the host field blank and proceeds."""
     entry = await _setup_account_no_subentry(hass)
 
     with (
@@ -1235,18 +1234,13 @@ async def test_gateway_discovery_failure_leaves_host_blank(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "credentials"
     assert _credentials_host_is_blank(result)
-    assert any(
-        record.levelname == "WARNING" and "discovery failed" in record.message
-        for record in caplog.records
-    )
 
 
 @pytest.mark.usefixtures("mock_rsa_key")
 async def test_gateway_discovery_empty_leaves_host_blank(
     hass: HomeAssistant,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Discovery returning no address (without raising) leaves the host blank and warns."""
+    """Discovery returning no address (without raising) leaves the host blank and proceeds."""
     entry = await _setup_account_no_subentry(hass)
 
     with (
@@ -1266,10 +1260,6 @@ async def test_gateway_discovery_empty_leaves_host_blank(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "credentials"
     assert _credentials_host_is_blank(result)
-    assert any(
-        record.levelname == "WARNING" and "no address" in record.message
-        for record in caplog.records
-    )
 
 
 @pytest.mark.usefixtures("mock_rsa_key")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When gateway discovery failed, the local Powerwall credentials step pre-filled the setup access-point address as if it had been discovered, so a user on a normally-connected gateway got a wrong address that looked like it could be correct. The host field is now left blank when discovery finds nothing, and discovery failures are logged as warnings instead of debug.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cdf7AQCLsyCNYmXTZZg48P

