### PR TITLE
Fix Teslemetry energy-site setup crash on encrypted RSA key

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -342,7 +342,8 @@ async def _async_get_rsa_key_pem(hass: HomeAssistant) -> bytes:
 
 
 # aiopowerwall raises PowerwallError; key I/O and parsing raise OSError/ValueError.
-_LOCAL_CONTROL_ERRORS: Final = (OSError, ValueError, PowerwallError)
+# An encrypted key PEM surfaces as TypeError from the cryptography loader.
+_LOCAL_CONTROL_ERRORS: Final = (OSError, TypeError, ValueError, PowerwallError)
 
 
 async def _async_resolve_local_control(

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -333,17 +333,20 @@ async def _async_get_rsa_key_pem(hass: HomeAssistant) -> bytes:
     pem: bytes | None = hass.data.get(RSA_PARENT_KEY)
     if pem is None:
         path = hass.config.path(POWERWALL_KEY_FILE)
-        await Teslemetry(
-            session=async_get_clientsession(hass), access_token=""
-        ).get_rsa_private_key(path)
+        try:
+            await Teslemetry(
+                session=async_get_clientsession(hass), access_token=""
+            ).get_rsa_private_key(path)
+        except TypeError as err:
+            # An encrypted PEM surfaces as TypeError from the cryptography loader.
+            raise ValueError("RSA private key file is encrypted") from err
         pem = await hass.async_add_executor_job(Path(path).read_bytes)
         hass.data[RSA_PARENT_KEY] = pem
     return pem
 
 
 # aiopowerwall raises PowerwallError; key I/O and parsing raise OSError/ValueError.
-# An encrypted key PEM surfaces as TypeError from the cryptography loader.
-_LOCAL_CONTROL_ERRORS: Final = (OSError, TypeError, ValueError, PowerwallError)
+_LOCAL_CONTROL_ERRORS: Final = (OSError, ValueError, PowerwallError)
 
 
 async def _async_resolve_local_control(

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -277,7 +277,7 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             self._key_pem = await self.hass.async_add_executor_job(
                 Path(path).read_bytes
             )
-        except (OSError, ValueError) as err:
+        except (OSError, TypeError, ValueError) as err:
             LOGGER.debug("RSA key load failed: %s", err)
             return self.async_abort(reason="cannot_connect")
         self._public_key_der = keyholder.rsa_public_der_pkcs1

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -273,11 +273,15 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             session=async_get_clientsession(self.hass), access_token=""
         )
         try:
-            await keyholder.get_rsa_private_key(path)
+            try:
+                await keyholder.get_rsa_private_key(path)
+            except TypeError as err:
+                # An encrypted PEM surfaces as TypeError from the cryptography loader.
+                raise ValueError("RSA private key file is encrypted") from err
             self._key_pem = await self.hass.async_add_executor_job(
                 Path(path).read_bytes
             )
-        except (OSError, TypeError, ValueError) as err:
+        except (OSError, ValueError) as err:
             LOGGER.debug("RSA key load failed: %s", err)
             return self.async_abort(reason="cannot_connect")
         self._public_key_der = keyholder.rsa_public_der_pkcs1

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -1378,6 +1378,12 @@ async def test_pair_step_second_lookup_errors(
             ValueError,
             id="key_read_valueerror",
         ),
+        # An encrypted key PEM surfaces as TypeError from the cryptography loader.
+        pytest.param(
+            "homeassistant.components.teslemetry.config_flow.Teslemetry.get_rsa_private_key",
+            TypeError,
+            id="key_fetch_typeerror",
+        ),
     ],
 )
 async def test_rsa_key_load_failure_aborts(

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -1379,11 +1379,6 @@ async def test_no_subentry_created_at_setup(hass: HomeAssistant) -> None:
         pytest.param(OSError("disk gone"), id="os_error"),
         pytest.param(ValueError("bad key"), id="value_error"),
         pytest.param(PowerwallError("client boom"), id="powerwall_error"),
-        # An encrypted key PEM surfaces as TypeError from the cryptography loader.
-        pytest.param(
-            TypeError("Password was not given but private key is encrypted"),
-            id="type_error",
-        ),
     ],
 )
 async def test_local_control_failure_falls_back_to_cloud(
@@ -1421,6 +1416,71 @@ async def test_local_control_failure_falls_back_to_cloud(
         record.levelname == "WARNING" and str(SITE_ID) in record.message
         for record in caplog.records
     )
+
+
+async def test_local_control_encrypted_key_falls_back_to_cloud(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An encrypted RSA key PEM degrades the site to cloud control.
+
+    The cryptography loader raises TypeError for an encrypted PEM; the key
+    helper converts that to ValueError so the site falls back to cloud control
+    instead of tearing the integration down. Raise from the real
+    ``get_rsa_private_key`` call so the conversion is exercised end to end.
+    """
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry.Teslemetry.get_rsa_private_key",
+            side_effect=TypeError(
+                "Password was not given but private key is encrypted"
+            ),
+        ),
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+        caplog.at_level(logging.WARNING),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    energysite = entry.runtime_data.energysites[0]
+    assert isinstance(energysite.api, EnergySite)
+    assert not isinstance(energysite.api, EnergySiteRouter)
+    assert energysite.can_local_control
+    assert "falling back to cloud control" in caplog.text
+
+
+async def test_local_control_unexpected_typeerror_is_not_swallowed(
+    hass: HomeAssistant,
+) -> None:
+    """A TypeError outside the key load is a real bug and must not degrade silently.
+
+    ``_LOCAL_CONTROL_ERRORS`` deliberately excludes TypeError: only the key
+    loader's encrypted-PEM TypeError is converted to ValueError. A TypeError
+    from anywhere else in the resolve path (here, client construction) must
+    fail setup rather than silently falling back to cloud control.
+    """
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry._async_get_rsa_key_pem",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+        patch(
+            "homeassistant.components.teslemetry.PowerwallClient",
+            side_effect=TypeError("unexpected argument"),
+        ),
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_get_rsa_key_pem_generates_and_caches(hass: HomeAssistant) -> None:

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -1422,13 +1422,7 @@ async def test_local_control_encrypted_key_falls_back_to_cloud(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """An encrypted RSA key PEM degrades the site to cloud control.
-
-    The cryptography loader raises TypeError for an encrypted PEM; the key
-    helper converts that to ValueError so the site falls back to cloud control
-    instead of tearing the integration down. Raise from the real
-    ``get_rsa_private_key`` call so the conversion is exercised end to end.
-    """
+    """Fall back to cloud control when RSA key loading reports an encrypted PEM."""
     entry = _entry_with_powerwall()
     entry.add_to_hass(hass)
 

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -1379,6 +1379,11 @@ async def test_no_subentry_created_at_setup(hass: HomeAssistant) -> None:
         pytest.param(OSError("disk gone"), id="os_error"),
         pytest.param(ValueError("bad key"), id="value_error"),
         pytest.param(PowerwallError("client boom"), id="powerwall_error"),
+        # An encrypted key PEM surfaces as TypeError from the cryptography loader.
+        pytest.param(
+            TypeError("Password was not given but private key is encrypted"),
+            id="type_error",
+        ),
     ],
 )
 async def test_local_control_failure_falls_back_to_cloud(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

An encrypted Powerwall RSA key PEM makes the key loader raise `TypeError`, not `ValueError`, so it escaped both the setup and config-flow guards and failed setup outright. Catch `TypeError` at both sites so the site falls back to cloud control (or aborts `cannot_connect`) like every other key-load failure.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
