### PR TITLE
data_grand_lyon alerts

### DIFF
--- a/homeassistant/components/data_grand_lyon/__init__.py
+++ b/homeassistant/components/data_grand_lyon/__init__.py
@@ -18,7 +18,7 @@ from .coordinator import (
     DataGrandLyonVelovCoordinator,
 )
 
-PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.CALENDAR, Platform.SENSOR]
 
 
 async def async_setup_entry(

--- a/homeassistant/components/data_grand_lyon/__init__.py
+++ b/homeassistant/components/data_grand_lyon/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .coordinator import (
+    DataGrandLyonAlertsCoordinator,
     DataGrandLyonConfigEntry,
     DataGrandLyonData,
     DataGrandLyonParkAndRideCoordinator,
@@ -34,11 +35,13 @@ async def async_setup_entry(
     tcl_coordinator = DataGrandLyonTclCoordinator(hass, entry, client)
     velov_coordinator = DataGrandLyonVelovCoordinator(hass, entry, client)
     park_and_ride_coordinator = DataGrandLyonParkAndRideCoordinator(hass, entry, client)
+    alerts_coordinator = DataGrandLyonAlertsCoordinator(hass, entry, client)
 
     coordinators: list[DataUpdateCoordinator] = [
         tcl_coordinator,
         velov_coordinator,
         park_and_ride_coordinator,
+        alerts_coordinator,
     ]
     await asyncio.gather(*(c.async_config_entry_first_refresh() for c in coordinators))
 
@@ -46,6 +49,7 @@ async def async_setup_entry(
         tcl_coordinator=tcl_coordinator,
         velov_coordinator=velov_coordinator,
         park_and_ride_coordinator=park_and_ride_coordinator,
+        alerts_coordinator=alerts_coordinator,
     )
 
     entry.async_on_unload(entry.add_update_listener(async_update_entry))

--- a/homeassistant/components/data_grand_lyon/calendar.py
+++ b/homeassistant/components/data_grand_lyon/calendar.py
@@ -74,12 +74,17 @@ class DataGrandLyonLineCalendar(DataGrandLyonLineEntity, CalendarEntity):
     @property
     @override
     def event(self) -> CalendarEvent | None:
-        """Return the most relevant alert that has not ended yet."""
+        """Return the alert in progress, or the most relevant upcoming one."""
         now = _tcl_now()
         alerts = filter_tcl_active_alerts(self.coordinator.data[self._subentry_id], now)
         if not alerts:
             return None
-        return _calendar_event(sort_tcl_alerts_by_relevance(alerts, now)[0])
+        ranked = sort_tcl_alerts_by_relevance(alerts, now)
+        # An alert starting later today shares the library's CURRENT bucket with
+        # one already running, so an in-progress alert must be preferred here
+        # for the on/off state (computed from event start/end) to stay truthful.
+        started = [alert for alert in ranked if alert.debut <= now]
+        return _calendar_event(started[0] if started else ranked[0])
 
     @override
     async def async_get_events(

--- a/homeassistant/components/data_grand_lyon/calendar.py
+++ b/homeassistant/components/data_grand_lyon/calendar.py
@@ -1,0 +1,95 @@
+"""Calendar platform for the Data Grand Lyon integration."""
+
+from datetime import datetime
+from typing import override
+
+from data_grand_lyon_ha import (
+    TclAlert,
+    filter_tcl_active_alerts,
+    sort_tcl_alerts_by_relevance,
+)
+
+from homeassistant.components.calendar import (
+    CalendarEntity,
+    CalendarEntityDescription,
+    CalendarEvent,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
+
+from .const import SUBENTRY_TYPE_LINE, TZ_PARIS
+from .coordinator import DataGrandLyonConfigEntry
+from .entity import DataGrandLyonLineEntity
+
+PARALLEL_UPDATES = 0
+
+ALERTS_DESCRIPTION = CalendarEntityDescription(
+    key="alerts",
+    translation_key="alerts",
+)
+
+
+def _tcl_now() -> datetime:
+    """Return the current time as a naive Paris datetime, as TCL publishes them."""
+    return dt_util.utcnow().astimezone(TZ_PARIS).replace(tzinfo=None)
+
+
+def _calendar_event(alert: TclAlert) -> CalendarEvent:
+    """Convert a TCL alert into a calendar event."""
+    # TCL's `n` field is a positional index that changes on every fetch, so no
+    # stable event uid can be derived from the data.
+    return CalendarEvent(
+        start=alert.debut.replace(tzinfo=TZ_PARIS),
+        end=alert.fin.replace(tzinfo=TZ_PARIS),
+        summary=alert.titre.strip(),
+        description=f"{alert.message}\n\nCause: {alert.cause}\nType: {alert.type}",
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: DataGrandLyonConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Data Grand Lyon calendar entities."""
+    alerts_coordinator = entry.runtime_data.alerts_coordinator
+
+    for subentry in entry.get_subentries_of_type(SUBENTRY_TYPE_LINE):
+        async_add_entities(
+            [
+                DataGrandLyonLineCalendar(
+                    alerts_coordinator, subentry, ALERTS_DESCRIPTION
+                )
+            ],
+            config_subentry_id=subentry.subentry_id,
+        )
+
+
+class DataGrandLyonLineCalendar(DataGrandLyonLineEntity, CalendarEntity):
+    """Calendar of TCL traffic alerts for a line."""
+
+    _attr_name = None
+
+    @property
+    @override
+    def event(self) -> CalendarEvent | None:
+        """Return the most relevant alert that has not ended yet."""
+        now = _tcl_now()
+        alerts = filter_tcl_active_alerts(self.coordinator.data[self._subentry_id], now)
+        if not alerts:
+            return None
+        return _calendar_event(sort_tcl_alerts_by_relevance(alerts, now)[0])
+
+    @override
+    async def async_get_events(
+        self, hass: HomeAssistant, start_date: datetime, end_date: datetime
+    ) -> list[CalendarEvent]:
+        """Return the line's alerts overlapping the requested window."""
+        window_start = start_date.astimezone(TZ_PARIS).replace(tzinfo=None)
+        window_end = end_date.astimezone(TZ_PARIS).replace(tzinfo=None)
+        return [
+            _calendar_event(alert)
+            for alert in self.coordinator.data[self._subentry_id]
+            if alert.debut < window_end and alert.fin > window_start
+        ]

--- a/homeassistant/components/data_grand_lyon/calendar.py
+++ b/homeassistant/components/data_grand_lyon/calendar.py
@@ -69,22 +69,25 @@ async def async_setup_entry(
 class DataGrandLyonLineCalendar(DataGrandLyonLineEntity, CalendarEntity):
     """Calendar of TCL traffic alerts for a line."""
 
-    _attr_name = None
-
     @property
     @override
     def event(self) -> CalendarEvent | None:
         """Return the alert in progress, or the most relevant upcoming one."""
         now = _tcl_now()
-        alerts = filter_tcl_active_alerts(self.coordinator.data[self._subentry_id], now)
+        alerts = filter_tcl_active_alerts(
+            self.coordinator.data.get(self._subentry_id, []), now
+        )
         if not alerts:
             return None
         ranked = sort_tcl_alerts_by_relevance(alerts, now)
         # An alert starting later today shares the library's CURRENT bucket with
         # one already running, so an in-progress alert must be preferred here
         # for the on/off state (computed from event start/end) to stay truthful.
+        # Among alerts that haven't started yet, the soonest one governs when
+        # HA arms the next on/off transition, so it must win over severity too.
         started = [alert for alert in ranked if alert.debut <= now]
-        return _calendar_event(started[0] if started else ranked[0])
+        event = started[0] if started else min(ranked, key=lambda alert: alert.debut)
+        return _calendar_event(event)
 
     @override
     async def async_get_events(
@@ -95,6 +98,6 @@ class DataGrandLyonLineCalendar(DataGrandLyonLineEntity, CalendarEntity):
         window_end = end_date.astimezone(TZ_PARIS).replace(tzinfo=None)
         return [
             _calendar_event(alert)
-            for alert in self.coordinator.data[self._subentry_id]
+            for alert in self.coordinator.data.get(self._subentry_id, [])
             if alert.debut < window_end and alert.fin > window_start
         ]

--- a/homeassistant/components/data_grand_lyon/config_flow.py
+++ b/homeassistant/components/data_grand_lyon/config_flow.py
@@ -499,8 +499,13 @@ class LineSubentryFlowHandler(ConfigSubentryFlow):
             if error := await self._async_load_lines():
                 return self.async_abort(reason=error)
 
+        errors: dict[str, str] = {}
         if user_input is not None:
-            return self._create_line(user_input[CONF_LINE])
+            line_code = user_input[CONF_LINE].strip()
+            if not line_code:
+                errors[CONF_LINE] = "invalid_line"
+            else:
+                return self._create_line(line_code)
 
         schema = vol.Schema(
             {
@@ -514,7 +519,7 @@ class LineSubentryFlowHandler(ConfigSubentryFlow):
                 )
             }
         )
-        return self.async_show_form(step_id="user", data_schema=schema)
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
     async def _async_load_lines(self) -> str | None:
         """Fetch TCL lines from the API, returning an error key on failure."""

--- a/homeassistant/components/data_grand_lyon/config_flow.py
+++ b/homeassistant/components/data_grand_lyon/config_flow.py
@@ -7,6 +7,7 @@ from typing import Any, override
 from aiohttp import ClientError, ClientResponseError
 from data_grand_lyon_ha import (
     DataGrandLyonClient,
+    TclLinePictogram,
     TclParkAndRide,
     TclStop,
     VelovStation,
@@ -38,6 +39,7 @@ from .const import (
     CONF_STATION_ID,
     CONF_STOP_ID,
     DOMAIN,
+    SUBENTRY_TYPE_LINE,
     SUBENTRY_TYPE_PARK_AND_RIDE,
     SUBENTRY_TYPE_STOP,
     SUBENTRY_TYPE_VELOV_STATION,
@@ -75,6 +77,7 @@ class DataGrandLyonConfigFlow(ConfigFlow, domain=DOMAIN):
             SUBENTRY_TYPE_STOP: StopSubentryFlowHandler,
             SUBENTRY_TYPE_VELOV_STATION: VelovStationSubentryFlowHandler,
             SUBENTRY_TYPE_PARK_AND_RIDE: ParkAndRideSubentryFlowHandler,
+            SUBENTRY_TYPE_LINE: LineSubentryFlowHandler,
         }
 
     @override
@@ -479,3 +482,72 @@ class ParkAndRideSubentryFlowHandler(ConfigSubentryFlow):
 
 def _park_and_ride_label(park: TclParkAndRide) -> str:
     return f"{park.nom} - {park.id}"
+
+
+class LineSubentryFlowHandler(ConfigSubentryFlow):
+    """Handle a subentry flow for adding a TCL line."""
+
+    def __init__(self) -> None:
+        """Initialize the flow."""
+        self._lines: list[TclLinePictogram] = []
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Pick a line from the list fetched from the API, or enter one manually."""
+        if not self._lines:
+            if error := await self._async_load_lines():
+                return self.async_abort(reason=error)
+
+        if user_input is not None:
+            return self._create_line(user_input[CONF_LINE])
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_LINE): SelectSelector(
+                    SelectSelectorConfig(
+                        options=sorted({line.code_ligne for line in self._lines}),
+                        mode=SelectSelectorMode.DROPDOWN,
+                        sort=False,
+                        custom_value=True,
+                    )
+                )
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=schema)
+
+    async def _async_load_lines(self) -> str | None:
+        """Fetch TCL lines from the API, returning an error key on failure."""
+        entry = self._get_entry()
+        session = async_get_clientsession(self.hass)
+        client = DataGrandLyonClient(
+            session=session,
+            username=entry.data[CONF_USERNAME],
+            password=entry.data[CONF_PASSWORD],
+        )
+        try:
+            self._lines = await client.get_tcl_line_pictograms()
+        except ClientResponseError as err:
+            if err.status in (401, 403):
+                return "invalid_auth"
+            return "cannot_connect"
+        except ClientError, TimeoutError:
+            return "cannot_connect"
+        except Exception:
+            _LOGGER.exception("Unexpected error fetching Data Grand Lyon TCL lines")
+            return "unknown"
+        return None
+
+    def _create_line(self, line: str) -> SubentryFlowResult:
+        """Create the line subentry, aborting on duplicate."""
+        entry = self._get_entry()
+        unique_id = f"line_{line}"
+        for subentry in entry.subentries.values():
+            if subentry.unique_id == unique_id:
+                return self.async_abort(reason="already_configured")
+
+        return self.async_create_entry(
+            title=f"Line {line}",
+            data={CONF_LINE: line},
+            unique_id=unique_id,
+        )

--- a/homeassistant/components/data_grand_lyon/const.py
+++ b/homeassistant/components/data_grand_lyon/const.py
@@ -1,13 +1,18 @@
 """Constants for the Data Grand Lyon integration."""
 
 import logging
+from zoneinfo import ZoneInfo
 
 DOMAIN = "data_grand_lyon"
 LOGGER = logging.getLogger(__package__)
 
+# TCL publishes naive datetimes in local Paris time.
+TZ_PARIS = ZoneInfo("Europe/Paris")
+
 SUBENTRY_TYPE_STOP = "stop"
 SUBENTRY_TYPE_VELOV_STATION = "velov_station"
 SUBENTRY_TYPE_PARK_AND_RIDE = "park_and_ride"
+SUBENTRY_TYPE_LINE = "line"
 
 CONF_LINE = "line"
 CONF_STOP_ID = "stop_id"

--- a/homeassistant/components/data_grand_lyon/coordinator.py
+++ b/homeassistant/components/data_grand_lyon/coordinator.py
@@ -7,9 +7,11 @@ from typing import override
 from aiohttp import ClientError, ClientResponseError
 from data_grand_lyon_ha import (
     DataGrandLyonClient,
+    TclAlert,
     TclParkAndRide,
     TclPassage,
     VelovStation,
+    filter_tcl_alerts_by_line,
     filter_tcl_passages_by_lines_stops,
     find_tcl_park_and_ride_by_id,
     find_velov_stations_by_ids,
@@ -28,6 +30,7 @@ from .const import (
     CONF_STOP_ID,
     DOMAIN,
     LOGGER,
+    SUBENTRY_TYPE_LINE,
     SUBENTRY_TYPE_PARK_AND_RIDE,
     SUBENTRY_TYPE_STOP,
     SUBENTRY_TYPE_VELOV_STATION,
@@ -41,6 +44,7 @@ class DataGrandLyonData:
     tcl_coordinator: DataGrandLyonTclCoordinator
     velov_coordinator: DataGrandLyonVelovCoordinator
     park_and_ride_coordinator: DataGrandLyonParkAndRideCoordinator
+    alerts_coordinator: DataGrandLyonAlertsCoordinator
 
 
 type DataGrandLyonConfigEntry = ConfigEntry[DataGrandLyonData]
@@ -238,3 +242,60 @@ class DataGrandLyonParkAndRideCoordinator(
                     subentry.subentry_id,
                 )
         return parks
+
+
+class DataGrandLyonAlertsCoordinator(DataUpdateCoordinator[dict[str, list[TclAlert]]]):
+    """Coordinator for TCL traffic alerts."""
+
+    config_entry: DataGrandLyonConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: DataGrandLyonConfigEntry,
+        client: DataGrandLyonClient,
+    ) -> None:
+        """Initialize the coordinator."""
+        self.client = client
+        super().__init__(
+            hass,
+            LOGGER,
+            config_entry=entry,
+            name=f"{DOMAIN}_alerts",
+            update_interval=timedelta(minutes=5),
+        )
+
+    @override
+    async def _async_update_data(self) -> dict[str, list[TclAlert]]:
+        """Fetch alerts for all monitored lines."""
+        line_subentries = list(
+            self.config_entry.get_subentries_of_type(SUBENTRY_TYPE_LINE)
+        )
+        if not line_subentries:
+            return {}
+
+        try:
+            all_alerts = await self.client.get_tcl_alerts()
+        except ClientResponseError as err:
+            if err.status in (401, 403):
+                raise ConfigEntryAuthFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="auth_failed",
+                ) from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed_alerts",
+            ) from err
+        except (ClientError, TimeoutError) as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed_alerts",
+            ) from err
+
+        # A line with no alert must stay available, so its key is always set.
+        return {
+            subentry.subentry_id: filter_tcl_alerts_by_line(
+                all_alerts, subentry.data[CONF_LINE]
+            )
+            for subentry in line_subentries
+        }

--- a/homeassistant/components/data_grand_lyon/diagnostics.py
+++ b/homeassistant/components/data_grand_lyon/diagnostics.py
@@ -31,5 +31,9 @@ async def async_get_config_entry_diagnostics(
                 subentry_id: asdict(park)
                 for subentry_id, park in entry.runtime_data.park_and_ride_coordinator.data.items()
             },
+            "alerts": {
+                subentry_id: [asdict(alert) for alert in alerts]
+                for subentry_id, alerts in entry.runtime_data.alerts_coordinator.data.items()
+            },
         },
     }

--- a/homeassistant/components/data_grand_lyon/entity.py
+++ b/homeassistant/components/data_grand_lyon/entity.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import DOMAIN
 from .coordinator import (
+    DataGrandLyonAlertsCoordinator,
     DataGrandLyonParkAndRideCoordinator,
     DataGrandLyonTclCoordinator,
     DataGrandLyonVelovCoordinator,
@@ -94,3 +95,16 @@ class DataGrandLyonParkAndRideEntity(
     ) -> None:
         """Initialize the park-and-ride entity."""
         super().__init__(coordinator, subentry, description, "TCL", "Park & Ride")
+
+
+class DataGrandLyonLineEntity(DataGrandLyonEntity[DataGrandLyonAlertsCoordinator]):
+    """Base entity for Data Grand Lyon TCL lines."""
+
+    def __init__(
+        self,
+        coordinator: DataGrandLyonAlertsCoordinator,
+        subentry: ConfigSubentry,
+        description: EntityDescription,
+    ) -> None:
+        """Initialize the line entity."""
+        super().__init__(coordinator, subentry, description, "TCL", "Line")

--- a/homeassistant/components/data_grand_lyon/icons.json
+++ b/homeassistant/components/data_grand_lyon/icons.json
@@ -10,7 +10,7 @@
     },
     "calendar": {
       "alerts": {
-        "default": "mdi:bus-alert"
+        "default": "mdi:transit-detour"
       }
     },
     "sensor": {

--- a/homeassistant/components/data_grand_lyon/icons.json
+++ b/homeassistant/components/data_grand_lyon/icons.json
@@ -8,6 +8,11 @@
         }
       }
     },
+    "calendar": {
+      "alerts": {
+        "default": "mdi:bus-alert"
+      }
+    },
     "sensor": {
       "accessible_spaces": {
         "default": "mdi:wheelchair-accessibility"

--- a/homeassistant/components/data_grand_lyon/sensor.py
+++ b/homeassistant/components/data_grand_lyon/sensor.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import override
-from zoneinfo import ZoneInfo
 
 from data_grand_lyon_ha import TclParkAndRide, TclPassage, TclPassageType, VelovStation
 
@@ -22,6 +21,7 @@ from .const import (
     SUBENTRY_TYPE_PARK_AND_RIDE,
     SUBENTRY_TYPE_STOP,
     SUBENTRY_TYPE_VELOV_STATION,
+    TZ_PARIS,
 )
 from .coordinator import DataGrandLyonConfigEntry
 from .entity import (
@@ -32,8 +32,6 @@ from .entity import (
 
 PARALLEL_UPDATES = 0
 
-_TZ_PARIS = ZoneInfo("Europe/Paris")
-
 _DEPARTURE_TYPE_OPTIONS = [t.name.lower() for t in TclPassageType]
 
 
@@ -41,7 +39,7 @@ def _departure_time(departure: TclPassage) -> datetime:
     """Return the departure time, localized to Europe/Paris if naive."""
     dt = departure.heure_passage
     if dt.tzinfo is None:
-        return dt.replace(tzinfo=_TZ_PARIS)
+        return dt.replace(tzinfo=TZ_PARIS)
     return dt
 
 

--- a/homeassistant/components/data_grand_lyon/strings.json
+++ b/homeassistant/components/data_grand_lyon/strings.json
@@ -214,6 +214,9 @@
     "auth_failed": {
       "message": "Authentication failed for Data Grand Lyon."
     },
+    "update_failed_alerts": {
+      "message": "Error fetching TCL traffic alerts from Data Grand Lyon."
+    },
     "update_failed_park_and_ride": {
       "message": "Error fetching park & ride availability from Data Grand Lyon."
     },

--- a/homeassistant/components/data_grand_lyon/strings.json
+++ b/homeassistant/components/data_grand_lyon/strings.json
@@ -44,6 +44,28 @@
     }
   },
   "config_subentries": {
+    "line": {
+      "abort": {
+        "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+        "unknown": "[%key:common::config_flow::error::unknown%]"
+      },
+      "entry_type": "Transit line",
+      "initiate_flow": {
+        "user": "Add transit line"
+      },
+      "step": {
+        "user": {
+          "data": {
+            "line": "Line"
+          },
+          "data_description": {
+            "line": "Pick a line, or enter a line code directly."
+          }
+        }
+      }
+    },
     "park_and_ride": {
       "abort": {
         "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",

--- a/homeassistant/components/data_grand_lyon/strings.json
+++ b/homeassistant/components/data_grand_lyon/strings.json
@@ -52,6 +52,9 @@
         "unknown": "[%key:common::config_flow::error::unknown%]"
       },
       "entry_type": "Transit line",
+      "error": {
+        "invalid_line": "Enter a line code."
+      },
       "initiate_flow": {
         "user": "Add transit line"
       },
@@ -148,6 +151,11 @@
     "binary_sensor": {
       "station_open": {
         "name": "Station open"
+      }
+    },
+    "calendar": {
+      "alerts": {
+        "name": "Alerts"
       }
     },
     "sensor": {

--- a/tests/components/data_grand_lyon/conftest.py
+++ b/tests/components/data_grand_lyon/conftest.py
@@ -5,6 +5,9 @@ from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 from data_grand_lyon_ha import (
+    TclAlert,
+    TclAlertSeverityType,
+    TclAlertType,
     TclParkAndRide,
     TclPassage,
     TclPassageType,
@@ -22,6 +25,7 @@ from homeassistant.components.data_grand_lyon.const import (
     CONF_STATION_ID,
     CONF_STOP_ID,
     DOMAIN,
+    SUBENTRY_TYPE_LINE,
     SUBENTRY_TYPE_PARK_AND_RIDE,
     SUBENTRY_TYPE_STOP,
     SUBENTRY_TYPE_VELOV_STATION,
@@ -171,6 +175,88 @@ MOCK_PARK_AND_RIDES = [
 ]
 
 
+MOCK_TCL_ALERTS = [
+    TclAlert(
+        type=TclAlertType.DISRUPTION,
+        cause="travaux",
+        debut=datetime(2026, 4, 1, 7, 0),
+        fin=datetime(2026, 4, 30, 17, 30),
+        mode="Bus",
+        ligne_com="C3",
+        ligne_cli="C3",
+        titre="Déviée dir. Cordeliers",
+        message="Les arrêts de Gare St-Paul à Cordeliers ne sont plus desservis.",
+        last_update_fme=datetime(2026, 4, 10, 9, 15),
+        n=1,
+        type_severite=TclAlertSeverityType.SIGNIFICANT_DELAYS,
+        niveau_severite=20,
+        type_objet="line",
+        liste_objet="C3",
+    ),
+    TclAlert(
+        type=TclAlertType.INFORMATION,
+        cause="événement",
+        debut=datetime(2026, 3, 1, 4, 30),
+        fin=datetime(2026, 3, 2, 1, 30),
+        mode="Bus",
+        ligne_com="C3",
+        ligne_cli="C3",
+        titre="Fête de la Musique",
+        message="Horaires prolongés.",
+        last_update_fme=datetime(2026, 3, 1, 9, 15),
+        n=2,
+        type_severite=TclAlertSeverityType.OTHER_EFFECT,
+        niveau_severite=30,
+        type_objet="line",
+        liste_objet="C3",
+    ),
+    TclAlert(
+        type=TclAlertType.DISRUPTION,
+        cause="panne bus",
+        debut=datetime(2026, 4, 10, 8, 0),
+        fin=datetime(2026, 4, 10, 20, 0),
+        mode="Bus",
+        ligne_com="27",
+        ligne_cli="27",
+        titre="Terminus Cordeliers",
+        message="La ligne est déviée.",
+        last_update_fme=datetime(2026, 4, 10, 9, 15),
+        n=3,
+        type_severite=TclAlertSeverityType.SIGNIFICANT_DELAYS,
+        niveau_severite=20,
+        type_objet="line",
+        liste_objet="27",
+    ),
+]
+
+
+@pytest.fixture
+def mock_line_subentries() -> list[ConfigSubentryData]:
+    """Mock TCL line subentries."""
+    return [
+        ConfigSubentryData(
+            data={CONF_LINE: "C3"},
+            subentry_id="line_1",
+            subentry_type=SUBENTRY_TYPE_LINE,
+            title="Line C3",
+            unique_id="line_C3",
+        )
+    ]
+
+
+@pytest.fixture
+def mock_line_config_entry(
+    mock_line_subentries: list[ConfigSubentryData],
+) -> MockConfigEntry:
+    """Create a mock config entry with TCL line subentries."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Data Grand Lyon",
+        data={CONF_USERNAME: "user", CONF_PASSWORD: "pass"},
+        subentries_data=mock_line_subentries,
+    )
+
+
 @pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock]:
     """Override async_setup_entry."""
@@ -279,4 +365,5 @@ def mock_tcl_client() -> Generator[AsyncMock]:
         client.get_tcl_stops.return_value = MOCK_TCL_STOPS
         client.get_velov_stations.return_value = MOCK_VELOV_STATIONS
         client.get_tcl_park_and_rides.return_value = MOCK_PARK_AND_RIDES
+        client.get_tcl_alerts.return_value = MOCK_TCL_ALERTS
         yield client

--- a/tests/components/data_grand_lyon/conftest.py
+++ b/tests/components/data_grand_lyon/conftest.py
@@ -8,6 +8,7 @@ from data_grand_lyon_ha import (
     TclAlert,
     TclAlertSeverityType,
     TclAlertType,
+    TclLinePictogram,
     TclParkAndRide,
     TclPassage,
     TclPassageType,
@@ -230,6 +231,22 @@ MOCK_TCL_ALERTS = [
 ]
 
 
+MOCK_TCL_LINE_PICTOGRAMS = [
+    TclLinePictogram(
+        code_ligne="C3",
+        picto_mode="mode_bus.svg",
+        picto_ligne="C3_ligne.svg",
+        picto_complet="C3.svg",
+    ),
+    TclLinePictogram(
+        code_ligne="A",
+        picto_mode="mode_metro.svg",
+        picto_ligne="A_ligne.svg",
+        picto_complet="A.svg",
+    ),
+]
+
+
 @pytest.fixture
 def mock_line_subentries() -> list[ConfigSubentryData]:
     """Mock TCL line subentries."""
@@ -366,4 +383,5 @@ def mock_tcl_client() -> Generator[AsyncMock]:
         client.get_velov_stations.return_value = MOCK_VELOV_STATIONS
         client.get_tcl_park_and_rides.return_value = MOCK_PARK_AND_RIDES
         client.get_tcl_alerts.return_value = MOCK_TCL_ALERTS
+        client.get_tcl_line_pictograms.return_value = MOCK_TCL_LINE_PICTOGRAMS
         yield client

--- a/tests/components/data_grand_lyon/snapshots/test_calendar.ambr
+++ b/tests/components/data_grand_lyon/snapshots/test_calendar.ambr
@@ -1,0 +1,62 @@
+# serializer version: 1
+# name: test_all_entities[calendar.line_c3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'calendar',
+    'entity_category': None,
+    'entity_id': 'calendar.line_c3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'data_grand_lyon',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'alerts',
+    'unique_id': 'line_C3-alerts',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[calendar.line_c3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <CalendarEntityStateAttribute.ALL_DAY: 'all_day'>: False,
+      <CalendarEntityStateAttribute.DESCRIPTION: 'description'>: '''
+        Les arrêts de Gare St-Paul à Cordeliers ne sont plus desservis.
+        
+        Cause: travaux
+        Type: Perturbation
+      ''',
+      <CalendarEntityStateAttribute.END_TIME: 'end_time'>: '2026-04-30 08:30:00',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Line C3',
+      <CalendarEntityStateAttribute.LOCATION: 'location'>: '',
+      <CalendarEntityStateAttribute.MESSAGE: 'message'>: 'Déviée dir. Cordeliers',
+      <CalendarEntityStateAttribute.START_TIME: 'start_time'>: '2026-03-31 22:00:00',
+    }),
+    'context': <ANY>,
+    'entity_id': 'calendar.line_c3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/data_grand_lyon/snapshots/test_calendar.ambr
+++ b/tests/components/data_grand_lyon/snapshots/test_calendar.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_all_entities[calendar.line_c3-entry]
+# name: test_all_entities[calendar.line_c3_alerts-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'calendar',
     'entity_category': None,
-    'entity_id': 'calendar.line_c3',
+    'entity_id': 'calendar.line_c3_alerts',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -21,12 +21,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Alerts',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Alerts',
     'platform': 'data_grand_lyon',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36,7 +36,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[calendar.line_c3-state]
+# name: test_all_entities[calendar.line_c3_alerts-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <CalendarEntityStateAttribute.ALL_DAY: 'all_day'>: False,
@@ -47,13 +47,13 @@
         Type: Perturbation
       ''',
       <CalendarEntityStateAttribute.END_TIME: 'end_time'>: '2026-04-30 08:30:00',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Line C3',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Line C3 Alerts',
       <CalendarEntityStateAttribute.LOCATION: 'location'>: '',
       <CalendarEntityStateAttribute.MESSAGE: 'message'>: 'Déviée dir. Cordeliers',
       <CalendarEntityStateAttribute.START_TIME: 'start_time'>: '2026-03-31 22:00:00',
     }),
     'context': <ANY>,
-    'entity_id': 'calendar.line_c3',
+    'entity_id': 'calendar.line_c3_alerts',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/data_grand_lyon/snapshots/test_diagnostics.ambr
+++ b/tests/components/data_grand_lyon/snapshots/test_diagnostics.ambr
@@ -32,6 +32,8 @@
       'version': 1,
     }),
     'coordinator_data': dict({
+      'alerts': dict({
+      }),
       'park_and_rides': dict({
       }),
       'stops': dict({
@@ -95,6 +97,8 @@
       'version': 1,
     }),
     'coordinator_data': dict({
+      'alerts': dict({
+      }),
       'park_and_rides': dict({
         'park_1': dict({
           'capacite': 240,
@@ -148,6 +152,8 @@
       'version': 1,
     }),
     'coordinator_data': dict({
+      'alerts': dict({
+      }),
       'park_and_rides': dict({
       }),
       'stops': dict({

--- a/tests/components/data_grand_lyon/snapshots/test_diagnostics.ambr
+++ b/tests/components/data_grand_lyon/snapshots/test_diagnostics.ambr
@@ -65,6 +65,85 @@
     }),
   })
 # ---
+# name: test_config_entry_diagnostics_with_line
+  dict({
+    'config_entry': dict({
+      'data': dict({
+        'password': '**REDACTED**',
+        'username': '**REDACTED**',
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'data_grand_lyon',
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'subentries': list([
+        dict({
+          'data': dict({
+            'line': 'C3',
+          }),
+          'subentry_type': 'line',
+          'title': 'Line C3',
+          'unique_id': 'line_C3',
+        }),
+      ]),
+      'title': 'Data Grand Lyon',
+      'unique_id': None,
+      'version': 1,
+    }),
+    'coordinator_data': dict({
+      'alerts': dict({
+        'line_1': list([
+          dict({
+            'cause': 'travaux',
+            'debut': '2026-04-01T07:00:00',
+            'fin': '2026-04-30T17:30:00',
+            'last_update_fme': '2026-04-10T09:15:00',
+            'ligne_cli': 'C3',
+            'ligne_com': 'C3',
+            'liste_objet': 'C3',
+            'message': 'Les arrêts de Gare St-Paul à Cordeliers ne sont plus desservis.',
+            'mode': 'Bus',
+            'n': 1,
+            'niveau_severite': 20,
+            'titre': 'Déviée dir. Cordeliers',
+            'type': 'Perturbation',
+            'type_objet': 'line',
+            'type_severite': 'SIGNIFICANT_DELAYS',
+          }),
+          dict({
+            'cause': 'événement',
+            'debut': '2026-03-01T04:30:00',
+            'fin': '2026-03-02T01:30:00',
+            'last_update_fme': '2026-03-01T09:15:00',
+            'ligne_cli': 'C3',
+            'ligne_com': 'C3',
+            'liste_objet': 'C3',
+            'message': 'Horaires prolongés.',
+            'mode': 'Bus',
+            'n': 2,
+            'niveau_severite': 30,
+            'titre': 'Fête de la Musique',
+            'type': 'Information',
+            'type_objet': 'line',
+            'type_severite': 'OTHER_EFFECT',
+          }),
+        ]),
+      }),
+      'park_and_rides': dict({
+      }),
+      'stops': dict({
+      }),
+      'velov_stations': dict({
+      }),
+    }),
+  })
+# ---
 # name: test_config_entry_diagnostics_with_park_and_ride
   dict({
     'config_entry': dict({

--- a/tests/components/data_grand_lyon/test_calendar.py
+++ b/tests/components/data_grand_lyon/test_calendar.py
@@ -1,0 +1,127 @@
+"""Tests for the Data Grand Lyon calendar platform."""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.data_grand_lyon.const import TZ_PARIS
+from homeassistant.const import STATE_OFF, STATE_ON, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+ENTITY_ID = "calendar.line_c3"
+
+
+@pytest.fixture(autouse=True)
+def frozen_time(freezer: FrozenDateTimeFactory) -> None:
+    """Freeze time inside the in-progress alert of MOCK_TCL_ALERTS."""
+    freezer.move_to(datetime(2026, 4, 10, 14, 0, tzinfo=TZ_PARIS))
+
+
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    entity_registry: er.EntityRegistry,
+    mock_line_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+) -> None:
+    """Test all calendar entities (state, attributes, registry)."""
+    with patch(
+        "homeassistant.components.data_grand_lyon.PLATFORMS", [Platform.CALENDAR]
+    ):
+        mock_line_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_line_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await snapshot_platform(
+        hass, entity_registry, snapshot, mock_line_config_entry.entry_id
+    )
+
+
+async def test_state_reflects_alert_in_progress(
+    hass: HomeAssistant,
+    mock_line_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+) -> None:
+    """Test the calendar is on while an alert is in progress."""
+    mock_line_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_line_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.attributes["message"] == "Déviée dir. Cordeliers"
+    assert "Cause: travaux" in state.attributes["description"]
+
+
+async def test_state_off_without_alert(
+    hass: HomeAssistant,
+    mock_line_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+) -> None:
+    """Test a line with no alert is available and off."""
+    mock_tcl_client.get_tcl_alerts.return_value = []
+    mock_line_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_line_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "expected"),
+    [
+        pytest.param(
+            datetime(2026, 4, 9, 0, 0, tzinfo=TZ_PARIS),
+            datetime(2026, 4, 11, 0, 0, tzinfo=TZ_PARIS),
+            ["Déviée dir. Cordeliers"],
+            id="inside_ongoing_alert",
+        ),
+        pytest.param(
+            datetime(2026, 2, 1, 0, 0, tzinfo=TZ_PARIS),
+            datetime(2026, 5, 1, 0, 0, tzinfo=TZ_PARIS),
+            ["Déviée dir. Cordeliers", "Fête de la Musique"],
+            id="spans_both_alerts",
+        ),
+        pytest.param(
+            datetime(2026, 1, 1, 0, 0, tzinfo=TZ_PARIS),
+            datetime(2026, 1, 2, 0, 0, tzinfo=TZ_PARIS),
+            [],
+            id="before_every_alert",
+        ),
+    ],
+)
+async def test_get_events(
+    hass: HomeAssistant,
+    mock_line_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+    start: datetime,
+    end: datetime,
+    expected: list[str],
+) -> None:
+    """Test the requested window selects the overlapping alerts."""
+    mock_line_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_line_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    response = await hass.services.async_call(
+        "calendar",
+        "get_events",
+        {
+            "entity_id": ENTITY_ID,
+            "start_date_time": start.isoformat(),
+            "end_date_time": end.isoformat(),
+        },
+        blocking=True,
+        return_response=True,
+    )
+    summaries = [event["summary"] for event in response[ENTITY_ID]["events"]]
+    assert sorted(summaries) == sorted(expected)

--- a/tests/components/data_grand_lyon/test_calendar.py
+++ b/tests/components/data_grand_lyon/test_calendar.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
+from data_grand_lyon_ha import TclAlert, TclAlertSeverityType, TclAlertType
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -11,6 +12,8 @@ from homeassistant.components.data_grand_lyon.const import TZ_PARIS
 from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+
+from .conftest import MOCK_TCL_ALERTS
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -74,6 +77,81 @@ async def test_state_off_without_alert(
     state = hass.states.get(ENTITY_ID)
     assert state is not None
     assert state.state == STATE_OFF
+
+
+async def test_state_off_when_every_alert_has_ended(
+    hass: HomeAssistant,
+    mock_line_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+) -> None:
+    """Test a line whose only alert has already ended is off."""
+    mock_tcl_client.get_tcl_alerts.return_value = [MOCK_TCL_ALERTS[1]]
+    mock_line_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_line_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_state_on_prefers_started_alert_over_later_one(
+    hass: HomeAssistant,
+    mock_line_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+) -> None:
+    """Test an alert already running is preferred over one starting later today.
+
+    Both alerts share the library's relevance bucket (an alert starting later
+    today counts as CURRENT too), and within that bucket the lower-severity
+    (more disruptive) alert would normally sort first. If the entity naively
+    took that top-ranked alert, it would report an alert starting at 18:00 as
+    the event at 14:00, and HA would compute the on/off state as off despite
+    the ongoing alert.
+    """
+    ongoing = TclAlert(
+        type=TclAlertType.INFORMATION,
+        cause="événement",
+        debut=datetime(2026, 4, 10, 8, 0),
+        fin=datetime(2026, 4, 10, 20, 0),
+        mode="Bus",
+        ligne_com="C3",
+        ligne_cli="C3",
+        titre="Ongoing information",
+        message="Service normal, information seulement.",
+        last_update_fme=datetime(2026, 4, 10, 9, 15),
+        n=10,
+        type_severite=TclAlertSeverityType.OTHER_EFFECT,
+        niveau_severite=30,
+        type_objet="line",
+        liste_objet="C3",
+    )
+    later_today = TclAlert(
+        type=TclAlertType.DISRUPTION,
+        cause="travaux",
+        debut=datetime(2026, 4, 10, 18, 0),
+        fin=datetime(2026, 4, 10, 22, 0),
+        mode="Bus",
+        ligne_com="C3",
+        ligne_cli="C3",
+        titre="Later disruption",
+        message="Déviation à partir de 18h.",
+        last_update_fme=datetime(2026, 4, 10, 9, 15),
+        n=11,
+        type_severite=TclAlertSeverityType.SIGNIFICANT_DELAYS,
+        niveau_severite=20,
+        type_objet="line",
+        liste_objet="C3",
+    )
+    mock_tcl_client.get_tcl_alerts.return_value = [ongoing, later_today]
+    mock_line_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_line_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.attributes["message"] == "Ongoing information"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/data_grand_lyon/test_calendar.py
+++ b/tests/components/data_grand_lyon/test_calendar.py
@@ -17,7 +17,7 @@ from .conftest import MOCK_TCL_ALERTS
 
 from tests.common import MockConfigEntry, snapshot_platform
 
-ENTITY_ID = "calendar.line_c3"
+ENTITY_ID = "calendar.line_c3_alerts"
 
 
 @pytest.fixture(autouse=True)
@@ -26,12 +26,12 @@ def frozen_time(freezer: FrozenDateTimeFactory) -> None:
     freezer.move_to(datetime(2026, 4, 10, 14, 0, tzinfo=TZ_PARIS))
 
 
+@pytest.mark.usefixtures("mock_tcl_client")
 async def test_all_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     mock_line_config_entry: MockConfigEntry,
-    mock_tcl_client: AsyncMock,
 ) -> None:
     """Test all calendar entities (state, attributes, registry)."""
     with patch(
@@ -46,10 +46,10 @@ async def test_all_entities(
     )
 
 
+@pytest.mark.usefixtures("mock_tcl_client")
 async def test_state_reflects_alert_in_progress(
     hass: HomeAssistant,
     mock_line_config_entry: MockConfigEntry,
-    mock_tcl_client: AsyncMock,
 ) -> None:
     """Test the calendar is on while an alert is in progress."""
     mock_line_config_entry.add_to_hass(hass)
@@ -155,6 +155,99 @@ async def test_state_on_prefers_started_alert_over_later_one(
 
 
 @pytest.mark.parametrize(
+    ("alerts", "expected_message"),
+    [
+        pytest.param(
+            [
+                TclAlert(
+                    type=TclAlertType.DISRUPTION,
+                    cause="travaux",
+                    debut=datetime(2026, 4, 10, 18, 0),
+                    fin=datetime(2026, 4, 10, 22, 0),
+                    mode="Bus",
+                    ligne_com="C3",
+                    ligne_cli="C3",
+                    titre="Upcoming disruption",
+                    message="Déviation à partir de 18h.",
+                    last_update_fme=datetime(2026, 4, 10, 9, 15),
+                    n=20,
+                    type_severite=TclAlertSeverityType.SIGNIFICANT_DELAYS,
+                    niveau_severite=20,
+                    type_objet="line",
+                    liste_objet="C3",
+                )
+            ],
+            "Upcoming disruption",
+            id="single_upcoming_alert",
+        ),
+        pytest.param(
+            [
+                TclAlert(
+                    type=TclAlertType.INFORMATION,
+                    cause="événement",
+                    debut=datetime(2026, 4, 10, 16, 0),
+                    fin=datetime(2026, 4, 10, 20, 0),
+                    mode="Bus",
+                    ligne_com="C3",
+                    ligne_cli="C3",
+                    titre="Soonest information",
+                    message="Information seulement.",
+                    last_update_fme=datetime(2026, 4, 10, 9, 15),
+                    n=21,
+                    type_severite=TclAlertSeverityType.OTHER_EFFECT,
+                    niveau_severite=30,
+                    type_objet="line",
+                    liste_objet="C3",
+                ),
+                TclAlert(
+                    type=TclAlertType.DISRUPTION,
+                    cause="travaux",
+                    debut=datetime(2026, 4, 10, 18, 0),
+                    fin=datetime(2026, 4, 10, 22, 0),
+                    mode="Bus",
+                    ligne_com="C3",
+                    ligne_cli="C3",
+                    titre="Later severe disruption",
+                    message="Déviation à partir de 18h.",
+                    last_update_fme=datetime(2026, 4, 10, 9, 15),
+                    n=22,
+                    type_severite=TclAlertSeverityType.SIGNIFICANT_DELAYS,
+                    niveau_severite=20,
+                    type_objet="line",
+                    liste_objet="C3",
+                ),
+            ],
+            "Soonest information",
+            id="soonest_upcoming_alert_wins_over_severity",
+        ),
+    ],
+)
+async def test_state_off_with_upcoming_alert_picks_soonest(
+    hass: HomeAssistant,
+    mock_line_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+    alerts: list[TclAlert],
+    expected_message: str,
+) -> None:
+    """Test the event is the soonest upcoming alert, not the most severe one.
+
+    Both alerts start later today (frozen time is 14:00), so nothing has
+    started yet. The severe one starting later must not win: HA arms its
+    next on/off transition from the event's start, so picking anything but
+    the soonest alert arms the wrong moment.
+    """
+    mock_tcl_client.get_tcl_alerts.return_value = alerts
+    mock_line_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_line_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert state.attributes["message"] == expected_message
+
+
+@pytest.mark.parametrize(
     ("start", "end", "expected"),
     [
         pytest.param(
@@ -175,12 +268,26 @@ async def test_state_on_prefers_started_alert_over_later_one(
             [],
             id="before_every_alert",
         ),
+        pytest.param(
+            # MOCK_TCL_ALERTS[0]'s own `fin` as the window start.
+            datetime(2026, 4, 30, 17, 30, tzinfo=TZ_PARIS),
+            datetime(2026, 5, 1, 0, 0, tzinfo=TZ_PARIS),
+            [],
+            id="ends_exactly_at_window_start",
+        ),
+        pytest.param(
+            datetime(2026, 3, 15, 0, 0, tzinfo=TZ_PARIS),
+            # MOCK_TCL_ALERTS[0]'s own `debut` as the window end.
+            datetime(2026, 4, 1, 7, 0, tzinfo=TZ_PARIS),
+            [],
+            id="starts_exactly_at_window_end",
+        ),
     ],
 )
+@pytest.mark.usefixtures("mock_tcl_client")
 async def test_get_events(
     hass: HomeAssistant,
     mock_line_config_entry: MockConfigEntry,
-    mock_tcl_client: AsyncMock,
     start: datetime,
     end: datetime,
     expected: list[str],

--- a/tests/components/data_grand_lyon/test_config_flow.py
+++ b/tests/components/data_grand_lyon/test_config_flow.py
@@ -780,10 +780,10 @@ async def test_line_subentry_flow_custom_value(
         pytest.param("C3", id="exact"),
     ],
 )
+@pytest.mark.usefixtures("mock_tcl_client")
 async def test_line_subentry_flow_trims_line_code(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_tcl_client: AsyncMock,
     line_code: str,
 ) -> None:
     """Test a line code with surrounding whitespace is trimmed before use."""
@@ -811,10 +811,10 @@ async def test_line_subentry_flow_trims_line_code(
         pytest.param("   ", id="whitespace_only"),
     ],
 )
+@pytest.mark.usefixtures("mock_tcl_client")
 async def test_line_subentry_flow_rejects_empty_line_code(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_tcl_client: AsyncMock,
     line_code: str,
 ) -> None:
     """Test an empty (or whitespace-only) line code re-renders the form with an error."""

--- a/tests/components/data_grand_lyon/test_config_flow.py
+++ b/tests/components/data_grand_lyon/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the Data Grand Lyon config flow."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from aiohttp import ClientConnectionError, ClientResponseError
 import pytest
@@ -12,10 +12,12 @@ from homeassistant.components.data_grand_lyon.const import (
     CONF_STATION_ID,
     CONF_STOP_ID,
     DOMAIN,
+    SUBENTRY_TYPE_LINE,
     SUBENTRY_TYPE_PARK_AND_RIDE,
     SUBENTRY_TYPE_STOP,
     SUBENTRY_TYPE_VELOV_STATION,
 )
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -719,5 +721,117 @@ async def test_park_and_ride_subentry_picker_load_errors(
         context={"source": config_entries.SOURCE_USER},
     )
 
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == reason
+
+
+# Line subentry tests
+
+
+async def test_line_subentry_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+) -> None:
+    """Test adding a TCL line subentry."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_LINE),
+        context={"source": SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LINE: "C3"}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Line C3"
+    assert result["data"] == {CONF_LINE: "C3"}
+
+
+async def test_line_subentry_flow_custom_value(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+) -> None:
+    """Test a line code absent from the pictogram CSV is accepted."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_LINE),
+        context={"source": SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LINE: "ZI3"}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_LINE: "ZI3"}
+
+
+async def test_line_subentry_flow_already_configured(
+    hass: HomeAssistant,
+    mock_line_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+) -> None:
+    """Test adding a line that is already configured aborts."""
+    mock_line_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_line_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_line_config_entry.entry_id, SUBENTRY_TYPE_LINE),
+        context={"source": SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LINE: "C3"}
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "reason"),
+    [
+        pytest.param(
+            ClientResponseError(Mock(), Mock(), status=401),
+            "invalid_auth",
+            id="invalid_auth",
+        ),
+        pytest.param(
+            ClientResponseError(Mock(), Mock(), status=500),
+            "cannot_connect",
+            id="cannot_connect_http",
+        ),
+        pytest.param(
+            ClientConnectionError("boom"), "cannot_connect", id="cannot_connect_client"
+        ),
+        pytest.param(TimeoutError, "cannot_connect", id="cannot_connect_timeout"),
+        pytest.param(Exception("boom"), "unknown", id="unknown"),
+    ],
+)
+async def test_line_subentry_flow_errors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+    side_effect: Exception,
+    reason: str,
+) -> None:
+    """Test the line subentry flow aborts when the line list cannot be fetched."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_tcl_client.get_tcl_line_pictograms.side_effect = side_effect
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_LINE),
+        context={"source": SOURCE_USER},
+    )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == reason

--- a/tests/components/data_grand_lyon/test_config_flow.py
+++ b/tests/components/data_grand_lyon/test_config_flow.py
@@ -17,7 +17,6 @@ from homeassistant.components.data_grand_lyon.const import (
     SUBENTRY_TYPE_STOP,
     SUBENTRY_TYPE_VELOV_STATION,
 )
-from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -728,10 +727,10 @@ async def test_park_and_ride_subentry_picker_load_errors(
 # Line subentry tests
 
 
+@pytest.mark.usefixtures("mock_tcl_client")
 async def test_line_subentry_flow(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_tcl_client: AsyncMock,
 ) -> None:
     """Test adding a TCL line subentry."""
     mock_config_entry.add_to_hass(hass)
@@ -740,7 +739,7 @@ async def test_line_subentry_flow(
 
     result = await hass.config_entries.subentries.async_init(
         (mock_config_entry.entry_id, SUBENTRY_TYPE_LINE),
-        context={"source": SOURCE_USER},
+        context={"source": config_entries.SOURCE_USER},
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
@@ -753,10 +752,10 @@ async def test_line_subentry_flow(
     assert result["data"] == {CONF_LINE: "C3"}
 
 
+@pytest.mark.usefixtures("mock_tcl_client")
 async def test_line_subentry_flow_custom_value(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_tcl_client: AsyncMock,
 ) -> None:
     """Test a line code absent from the pictogram CSV is accepted."""
     mock_config_entry.add_to_hass(hass)
@@ -765,7 +764,7 @@ async def test_line_subentry_flow_custom_value(
 
     result = await hass.config_entries.subentries.async_init(
         (mock_config_entry.entry_id, SUBENTRY_TYPE_LINE),
-        context={"source": SOURCE_USER},
+        context={"source": config_entries.SOURCE_USER},
     )
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"], {CONF_LINE: "ZI3"}
@@ -774,10 +773,71 @@ async def test_line_subentry_flow_custom_value(
     assert result["data"] == {CONF_LINE: "ZI3"}
 
 
+@pytest.mark.parametrize(
+    "line_code",
+    [
+        pytest.param(" C3 ", id="padded"),
+        pytest.param("C3", id="exact"),
+    ],
+)
+async def test_line_subentry_flow_trims_line_code(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+    line_code: str,
+) -> None:
+    """Test a line code with surrounding whitespace is trimmed before use."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_LINE),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LINE: line_code}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Line C3"
+    assert result["data"] == {CONF_LINE: "C3"}
+    assert result["unique_id"] == "line_C3"
+
+
+@pytest.mark.parametrize(
+    "line_code",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="whitespace_only"),
+    ],
+)
+async def test_line_subentry_flow_rejects_empty_line_code(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+    line_code: str,
+) -> None:
+    """Test an empty (or whitespace-only) line code re-renders the form with an error."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.subentries.async_init(
+        (mock_config_entry.entry_id, SUBENTRY_TYPE_LINE),
+        context={"source": config_entries.SOURCE_USER},
+    )
+    result = await hass.config_entries.subentries.async_configure(
+        result["flow_id"], {CONF_LINE: line_code}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_LINE: "invalid_line"}
+
+
+@pytest.mark.usefixtures("mock_tcl_client")
 async def test_line_subentry_flow_already_configured(
     hass: HomeAssistant,
     mock_line_config_entry: MockConfigEntry,
-    mock_tcl_client: AsyncMock,
 ) -> None:
     """Test adding a line that is already configured aborts."""
     mock_line_config_entry.add_to_hass(hass)
@@ -786,7 +846,7 @@ async def test_line_subentry_flow_already_configured(
 
     result = await hass.config_entries.subentries.async_init(
         (mock_line_config_entry.entry_id, SUBENTRY_TYPE_LINE),
-        context={"source": SOURCE_USER},
+        context={"source": config_entries.SOURCE_USER},
     )
     result = await hass.config_entries.subentries.async_configure(
         result["flow_id"], {CONF_LINE: "C3"}
@@ -831,7 +891,7 @@ async def test_line_subentry_flow_errors(
 
     result = await hass.config_entries.subentries.async_init(
         (mock_config_entry.entry_id, SUBENTRY_TYPE_LINE),
-        context={"source": SOURCE_USER},
+        context={"source": config_entries.SOURCE_USER},
     )
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == reason

--- a/tests/components/data_grand_lyon/test_coordinator.py
+++ b/tests/components/data_grand_lyon/test_coordinator.py
@@ -11,10 +11,10 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.usefixtures("mock_tcl_client")
 async def test_alerts_filtered_by_line(
     hass: HomeAssistant,
     mock_line_config_entry: MockConfigEntry,
-    mock_tcl_client: AsyncMock,
 ) -> None:
     """Test alerts are filtered to the monitored line only."""
     mock_line_config_entry.add_to_hass(hass)

--- a/tests/components/data_grand_lyon/test_coordinator.py
+++ b/tests/components/data_grand_lyon/test_coordinator.py
@@ -1,0 +1,85 @@
+"""Tests for the Data Grand Lyon alerts coordinator."""
+
+from unittest.mock import AsyncMock, Mock
+
+from aiohttp import ClientConnectionError, ClientResponseError
+import pytest
+
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_alerts_filtered_by_line(
+    hass: HomeAssistant,
+    mock_line_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+) -> None:
+    """Test alerts are filtered to the monitored line only."""
+    mock_line_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_line_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    data = mock_line_config_entry.runtime_data.alerts_coordinator.data
+    assert list(data) == ["line_1"]
+    assert [alert.titre for alert in data["line_1"]] == [
+        "Déviée dir. Cordeliers",
+        "Fête de la Musique",
+    ]
+
+
+async def test_line_with_no_alert_keeps_its_key(
+    hass: HomeAssistant,
+    mock_line_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+) -> None:
+    """Test a line without any alert is still present in the coordinator data."""
+    mock_tcl_client.get_tcl_alerts.return_value = []
+    mock_line_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_line_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    data = mock_line_config_entry.runtime_data.alerts_coordinator.data
+    assert data == {"line_1": []}
+
+
+async def test_auth_failure_starts_reauth(
+    hass: HomeAssistant,
+    mock_line_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+) -> None:
+    """Test a 401 on the alerts fetch starts the reauth flow."""
+    mock_tcl_client.get_tcl_alerts.side_effect = ClientResponseError(
+        Mock(), Mock(), status=401
+    )
+    mock_line_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_line_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_line_config_entry.state is ConfigEntryState.SETUP_ERROR
+    flows = hass.config_entries.flow.async_progress()
+    assert [flow["context"]["source"] for flow in flows] == [SOURCE_REAUTH]
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        pytest.param(ClientResponseError(Mock(), Mock(), status=500), id="http_error"),
+        pytest.param(ClientConnectionError("boom"), id="connection_error"),
+        pytest.param(TimeoutError, id="timeout"),
+    ],
+)
+async def test_fetch_failure_retries_setup(
+    hass: HomeAssistant,
+    mock_line_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+    side_effect: Exception,
+) -> None:
+    """Test a failed alerts fetch leaves the entry retrying, not errored."""
+    mock_tcl_client.get_tcl_alerts.side_effect = side_effect
+    mock_line_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_line_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_line_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/data_grand_lyon/test_diagnostics.py
+++ b/tests/components/data_grand_lyon/test_diagnostics.py
@@ -61,3 +61,20 @@ async def test_config_entry_diagnostics_with_park_and_ride(
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, mock_park_and_ride_config_entry
     ) == snapshot(exclude=props("created_at", "modified_at", "entry_id", "subentry_id"))
+
+
+async def test_config_entry_diagnostics_with_line(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_line_config_entry: MockConfigEntry,
+    mock_tcl_client: AsyncMock,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test config entry diagnostics with a line's traffic alerts."""
+    mock_line_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_line_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_line_config_entry
+    ) == snapshot(exclude=props("created_at", "modified_at", "entry_id", "subentry_id"))

--- a/tests/components/data_grand_lyon/test_diagnostics.py
+++ b/tests/components/data_grand_lyon/test_diagnostics.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
 
@@ -63,11 +64,11 @@ async def test_config_entry_diagnostics_with_park_and_ride(
     ) == snapshot(exclude=props("created_at", "modified_at", "entry_id", "subentry_id"))
 
 
+@pytest.mark.usefixtures("mock_tcl_client")
 async def test_config_entry_diagnostics_with_line(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     mock_line_config_entry: MockConfigEntry,
-    mock_tcl_client: AsyncMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics with a line's traffic alerts."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add transit network alerts to the data_grand_lyon integration. There are many alert kinds and it would be difficult to prioritize them for the user so instead I opted for a calendar which shows all alerts with their start and end date.
As usual with this data source, we fetch all alerts for the whole network in a single call.
I created a "transit line" sub entry type, we may add things there later and alerts are scoped to a line.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47897
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
