### PR TITLE
Read Teslemetry backup reserve and operation mode from a local Powerwall

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -59,6 +59,7 @@ from .const import (
 )
 from .coordinator import (
     TeslemetryEnergyHistoryCoordinator,
+    TeslemetryEnergySiteConfigLocalCoordinator,
     TeslemetryEnergySiteInfoCoordinator,
     TeslemetryEnergySiteLiveCoordinator,
     TeslemetryMetadataCoordinator,
@@ -596,11 +597,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 hass, entry, bool(battery), site_id, energy_site
             )
 
+            # A paired site also reads its config.json locally so the
+            # config-backed entities read back from the LAN gateway.
+            config_local_coordinator = (
+                TeslemetryEnergySiteConfigLocalCoordinator(
+                    hass, entry, energy_site_api.primary.powerwall
+                )
+                if isinstance(energy_site_api, EnergySiteRouter)
+                else None
+            )
+
             energysites.append(
                 TeslemetryEnergyData(
                     api=energy_site_api,
                     live_coordinator=live_coordinator,
                     info_coordinator=info_coordinator,
+                    config_local_coordinator=config_local_coordinator,
                     history_coordinator=history_coordinator,
                     id=site_id,
                     device=device,
@@ -620,6 +632,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
         *(
             energysite.info_coordinator.async_config_entry_first_refresh()
             for energysite in energysites
+        ),
+        # A local config read must not fail setup: a paired gateway that is
+        # briefly unreachable should still load with cloud functionality, so
+        # refresh non-fatally and let the config-backed entities go unavailable.
+        *(
+            energysite.config_local_coordinator.async_refresh()
+            for energysite in energysites
+            if energysite.config_local_coordinator is not None
         ),
     )
 

--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, override
 
+from aiopowerwall import PowerwallClient, PowerwallError, raw_to_scaled_reserve
 from tesla_fleet_api.const import TeslaEnergyPeriod, VehicleDataEndpoint
 from tesla_fleet_api.exceptions import (
     GatewayTimeout,
@@ -47,6 +48,9 @@ VEHICLE_INTERVAL = timedelta(seconds=60)
 VEHICLE_WAIT = timedelta(minutes=15)
 ENERGY_HISTORY_INTERVAL = timedelta(seconds=60)
 METADATA_INTERVAL = timedelta(hours=1)
+# The gateway's config.json has no stream, so poll it to pick up changes made
+# outside Home Assistant (e.g. the Tesla app).
+ENERGY_CONFIG_INTERVAL = timedelta(seconds=30)
 
 # Keys within tariff_content_v2 kept as nested dicts rather than flattened,
 # since entities and calendars read them as whole structures.
@@ -64,6 +68,36 @@ ENDPOINTS = [
     VehicleDataEndpoint.VEHICLE_STATE,
     VehicleDataEndpoint.VEHICLE_CONFIG,
 ]
+
+# Info keys a paired Powerwall can serve from its config.json. Entities for
+# these keys read the local config coordinator; every other info key stays on
+# the cloud info coordinator.
+LOCAL_CONFIG_COORDINATOR_KEYS: frozenset[str] = frozenset(
+    {
+        "backup_reserve_percent",
+        "default_real_mode",
+    }
+)
+
+
+def _local_config_snapshot(config: dict[str, Any]) -> dict[str, Any]:
+    """Map a local ``config.json`` payload onto cloud-shaped info keys.
+
+    Only the keys a local gateway can faithfully serve are emitted; anything
+    missing is left out so the entity reads unavailable rather than a guess.
+    """
+    snapshot: dict[str, Any] = {}
+    site_info = config.get("site_info")
+    if isinstance(site_info, dict):
+        raw_reserve = site_info.get("backup_reserve_percent")
+        if isinstance(raw_reserve, (int, float)):
+            # config.json stores the raw reserve (5% is an inaccessible buffer);
+            # scale it to the user-facing percentage the cloud site_info reports.
+            snapshot["backup_reserve_percent"] = raw_to_scaled_reserve(raw_reserve)
+    mode = config.get("default_real_mode")
+    if isinstance(mode, str):
+        snapshot["default_real_mode"] = mode
+    return snapshot
 
 
 class TeslemetryMetadataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -327,6 +361,47 @@ class TeslemetryEnergySiteInfoCoordinator(DataUpdateCoordinator[dict[str, Any]])
             ) from e
 
         return self._ingest_site_info(data)
+
+
+class TeslemetryEnergySiteConfigLocalCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Local config coordinator for a paired Powerwall energy site.
+
+    Reads the gateway's ``config.json`` over the local network so the site's
+    config-backed entities read back from the LAN gateway. One shared snapshot
+    serves every such entity; the write path stays on the local-first router.
+    """
+
+    config_entry: TeslemetryConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: TeslemetryConfigEntry,
+        client: PowerwallClient,
+    ) -> None:
+        """Initialize Teslemetry Energy Site Local Config coordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            config_entry=config_entry,
+            name="Teslemetry Energy Site Local Config",
+            update_interval=ENERGY_CONFIG_INTERVAL,
+        )
+        self.client = client
+        self.data = {}
+
+    @override
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Read the local gateway config.json."""
+        try:
+            config = await self.client.get_config()
+        except PowerwallError as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+                translation_placeholders={"message": str(e)},
+            ) from e
+        return _local_config_snapshot(config)
 
 
 class TeslemetryEnergyHistoryCoordinator(DataUpdateCoordinator[dict[str, Any]]):

--- a/homeassistant/components/teslemetry/entity.py
+++ b/homeassistant/components/teslemetry/entity.py
@@ -190,6 +190,21 @@ class TeslemetryEnergyInfoEntity(TeslemetryPollingEntity):
 
         super().__init__(coordinator, key)
 
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if the entity is available.
+
+        A key served by the local config coordinator that a successful read did
+        not include is left unavailable rather than surfacing a guessed value.
+        """
+        if (
+            isinstance(self.coordinator, TeslemetryEnergySiteConfigLocalCoordinator)
+            and self.key not in self.coordinator.data
+        ):
+            return False
+        return super().available
+
 
 class TeslemetryEnergyHistoryEntity(TeslemetryPollingEntity):
     """Parent class for Teslemetry Energy History Entities."""

