### PR TITLE
Read ViCare entity values in the executor

### DIFF
--- a/homeassistant/components/vicare/coordinator.py
+++ b/homeassistant/components/vicare/coordinator.py
@@ -1,5 +1,6 @@
 """DataUpdateCoordinator for the ViCare integration."""
 
+from collections.abc import Callable
 from datetime import timedelta
 import logging
 from typing import override
@@ -16,7 +17,7 @@ from PyViCare.PyViCareUtils import (
 )
 import requests
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -55,6 +56,17 @@ class ViCareCoordinator(DataUpdateCoordinator[None]):
         )
         self._device = device
         self._accessor = accessor
+        self._value_readers: list[Callable[[], None]] = []
+
+    @callback
+    def async_add_value_reader(self, reader: Callable[[], None]) -> Callable[[], None]:
+        """Register a reader to run in the executor after each fetch."""
+        self._value_readers.append(reader)
+
+        def remove_value_reader() -> None:
+            self._value_readers.remove(reader)
+
+        return remove_value_reader
 
     @override
     async def _async_update_data(self) -> None:
@@ -81,3 +93,13 @@ class ViCareCoordinator(DataUpdateCoordinator[None]):
             requests.RequestException,
         ) as err:
             raise UpdateFailed(str(err)) from err
+        else:
+            # Only after a successful fetch: the cache was emptied above, and a
+            # reader must not be the one to refill it from the event loop.
+            # Iterate a copy, entities deregister from the event loop thread.
+            for reader in list(self._value_readers):
+                try:
+                    reader()
+                except Exception:
+                    # One unreadable value must not take the whole device down.
+                    _LOGGER.exception("Error reading a ViCare entity value")

--- a/homeassistant/components/vicare/entity.py
+++ b/homeassistant/components/vicare/entity.py
@@ -123,7 +123,13 @@ class ViCareEntity(Entity):
 
 
 class ViCareCoordinatorEntity(CoordinatorEntity[ViCareCoordinator], ViCareEntity):
