### PR TITLE
minecraft_server: initialize mcstatus' objects using `raw` data

### DIFF
--- a/homeassistant/components/minecraft_server/manifest.json
+++ b/homeassistant/components/minecraft_server/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "loggers": ["dnspython", "mcstatus"],
   "quality_scale": "silver",
-  "requirements": ["mcstatus==13.1.0"]
+  "requirements": ["mcstatus==14.2.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1587,7 +1587,7 @@ mbddns==0.1.2
 mcp==1.26.0
 
 # homeassistant.components.minecraft_server
-mcstatus==13.1.0
+mcstatus==14.2.0
 
 # homeassistant.components.meater
 meater-python==0.0.8
@@ -1703,7 +1703,7 @@ netdata==1.3.0
 # homeassistant.components.nmap_tracker
 netmap==0.7.0.2
 
-# homeassistant.components.nam
+# homeassistant.components.name
 nettigo-air-monitor==5.1.0
 
 # homeassistant.components.neurio_energy

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1703,7 +1703,7 @@ netdata==1.3.0
 # homeassistant.components.nmap_tracker
 netmap==0.7.0.2
 
-# homeassistant.components.name
+# homeassistant.components.nam
 nettigo-air-monitor==5.1.0
 
 # homeassistant.components.neurio_energy

--- a/tests/components/minecraft_server/const.py
+++ b/tests/components/minecraft_server/const.py
@@ -1,17 +1,9 @@
 """Constants for Minecraft Server integration tests."""
 
-from mcstatus.motd import Motd
 from mcstatus.responses import (
-    BedrockStatusPlayers,
     BedrockStatusResponse,
-    BedrockStatusVersion,
-    JavaStatusPlayer,
-    JavaStatusPlayers,
     JavaStatusResponse,
-    JavaStatusVersion,
-    LegacyStatusPlayers,
     LegacyStatusResponse,
-    LegacyStatusVersion,
 )
 
 from homeassistant.components.minecraft_server.api import MinecraftServerData
@@ -21,23 +13,21 @@ TEST_HOST = "mc.dummyserver.com"
 TEST_PORT = 25566
 TEST_ADDRESS = f"{TEST_HOST}:{TEST_PORT}"
 
-TEST_JAVA_STATUS_RESPONSE = JavaStatusResponse(
-    raw={"foo": "bar"},
-    players=JavaStatusPlayers(
-        online=3,
-        max=10,
-        sample=[
-            JavaStatusPlayer(id="1", name="Player 1"),
-            JavaStatusPlayer(id="2", name="Player 2"),
-            JavaStatusPlayer(id="3", name="Player 3"),
-        ],
-    ),
-    version=JavaStatusVersion(name="Dummy Version", protocol=123),
-    motd=Motd.parse("Dummy MOTD", bedrock=False),
-    icon=None,
-    enforces_secure_chat=False,
+TEST_JAVA_STATUS_RESPONSE = JavaStatusResponse.build(
+    {
+        "players": {
+            "online": 3,
+            "max": 10,
+            "sample": [
+                {"id": "1", "name": "Player 1"},
+                {"id": "2", "name": "Player 2"},
+                {"id": "3", "name": "Player 3"},
+            ],
+        },
+        "version": {},
+        "description": "Dummy MOTD",
+    },
     latency=5,
-    forge_data=None,
 )
 
 TEST_JAVA_DATA = MinecraftServerData(
@@ -53,13 +43,19 @@ TEST_JAVA_DATA = MinecraftServerData(
     map_name=None,
 )
 
-TEST_BEDROCK_STATUS_RESPONSE = BedrockStatusResponse(
-    players=BedrockStatusPlayers(online=3, max=10),
-    version=BedrockStatusVersion(brand="MCPE", name="Dummy Version", protocol=123),
-    motd=Motd.parse("Dummy MOTD", bedrock=True),
+TEST_BEDROCK_STATUS_RESPONSE = BedrockStatusResponse.build(
+    [
+        "MCPE",  # version.brand
+        "Dummy MOTD",  # motd
+        123,  # version.protocol
+        "Dummy Version",  # version.name
+        3,  # players.online
+        10,  # players.max
+        "Dummy Server ID",  # server unique ID
+        "Dummy Map Name",  # map_name
+        "Dummy Game Mode",  # gamemode
+    ],
     latency=5,
-    gamemode="Dummy Game Mode",
-    map_name="Dummy Map Name",
 )
 
 TEST_BEDROCK_DATA = MinecraftServerData(
@@ -75,9 +71,13 @@ TEST_BEDROCK_DATA = MinecraftServerData(
     map_name="Dummy Map Name",
 )
 
-TEST_LEGACY_JAVA_STATUS_RESPONSE = LegacyStatusResponse(
-    players=LegacyStatusPlayers(online=3, max=10),
-    version=LegacyStatusVersion(name="1.6.4", protocol=78),
-    motd=Motd.parse("Dummy MOTD"),
+TEST_LEGACY_JAVA_STATUS_RESPONSE = LegacyStatusResponse.build(
+    [
+        78,  # version.protocol
+        "1.6.4",  # version.name
+        "Dummy MOTD",  # motd
+        3,  # players online
+        10,  # players max
+    ],
     latency=5,
 )

--- a/tests/components/minecraft_server/const.py
+++ b/tests/components/minecraft_server/const.py
@@ -50,10 +50,10 @@ TEST_BEDROCK_STATUS_RESPONSE = BedrockStatusResponse.build(
     [
         "MCPE",  # version.brand
         "Dummy MOTD",  # motd
-        123,  # version.protocol
+        "123",  # version.protocol
         "Dummy Version",  # version.name
-        3,  # players.online
-        10,  # players.max
+        "3",  # players.online
+        "10",  # players.max
         "Dummy Server ID",  # server unique ID
         "Dummy Map Name",  # map_name
         "Dummy Game Mode",  # gamemode
@@ -76,11 +76,11 @@ TEST_BEDROCK_DATA = MinecraftServerData(
 
 TEST_LEGACY_JAVA_STATUS_RESPONSE = LegacyStatusResponse.build(
     [
-        78,  # version.protocol
+        "78",  # version.protocol
         "1.6.4",  # version.name
         "Dummy MOTD",  # motd
-        3,  # players online
-        10,  # players max
+        "3",  # players online
+        "10",  # players max
     ],
     latency=5,
 )

--- a/tests/components/minecraft_server/const.py
+++ b/tests/components/minecraft_server/const.py
@@ -24,7 +24,10 @@ TEST_JAVA_STATUS_RESPONSE = JavaStatusResponse.build(
                 {"id": "3", "name": "Player 3"},
             ],
         },
-        "version": {},
+        "version": {
+            "name": "Dummy Version",
+            "protocol": 123,
+        },
         "description": "Dummy MOTD",
     },
     latency=5,


### PR DESCRIPTION
> [!NOTE]
> I am a maintainer of mcstatus and noticed a failure in Home Assistant's tests with the new mcstatus version.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

Changelog: https://github.com/py-mine/mcstatus/releases/tag/v14.2.0
Diff: https://github.com/py-mine/mcstatus/compare/v14.1.0...v14.2.0 / https://github.com/py-mine/mcstatus/compare/v13.1.0...v14.2.0

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Initializing mcstatus's response classes is fragile because if they add a new field, tests break. Example: https://github.com/py-mine/mcstatus/pull/1203. Initializing objects using raw values is stable because this is what Minecraft sends, and mcstatus has to maintain backward compatibility for that


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
