### PR TITLE
Fix delayed Duco bypass target updates

### DIFF
--- a/homeassistant/components/duco/number.py
+++ b/homeassistant/components/duco/number.py
@@ -158,6 +158,7 @@ class DucoBypassSupplyTemperatureTargetNumber(DucoEntity, NumberEntity):
                 translation_key="failed_to_set_bypass_supply_temperature_target",
             ) from err
 
+        # Do not let a completed write mask a concurrent coordinator refresh failure.
         if self.coordinator.last_update_success:
             self.coordinator.async_set_updated_data(
                 replace(

--- a/homeassistant/components/duco/number.py
+++ b/homeassistant/components/duco/number.py
@@ -158,12 +158,13 @@ class DucoBypassSupplyTemperatureTargetNumber(DucoEntity, NumberEntity):
                 translation_key="failed_to_set_bypass_supply_temperature_target",
             ) from err
 
-        self.coordinator.async_set_updated_data(
-            replace(
-                self.coordinator.data,
-                bypass_supply_temperature_targets={
-                    **self.coordinator.data.bypass_supply_temperature_targets,
-                    self._zone_id: updated_target,
-                },
+        if self.coordinator.last_update_success:
+            self.coordinator.async_set_updated_data(
+                replace(
+                    self.coordinator.data,
+                    bypass_supply_temperature_targets={
+                        **self.coordinator.data.bypass_supply_temperature_targets,
+                        self._zone_id: updated_target,
+                    },
+                )
             )
-        )

--- a/homeassistant/components/duco/number.py
+++ b/homeassistant/components/duco/number.py
@@ -1,5 +1,6 @@
 """Number platform for the Duco integration."""
 
+from dataclasses import replace
 import logging
 from typing import override
 
@@ -129,7 +130,7 @@ class DucoBypassSupplyTemperatureTargetNumber(DucoEntity, NumberEntity):
         try:
             if self.unit_of_measurement != self.native_unit_of_measurement:
                 value = target.normalize_value(value)
-            await self.coordinator.client.async_set_bypass_supply_temperature_target(
+            updated_target = await self.coordinator.client.async_set_bypass_supply_temperature_target(
                 self._zone_id, value, target=target
             )
         except ValueError as err:
@@ -157,4 +158,12 @@ class DucoBypassSupplyTemperatureTargetNumber(DucoEntity, NumberEntity):
                 translation_key="failed_to_set_bypass_supply_temperature_target",
             ) from err
 
-        await self.coordinator.async_request_refresh()
+        self.coordinator.async_set_updated_data(
+            replace(
+                self.coordinator.data,
+                bypass_supply_temperature_targets={
+                    **self.coordinator.data.bypass_supply_temperature_targets,
+                    self._zone_id: updated_target,
+                },
+            )
+        )

--- a/tests/components/duco/conftest.py
+++ b/tests/components/duco/conftest.py
@@ -284,7 +284,9 @@ def mock_duco_client(
         target: BypassSupplyTemperatureTarget,
     ) -> BypassSupplyTemperatureTarget:
         target.validate_value(temperature)
-        return replace(target, zone_id=zone_id, value=temperature)
+        updated_target = replace(target, zone_id=zone_id, value=temperature)
+        mock_bypass_supply_temperature_targets[zone_id] = updated_target
+        return updated_target
 
     with (
         patch(

--- a/tests/components/duco/conftest.py
+++ b/tests/components/duco/conftest.py
@@ -282,11 +282,9 @@ def mock_duco_client(
         temperature: float,
         *,
         target: BypassSupplyTemperatureTarget,
-    ) -> None:
+    ) -> BypassSupplyTemperatureTarget:
         target.validate_value(temperature)
-        mock_bypass_supply_temperature_targets[zone_id] = replace(
-            target, value=temperature
-        )
+        return replace(target, zone_id=zone_id, value=temperature)
 
     with (
         patch(

--- a/tests/components/duco/test_number.py
+++ b/tests/components/duco/test_number.py
@@ -1,5 +1,6 @@
 """Tests for the Duco number platform."""
 
+import asyncio
 from dataclasses import replace
 from unittest.mock import AsyncMock, call
 
@@ -68,29 +69,54 @@ async def test_bypass_supply_temperature_target_numbers_support_all_exposed_zone
 
 async def test_successful_write_does_not_recover_failed_coordinator(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
+    mock_bypass_supply_temperature_targets: dict[int, BypassSupplyTemperatureTarget],
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
 ) -> None:
     """Test a successful write does not recover a failed coordinator."""
     await setup_platform_integration(hass, mock_config_entry, [Platform.NUMBER])
+    write_started = asyncio.Event()
+    release_write = asyncio.Event()
+    target = mock_bypass_supply_temperature_targets[1]
+
+    async def set_bypass_supply_temperature_target(
+        zone_id: int,
+        temperature: float,
+        *,
+        target: BypassSupplyTemperatureTarget,
+    ) -> BypassSupplyTemperatureTarget:
+        updated_target = replace(target, zone_id=zone_id, value=temperature)
+        mock_bypass_supply_temperature_targets[zone_id] = updated_target
+        write_started.set()
+        await release_write.wait()
+        return updated_target
+
+    mock_duco_client.async_set_bypass_supply_temperature_target.side_effect = (
+        set_bypass_supply_temperature_target
+    )
+    write_task = asyncio.create_task(
+        hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: _ZONE_1_ENTITY_ID, "value": 20.5},
+            blocking=True,
+        )
+    )
+    await write_started.wait()
 
     mock_duco_client.async_get_nodes.side_effect = DucoError("Temporary update failure")
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await mock_config_entry.runtime_data.async_refresh()
 
     state = hass.states.get(_ZONE_1_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
-    await hass.services.async_call(
-        NUMBER_DOMAIN,
-        SERVICE_SET_VALUE,
-        {ATTR_ENTITY_ID: _ZONE_1_ENTITY_ID, "value": 20.5},
-        blocking=True,
-    )
+    release_write.set()
+    await write_task
 
+    mock_duco_client.async_set_bypass_supply_temperature_target.assert_awaited_once_with(
+        1, 20.5, target=target
+    )
     state = hass.states.get(_ZONE_1_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE

--- a/tests/components/duco/test_number.py
+++ b/tests/components/duco/test_number.py
@@ -66,6 +66,36 @@ async def test_bypass_supply_temperature_target_numbers_support_all_exposed_zone
     mock_duco_client.async_get_bypass_supply_temperature_targets.assert_awaited_once_with()
 
 
+async def test_successful_write_does_not_recover_failed_coordinator(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test a successful write does not recover a failed coordinator."""
+    await setup_platform_integration(hass, mock_config_entry, [Platform.NUMBER])
+
+    mock_duco_client.async_get_nodes.side_effect = DucoError("Temporary update failure")
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(_ZONE_1_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: _ZONE_1_ENTITY_ID, "value": 20.5},
+        blocking=True,
+    )
+
+    state = hass.states.get(_ZONE_1_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
 async def test_bypass_supply_temperature_target_number_entities_state(
     hass: HomeAssistant,
@@ -121,6 +151,7 @@ async def test_set_bypass_supply_temperature_target(
         ]
     )
     mock_duco_client.async_get_bypass_supply_temperature_targets.assert_awaited_once_with()
+    assert mock_bypass_supply_temperature_targets[1] == replace(target, value=21.0)
 
 
 async def test_set_bypass_supply_temperature_target_honors_increment_metadata(

--- a/tests/components/duco/test_number.py
+++ b/tests/components/duco/test_number.py
@@ -1,7 +1,7 @@
 """Tests for the Duco number platform."""
 
 from dataclasses import replace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
 from duco_connectivity import (
     BypassSupplyTemperatureTarget,
@@ -98,22 +98,29 @@ async def test_set_bypass_supply_temperature_target(
     mock_bypass_supply_temperature_targets: dict[int, BypassSupplyTemperatureTarget],
     mock_duco_client: AsyncMock,
 ) -> None:
-    """Test setting a bypass target refreshes the number from the box."""
+    """Test consecutive bypass target writes update directly from their responses."""
     target = mock_bypass_supply_temperature_targets[1]
 
-    await hass.services.async_call(
-        NUMBER_DOMAIN,
-        SERVICE_SET_VALUE,
-        {ATTR_ENTITY_ID: _ZONE_1_ENTITY_ID, "value": 20.5},
-        blocking=True,
-    )
+    for value in (20.5, 21.0):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: _ZONE_1_ENTITY_ID, "value": value},
+            blocking=True,
+        )
 
-    mock_duco_client.async_set_bypass_supply_temperature_target.assert_awaited_once_with(
-        1, 20.5, target=target
+        state = hass.states.get(_ZONE_1_ENTITY_ID)
+        assert state is not None
+        assert state.state == str(value)
+
+    assert (
+        mock_duco_client.async_set_bypass_supply_temperature_target.await_args_list
+        == [
+            call(1, 20.5, target=target),
+            call(1, 21.0, target=replace(target, value=20.5)),
+        ]
     )
-    state = hass.states.get(_ZONE_1_ENTITY_ID)
-    assert state is not None
-    assert state.state == "20.5"
+    mock_duco_client.async_get_bypass_supply_temperature_targets.assert_awaited_once_with()
 
 
 async def test_set_bypass_supply_temperature_target_honors_increment_metadata(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update Duco bypass target number entities directly from the authoritative PATCH response instead of waiting for a debounced full coordinator refresh. This makes consecutive target changes visible immediately after each write completes and avoids an unnecessary multi-endpoint refresh.

The regression tests cover consecutive writes, verify that the second write uses the target returned by the first response, confirm that no additional bulk target read is requested, and ensure that an in-flight successful write does not restore availability after a concurrent coordinator refresh failure.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please, be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr