### PR TITLE
Apply clock drift tolerance to TOTP setup flow

### DIFF
--- a/homeassistant/auth/mfa_modules/totp.py
+++ b/homeassistant/auth/mfa_modules/totp.py
@@ -1,6 +1,7 @@
 """Time-based One Time Password auth module."""
 
 import asyncio
+from functools import partial
 from io import BytesIO
 from typing import Any, cast, override
 
@@ -210,7 +211,11 @@ class TotpSetupFlow(SetupFlow[TotpAuthModule]):
 
         if user_input:
             verified = await self.hass.async_add_executor_job(
-                pyotp.TOTP(self._ota_secret).verify, user_input["code"]
+                partial(
+                    pyotp.TOTP(self._ota_secret).verify,
+                    user_input["code"],
+                    valid_window=1,
+                )
             )
             if verified:
                 result = await self._auth_module.async_setup_user(

--- a/tests/auth/mfa_modules/test_totp.py
+++ b/tests/auth/mfa_modules/test_totp.py
@@ -1,12 +1,17 @@
 """Test the Time-based One Time Password (MFA) auth module."""
 
 import asyncio
+from datetime import datetime, timedelta
 from unittest.mock import patch
+
+from freezegun import freeze_time
+import pyotp
 
 from homeassistant import data_entry_flow
 from homeassistant.auth import auth_manager_from_config, models as auth_models
 from homeassistant.auth.mfa_modules import auth_mfa_module_from_config
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockUser
 
@@ -130,6 +135,24 @@ async def test_login_flow_validates_mfa(hass: HomeAssistant) -> None:
         )
         assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["data"].id == "mock-id"
+
+
+async def test_setup_flow_accepts_code_with_clock_drift(hass: HomeAssistant) -> None:
+    """Test setup flow tolerates the same clock drift as login validation."""
+    totp_auth_module = await auth_mfa_module_from_config(hass, {"type": "totp"})
+    user = MockUser(id="mock-user").add_to_auth_manager(hass.auth)
+
+    with freeze_time(datetime(2024, 1, 1, 0, 0, 5)):
+        flow = await totp_auth_module.async_setup_flow(user.id)
+        flow.hass = hass
+        await flow.async_step_init()
+
+        drifted_code = pyotp.TOTP(flow._ota_secret).at(
+            dt_util.naive_now() - timedelta(seconds=25)
+        )
+        result = await flow.async_step_init({"code": drifted_code})
+
+    assert result["type"] is data_entry_flow.FlowResultType.CREATE_ENTRY
 
 
 async def test_race_condition_in_data_loading(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change

`TotpSetupFlow.async_step_init` verifies the enrollment code with `pyotp.TOTP(...).verify(code)` and no `valid_window`, which defaults to 0 (exact match only). `TotpAuthModule._validate_2fa`, used for every login afterward, calls `verify(code, valid_window=1)` and tolerates one time-step (about 30 seconds) of clock drift.

This means a code that would be accepted at every subsequent login is rejected during the one-time enrollment step if the authenticator app's clock has even a small drift, with no indication to the user that drift is the cause.

This PR passes `valid_window=1` through the setup flow's verification call as well, via `functools.partial` since `async_add_executor_job` only forwards positional arguments, so enrollment now tolerates the same drift as login.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #181369
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