--- a/homeassistant/components/teslemetry/entity.py
+++ b/homeassistant/components/teslemetry/entity.py
@@ -16,7 +16,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import (
+    LOCAL_CONFIG_COORDINATOR_KEYS,
     TeslemetryEnergyHistoryCoordinator,
+    TeslemetryEnergySiteConfigLocalCoordinator,
     TeslemetryEnergySiteInfoCoordinator,
     TeslemetryEnergySiteLiveCoordinator,
     TeslemetryVehicleDataCoordinator,
@@ -47,6 +49,7 @@ class TeslemetryPollingEntity(
         | TeslemetryEnergyHistoryCoordinator
         | TeslemetryEnergySiteLiveCoordinator
         | TeslemetryEnergySiteInfoCoordinator
+        | TeslemetryEnergySiteConfigLocalCoordinator
     ],
 ):
     """Parent class for all Teslemetry Coordinator entities."""
@@ -56,7 +59,8 @@ class TeslemetryPollingEntity(
         coordinator: TeslemetryVehicleDataCoordinator
         | TeslemetryEnergyHistoryCoordinator
         | TeslemetryEnergySiteLiveCoordinator
-        | TeslemetryEnergySiteInfoCoordinator,
+        | TeslemetryEnergySiteInfoCoordinator
+        | TeslemetryEnergySiteConfigLocalCoordinator,
         key: str,
     ) -> None:
         """Initialize common aspects of a Teslemetry entity."""
@@ -172,7 +176,19 @@ class TeslemetryEnergyInfoEntity(TeslemetryPollingEntity):
         self._attr_unique_id = f"{data.id}-{key}"
         self._attr_device_info = data.device
 
