### PR TITLE
Add Tesla Fleet Energy Site read-only profile

### DIFF
--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -1,6 +1,6 @@
 """Tesla Fleet integration."""
 
-from typing import Final
+from typing import Final, cast
 
 import jwt
 from tesla_fleet_api import TeslaFleetApi, is_valid_region
@@ -13,7 +13,7 @@ from tesla_fleet_api.exceptions import (
     OAuthExpired,
     TeslaFleetError,
 )
-from tesla_fleet_api.tesla import VehicleFleet
+from tesla_fleet_api.tesla import EnergySite, VehicleFleet
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
@@ -32,7 +32,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 )
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from .const import DOMAIN, LOGGER
+from .const import CONF_AUTHORIZATION_PROFILE, DOMAIN, LOGGER, AuthorizationProfile
 from .coordinator import (
     TeslaFleetEnergySiteHistoryCoordinator,
     TeslaFleetEnergySiteInfoCoordinator,
@@ -40,7 +40,13 @@ from .coordinator import (
     TeslaFleetVehicleDataCoordinator,
     _stale_site_info_error,
 )
-from .models import TeslaFleetData, TeslaFleetEnergyData, TeslaFleetVehicleData
+from .models import (
+    TeslaFleetData,
+    TeslaFleetEnergyData,
+    TeslaFleetEnergySiteReadOnly,
+    TeslaFleetVehicleData,
+)
+from .oauth import has_exact_energy_site_read_only_scopes
 
 PLATFORMS: Final = [
     Platform.BINARY_SENSOR,
@@ -55,6 +61,11 @@ PLATFORMS: Final = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.UPDATE,
+]
+
+ENERGY_SITE_READ_ONLY_PLATFORMS: Final = [
+    Platform.BINARY_SENSOR,
+    Platform.SENSOR,
 ]
 
 type TeslaFleetConfigEntry = ConfigEntry[TeslaFleetData]
@@ -121,14 +132,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
     session = async_get_clientsession(hass)
 
     token = jwt.decode(access_token, options={"verify_signature": False})
+    try:
+        authorization_profile = AuthorizationProfile(
+            entry.data.get(CONF_AUTHORIZATION_PROFILE, AuthorizationProfile.STANDARD)
+        )
+    except (TypeError, ValueError) as err:
+        raise ConfigEntryAuthFailed(
+            "Invalid Tesla Fleet authorization profile"
+        ) from err
+    energy_site_read_only = (
+        authorization_profile is AuthorizationProfile.ENERGY_SITE_READ_ONLY
+    )
+    if energy_site_read_only and not has_exact_energy_site_read_only_scopes(
+        token.get("scp")
+    ):
+        raise ConfigEntryAuthFailed(
+            "Tesla Fleet Energy Site read-only token scope validation failed"
+        )
     scopes: list[Scope] = [Scope(s) for s in token["scp"]]
     region_code = token["ou_code"].lower()
     region = region_code if is_valid_region(region_code) else None
 
     async def _get_access_token() -> str:
         await oauth_session.async_ensure_token_valid()
-        token: str = oauth_session.token[CONF_ACCESS_TOKEN]
-        return token
+        current_access_token: str = oauth_session.token[CONF_ACCESS_TOKEN]
+        if energy_site_read_only:
+            current_token = jwt.decode(
+                current_access_token, options={"verify_signature": False}
+            )
+            if not has_exact_energy_site_read_only_scopes(current_token.get("scp")):
+                raise ConfigEntryAuthFailed(
+                    "Tesla Fleet Energy Site read-only token scope validation failed"
+                )
+        return current_access_token
 
     # Create API connection
     tesla = TeslaFleetApi(
@@ -138,7 +174,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
         charging_scope=False,
         partner_scope=False,
         energy_scope=Scope.ENERGY_DEVICE_DATA in scopes,
-        vehicle_scope=Scope.VEHICLE_DEVICE_DATA in scopes,
+        vehicle_scope=(
+            not energy_site_read_only and Scope.VEHICLE_DEVICE_DATA in scopes
+        ),
     )
     products = await _async_get_products(tesla)
 
@@ -148,7 +186,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
     vehicles: list[TeslaFleetVehicleData] = []
     energysites: list[TeslaFleetEnergyData] = []
     for product in products:
-        if "vin" in product and Scope.VEHICLE_DEVICE_DATA in scopes:
+        if (
+            not energy_site_read_only
+            and "vin" in product
+            and Scope.VEHICLE_DEVICE_DATA in scopes
+        ):
             # Remove the protobuff 'cached_data' that we do not use to save memory
             product.pop("cached_data", None)
             vin = product["vin"]
@@ -196,7 +238,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
                 )
                 continue
 