-    """Base class for ViCare entities backed by the update coordinator."""
+    """Base class for ViCare entities backed by the update coordinator.
+
+    Values are read in ``_read_value``, which the coordinator calls from its
+    executor job. Properties must only return what was read there: a PyViCare
+    getter takes the library cache lock and does blocking I/O when that cache
+    is cold.
+    """
 
     def __init__(
         self,
@@ -139,3 +145,14 @@ class ViCareCoordinatorEntity(CoordinatorEntity[ViCareCoordinator], ViCareEntity
         ViCareEntity.__init__(
             self, unique_id_suffix, device_serial, device_config, device, component
         )
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register the value reader and prime the first value."""
+        await super().async_added_to_hass()
+        self.async_on_remove(self.coordinator.async_add_value_reader(self._read_value))
+        # The coordinator's first refresh ran before this entity existed.
+        await self.hass.async_add_executor_job(self._read_value)
+
+    def _read_value(self) -> None:
+        """Read this entity's value from the API. Runs in the executor."""

--- a/homeassistant/components/vicare/fan.py
+++ b/homeassistant/components/vicare/fan.py
@@ -121,6 +121,7 @@ class ViCareFan(ViCareEntity, FanEntity):
     _attr_speed_count = len(ORDERED_NAMED_FAN_SPEEDS)
     _attr_translation_key = "ventilation"
     _attributes: dict[str, Any] = {}
+    _standby: bool = False
 
     def __init__(
         self,
@@ -170,6 +171,12 @@ class ViCareFan(ViCareEntity, FanEntity):
                     self._api.getActiveVentilationMode()
                 )
 
+            if VentilationQuickmode.STANDBY in self._attributes["vicare_quickmodes"]:
+                with suppress(PyViCareNotSupportedFeatureError):
+                    self._standby = self._api.getVentilationQuickmode(
+                        VentilationQuickmode.STANDBY
+                    )
+
             with suppress(PyViCareNotSupportedFeatureError):
                 level = filter_state(self._api.getVentilationLevel())
             if level is not None and level in ORDERED_NAMED_FAN_SPEEDS:
@@ -183,9 +190,7 @@ class ViCareFan(ViCareEntity, FanEntity):
     @override
     def is_on(self) -> bool | None:
         """Return true if the entity is on."""
-        if VentilationQuickmode.STANDBY in self._attributes[
-            "vicare_quickmodes"
-        ] and self._api.getVentilationQuickmode(VentilationQuickmode.STANDBY):
+        if self._standby:
             return False
 
         return self.percentage is not None and self.percentage > 0
@@ -199,9 +204,7 @@ class ViCareFan(ViCareEntity, FanEntity):
     @override
     def icon(self) -> str | None:
         """Return the icon to use in the frontend."""
-        if VentilationQuickmode.STANDBY in self._attributes[
-            "vicare_quickmodes"
-        ] and self._api.getVentilationQuickmode(VentilationQuickmode.STANDBY):
+        if self._standby:
             return "mdi:fan-off"
         if hasattr(self, "_attr_preset_mode"):
             if self._attr_preset_mode == VentilationMode.VENTILATION:

--- a/homeassistant/components/vicare/sensor.py
+++ b/homeassistant/components/vicare/sensor.py
@@ -38,7 +38,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.typing import StateType
 
 from .const import (
     VICARE_BAR,
@@ -1642,10 +1641,11 @@ class ViCareSensor(ViCareCoordinatorEntity, SensorEntity):
                             vicare_unit
                         ]
 
-    @property
     @override
-    def native_value(self) -> StateType:
-        """Return the state of the sensor."""
-        with suppress(PyViCareNotSupportedFeatureError):
-            return self.entity_description.value_getter(self._api)
-        return None
+    def _read_value(self) -> None:
+        """Read the sensor value from the API."""
+        # Both context managers swallow read failures, so clear first rather
+        # than republish the previous value.
+        self._attr_native_value = None
+        with self.vicare_api_handler(), suppress(PyViCareNotSupportedFeatureError):
+            self._attr_native_value = self.entity_description.value_getter(self._api)

--- a/tests/components/vicare/test_sensor.py
+++ b/tests/components/vicare/test_sensor.py
@@ -1,18 +1,28 @@
 """Test ViCare sensor entity."""
 
+from contextlib import ExitStack
+from datetime import timedelta
+import threading
+from typing import Any
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
+from PyViCare.PyViCareService import ViCareDeviceAccessor
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.vicare.const import DEFAULT_CACHE_DURATION
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_component import async_update_entity
 
 from . import MODULE, setup_integration
 from .conftest import Fixture, MockPyViCare
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -55,3 +65,73 @@ async def test_all_entities(
         await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_no_api_read_on_event_loop(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Entity values must be read in the executor, never on the event loop.
+
+    A PyViCare getter takes the library's cache lock and does blocking I/O when
+    that cache is cold, so reading a value from a property freezes the loop for
+    the length of an HTTP request.
+    """
+    fixtures: list[Fixture] = [
+        Fixture({"type:heatpump"}, "vicare/Vitocal250A.json"),
+        Fixture({"type:ventilation"}, "vicare/VitoPure.json"),
+    ]
+    mock_vicare = MockPyViCare(fixtures)
+    services = {id(d.service): d.service for d in mock_vicare.devices}
+
+    loop_thread_id = threading.get_ident()
+    reads_on_loop: list[str] = []
+    reads_in_executor: list[str] = []
+
+    def guard(service):
+        read_property = service.getProperty
+
+        def guarded_get_property(
+            accessor: ViCareDeviceAccessor, property_name: str
+        ) -> Any:
+            if threading.get_ident() == loop_thread_id:
+                reads_on_loop.append(property_name)
+            else:
+                reads_in_executor.append(property_name)
+            return read_property(accessor, property_name)
+
+        return patch.object(service, "getProperty", guarded_get_property)
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+        ),
+        patch(
+            f"{MODULE}._setup_vicare_api",
+            return_value=mock_vicare.as_vicare_data(),
+        ),
+        patch(f"{MODULE}.PLATFORMS", [Platform.SENSOR, Platform.FAN]),
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+        entity_ids = hass.states.async_entity_ids(SENSOR_DOMAIN)
+        fan_ids = hass.states.async_entity_ids(FAN_DOMAIN)
+        assert entity_ids
+        assert fan_ids
+
+        with ExitStack() as stack:
+            for service in services.values():
+                stack.enter_context(guard(service))
+
+            freezer.tick(timedelta(seconds=DEFAULT_CACHE_DURATION * 2))
+            async_fire_time_changed(hass)
+            await hass.async_block_till_done()
+
+            for entity_id in (entity_ids[0], fan_ids[0]):
+                await async_update_entity(hass, entity_id)
+
+    assert not reads_on_loop
+    # Without this the test would also pass if nothing read a value at all.
+    assert reads_in_executor


### PR DESCRIPTION
## Proposed change

`ViCareSensor.native_value` calls a PyViCare getter. That getter takes the library's cache lock and performs an HTTP request whenever the cache is cold, so reading it runs API access on the event loop. Since the coordinator migration in 2026.9.0 this is the only path that produces sensor values, which leaves users with blocking call errors and with event loop freezes long enough for the Supervisor watchdog to restart Core.

Entities now register a reader that the coordinator runs inside the same executor job as the feature fetch, and properties only return what was read there. Readers run only after a successful fetch, because the coordinator empties PyViCare's cache before fetching and a failed fetch leaves it empty.

The added test records the event loop's thread id and fails if any PyViCare read happens on it during a coordinator update or an `update_entity` call.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #181371
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

This is a regression in 2026.9.0. The cherry-pick to `rc` conflicts in `coordinator.py`, which differs there because the per-gateway coordinator (#176163) is not in 2026.9; a resolved backport is ready if you want it as a separate PR.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
