### PR TITLE
Read Teslemetry live energy values from a local Powerwall

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Callable
+from copy import deepcopy
 from functools import partial
 from pathlib import Path
 from typing import Any, Final, cast
@@ -61,6 +62,7 @@ from .coordinator import (
     TeslemetryEnergyHistoryCoordinator,
     TeslemetryEnergySiteInfoCoordinator,
     TeslemetryEnergySiteLiveCoordinator,
+    TeslemetryEnergySiteLiveLocalCoordinator,
     TeslemetryMetadataCoordinator,
     TeslemetryVehicleDataCoordinator,
 )
@@ -578,6 +580,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 live_coordinator,
                 info_coordinator,
                 history_coordinator,
+                raw_live_status,
             ) = await _async_setup_energy_site(
                 hass,
                 entry,
@@ -596,10 +599,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 hass, entry, bool(battery), site_id, energy_site
             )
 
+            # A paired site gets a second, local-first live coordinator that
+            # polls the LAN gateway for its supported keys; the cloud live
+            # coordinator keeps serving the cloud-only live entities.
+            live_local_coordinator = (
+                TeslemetryEnergySiteLiveLocalCoordinator(
+                    hass, entry, energy_site_api, raw_live_status
+                )
+                if isinstance(energy_site_api, EnergySiteRouter)
+                and raw_live_status is not None
+                else None
+            )
+
             energysites.append(
                 TeslemetryEnergyData(
                     api=energy_site_api,
                     live_coordinator=live_coordinator,
+                    live_local_coordinator=live_local_coordinator,
                     info_coordinator=info_coordinator,
                     history_coordinator=history_coordinator,
                     id=site_id,
@@ -739,8 +755,14 @@ async def _async_setup_energy_site(
     TeslemetryEnergySiteLiveCoordinator | None,
     TeslemetryEnergySiteInfoCoordinator,
     TeslemetryEnergyHistoryCoordinator | None,
+    dict[str, Any] | None,
 ]:
-    """Cold-read live status, build the energy coordinators, and register listeners."""
+    """Cold-read live status, build the energy coordinators, and register listeners.
+
+    Also returns the raw live_status dict (or None), captured before the live
+    coordinator normalises it in place, so a paired site can seed its local
+    coordinator from an independent copy.
+    """
     # The stream has no ready boundary, so keep a deterministic REST cold read
     # for setup auth/error handling before switching to listener-driven updates.
     try:
@@ -770,6 +792,9 @@ async def _async_setup_energy_site(
             translation_domain=DOMAIN,
             translation_key="not_ready_api_error",
         ) from e
+
+    # Snapshot before the live coordinator normalises wall_connectors in place.
+    raw_live_status = deepcopy(live_status) if isinstance(live_status, dict) else None
 
     live_coordinator = (
         TeslemetryEnergySiteLiveCoordinator(hass, entry, energy_site, live_status)
@@ -801,7 +826,7 @@ async def _async_setup_energy_site(
         else None
     )
 
-    return live_coordinator, info_coordinator, history_coordinator
+    return live_coordinator, info_coordinator, history_coordinator, raw_live_status
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:

--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -15,6 +15,7 @@ from tesla_fleet_api.exceptions import (
     SubscriptionRequired,
     TeslaFleetError,
 )
+from tesla_fleet_api.tesla import EnergySiteRouter
 from tesla_fleet_api.teslemetry import EnergySite, Teslemetry, Vehicle
 
 from homeassistant.core import HomeAssistant
@@ -45,6 +46,8 @@ def _get_retry_after(e: TeslaFleetError) -> float:
 
 VEHICLE_INTERVAL = timedelta(seconds=60)
 VEHICLE_WAIT = timedelta(minutes=15)
+# The LAN Powerwall gateway is not on the stream, so its live coordinator polls.
+ENERGY_LIVE_INTERVAL = timedelta(seconds=30)
 ENERGY_HISTORY_INTERVAL = timedelta(seconds=60)
 METADATA_INTERVAL = timedelta(hours=1)
 
@@ -64,6 +67,24 @@ ENDPOINTS = [
     VehicleDataEndpoint.VEHICLE_STATE,
     VehicleDataEndpoint.VEHICLE_CONFIG,
 ]
+
+# live_status keys a local Powerwall can serve. On a paired site the entities
+# for these keys read the local live coordinator; every other live key stays on
+# the cloud live coordinator, which has no local gateway equivalent.
+LOCAL_LIVE_COORDINATOR_KEYS: frozenset[str] = frozenset(
+    {
+        "solar_power",
+        "energy_left",
+        "total_pack_energy",
+        "percentage_charged",
+        "battery_power",
+        "load_power",
+        "grid_power",
+        "generator_power",
+        "island_status",
+        "grid_status",
+    }
+)
 
 
 class TeslemetryMetadataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -200,7 +221,7 @@ class TeslemetryEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]])
         self,
         hass: HomeAssistant,
         config_entry: TeslemetryConfigEntry,
-        api: EnergySite,
+        api: EnergySite | EnergySiteRouter,
         data: dict[str, Any],
     ) -> None:
         """Initialize Teslemetry Energy Site Live coordinator."""
@@ -238,6 +259,30 @@ class TeslemetryEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]])
                 translation_placeholders={"message": e.message},
             ) from e
         return _index_wall_connectors(data)
+
+
+class TeslemetryEnergySiteLiveLocalCoordinator(TeslemetryEnergySiteLiveCoordinator):
+    """Local-first live coordinator for a paired Powerwall energy site.
+
+    Reuses the cloud coordinator's fetch and normalisation, but is handed the
+    local-first ``EnergySiteRouter`` and polls it on an interval: the LAN
+    gateway is not on the stream, so its locally supported live keys must be
+    read over REST (with cloud fallback through the router). It runs alongside
+    the stream-driven cloud coordinator, which keeps serving every cloud-only
+    live key.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: TeslemetryConfigEntry,
+        api: EnergySiteRouter,
+        data: dict[str, Any],
+    ) -> None:
+        """Initialize Teslemetry Energy Site Local Live coordinator."""
+        super().__init__(hass, config_entry, api, data)
+        self.name = "Teslemetry Energy Site Local Live"
+        self.update_interval = ENERGY_LIVE_INTERVAL
 
 
 class TeslemetryEnergySiteInfoCoordinator(DataUpdateCoordinator[dict[str, Any]]):

--- a/homeassistant/components/teslemetry/entity.py
+++ b/homeassistant/components/teslemetry/entity.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import (
+    LOCAL_LIVE_COORDINATOR_KEYS,
     TeslemetryEnergyHistoryCoordinator,
     TeslemetryEnergySiteInfoCoordinator,
     TeslemetryEnergySiteLiveCoordinator,
@@ -153,7 +154,15 @@ class TeslemetryEnergyLiveEntity(TeslemetryPollingEntity):
         self._attr_unique_id = f"{data.id}-{key}"
         self._attr_device_info = data.device
 
-        super().__init__(data.live_coordinator, key)
+        # A paired site serves the locally supported live keys from its local
+        # coordinator; every other key stays on the cloud live coordinator.
+        if (
+            data.live_local_coordinator is not None
+            and key in LOCAL_LIVE_COORDINATOR_KEYS
+        ):
+            super().__init__(data.live_local_coordinator, key)
+        else:
+            super().__init__(data.live_coordinator, key)
 
 
 class TeslemetryEnergyInfoEntity(TeslemetryPollingEntity):

--- a/homeassistant/components/teslemetry/models.py
+++ b/homeassistant/components/teslemetry/models.py
@@ -15,6 +15,7 @@ from .coordinator import (
     TeslemetryEnergyHistoryCoordinator,
     TeslemetryEnergySiteInfoCoordinator,
     TeslemetryEnergySiteLiveCoordinator,
+    TeslemetryEnergySiteLiveLocalCoordinator,
     TeslemetryMetadataCoordinator,
     TeslemetryVehicleDataCoordinator,
 )
@@ -53,6 +54,9 @@ class TeslemetryEnergyData:
 
     api: EnergySite | EnergySiteRouter
     live_coordinator: TeslemetryEnergySiteLiveCoordinator | None
+    # Present only for a paired Powerwall site; None keeps the site's live
+    # entities on the cloud coordinator.
+    live_local_coordinator: TeslemetryEnergySiteLiveLocalCoordinator | None
     info_coordinator: TeslemetryEnergySiteInfoCoordinator
     history_coordinator: TeslemetryEnergyHistoryCoordinator | None
     id: int

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -41,6 +41,7 @@ from homeassistant.components.teslemetry.const import (
 # Coordinator constants
 from homeassistant.components.teslemetry.coordinator import (
     ENERGY_HISTORY_INTERVAL,
+    ENERGY_LIVE_INTERVAL,
     INSUFFICIENT_CREDITS_RETRY_AFTER,
     METADATA_INTERVAL,
     VEHICLE_INTERVAL,
@@ -1761,3 +1762,165 @@ async def test_energy_stream_disconnect_marks_unavailable_and_recovers(
         for flow in hass.config_entries.flow.async_progress()
         if flow["handler"] == DOMAIN
     ]
+
+
+# Local gateway live_status: distinct values for the ten locally supported keys
+# (grid_status "Inactive" and island_status "off_grid" differ from the cloud
+# fixture so a reroute is observable) and None for every cloud-only key, as the
+# local adapter actually returns them.
+LOCAL_LIVE_STATUS = {
+    "response": {
+        "solar_power": 2000,
+        "energy_left": 20000,
+        "total_pack_energy": 40000,
+        "percentage_charged": 80.0,
+        "backup_capable": None,
+        "battery_power": 3000,
+        "load_power": 4000,
+        "grid_status": "Inactive",
+        "grid_services_active": None,
+        "grid_power": 1000,
+        "grid_services_power": None,
+        "generator_power": 500,
+        "island_status": "off_grid",
+        "storm_mode_active": None,
+        "timestamp": None,
+        "wall_connectors": None,
+    }
+}
+
+# entity_id -> state once a local poll has replaced the cloud seed. Power/energy
+# keys convert W/Wh to kW/kWh; island_status is an enum passed through.
+_LOCAL_LIVE_STATES = {
+    "sensor.energy_site_solar_power": "2.0",
+    "sensor.energy_site_energy_left": "20.0",
+    "sensor.energy_site_total_pack_energy": "40.0",
+    "sensor.energy_site_percentage_charged": "80.0",
+    "sensor.energy_site_battery_power": "3.0",
+    "sensor.energy_site_load_power": "4.0",
+    "sensor.energy_site_grid_power": "1.0",
+    "sensor.energy_site_generator_power": "0.5",
+    "sensor.energy_site_island_status": "off_grid",
+    "binary_sensor.energy_site_grid_status": STATE_OFF,
+}
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_paired_site_live_reads_route_to_local(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A paired site serves the ten local live keys from the LAN gateway.
+
+    Every locally supported sensor and binary sensor follows the local snapshot
+    while the cloud-only live entities keep reading the cloud coordinator, and a
+    single interval poll feeds all ten (one shared gateway request).
+    """
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+
+    local_live = AsyncMock(return_value=LOCAL_LIVE_STATUS)
+    with (
+        patch(
+            "homeassistant.components.teslemetry._async_get_rsa_key_pem",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+        patch(
+            "aiopowerwall.energysite.PowerwallEnergySite.live_status",
+            new=local_live,
+        ),
+        patch(
+            "homeassistant.components.teslemetry.PLATFORMS",
+            [Platform.SENSOR, Platform.BINARY_SENSOR],
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert entry.runtime_data.energysites[0].live_local_coordinator is not None
+        # The setup cold read seeds the local coordinator from the cloud, so the
+        # local keys show cloud values until the first LAN poll.
+        assert hass.states.get("sensor.energy_site_solar_power").state == "1.185"
+
+        # One shared snapshot per refresh: a single interval tick makes exactly
+        # one local gateway call regardless of how many entities read it.
+        freezer.tick(ENERGY_LIVE_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert local_live.await_count == 1
+    for entity_id, expected in _LOCAL_LIVE_STATES.items():
+        assert hass.states.get(entity_id).state == expected
+
+    # Cloud-only live entities keep reading the separate cloud coordinator; the
+    # local success returning None for their keys must not clobber them.
+    assert hass.states.get("sensor.energy_site_grid_services_power").state == "0.0"
+    assert hass.states.get("binary_sensor.energy_site_backup_capable").state == STATE_ON
+    assert (
+        hass.states.get("binary_sensor.energy_site_grid_services_active").state
+        == STATE_OFF
+    )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_paired_site_local_reads_survive_stream_disconnect(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_add_connection_listener: MagicMock,
+) -> None:
+    """A dropped stream leaves the local live entities available.
+
+    The stream is the cloud coordinator's only freshness signal, so a disconnect
+    marks the cloud-only live entities unavailable; the local coordinator polls
+    the LAN gateway independently and keeps its keys alive.
+    """
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+
+    local_live = AsyncMock(return_value=LOCAL_LIVE_STATUS)
+    with (
+        patch(
+            "homeassistant.components.teslemetry._async_get_rsa_key_pem",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+        patch(
+            "aiopowerwall.energysite.PowerwallEnergySite.live_status",
+            new=local_live,
+        ),
+        patch(
+            "homeassistant.components.teslemetry.PLATFORMS",
+            [Platform.SENSOR, Platform.BINARY_SENSOR],
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        freezer.tick(ENERGY_LIVE_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        mock_add_connection_listener.send(False)
+        await hass.async_block_till_done()
+
+    for entity_id, expected in _LOCAL_LIVE_STATES.items():
+        assert hass.states.get(entity_id).state == expected
+
+    assert (
+        hass.states.get("sensor.energy_site_grid_services_power").state
+        == STATE_UNAVAILABLE
+    )
+    assert (
+        hass.states.get("binary_sensor.energy_site_backup_capable").state
+        == STATE_UNAVAILABLE
+    )
+
+
+async def test_unpaired_site_has_no_local_live_coordinator(
+    hass: HomeAssistant,
+) -> None:
+    """An unpaired site builds no local coordinator and reads only the cloud."""
+    entry = await setup_platform(hass, [Platform.SENSOR])
+
+    energysite = entry.runtime_data.energysites[0]
+    assert energysite.live_local_coordinator is None
+    assert hass.states.get("sensor.energy_site_solar_power").state == "1.185"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Local Powerwall control (#176969) added the write path, but a paired energy site's live entities still read only the cloud. This routes the locally supported live values — solar, battery, load, grid and generator power, energy and charge state, and island and grid status — through the same local-first router that already carries commands, so a paired site reads them from the LAN gateway with automatic cloud fallback. No new entities: the entity IDs and values are unchanged, only the data source moves, and unpaired sites are unaffected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
