### PR TITLE
Add Helty Flow Cloud integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -263,6 +263,7 @@ homeassistant.components.hardkernel.*
 homeassistant.components.hardware.*
 homeassistant.components.harman_luxury.*
 homeassistant.components.hdfury.*
+homeassistant.components.helty_cloud.*
 homeassistant.components.heos.*
 homeassistant.components.here_travel_time.*
 homeassistant.components.history.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -752,6 +752,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/hegel/ @boazca
 /homeassistant/components/helty/ @ebaschiera
 /tests/components/helty/ @ebaschiera
+/homeassistant/components/helty_cloud/ @ebaschiera
+/tests/components/helty_cloud/ @ebaschiera
 /homeassistant/components/heos/ @andrewsayre
 /tests/components/heos/ @andrewsayre
 /homeassistant/components/here_travel_time/ @eifinger

--- a/homeassistant/components/helty_cloud/__init__.py
+++ b/homeassistant/components/helty_cloud/__init__.py
@@ -1,0 +1,54 @@
+"""The Helty Flow Cloud integration."""
+
+from pyheltycloud import HeltyCloud, HeltyCloudAuthError, HeltyCloudError
+
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
+from .coordinator import HeltyCloudConfigEntry, HeltyCloudDataUpdateCoordinator
+
+PLATFORMS: list[Platform] = [Platform.FAN]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: HeltyCloudConfigEntry) -> bool:
+    """Set up Helty Flow Cloud from a config entry."""
+    client = HeltyCloud(
+        entry.data[CONF_EMAIL],
+        entry.data[CONF_PASSWORD],
+        session=async_get_clientsession(hass),
+    )
+    try:
+        devices = await client.get_devices()
+    except HeltyCloudAuthError as err:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN, translation_key="invalid_auth"
+        ) from err
+    except HeltyCloudError as err:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+            translation_placeholders={"error": str(err)},
+        ) from err
+
+    coordinators = [
+        HeltyCloudDataUpdateCoordinator(hass, entry, client, device)
+        for device in devices
+    ]
+    # get_devices() has already proved the credentials and reached the cloud.
+    # A unit with nothing to read past that point is a panel that has gone
+    # quiet, which is a condition of that one device: let it come up
+    # unavailable rather than hold back every other unit on the account.
+    for coordinator in coordinators:
+        await coordinator.async_refresh()
+
+    entry.runtime_data = coordinators
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: HeltyCloudConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/helty_cloud/config_flow.py
+++ b/homeassistant/components/helty_cloud/config_flow.py
@@ -1,0 +1,82 @@
+"""Config flow for the Helty Flow Cloud integration."""
+
+from collections.abc import Mapping
+from typing import Any, override
+
+from pyheltycloud import HeltyCloud, HeltyCloudAuthError, HeltyCloudError
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_EMAIL): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+STEP_REAUTH_DATA_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
+
+
+class HeltyCloudConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Helty Flow Cloud."""
+
+    async def _async_validate(self, email: str, password: str) -> dict[str, str]:
+        """Check the credentials, returning the errors to show, if any."""
+        client = HeltyCloud(email, password, session=async_get_clientsession(self.hass))
+        try:
+            await client.get_devices()
+        except HeltyCloudAuthError:
+            return {"base": "invalid_auth"}
+        except HeltyCloudError:
+            return {"base": "cannot_connect"}
+        return {}
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial setup step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            email = user_input[CONF_EMAIL]
+            await self.async_set_unique_id(email.lower())
+            self._abort_if_unique_id_configured()
+            errors = await self._async_validate(email, user_input[CONF_PASSWORD])
+            if not errors:
+                return self.async_create_entry(title=email, data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle a password that the cloud no longer accepts."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Ask for the new password."""
+        errors: dict[str, str] = {}
+        reauth_entry = self._get_reauth_entry()
+        if user_input is not None:
+            errors = await self._async_validate(
+                reauth_entry.data[CONF_EMAIL], user_input[CONF_PASSWORD]
+            )
+            if not errors:
+                return self.async_update_reload_and_abort(
+                    reauth_entry, data_updates=user_input
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_REAUTH_DATA_SCHEMA,
+            description_placeholders={CONF_EMAIL: reauth_entry.data[CONF_EMAIL]},
+            errors=errors,
+        )