-            api_energy = tesla.energySites.create(site_id)
+            api_energy_raw = tesla.energySites.create(site_id)
+            api_energy = (
+                cast(EnergySite, TeslaFleetEnergySiteReadOnly(api_energy_raw))
+                if energy_site_read_only
+                else api_energy_raw
+            )
             info_coordinator = TeslaFleetEnergySiteInfoCoordinator(
                 hass, entry, api_energy, product
             )
@@ -262,10 +309,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
 
     # Setup Platforms
     entry.runtime_data = TeslaFleetData(vehicles, energysites, scopes)
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(
+        entry,
+        ENERGY_SITE_READ_ONLY_PLATFORMS if energy_site_read_only else PLATFORMS,
+    )
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -> bool:
     """Unload TeslaFleet Config."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    authorization_profile = AuthorizationProfile(
+        entry.data.get(CONF_AUTHORIZATION_PROFILE, AuthorizationProfile.STANDARD)
+    )
+    return await hass.config_entries.async_unload_platforms(
+        entry,
+        ENERGY_SITE_READ_ONLY_PLATFORMS
+        if authorization_profile is AuthorizationProfile.ENERGY_SITE_READ_ONLY
+        else PLATFORMS,
+    )

--- a/homeassistant/components/tesla_fleet/config_flow.py
+++ b/homeassistant/components/tesla_fleet/config_flow.py
@@ -30,8 +30,16 @@ from homeassistant.helpers.selector import (
     SelectSelectorMode,
 )
 
-from .const import DOMAIN, LOGGER, REGION_SERVERS, REGIONS
-from .oauth import TeslaUserImplementation
+from .const import (
+    AUTHORIZATION_PROFILE_SCOPES,
+    CONF_AUTHORIZATION_PROFILE,
+    DOMAIN,
+    LOGGER,
+    REGION_SERVERS,
+    REGIONS,
+    AuthorizationProfile,
+)
+from .oauth import TeslaUserImplementation, has_exact_energy_site_read_only_scopes
 
 
 class OAuth2FlowHandler(
@@ -49,6 +57,16 @@ class OAuth2FlowHandler(
         self.uid: str | None = None
         self.region: str = REGIONS[0]
         self.api: TeslaFleetApi | None = None
+        self.authorization_profile: AuthorizationProfile | None = None
+
+    @property
+    @override
+    def extra_authorize_data(self) -> dict[str, Any]:
+        """Set the scopes selected for this authorization flow."""
+        assert self.authorization_profile is not None
+        return {
+            "scope": " ".join(AUTHORIZATION_PROFILE_SCOPES[self.authorization_profile])
+        }
 
     @property
     @override
@@ -66,14 +84,22 @@ class OAuth2FlowHandler(
             data["token"]["access_token"], options={"verify_signature": False}
         )
 
-        self.data = data
+        assert self.authorization_profile is not None
+        if self.authorization_profile is AuthorizationProfile.ENERGY_SITE_READ_ONLY:
+            if not has_exact_energy_site_read_only_scopes(token.get("scp")):
+                return self.async_abort(reason="invalid_energy_site_read_only_scopes")
+
+        self.data = {
+            **data,
+            CONF_AUTHORIZATION_PROFILE: self.authorization_profile,
+        }
         self.uid = token["sub"]
 
         await self.async_set_unique_id(self.uid)
         if self.source == SOURCE_REAUTH:
             self._abort_if_unique_id_mismatch(reason="reauth_account_mismatch")
             return self.async_update_reload_and_abort(
-                self._get_reauth_entry(), data=data
+                self._get_reauth_entry(), data=self.data
             )
         self._abort_if_unique_id_configured()
 
@@ -215,6 +241,9 @@ class OAuth2FlowHandler(
         ):
             errors["base"] = "public_key_mismatch"
         else:
+            if self.authorization_profile is AuthorizationProfile.ENERGY_SITE_READ_ONLY:
+                assert self.uid
+                return self.async_create_entry(title=self.uid, data=self.data)
             return await self.async_step_registration_complete()
 
         return self.async_show_form(
@@ -258,6 +287,14 @@ class OAuth2FlowHandler(
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Perform reauth upon an API authentication error."""
+        try:
+            self.authorization_profile = AuthorizationProfile(
+                entry_data.get(
+                    CONF_AUTHORIZATION_PROFILE, AuthorizationProfile.STANDARD
+                )
+            )
+        except TypeError, ValueError:
+            return self.async_abort(reason="invalid_authorization_profile")
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
@@ -271,6 +308,35 @@ class OAuth2FlowHandler(
             )
         # For reauth, skip domain registration and go straight to OAuth
         return await super().async_step_user()
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Select an authorization profile before starting OAuth."""
+        if user_input is not None:
+            self.authorization_profile = AuthorizationProfile(
+                user_input[CONF_AUTHORIZATION_PROFILE]
+            )
+            return await super().async_step_user()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_AUTHORIZATION_PROFILE,
+                        default=AuthorizationProfile.STANDARD,
+                    ): SelectSelector(
+                        SelectSelectorConfig(
+                            options=list(AuthorizationProfile),
+                            translation_key="authorization_profile",
+                            mode=SelectSelectorMode.LIST,
+                        )
+                    )
+                }
+            ),
+        )
 
     def _is_valid_domain(self, domain: str) -> bool:
         """Validate domain format."""

--- a/homeassistant/components/tesla_fleet/const.py
+++ b/homeassistant/components/tesla_fleet/const.py
@@ -8,6 +8,7 @@ from tesla_fleet_api.const import SERVERS, Scope
 DOMAIN = "tesla_fleet"
 
 CONF_REFRESH_TOKEN = "refresh_token"
+CONF_AUTHORIZATION_PROFILE = "authorization_profile"
 
 # Regions the user can register in; China uses separate infrastructure.
 REGION_SERVERS: dict[str, str] = {
@@ -20,6 +21,14 @@ LOGGER = logging.getLogger(__package__)
 AUTHORIZE_URL = "https://fleet-auth.prd.vn.cloud.tesla.com/oauth2/v3/authorize"
 TOKEN_URL = "https://fleet-auth.prd.vn.cloud.tesla.com/oauth2/v3/token"
 
+
+class AuthorizationProfile(StrEnum):
+    """Tesla Fleet authorization profiles."""
+
+    STANDARD = "standard"
+    ENERGY_SITE_READ_ONLY = "energy_site_read_only"
+
+
 SCOPES = [
     Scope.OPENID,
     Scope.OFFLINE_ACCESS,
@@ -30,6 +39,17 @@ SCOPES = [
     Scope.ENERGY_DEVICE_DATA,
     Scope.ENERGY_CMDS,
 ]
+
+ENERGY_SITE_READ_ONLY_SCOPES = (
+    Scope.OPENID,
+    Scope.OFFLINE_ACCESS,
+    Scope.ENERGY_DEVICE_DATA,
+)
+
+AUTHORIZATION_PROFILE_SCOPES = {
+    AuthorizationProfile.STANDARD: SCOPES,
+    AuthorizationProfile.ENERGY_SITE_READ_ONLY: ENERGY_SITE_READ_ONLY_SCOPES,
+}
 
 ENERGY_HISTORY_FIELDS = [
     "solar_energy_exported",

--- a/homeassistant/components/tesla_fleet/models.py
+++ b/homeassistant/components/tesla_fleet/models.py
@@ -1,9 +1,11 @@
 """The Tesla Fleet integration models."""
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from typing import Any
 
-from tesla_fleet_api.const import Scope
+from tesla_fleet_api.const import Scope, TeslaEnergyPeriod
 from tesla_fleet_api.tesla import EnergySite, VehicleFleet
 
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -14,6 +16,50 @@ from .coordinator import (
     TeslaFleetEnergySiteLiveCoordinator,
     TeslaFleetVehicleDataCoordinator,
 )
+
+
+class TeslaFleetEnergySiteReadOnly:
+    """Expose only Energy Site operations needed for read-only telemetry."""
+
+    __slots__ = (
+        "__energy_history",
+        "__live_status",
+        "__site_info",
+        "energy_site_id",
+    )
+
+    def __init__(self, api: EnergySite) -> None:
+        """Initialize a read-only facade around an Energy Site client."""
+        self.energy_site_id = api.energy_site_id
+        self.__energy_history: Callable[
+            [
+                TeslaEnergyPeriod | str | None,
+                str | None,
+                str | None,
+                str | None,
+            ],
+            Awaitable[dict[str, Any]],
+        ] = api.energy_history
+        self.__live_status: Callable[[], Awaitable[dict[str, Any]]] = api.live_status
+        self.__site_info: Callable[[], Awaitable[dict[str, Any]]] = api.site_info
+
+    async def energy_history(
+        self,
+        period: TeslaEnergyPeriod | str | None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        time_zone: str | None = None,
+    ) -> dict[str, Any]:
+        """Return Energy Site history."""
+        return await self.__energy_history(period, start_date, end_date, time_zone)
+
+    async def live_status(self) -> dict[str, Any]:
+        """Return Energy Site live status."""
+        return await self.__live_status()
+
+    async def site_info(self) -> dict[str, Any]:
+        """Return Energy Site information."""
+        return await self.__site_info()
 
 
 @dataclass

--- a/homeassistant/components/tesla_fleet/oauth.py
+++ b/homeassistant/components/tesla_fleet/oauth.py
@@ -9,7 +9,29 @@ from homeassistant.components.application_credentials import (
 )
 from homeassistant.core import HomeAssistant
 
-from .const import AUTHORIZE_URL, SCOPES, TOKEN_URL
+from .const import (
+    AUTHORIZATION_PROFILE_SCOPES,
+    AUTHORIZE_URL,
+    SCOPES,
+    TOKEN_URL,
+    AuthorizationProfile,
+)
+
+
+def has_exact_energy_site_read_only_scopes(scopes: Any) -> bool:
+    """Return whether the effective token has exactly the read-only scopes."""
+    return (
+        isinstance(scopes, list)
+        and all(isinstance(scope, str) for scope in scopes)
+        and len(scopes) == len(set(scopes))
+        and set(scopes)
+        == {
+            str(scope)
+            for scope in AUTHORIZATION_PROFILE_SCOPES[
+                AuthorizationProfile.ENERGY_SITE_READ_ONLY
+            ]
+        }
+    )
 
 
 class TeslaUserImplementation(AuthImplementation):

--- a/homeassistant/components/tesla_fleet/strings.json
+++ b/homeassistant/components/tesla_fleet/strings.json
@@ -2,6 +2,8 @@
   "config": {
     "abort": {
       "already_configured": "Configuration updated for profile.",
+      "invalid_authorization_profile": "The stored Tesla authorization profile is invalid.",
+      "invalid_energy_site_read_only_scopes": "Tesla did not grant exactly the scopes required by the Energy Site read-only profile. No integration entry was created.",
       "missing_configuration": "[%key:common::config_flow::abort::oauth2_missing_configuration%]",
       "reauth_account_mismatch": "The reauthentication account does not match the original account",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
@@ -43,7 +45,7 @@
         "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
       },
       "reauth_confirm": {
-        "description": "The {name} integration needs to re-authenticate your account. Reauthentication refreshes the Tesla API permissions granted to Home Assistant, including any newly enabled scopes.",
+        "description": "The {name} integration needs to re-authenticate your account. Reauthentication refreshes the Tesla API permissions granted to Home Assistant. The selected authorization profile is retained.",
         "title": "[%key:common::config_flow::title::reauth%]"
       },
       "region": {
@@ -64,6 +66,16 @@
         },
         "description": "To enable command signing, you must open the Tesla app, select your vehicle, and then visit the following URL to set up a virtual key. You must repeat this process for each vehicle.\n\n{virtual_key_url}\n\nIf you later enable additional Tesla API permissions, reauthenticate the integration to refresh the granted scopes.",
         "title": "Command signing"
+      },
+      "user": {
+        "data": {
+          "authorization_profile": "Authorization profile"
+        },
+        "data_description": {
+          "authorization_profile": "Choose the Tesla products and operations Home Assistant will request access to."
+        },
+        "description": "The **Standard** profile supports vehicles and energy sites, including commands and settings. The **Energy Site read-only** profile requests Energy telemetry only. It cannot access vehicles or change Energy settings.",
+        "title": "Choose Tesla authorization profile"
       }
     }
   },
@@ -646,6 +658,12 @@
     }
   },
   "selector": {
+    "authorization_profile": {
+      "options": {
+        "energy_site_read_only": "Energy Site read-only",
+        "standard": "Standard"
+      }
+    },
     "region": {
       "options": {
         "eu": "Europe, Middle East & Africa",

--- a/tests/components/tesla_fleet/conftest.py
+++ b/tests/components/tesla_fleet/conftest.py
@@ -9,7 +9,13 @@ import jwt
 import pytest
 from tesla_fleet_api.const import Scope
 
-from homeassistant.components.tesla_fleet.const import DOMAIN, SCOPES
+from homeassistant.components.tesla_fleet.const import (
+    CONF_AUTHORIZATION_PROFILE,
+    DOMAIN,
+    ENERGY_SITE_READ_ONLY_SCOPES,
+    SCOPES,
+    AuthorizationProfile,
+)
 
 from .const import (
     COMMAND_OK,
@@ -37,6 +43,7 @@ def create_config_entry(
     scopes: list[Scope],
     implementation: str = DOMAIN,
     region: str = "NA",
+    authorization_profile: AuthorizationProfile | None = None,
 ) -> MockConfigEntry:
     """Create Tesla Fleet entry in Home Assistant."""
     access_token = jwt.encode(
@@ -56,6 +63,11 @@ def create_config_entry(
         unique_id=UID,
         data={
             "auth_implementation": implementation,
+            **(
+                {CONF_AUTHORIZATION_PROFILE: authorization_profile}
+                if authorization_profile is not None
+                else {}
+            ),
             "token": {
                 "status": 0,
                 "userid": UID,
@@ -91,6 +103,16 @@ def readonly_config_entry(expires_at: int) -> MockConfigEntry:
             Scope.VEHICLE_DEVICE_DATA,
             Scope.ENERGY_DEVICE_DATA,
         ],
+    )
+
+
+@pytest.fixture
+def energy_site_read_only_config_entry(expires_at: int) -> MockConfigEntry:
+    """Create a Tesla Fleet Energy Site read-only entry."""
+    return create_config_entry(
+        expires_at,
+        list(ENERGY_SITE_READ_ONLY_SCOPES),
+        authorization_profile=AuthorizationProfile.ENERGY_SITE_READ_ONLY,
     )
 
 

--- a/tests/components/tesla_fleet/test_config_flow.py
+++ b/tests/components/tesla_fleet/test_config_flow.py
@@ -1,10 +1,11 @@
 """Test the Tesla Fleet config flow."""
 
+from collections.abc import Sequence
 from unittest.mock import AsyncMock, Mock, patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-from tesla_fleet_api.const import SERVERS
+from tesla_fleet_api.const import SERVERS, Scope
 from tesla_fleet_api.exceptions import (
     InvalidResponse,
     LoginRequired,
@@ -20,11 +21,14 @@ from homeassistant.components.application_credentials import (
 from homeassistant.components.tesla_fleet.config_flow import OAuth2FlowHandler
 from homeassistant.components.tesla_fleet.const import (
     AUTHORIZE_URL,
+    CONF_AUTHORIZATION_PROFILE,
     DOMAIN,
+    ENERGY_SITE_READ_ONLY_SCOPES,
     SCOPES,
     TOKEN_URL,
+    AuthorizationProfile,
 )
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER, ConfigFlowResult
 from homeassistant.const import CONF_DOMAIN, CONF_REGION
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -37,6 +41,130 @@ from tests.typing import ClientSessionGenerator
 
 REDIRECT = "https://example.com/auth/external/callback"
 UNIQUE_ID = "uid"
+
+
+async def start_user_flow(
+    hass: HomeAssistant,
+    authorization_profile: AuthorizationProfile = AuthorizationProfile.STANDARD,
+) -> ConfigFlowResult:
+    """Start a user flow and select an authorization profile."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    return await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_AUTHORIZATION_PROFILE: authorization_profile},
+    )
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+async def test_energy_site_read_only_authorize_url_has_exact_scopes(
+    hass: HomeAssistant,
+) -> None:
+    """Test Energy Site read-only requests exactly its three scopes."""
+    result = await start_user_flow(hass, AuthorizationProfile.ENERGY_SITE_READ_ONLY)
+
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+    assert result["url"].startswith(AUTHORIZE_URL)
+    requested_scopes = parse_qs(urlparse(result["url"]).query)["scope"][0].split()
+    assert requested_scopes == [str(scope) for scope in ENERGY_SITE_READ_ONLY_SCOPES]
+    assert set(requested_scopes).isdisjoint(
+        {
+            "energy_cmds",
+            "vehicle_device_data",
+            "vehicle_location",
+            "vehicle_cmds",
+            "vehicle_charging_cmds",
+        }
+    )
+
+
+@pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.parametrize(
+    ("scopes", "accepted"),
+    [
+        (["openid", "offline_access", "energy_device_data"], True),
+        (["openid", "offline_access"], False),
+        (["openid", "offline_access", "energy_device_data", "energy_cmds"], False),
+        (
+            ["openid", "offline_access", "energy_device_data", "vehicle_device_data"],
+            False,
+        ),
+        (
+            ["openid", "offline_access", "energy_device_data", "vehicle_location"],
+            False,
+        ),
+        (["openid", "offline_access", "energy_device_data", "vehicle_cmds"], False),
+        (
+            [
+                "openid",
+                "offline_access",
+                "energy_device_data",
+                "vehicle_charging_cmds",
+            ],
+            False,
+        ),
+        (None, False),
+        ("openid offline_access energy_device_data", False),
+        (["openid", "offline_access", "energy_device_data", "openid"], False),
+        (["openid", "offline_access", "energy_device_data", 1], False),
+        (["openid", "offline_access", "energy_device_data", "future_scope"], False),
+    ],
+    ids=[
+        "exact",
+        "missing-energy-device-data",
+        "energy-commands",
+        "vehicle-data",
+        "vehicle-location",
+        "vehicle-commands",
+        "vehicle-charging-commands",
+        "absent",
+        "malformed",
+        "duplicate",
+        "non-string",
+        "unknown",
+    ],
+)
+async def test_energy_site_read_only_effective_token_scopes(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    scopes: object,
+    accepted: bool,
+) -> None:
+    """Test Energy Site read-only token scopes fail closed."""
+    result = await start_user_flow(hass, AuthorizationProfile.ENERGY_SITE_READ_ONLY)
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {"flow_id": result["flow_id"], "redirect_uri": REDIRECT},
+    )
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    claims: dict[str, object] = {"sub": UNIQUE_ID, "aud": [], "ou_code": "NA"}
+    if scopes is not None:
+        claims["scp"] = scopes
+    token = config_entry_oauth2_flow._encode_jwt(hass, claims)
+    aioclient_mock.post(
+        TOKEN_URL,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": token,
+            "type": "Bearer",
+            "expires_in": 60,
+        },
+    )
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    if accepted:
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "region"
+    else:
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "invalid_energy_site_read_only_scopes"
 
 
 @pytest.fixture
