### PR TITLE
scrape: fix unit_of_measurement field hardcoded to temperature units

### DIFF
--- a/homeassistant/components/scrape/config_flow.py
+++ b/homeassistant/components/scrape/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.components.rest.schema import (  # pylint: disable=home-assis
     DEFAULT_METHOD,
     METHODS,
 )
-from homeassistant.components.sensor import CONF_STATE_CLASS
+from homeassistant.components.sensor import CONF_STATE_CLASS, DEVICE_CLASS_UNITS
 from homeassistant.config_entries import (
     SOURCE_USER,
     ConfigEntry,
@@ -45,7 +45,6 @@ from homeassistant.const import (
     HTTP_BASIC_AUTHENTICATION,
     HTTP_DIGEST_AUTHENTICATION,
     Platform,
-    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.selector import (
@@ -159,10 +158,17 @@ SENSOR_SETTINGS = vol.Schema(
                     vol.Optional(CONF_STATE_CLASS): StateClassSelector(),
                     vol.Optional(CONF_UNIT_OF_MEASUREMENT): SelectSelector(
                         SelectSelectorConfig(
-                            options=[cls.value for cls in UnitOfTemperature],
-                            custom_value=True,
+                            options=list(
+                                {
+                                    str(unit)
+                                    for units in DEVICE_CLASS_UNITS.values()
+                                    for unit in units
+                                    if unit is not None
+                                }
+                            ),
                             mode=SelectSelectorMode.DROPDOWN,
-                            translation_key="unit_of_measurement",
+                            translation_key="sensor_unit_of_measurement",
+                            custom_value=True,
                             sort=True,
                         )
                     ),

--- a/homeassistant/components/scrape/strings.json
+++ b/homeassistant/components/scrape/strings.json
@@ -175,12 +175,5 @@
         }
       }
     }
-  },
-  "selector": {
-    "unit_of_measurement": {
-      "options": {
-        "none": "No unit of measurement"
-      }
-    }
   }
 }


### PR DESCRIPTION
## Proposed change

The `unit_of_measurement` field in the scrape sensor config flow's subentry form was hardcoded to `UnitOfTemperature` options:

```python
vol.Optional(CONF_UNIT_OF_MEASUREMENT): SelectSelector(
    SelectSelectorConfig(
        options=[cls.value for cls in UnitOfTemperature],
        custom_value=True,
        ...
    )
),
```

This meant every scrape sensor's unit dropdown only ever offered °C/°F/K, regardless of the `device_class` selected for that sensor - confirmed this was unrelated to `device_class`, the same three options showed up whether `device_class` was set to `temperature`, `data_size`, or left unset entirely.

There's no single canonical "all units" enum in Home Assistant to draw from (units are split across many separate `UnitOf*` classes per domain), so rather than substituting a different arbitrary hardcoded list, this builds the dropdown from `DEVICE_CLASS_UNITS` - the same source used by the `random` and `template` helpers' own sensor unit-of-measurement fields - so every unit valid for any device class is offered. `custom_value=True` is kept, so a unit outside that list can still be typed in manually.

Also removed the now-unused `UnitOfTemperature` import and the orphaned `selector.unit_of_measurement` translation block in `strings.json`, which only applied to the old `SelectSelector`'s `translation_key`. The field's own `translation_key` is renamed to `sensor_unit_of_measurement` to match the `random`/`template` convention; no corresponding `strings.json` options block is needed for it, same as `random`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