--- a/homeassistant/components/helty_cloud/const.py
+++ b/homeassistant/components/helty_cloud/const.py
@@ -1,0 +1,16 @@
+"""Constants for the Helty Flow Cloud integration."""
+
+from datetime import timedelta
+
+DOMAIN = "helty_cloud"
+
+#: How often the coordinator reads the cloud. The poll only reads the last
+#: message the panel sent, it does not wake the panel: the manufacturer asks
+#: not to solicit the panel on a short timer, and the panel reports on its
+#: own about every five minutes anyway.
+SCAN_INTERVAL = timedelta(minutes=5)
+
+# Fan preset mode identifiers (also used as translation keys).
+PRESET_BOOST = "boost"
+PRESET_NIGHT = "night"
+PRESET_FREE_COOLING = "free_cooling"

--- a/homeassistant/components/helty_cloud/coordinator.py
+++ b/homeassistant/components/helty_cloud/coordinator.py
@@ -1,0 +1,70 @@
+"""DataUpdateCoordinator for the Helty Flow Cloud integration."""
+
+import logging
+from typing import override
+
+from pyheltycloud import (
+    HeltyCloud,
+    HeltyCloudAuthError,
+    HeltyCloudError,
+    HeltyDevice,
+    HeltyState,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, SCAN_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+type HeltyCloudConfigEntry = ConfigEntry[list[HeltyCloudDataUpdateCoordinator]]
+
+
+class HeltyCloudDataUpdateCoordinator(DataUpdateCoordinator[HeltyState]):
+    """Coordinate a single poll of one VMC for all its entities."""
+
+    config_entry: HeltyCloudConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: HeltyCloudConfigEntry,
+        client: HeltyCloud,
+        device: HeltyDevice,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=f"{DOMAIN} {device.serial_number}",
+            update_interval=SCAN_INTERVAL,
+        )
+        self.client = client
+        self.device = device
+
+    @override
+    async def _async_update_data(self) -> HeltyState:
+        """Read the last state the panel sent to the cloud.
+
+        The panel holds its own connection to the cloud and reports on any
+        significant change as well as on a timer, so reading is enough to
+        follow it. Prompting it to report would be a message to the panel
+        itself, which the manufacturer asks to keep for the confirmation
+        after a command.
+        """
+        try:
+            return await self.client.get_last_telemetry(self.device.serial_number)
+        except HeltyCloudAuthError as err:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN, translation_key="invalid_auth"
+            ) from err
+        except HeltyCloudError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/homeassistant/components/helty_cloud/entity.py
+++ b/homeassistant/components/helty_cloud/entity.py
@@ -1,0 +1,26 @@
+"""Base entity for the Helty Flow Cloud integration."""
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import HeltyCloudDataUpdateCoordinator
+
+
+class HeltyCloudEntity(CoordinatorEntity[HeltyCloudDataUpdateCoordinator]):
+    """Common base for the entities of one VMC."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: HeltyCloudDataUpdateCoordinator) -> None:
+        """Initialize the entity and its shared device info."""
+        super().__init__(coordinator)
+        device = coordinator.device
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.serial_number)},
+            manufacturer="Helty",
+            model=device.model,
+            name=device.name,
+            serial_number=device.serial_number,
+            sw_version=device.firmware,
+        )

--- a/homeassistant/components/helty_cloud/fan.py
+++ b/homeassistant/components/helty_cloud/fan.py
@@ -1,0 +1,153 @@
+"""Fan platform for the Helty Flow Cloud integration."""
+
+from typing import Any, override
+
+from pyheltycloud import HeltyCloudError, VmcMode
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.percentage import (
+    ordered_list_item_to_percentage,
+    percentage_to_ordered_list_item,
+)
+
+from .const import DOMAIN, PRESET_BOOST, PRESET_FREE_COOLING, PRESET_NIGHT
+from .coordinator import HeltyCloudConfigEntry, HeltyCloudDataUpdateCoordinator
+from .entity import HeltyCloudEntity
+
+PARALLEL_UPDATES = 1
+
+# How many times a mode command is sent before the change is called failed.
+# Each attempt wakes the panel, which the manufacturer asks to keep rare, so
+# this only buys one retry for the command the cloud happened to drop.
+SET_MODE_ATTEMPTS = 2
+
+# Ordered list of discrete fan speeds, lowest to highest.
+ORDERED_SPEEDS: list[VmcMode] = [
+    VmcMode.SPEED_1,
+    VmcMode.SPEED_2,
+    VmcMode.SPEED_3,
+    VmcMode.SPEED_4,
+]
+
+PRESET_TO_MODE: dict[str, VmcMode] = {
+    PRESET_BOOST: VmcMode.HYPERVENTILATION,
+    PRESET_NIGHT: VmcMode.NIGHT,
+    PRESET_FREE_COOLING: VmcMode.FREE_COOLING,
+}
+MODE_TO_PRESET: dict[VmcMode, str] = {
+    mode: preset for preset, mode in PRESET_TO_MODE.items()
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HeltyCloudConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the fan of every VMC on the account."""
+    async_add_entities(HeltyCloudFan(coordinator) for coordinator in entry.runtime_data)
+
+
+class HeltyCloudFan(HeltyCloudEntity, FanEntity):
+    """The ventilation unit's fan, the device's primary feature."""
+
+    _attr_name = None
+    _attr_translation_key = "ventilation"
+    _attr_speed_count = len(ORDERED_SPEEDS)
+    _attr_supported_features = (
+        FanEntityFeature.SET_SPEED
+        | FanEntityFeature.PRESET_MODE
+        | FanEntityFeature.TURN_ON
+        | FanEntityFeature.TURN_OFF
+    )
+
+    def __init__(self, coordinator: HeltyCloudDataUpdateCoordinator) -> None:
+        """Initialize the fan."""
+        super().__init__(coordinator)
+        self._attr_unique_id = coordinator.device.serial_number
+        self._attr_preset_modes = list(PRESET_TO_MODE)
+
+    @property
+    def _mode(self) -> VmcMode:
+        return self.coordinator.data.mode
+
+    @property
+    @override
+    def is_on(self) -> bool:
+        """Return whether the fan is running."""
+        return self._mode is not VmcMode.OFF
+
+    @property
+    @override
+    def percentage(self) -> int | None:
+        """Return the current speed as a percentage, or None when on a preset."""
+        if self._mode in ORDERED_SPEEDS:
+            return ordered_list_item_to_percentage(ORDERED_SPEEDS, self._mode)
+        return None
+
+    @property
+    @override
+    def preset_mode(self) -> str | None:
+        """Return the active preset, or None when running on a discrete speed."""
+        return MODE_TO_PRESET.get(self._mode)
+
+    @override
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set a discrete fan speed from a percentage."""
+        if percentage == 0:
+            await self._async_set_mode(VmcMode.OFF)
+            return
+        await self._async_set_mode(
+            percentage_to_ordered_list_item(ORDERED_SPEEDS, percentage)
+        )
+
+    @override
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set a preset mode."""
+        await self._async_set_mode(PRESET_TO_MODE[preset_mode])
+
+    @override
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn the fan on."""
+        if preset_mode is not None:
+            await self.async_set_preset_mode(preset_mode)
+        elif percentage is not None:
+            await self.async_set_percentage(percentage)
+        else:
+            await self._async_set_mode(VmcMode.SPEED_1)
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the fan off."""
+        await self._async_set_mode(VmcMode.OFF)
+
+    async def _async_set_mode(self, mode: VmcMode) -> None:
+        """Set the mode and confirm the panel applied it.
+
+        The cloud takes a command and answers before the panel has acted on
+        it, and only ever serves the last message the panel sent, so the new
+        mode is not visible until the panel reports again: the read back
+        prompts it, and takes about three seconds. A command can be lost on
+        the way, and reading alone cannot tell that apart from a panel that
+        has not reported yet, so the mode is compared and sent once more
+        before giving up.
+        """
+        device = self.coordinator.device
+        try:
+            state = await self.coordinator.client.set_mode_verified(
+                device, mode, attempts=SET_MODE_ATTEMPTS
+            )
+        except HeltyCloudError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_fan_mode_failed",
+            ) from err
+        self.coordinator.async_set_updated_data(state)