@@ -103,9 +231,7 @@ async def test_partner_login_auth_error(
     mock_private_key,
 ) -> None:
     """Test partner login auth errors abort the flow cleanly."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    result = await start_user_flow(hass)
 
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -159,9 +285,7 @@ async def test_region_partner_login_error(
     mock_private_key,
 ) -> None:
     """Test a partner login error keeps the user on the region step."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    result = await start_user_flow(hass)
 
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -234,9 +358,7 @@ async def test_full_flow_with_domain_registration(
     mock_private_key,
 ) -> None:
     """Test full flow with domain registration."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    result = await start_user_flow(hass)
 
     assert result["type"] is FlowResultType.EXTERNAL_STEP
 
@@ -341,6 +463,30 @@ async def test_full_flow_with_domain_registration(
     assert mock_api_class.call_args.kwargs["server"] == SERVERS["na"]
 
 
+async def test_energy_site_read_only_skips_vehicle_key_pairing(
+    hass: HomeAssistant,
+) -> None:
+    """Test Energy Site read-only completes without vehicle key pairing."""
+    flow = OAuth2FlowHandler()
+    flow.hass = hass
+    flow.api = AsyncMock()
+    flow.api.private_key = Mock()
+    flow.api.public_uncompressed_point = "expected-public-key"
+    flow.api.partner.register.return_value = {
+        "response": {"public_key": "expected-public-key"}
+    }
+    flow.domain = "example.com"
+    flow.uid = UNIQUE_ID
+    flow.data = {CONF_AUTHORIZATION_PROFILE: AuthorizationProfile.ENERGY_SITE_READ_ONLY}
+    flow.authorization_profile = AuthorizationProfile.ENERGY_SITE_READ_ONLY
+
+    result = await flow.async_step_domain_registration()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == UNIQUE_ID
+    assert result["data"] == flow.data
+
+
 @pytest.mark.usefixtures("current_request_with_host")
 async def test_domain_input_invalid_domain(
     hass: HomeAssistant,
@@ -350,9 +496,7 @@ async def test_domain_input_invalid_domain(
     mock_private_key,
 ) -> None:
     """Test domain input with invalid domain."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    result = await start_user_flow(hass)
 
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -449,9 +593,7 @@ async def test_domain_registration_errors(
     expected_error,
 ) -> None:
     """Test domain registration with errors that stay on domain_registration step."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    result = await start_user_flow(hass)
 
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -515,9 +657,7 @@ async def test_domain_registration_precondition_failed(
     mock_private_key,
 ) -> None:
     """Test domain registration with PreconditionFailed redirects to domain_input."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    result = await start_user_flow(hass)
 
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -582,9 +722,7 @@ async def test_domain_registration_public_key_not_found(
     mock_private_key,
 ) -> None:
     """Test domain registration with missing public key."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    result = await start_user_flow(hass)
 
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -648,9 +786,7 @@ async def test_domain_registration_public_key_mismatch(
     mock_private_key,
 ) -> None:
     """Test domain registration with public key mismatch."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    result = await start_user_flow(hass)
 
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -716,9 +852,7 @@ async def test_region_override(
     mock_private_key,
 ) -> None:
     """Test overriding the detected region registers using the selected region."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    result = await start_user_flow(hass)
 
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -806,9 +940,7 @@ async def test_region_default_fallback(
         },
     )
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    result = await start_user_flow(hass)
 
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -889,18 +1021,32 @@ async def test_registration_complete_with_domain_no_user_input(
 
 
 @pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.parametrize(
+    ("entry_data", "authorization_profile", "scopes"),
+    [
+        ({}, AuthorizationProfile.STANDARD, SCOPES),
+        (
+            {CONF_AUTHORIZATION_PROFILE: AuthorizationProfile.ENERGY_SITE_READ_ONLY},
+            AuthorizationProfile.ENERGY_SITE_READ_ONLY,
+            ENERGY_SITE_READ_ONLY_SCOPES,
+        ),
+    ],
+    ids=["legacy-standard", "energy-site-read-only"],
+)
 async def test_reauthentication(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
     aioclient_mock: AiohttpClientMocker,
-    access_token: str,
+    entry_data: dict[str, AuthorizationProfile],
+    authorization_profile: AuthorizationProfile,
+    scopes: Sequence[Scope],
 ) -> None:
     """Test Tesla Fleet reauthentication."""
     old_entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id=UNIQUE_ID,
         version=1,
-        data={},
+        data=entry_data,
     )
     old_entry.add_to_hass(hass)
 
@@ -910,6 +1056,8 @@ async def test_reauthentication(
     assert len(flows) == 1
 
     result = await hass.config_entries.flow.async_configure(flows[0]["flow_id"], {})
+    requested_scopes = parse_qs(urlparse(result["url"]).query)["scope"][0].split()
+    assert requested_scopes == [str(scope) for scope in scopes]
 
     state = config_entry_oauth2_flow._encode_jwt(
         hass,
@@ -920,7 +1068,15 @@ async def test_reauthentication(
     )
     client = await hass_client_no_auth()
     await client.get(f"/auth/external/callback?code=abcd&state={state}")
-
+    access_token = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "sub": UNIQUE_ID,
+            "aud": [],
+            "scp": [str(scope) for scope in scopes],
+            "ou_code": "NA",
+        },
+    )
     aioclient_mock.post(
         TOKEN_URL,
         json={
@@ -936,9 +1092,28 @@ async def test_reauthentication(
     ):
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
-    assert result
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
+    assert old_entry.data[CONF_AUTHORIZATION_PROFILE] is authorization_profile
+
+
+@pytest.mark.parametrize("invalid_profile", [None, "invalid", []])
+async def test_reauthentication_rejects_invalid_authorization_profile(
+    hass: HomeAssistant, invalid_profile: object
+) -> None:
+    """Test reauthentication fails closed for an invalid stored profile."""
+    old_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=UNIQUE_ID,
+        version=1,
+        data={CONF_AUTHORIZATION_PROFILE: invalid_profile},
+    )
+    old_entry.add_to_hass(hass)
+
+    result = await old_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "invalid_authorization_profile"
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -1003,9 +1178,7 @@ async def test_duplicate_unique_id_abort(
     )
     existing_entry.add_to_hass(hass)
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
+    result = await start_user_flow(hass)
 
     state = config_entry_oauth2_flow._encode_jwt(
         hass,

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tesla_fleet_api import TeslaFleetApi
 from tesla_fleet_api.const import Scope, VehicleDataEndpoint
 from tesla_fleet_api.exceptions import (
     InternalServerError,
@@ -21,7 +22,13 @@ from tesla_fleet_api.exceptions import (
     VehicleOffline,
 )
 
-from homeassistant.components.tesla_fleet.const import DOMAIN, SCOPES
+from homeassistant.components.tesla_fleet.const import (
+    CONF_AUTHORIZATION_PROFILE,
+    DOMAIN,
+    ENERGY_SITE_READ_ONLY_SCOPES,
+    SCOPES,
+    AuthorizationProfile,
+)
 from homeassistant.components.tesla_fleet.coordinator import (
     ENERGY_HISTORY_INTERVAL,
     ENERGY_INTERVAL,
@@ -37,10 +44,11 @@ from homeassistant.const import CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
     OAuth2TokenRequestReauthError,
     OAuth2TokenRequestTransientError,
 )
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
 )
@@ -79,6 +87,145 @@ async def test_load_unload(
     await hass.async_block_till_done()
     assert normal_config_entry.state is ConfigEntryState.NOT_LOADED
     assert not hasattr(normal_config_entry, "runtime_data")
+
+
+async def test_energy_site_read_only_is_structurally_read_only(
+    hass: HomeAssistant,
+    energy_site_read_only_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    mock_vehicle_state: AsyncMock,
+    mock_vehicle_data: AsyncMock,
+    mock_wake_up: AsyncMock,
+    mock_energy_history: AsyncMock,
+) -> None:
+    """Test the Energy Site read-only profile constructs no command path."""
+    with patch(
+        "homeassistant.components.tesla_fleet.TeslaFleetVehicleDataCoordinator"
+    ) as vehicle_coordinator:
+        await setup_platform(hass, energy_site_read_only_config_entry)
+
+    assert energy_site_read_only_config_entry.state is ConfigEntryState.LOADED
+    assert not energy_site_read_only_config_entry.runtime_data.vehicles
+    assert energy_site_read_only_config_entry.runtime_data.energysites
+    energy_api = energy_site_read_only_config_entry.runtime_data.energysites[0].api
+    for command_method in (
+        "backup",
+        "grid_import_export",
+        "off_grid_vehicle_charging_reserve",
+        "operation",
+        "storm_mode",
+        "time_of_use_settings",
+    ):
+        assert not hasattr(energy_api, command_method)
+    assert energy_site_read_only_config_entry.runtime_data.energysites[
+        0
+    ].history_coordinator
+    vehicle_coordinator.assert_not_called()
+    mock_vehicle_state.assert_not_called()
+    mock_vehicle_data.assert_not_called()
+    mock_wake_up.assert_not_called()
+    mock_energy_history.assert_not_called()
+
+    entries = er.async_entries_for_config_entry(
+        entity_registry, energy_site_read_only_config_entry.entry_id
+    )
+    assert entries
+    assert {entry.domain for entry in entries} <= {"binary_sensor", "sensor"}
+    assert not (
+        {entry.domain for entry in entries}
+        & {
+            "button",
+            "climate",
+            "cover",
+            "device_tracker",
+            "lock",
+            "media_player",
+            "number",
+            "select",
+            "switch",
+            "update",
+        }
+    )
+    assert await hass.config_entries.async_unload(
+        energy_site_read_only_config_entry.entry_id
+    )
+
+
+@pytest.mark.parametrize(
+    "scopes",
+    [
+        [Scope.OPENID, Scope.OFFLINE_ACCESS],
+        [*ENERGY_SITE_READ_ONLY_SCOPES, Scope.ENERGY_CMDS],
+        [*ENERGY_SITE_READ_ONLY_SCOPES, Scope.VEHICLE_DEVICE_DATA],
+    ],
+)
+async def test_energy_site_read_only_setup_rejects_changed_token_scopes(
+    hass: HomeAssistant,
+    expires_at: int,
+    scopes: list[Scope],
+) -> None:
+    """Test setup revalidates effective scopes before constructing clients."""
+    entry = create_config_entry(
+        expires_at,
+        scopes,
+        authorization_profile=AuthorizationProfile.ENERGY_SITE_READ_ONLY,
+    )
+
+    await setup_platform(hass, entry)
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert not hasattr(entry, "runtime_data")
+
+
+async def test_energy_site_read_only_rejects_changed_scopes_on_access_token_get(
+    hass: HomeAssistant,
+    expires_at: int,
+    energy_site_read_only_config_entry: MockConfigEntry,
+) -> None:
+    """Test refreshed Energy Site read-only token scopes are revalidated."""
+    with patch(
+        "homeassistant.components.tesla_fleet.TeslaFleetApi", wraps=TeslaFleetApi
+    ) as api_class:
+        await setup_platform(hass, energy_site_read_only_config_entry)
+
+    get_access_token = api_class.call_args.kwargs["access_token"]
+    changed_token = create_config_entry(
+        expires_at,
+        [*ENERGY_SITE_READ_ONLY_SCOPES, Scope.ENERGY_CMDS],
+        authorization_profile=AuthorizationProfile.ENERGY_SITE_READ_ONLY,
+    ).data[CONF_TOKEN]
+    hass.config_entries.async_update_entry(
+        energy_site_read_only_config_entry,
+        data={
+            **energy_site_read_only_config_entry.data,
+            CONF_TOKEN: changed_token,
+        },
+    )
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await get_access_token()
+
+
+@pytest.mark.parametrize("invalid_profile", [None, "invalid", []])
+async def test_setup_rejects_invalid_authorization_profile(
+    hass: HomeAssistant,
+    expires_at: int,
+    invalid_profile: object,
+) -> None:
+    """Test setup fails closed for an invalid stored profile."""
+    valid_entry = create_config_entry(expires_at, SCOPES)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            **valid_entry.data,
+            CONF_AUTHORIZATION_PROFILE: invalid_profile,
+        },
+    )
+
+    await setup_platform(hass, entry)
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert not hasattr(entry, "runtime_data")
 
 
 @pytest.mark.parametrize(("side_effect", "state"), SETUP_ERRORS)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add an authorization-profile choice to Tesla Fleet before OAuth. The existing Standard profile remains the default and preserves the current scope request and runtime behavior, including for existing entries that do not have a stored profile. The new Energy Site read-only profile requests exactly `openid`, `offline_access`, and `energy_device_data`; it does not request `energy_cmds` or any vehicle scope.

The selected profile is stored in the config entry and retained during reauthentication. Energy Site read-only tokens are validated after OAuth, during setup, and whenever the current access token is obtained. This profile does not construct vehicle clients or coordinators, forwards only sensor and binary sensor platforms, and retains only a narrow Energy API facade for site information, live status, and energy history. It exposes no writable Energy path. Energy history retains the integration's existing five-minute cadence and existing Energy Site sensor behavior.

Local validation passed: all 193 Tesla Fleet tests and 425 snapshots, Ruff check and format, hassfest, full Core and Tesla Fleet component mypy, and change-scoped hooks. No real Tesla OAuth or production deployment was performed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: Pending; the documentation patch is prepared locally but no documentation PR has been opened.
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