-        super().__init__(data.info_coordinator, key)
+        # A paired site reads the config-backed keys from its local config
+        # coordinator; everything else stays on the cloud info coordinator.
+        coordinator: (
+            TeslemetryEnergySiteInfoCoordinator
+            | TeslemetryEnergySiteConfigLocalCoordinator
+        ) = data.info_coordinator
+        if (
+            data.config_local_coordinator is not None
+            and key in LOCAL_CONFIG_COORDINATOR_KEYS
+        ):
+            coordinator = data.config_local_coordinator
+
+        super().__init__(coordinator, key)
 
 
 class TeslemetryEnergyHistoryEntity(TeslemetryPollingEntity):

--- a/homeassistant/components/teslemetry/models.py
+++ b/homeassistant/components/teslemetry/models.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 
 from .coordinator import (
     TeslemetryEnergyHistoryCoordinator,
+    TeslemetryEnergySiteConfigLocalCoordinator,
     TeslemetryEnergySiteInfoCoordinator,
     TeslemetryEnergySiteLiveCoordinator,
     TeslemetryMetadataCoordinator,
@@ -54,6 +55,9 @@ class TeslemetryEnergyData:
     api: EnergySite | EnergySiteRouter
     live_coordinator: TeslemetryEnergySiteLiveCoordinator | None
     info_coordinator: TeslemetryEnergySiteInfoCoordinator
+    # Local config.json coordinator, present only for a paired Powerwall site;
+    # None keeps the site's config-backed entities on the cloud info coordinator.
+    config_local_coordinator: TeslemetryEnergySiteConfigLocalCoordinator | None
     history_coordinator: TeslemetryEnergyHistoryCoordinator | None
     id: int
     device: DeviceInfo

--- a/tests/components/teslemetry/conftest.py
+++ b/tests/components/teslemetry/conftest.py
@@ -306,3 +306,13 @@ def mock_stream_connected():
         return_value=True,
     ) as mock_stream_connected:
         yield mock_stream_connected
+
+
+@pytest.fixture(autouse=True)
+def mock_powerwall_config():
+    """Mock the local Powerwall config.json read used by paired energy sites."""
+    with patch(
+        "aiopowerwall.client.PowerwallClient.get_config",
+        return_value={},
+    ) as mock_powerwall_config:
+        yield mock_powerwall_config