--- a/homeassistant/components/helty_cloud/manifest.json
+++ b/homeassistant/components/helty_cloud/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "helty_cloud",
+  "name": "Helty Flow Cloud",
+  "codeowners": ["@ebaschiera"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/helty_cloud",
+  "integration_type": "hub",
+  "iot_class": "cloud_polling",
+  "loggers": ["pyheltycloud"],
+  "quality_scale": "bronze",
+  "requirements": ["pyheltycloud==0.1.0"]
+}

--- a/homeassistant/components/helty_cloud/quality_scale.yaml
+++ b/homeassistant/components/helty_cloud/quality_scale.yaml
@@ -1,0 +1,92 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: This integration does not provide additional actions.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: This integration does not provide additional actions.
+  docs-conditions:
+    status: exempt
+    comment: This integration does not have any conditions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: This integration does not have any triggers.
+  entity-event-setup:
+    status: exempt
+    comment: The cloud offers no event channel; the integration polls.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: This integration has no options to configure.
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: done
+  reauthentication-flow: done
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: The integration talks to a cloud service, not to a network device.
+  discovery:
+    status: exempt
+    comment: The panel exposes no local service to discover.
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: todo
+  entity-category:
+    status: exempt
+    comment: The fan is the primary entity of the device.
+  entity-device-class:
+    status: exempt
+    comment: The fan platform has no device classes.
+  entity-disabled-by-default:
+    status: exempt
+    comment: The only entity is the primary feature of the device.
+  entity-translations: done
+  exception-translations: done
+  icon-translations:
+    status: exempt
+    comment: The fan entity uses the default fan icon.
+  reconfiguration-flow:
+    status: exempt
+    comment: |
+      The account is identified by its email address; changing it means a
+      different account, which is a new config entry.
+  repair-issues:
+    status: exempt
+    comment: This integration has no repairable issues to surface.
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: done

--- a/homeassistant/components/helty_cloud/strings.json
+++ b/homeassistant/components/helty_cloud/strings.json
@@ -1,0 +1,63 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+    },
+    "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "password": "The current password of the Helty Home account {email}."
+        },
+        "title": "[%key:common::config_flow::title::reauth%]"
+      },
+      "user": {
+        "data": {
+          "email": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "data_description": {
+          "email": "The email address of your Helty Home account.",
+          "password": "The password of your Helty Home account."
+        },
+        "title": "Connect to your Helty Home account"
+      }
+    }
+  },
+  "entity": {
+    "fan": {
+      "ventilation": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "boost": "Boost",
+              "free_cooling": "Free cooling",
+              "night": "Night"
+            }
+          }
+        }
+      }
+    }
+  },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "Error talking to the Helty cloud: {error}"
+    },
+    "invalid_auth": {
+      "message": "The Helty cloud rejected the credentials of this account."
+    },
+    "set_fan_mode_failed": {
+      "message": "Failed to set the ventilation mode."
+    },
+    "update_failed": {
+      "message": "Error reading the state from the Helty cloud: {error}"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -319,6 +319,7 @@ FLOWS = {
         "hdfury",
         "hegel",
         "helty",
+        "helty_cloud",
         "heos",
         "here_travel_time",
         "hikvision",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -2940,6 +2940,12 @@
       "config_flow": true,
       "iot_class": "local_polling"
     },
+    "helty_cloud": {
+      "name": "Helty Flow Cloud",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "here_travel_time": {
       "name": "HERE Travel Time",
       "integration_type": "service",

--- a/mypy.ini
+++ b/mypy.ini
@@ -2388,6 +2388,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.helty_cloud.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.heos.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2282,6 +2282,9 @@ pyhaversion==22.8.0
 # homeassistant.components.helty
 pyhelty==0.2.0
 
+# homeassistant.components.helty_cloud
+pyheltycloud==0.1.0
+
 # homeassistant.components.heos
 pyheos==1.0.6
 

--- a/tests/components/helty_cloud/__init__.py
+++ b/tests/components/helty_cloud/__init__.py
@@ -1,0 +1,12 @@
+"""Tests for the Helty Flow Cloud integration."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+    """Set up the Helty Flow Cloud integration in Home Assistant."""
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/helty_cloud/conftest.py
+++ b/tests/components/helty_cloud/conftest.py
@@ -1,0 +1,94 @@
+"""Common fixtures for the Helty Flow Cloud tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+from pyheltycloud import HeltyDevice, HeltyState, VmcMode
+import pytest
+
+from homeassistant.components.helty_cloud.const import DOMAIN
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.util import dt as dt_util
+
+from tests.common import MockConfigEntry
+
+EMAIL = "user@example.com"
+PASSWORD = "hunter2"
+DEVICE_NAME = "VMC Soggiorno"
+SERIAL = "64000175853003"
+BOARD_SERIAL = "DCB4D9A8C966"
+
+DEVICE = HeltyDevice(
+    serial_number=SERIAL,
+    board_serial=BOARD_SERIAL,
+    name=DEVICE_NAME,
+    model="1VMC01012B FlowPLUS",
+    firmware="1.2.3",
+)
+
+
+def make_state(mode: VmcMode = VmcMode.SPEED_1) -> HeltyState:
+    """Build a representative state, reported just now."""
+    return HeltyState(
+        mode=mode,
+        temperature_indoor=30.8,
+        temperature_outdoor=37.4,
+        humidity=38.5,
+        fan_supply=17,
+        fan_exhaust=15,
+        alarms="0000000000000000",
+        timestamp=int(dt_util.utcnow().timestamp() * 1000),
+    )
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.helty_cloud.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_helty_cloud() -> Generator[AsyncMock]:
+    """Mock the cloud client at both the integration and config flow import sites."""
+    with (
+        patch(
+            "homeassistant.components.helty_cloud.HeltyCloud",
+            autospec=True,
+        ) as mock_client,
+        patch(
+            "homeassistant.components.helty_cloud.config_flow.HeltyCloud",
+            new=mock_client,
+        ),
+    ):
+        # The panel keeps the mode it was last told, so a read back after a
+        # command reflects it, as the real one does.
+        panel = {"mode": VmcMode.SPEED_1}
+
+        async def set_mode_verified(
+            device: HeltyDevice, mode: VmcMode, attempts: int = 3
+        ) -> HeltyState:
+            panel["mode"] = mode
+            return make_state(mode)
+
+        client = mock_client.return_value
+        client.get_devices.return_value = [DEVICE]
+        client.set_mode_verified.side_effect = set_mode_verified
+        # Polls read; only the confirmation after a command wakes the panel.
+        client.get_last_telemetry.side_effect = lambda serial: make_state(panel["mode"])
+        yield client
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a configured Helty Flow Cloud entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=EMAIL,
+        data={CONF_EMAIL: EMAIL, CONF_PASSWORD: PASSWORD},
+        unique_id=EMAIL,
+        entry_id="01HHHHHHHHHHHHHHHHHHHHHHHH",
+    )

--- a/tests/components/helty_cloud/snapshots/test_fan.ambr
+++ b/tests/components/helty_cloud/snapshots/test_fan.ambr
@@ -1,0 +1,66 @@
+# serializer version: 1
+# name: test_all_entities[fan.vmc_soggiorno-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'boost',
+        'night',
+        'free_cooling',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'fan',
+    'entity_category': None,
+    'entity_id': 'fan.vmc_soggiorno',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'helty_cloud',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <FanEntityFeature: 57>,
+    'translation_key': 'ventilation',
+    'unique_id': '64000175853003',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[fan.vmc_soggiorno-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'VMC Soggiorno',
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 25,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 25.0,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: None,
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'boost',
+        'night',
+        'free_cooling',
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <FanEntityFeature: 57>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.vmc_soggiorno',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/helty_cloud/test_config_flow.py
+++ b/tests/components/helty_cloud/test_config_flow.py
@@ -1,0 +1,119 @@
+"""Test the Helty Flow Cloud config flow."""
+
+from unittest.mock import AsyncMock
+
+from pyheltycloud import HeltyCloudAuthError, HeltyCloudConnectionError
+import pytest
+
+from homeassistant.components.helty_cloud.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import EMAIL, PASSWORD
+
+from tests.common import MockConfigEntry
+
+USER_INPUT = {CONF_EMAIL: EMAIL, CONF_PASSWORD: PASSWORD}
+
+
+async def test_full_flow(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test the happy path of the user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == EMAIL
+    assert result["data"] == USER_INPUT
+    assert result["result"].unique_id == EMAIL
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error"),
+    [
+        (HeltyCloudAuthError, "invalid_auth"),
+        (HeltyCloudConnectionError, "cannot_connect"),
+    ],
+)
+async def test_flow_errors_and_recovery(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    side_effect: type[Exception],
+    error: str,
+) -> None:
+    """Test the flow shows the error and recovers once the cloud answers."""
+    mock_helty_cloud.get_devices.side_effect = side_effect
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+    mock_helty_cloud.get_devices.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_duplicate_account(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the same account cannot be added twice."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_reauth(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the reauth flow updates the password of the existing entry."""
+    mock_config_entry.add_to_hass(hass)
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    mock_helty_cloud.get_devices.side_effect = HeltyCloudAuthError
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_PASSWORD: "wrong"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    mock_helty_cloud.get_devices.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_PASSWORD: "new-password"}
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data[CONF_PASSWORD] == "new-password"
+    assert mock_config_entry.data[CONF_EMAIL] == EMAIL

--- a/tests/components/helty_cloud/test_fan.py
+++ b/tests/components/helty_cloud/test_fan.py
@@ -1,0 +1,171 @@
+"""Test the Helty Flow Cloud fan platform."""
+
+from unittest.mock import AsyncMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+from pyheltycloud import (
+    HeltyCloudConnectionError,
+    HeltyCloudError,
+    HeltyCloudNoDataError,
+    VmcMode,
+)
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.fan import (
+    ATTR_PERCENTAGE,
+    ATTR_PRESET_MODE,
+    DOMAIN as FAN_DOMAIN,
+    SERVICE_SET_PERCENTAGE,
+    SERVICE_SET_PRESET_MODE,
+)
+from homeassistant.components.helty_cloud.const import SCAN_INTERVAL
+from homeassistant.components.helty_cloud.fan import SET_MODE_ATTEMPTS
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+from .conftest import DEVICE, make_state
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+FAN_ENTITY = "fan.vmc_soggiorno"
+
+
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_helty_cloud: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all entities."""
+    with patch(
+        "homeassistant.components.helty_cloud.PLATFORMS",
+        [Platform.FAN],
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_preset_state(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the fan reports an active preset instead of a percentage."""
+    mock_helty_cloud.get_last_telemetry.side_effect = lambda serial: make_state(
+        VmcMode.NIGHT
+    )
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(FAN_ENTITY)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_PRESET_MODE] == "night"
+    assert state.attributes[ATTR_PERCENTAGE] is None
+
+
+@pytest.mark.parametrize(
+    ("service", "service_data", "expected_mode", "expected_state"),
+    [
+        (SERVICE_TURN_ON, {}, VmcMode.SPEED_1, STATE_ON),
+        (SERVICE_TURN_OFF, {}, VmcMode.OFF, STATE_OFF),
+        (SERVICE_TURN_ON, {ATTR_PERCENTAGE: 100}, VmcMode.SPEED_4, STATE_ON),
+        (
+            SERVICE_TURN_ON,
+            {ATTR_PRESET_MODE: "boost"},
+            VmcMode.HYPERVENTILATION,
+            STATE_ON,
+        ),
+        (SERVICE_SET_PERCENTAGE, {ATTR_PERCENTAGE: 50}, VmcMode.SPEED_2, STATE_ON),
+        (SERVICE_SET_PERCENTAGE, {ATTR_PERCENTAGE: 0}, VmcMode.OFF, STATE_OFF),
+        (
+            SERVICE_SET_PRESET_MODE,
+            {ATTR_PRESET_MODE: "free_cooling"},
+            VmcMode.FREE_COOLING,
+            STATE_ON,
+        ),
+    ],
+)
+async def test_set_mode(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    service: str,
+    service_data: dict[str, object],
+    expected_mode: VmcMode,
+    expected_state: str,
+) -> None:
+    """Test every service call reaches the cloud and updates the state."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: FAN_ENTITY, **service_data},
+        blocking=True,
+    )
+
+    mock_helty_cloud.set_mode_verified.assert_awaited_once_with(
+        DEVICE, expected_mode, attempts=SET_MODE_ATTEMPTS
+    )
+    assert hass.states.get(FAN_ENTITY).state == expected_state
+
+
+async def test_set_mode_failure(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a command the panel never applied surfaces as an error."""
+    await setup_integration(hass, mock_config_entry)
+    mock_helty_cloud.set_mode_verified.side_effect = HeltyCloudError
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: FAN_ENTITY},
+            blocking=True,
+        )
+
+
+async def test_silent_panel_is_unavailable(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a panel that has not reported does not show a state at all."""
+    mock_helty_cloud.get_last_telemetry.side_effect = HeltyCloudNoDataError
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get(FAN_ENTITY).state == STATE_UNAVAILABLE
+
+
+async def test_unavailable_when_the_poll_fails(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a cloud that stops answering makes the entity unavailable."""
+    await setup_integration(hass, mock_config_entry)
+    assert hass.states.get(FAN_ENTITY).state == STATE_ON
+
+    mock_helty_cloud.get_last_telemetry.side_effect = HeltyCloudConnectionError
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(FAN_ENTITY).state == STATE_UNAVAILABLE

--- a/tests/components/helty_cloud/test_init.py
+++ b/tests/components/helty_cloud/test_init.py
@@ -1,0 +1,93 @@
+"""Test the Helty Flow Cloud setup."""
+
+from unittest.mock import AsyncMock
+
+from pyheltycloud import (
+    HeltyCloudAuthError,
+    HeltyCloudConnectionError,
+    HeltyCloudNoDataError,
+)
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_and_unload(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a config entry sets up and tears down cleanly."""
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_setup_connection_error(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a cloud error during setup leads to a retry."""
+    mock_helty_cloud.get_devices.side_effect = HeltyCloudConnectionError
+
+    mock_config_entry.add_to_hass(hass)
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_auth_error_starts_reauth(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test rejected credentials ask the user to authenticate again."""
+    mock_helty_cloud.get_devices.side_effect = HeltyCloudAuthError
+
+    mock_config_entry.add_to_hass(hass)
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == "reauth"
+
+
+@pytest.mark.parametrize("error", [HeltyCloudNoDataError, HeltyCloudConnectionError])
+async def test_a_unit_with_nothing_to_read_still_loads(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    error: type[Exception],
+) -> None:
+    """Test one unreadable unit does not hold back the rest of the account."""
+    mock_helty_cloud.get_last_telemetry.side_effect = error
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_expired_session_on_poll_starts_reauth(
+    hass: HomeAssistant,
+    mock_helty_cloud: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test credentials rejected while reading ask the user to authenticate again."""
+    mock_helty_cloud.get_last_telemetry.side_effect = HeltyCloudAuthError
+
+    await setup_integration(hass, mock_config_entry)
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == "reauth"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Adds `helty_cloud`, a new integration for [Helty](https://www.heltyair.com/) Flow ventilation units, with the fan platform.

Home Assistant already has [`helty`](https://www.home-assistant.io/integrations/helty/), which speaks the local TCP protocol of the older control panels. The panels Helty ships now expose no listening port at all: they hold an outbound connection to the manufacturer's cloud, and that is the only way to reach them. So this is the same brand and the same appliance, but a different transport, different credentials (an account, not an IP address) and a different set of readable values, which is why it is a separate integration rather than a second connection mode inside `helty`. Owners of the older panels keep using `helty` and are unaffected.

The unit is exposed as a fan: four discrete speeds mapped to percentages, plus three presets (boost, night, free cooling) for the modes that are not a speed.

Two things about the cloud shaped the design, both confirmed by the manufacturer:

- Reading and prompting are different operations. A poll reads the last message the panel pushed; it does not reach the panel and does not wake it. The manufacturer asked not to solicit the panel on a timer, so the coordinator only reads, at 5 minutes, which is roughly the panel's own reporting rhythm. The one solicit is after a command, to confirm the new mode.
- Because the cloud answers with the last stored message whether or not the panel is still alive, a poll always succeeds. Entities therefore go unavailable on the age of that message rather than on a request failing.

Only the fan is in this PR. Sensors will follow separately.

The dependency, `pyheltycloud`, is new and written for this integration. The cloud API is undocumented; the client was reconstructed by observing the app and one unit's traffic, then checked against written answers from the manufacturer. Where something is inferred rather than confirmed, the library says so.

- Library: https://github.com/ebaschiera/pyheltycloud
- Release notes for 0.1.0: https://github.com/ebaschiera/pyheltycloud/releases/tag/v0.1.0
- First release, so there is no version diff to link.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47901
- Link to brands pull request: https://github.com/home-assistant/brands/pull/11105
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