--- a/tests/components/teslemetry/test_number.py
+++ b/tests/components/teslemetry/test_number.py
@@ -12,7 +12,7 @@ from homeassistant.components.number import (
     DOMAIN as NUMBER_DOMAIN,
     SERVICE_SET_VALUE,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -218,3 +218,31 @@ async def test_paired_site_backup_reserve_reads_local(
         await hass.async_block_till_done()
 
     assert hass.states.get("number.energy_site_backup_reserve").state == expected
+
+
+async def test_paired_site_backup_reserve_unavailable_when_key_missing(
+    hass: HomeAssistant,
+    mock_powerwall_config: AsyncMock,
+) -> None:
+    """A successful local read that omits the key leaves the number unavailable.
+
+    The gateway answered, but config.json carried no backup_reserve_percent, so
+    the local-backed number reads unavailable rather than a guessed value.
+    """
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+    mock_powerwall_config.return_value = {"site_info": {}}
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry._async_get_rsa_key_pem",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+        patch("homeassistant.components.teslemetry.PLATFORMS", [Platform.NUMBER]),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("number.energy_site_backup_reserve").state == STATE_UNAVAILABLE
+    )

--- a/tests/components/teslemetry/test_number.py
+++ b/tests/components/teslemetry/test_number.py
@@ -19,6 +19,7 @@ from homeassistant.helpers import entity_registry as er
 
 from . import assert_entities, reload_platform, setup_platform
 from .const import COMMAND_ERRORS, COMMAND_OK, VEHICLE_DATA_ALT
+from .test_init import _TEST_RSA_KEY_PEM, _entry_with_powerwall
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -178,3 +179,42 @@ async def test_number_streaming(
     # Assert the entities restored their values with concrete assertions
     assert hass.states.get("number.test_charge_current").state == "24"
     assert hass.states.get("number.test_charge_limit").state == "99"
+
+
+@pytest.mark.parametrize(
+    ("raw_reserve", "expected"),
+    [
+        # config.json stores the raw reserve; raw_to_scaled_reserve is
+        # (raw - 5) / 0.95, so raw 24 -> 20.0 and raw 100 -> 100.0.
+        pytest.param(24, "20.0", id="mid"),
+        pytest.param(100, "100.0", id="full"),
+    ],
+)
+async def test_paired_site_backup_reserve_reads_local(
+    hass: HomeAssistant,
+    mock_powerwall_config: AsyncMock,
+    raw_reserve: int,
+    expected: str,
+) -> None:
+    """A paired site reads the backup reserve back from local config.json.
+
+    The cloud site_info reserve is 0; the number instead reflects the local
+    raw value scaled to the user-facing percentage.
+    """
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+    mock_powerwall_config.return_value = {
+        "site_info": {"backup_reserve_percent": raw_reserve}
+    }
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry._async_get_rsa_key_pem",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+        patch("homeassistant.components.teslemetry.PLATFORMS", [Platform.NUMBER]),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("number.energy_site_backup_reserve").state == expected

--- a/tests/components/teslemetry/test_number.py
+++ b/tests/components/teslemetry/test_number.py
@@ -196,11 +196,7 @@ async def test_paired_site_backup_reserve_reads_local(
     raw_reserve: int,
     expected: str,
 ) -> None:
-    """A paired site reads the backup reserve back from local config.json.
-
-    The cloud site_info reserve is 0; the number instead reflects the local
-    raw value scaled to the user-facing percentage.
-    """
+    """A paired site reads the backup reserve back from local config.json."""
     entry = _entry_with_powerwall()
     entry.add_to_hass(hass)
     mock_powerwall_config.return_value = {
@@ -224,11 +220,7 @@ async def test_paired_site_backup_reserve_unavailable_when_key_missing(
     hass: HomeAssistant,
     mock_powerwall_config: AsyncMock,
 ) -> None:
-    """A successful local read that omits the key leaves the number unavailable.
-
-    The gateway answered, but config.json carried no backup_reserve_percent, so
-    the local-backed number reads unavailable rather than a guessed value.
-    """
+    """A successful local read that omits the key leaves the number unavailable."""
     entry = _entry_with_powerwall()
     entry.add_to_hass(hass)
     mock_powerwall_config.return_value = {"site_info": {}}

--- a/tests/components/teslemetry/test_select.py
+++ b/tests/components/teslemetry/test_select.py
@@ -32,6 +32,7 @@ from .const import (
     SITE_INFO,
     VEHICLE_DATA_ALT,
 )
+from .test_init import _TEST_RSA_KEY_PEM, _entry_with_powerwall
 
 from tests.common import async_fire_time_changed
 
@@ -558,3 +559,37 @@ async def test_export_rule_update_attrs_logic(
     state = hass.states.get("select.energy_site_allow_export")
     assert state
     assert state.state == expected_state
+
+
+async def test_paired_site_operation_mode_reads_local(
+    hass: HomeAssistant,
+    mock_powerwall_config: AsyncMock,
+) -> None:
+    """A paired site reads the operation mode back from local config.json.
+
+    The cloud site_info mode is "self_consumption"; the operation select
+    instead reflects the local top-level default_real_mode, while the
+    export-rule select stays on cloud.
+    """
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+    mock_powerwall_config.return_value = {
+        "default_real_mode": EnergyOperationMode.AUTONOMOUS
+    }
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry._async_get_rsa_key_pem",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+        patch("homeassistant.components.teslemetry.PLATFORMS", [Platform.SELECT]),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("select.energy_site_operation_mode").state
+        == EnergyOperationMode.AUTONOMOUS
+    )
+    # The export rule select is not rerouted and keeps its cloud value.
+    assert hass.states.get("select.energy_site_allow_export").state == "pv_only"

--- a/tests/components/teslemetry/test_select.py
+++ b/tests/components/teslemetry/test_select.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable
 from copy import deepcopy
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from aiopowerwall import PowerwallError
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -16,9 +17,18 @@ from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.components.teslemetry.coordinator import VEHICLE_INTERVAL
+from homeassistant.components.teslemetry.coordinator import (
+    ENERGY_CONFIG_INTERVAL,
+    VEHICLE_INTERVAL,
+)
 from homeassistant.components.teslemetry.select import HIGH, LEVEL, LOW, MEDIUM, OFF
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -593,3 +603,47 @@ async def test_paired_site_operation_mode_reads_local(
     )
     # The export rule select is not rerouted and keeps its cloud value.
     assert hass.states.get("select.energy_site_allow_export").state == "pv_only"
+
+
+async def test_paired_site_operation_mode_recovers_after_local_failure(
+    hass: HomeAssistant,
+    mock_powerwall_config: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A failed initial local read does not abort setup; a later refresh recovers.
+
+    The first config.json read fails, so setup still completes with the site
+    falling back and the local-backed select unavailable. Once the gateway
+    answers on a later refresh, the select reads the local operation mode.
+    """
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+    mock_powerwall_config.side_effect = PowerwallError("gateway unreachable")
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry._async_get_rsa_key_pem",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+        patch("homeassistant.components.teslemetry.PLATFORMS", [Platform.SELECT]),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert (
+        hass.states.get("select.energy_site_operation_mode").state == STATE_UNAVAILABLE
+    )
+
+    mock_powerwall_config.side_effect = None
+    mock_powerwall_config.return_value = {
+        "default_real_mode": EnergyOperationMode.AUTONOMOUS
+    }
+    freezer.tick(ENERGY_CONFIG_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("select.energy_site_operation_mode").state
+        == EnergyOperationMode.AUTONOMOUS
+    )

--- a/tests/components/teslemetry/test_select.py
+++ b/tests/components/teslemetry/test_select.py
@@ -575,12 +575,7 @@ async def test_paired_site_operation_mode_reads_local(
     hass: HomeAssistant,
     mock_powerwall_config: AsyncMock,
 ) -> None:
-    """A paired site reads the operation mode back from local config.json.
-
-    The cloud site_info mode is "self_consumption"; the operation select
-    instead reflects the local top-level default_real_mode, while the
-    export-rule select stays on cloud.
-    """
+    """A paired site reads the operation mode back from local config.json."""
     entry = _entry_with_powerwall()
     entry.add_to_hass(hass)
     mock_powerwall_config.return_value = {
@@ -610,12 +605,7 @@ async def test_paired_site_operation_mode_recovers_after_local_failure(
     mock_powerwall_config: AsyncMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """A failed initial local read does not abort setup; a later refresh recovers.
-
-    The first config.json read fails, so setup still completes with the site
-    falling back and the local-backed select unavailable. Once the gateway
-    answers on a later refresh, the select reads the local operation mode.
-    """
+    """A failed initial local read does not abort setup; a later refresh recovers."""
     entry = _entry_with_powerwall()
     entry.add_to_hass(hass)
     mock_powerwall_config.side_effect = PowerwallError("gateway unreachable")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Setting a paired Teslemetry energy site's backup reserve and operation mode is
already local-first: those writes route through the `EnergySiteRouter` to the
Powerwall gateway. The matching read-back stayed on the cloud `site_info`, so
after a local write, or a change made in the Tesla app, the number and select
entities lagged the gateway until the cloud caught up.

A paired site now reads these two values back from the gateway's `config.json`
over the LAN through a dedicated coordinator, scaling the raw reserve onto the
user-facing percentage the cloud reports and passing the operation mode through
unchanged. The read refreshes non-fatally at setup, so a briefly unreachable
gateway still loads with cloud functionality and the config-backed entities go
unavailable until it returns. An unpaired site is untouched and keeps reading
from the cloud; no new entities are added, only the read source changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
