### PR TITLE
Clear webostv source when the current app is not in the source list

### DIFF
--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -233,16 +233,9 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
             ):
                 self._source_list[source["label"]] = source
 
-        # live tv is the source even when both lists leave it out
-        if not found_live_tv and tv_state.current_app_id == LIVE_TV_APP_ID:
-            self._current_source = "Live TV"
-
-        # empty list, TV may be off, keep previous list
-        if not self._source_list and source_list:
-            self._source_list = source_list
         # special handling of live tv since this might
         # not appear in the app or input lists in some cases
-        elif not found_live_tv:
+        if not found_live_tv:
             app = {"id": LIVE_TV_APP_ID, "title": "Live TV"}
             if tv_state.current_app_id == LIVE_TV_APP_ID:
                 self._current_source = app["title"]
@@ -254,6 +247,10 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
                 or any(word in app["id"] for word in conf_sources)
             ):
                 self._source_list["Live TV"] = app
+
+        # empty list, TV may be off, keep previous list
+        if not self._source_list and source_list:
+            self._source_list = source_list
 
     @property
     @override

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -74,7 +74,7 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
 
         # Assume that the TV is not paused
         self._paused = False
-        self._current_source: str | None = None
+        self._current_source = None
         self._source_list: dict = {}
 
         self._supported_features = MediaPlayerEntityFeature(0)
@@ -233,12 +233,12 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
             ):
                 self._source_list[source["label"]] = source
 
-        # decided before the live tv insert below can mask an empty update
-        keep_previous_list = not self._source_list and bool(source_list)
-
+        # empty list, TV may be off, keep previous list
+        if not self._source_list and source_list:
+            self._source_list = source_list
         # special handling of live tv since this might
         # not appear in the app or input lists in some cases
-        if not found_live_tv:
+        elif not found_live_tv:
             app = {"id": LIVE_TV_APP_ID, "title": "Live TV"}
             if tv_state.current_app_id == LIVE_TV_APP_ID:
                 self._current_source = app["title"]
@@ -250,10 +250,6 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
                 or any(word in app["id"] for word in conf_sources)
             ):
                 self._source_list["Live TV"] = app
-
-        # empty list, TV may be off, keep previous list
-        if keep_previous_list:
-            self._source_list = source_list
 
     @property
     @override

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -233,6 +233,10 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
             ):
                 self._source_list[source["label"]] = source
 
+        # live tv is the source even when both lists leave it out
+        if not found_live_tv and tv_state.current_app_id == LIVE_TV_APP_ID:
+            current_source = "Live TV"
+
         # empty list, TV may be off, keep previous list
         if not self._source_list and source_list:
             self._source_list = source_list
@@ -243,11 +247,9 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
         # not appear in the app or input lists in some cases
         elif not found_live_tv:
             app = {"id": LIVE_TV_APP_ID, "title": "Live TV"}
-            if tv_state.current_app_id == LIVE_TV_APP_ID:
-                current_source = app["title"]
-                self._source_list["Live TV"] = app
-            elif (
-                not conf_sources
+            if (
+                tv_state.current_app_id == LIVE_TV_APP_ID
+                or not conf_sources
                 or app["id"] in conf_sources
                 or any(word in app["title"] for word in conf_sources)
                 or any(word in app["id"] for word in conf_sources)

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -232,14 +232,15 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
             ):
                 self._source_list[source["label"]] = source
 
-        # empty list, TV may be off, keep previous list and source
+        # empty list, TV may be off, keep previous list
         if not self._source_list and source_list:
             self._source_list = source_list
-            return
-
+            # only a TV reporting nothing keeps its previous source
+            if not tv_state.apps and not tv_state.inputs:
+                return
         # special handling of live tv since this might
         # not appear in the app or input lists in some cases
-        if not found_live_tv:
+        elif not found_live_tv:
             app = {"id": LIVE_TV_APP_ID, "title": "Live TV"}
             if tv_state.current_app_id == LIVE_TV_APP_ID:
                 current_source = app["title"]

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -201,7 +201,6 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
         """Update list of sources from current source and apps."""
         tv_state = self._client.tv_state
         source_list = self._source_list
-        current_source = self._current_source
         self._source_list = {}
         self._current_source = None
         conf_sources = self._sources
@@ -241,9 +240,6 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
         # empty list, TV may be off, keep previous list
         if not self._source_list and source_list:
             self._source_list = source_list
-            # only a TV reporting nothing keeps its previous source
-            if not tv_state.apps and not tv_state.inputs:
-                self._current_source = current_source
         # special handling of live tv since this might
         # not appear in the app or input lists in some cases
         elif not found_live_tv:

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -202,13 +202,14 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
         source_list = self._source_list
         self._source_list = {}
         conf_sources = self._sources
+        current_source = None
 
         found_live_tv = False
         for app in tv_state.apps.values():
             if app["id"] == LIVE_TV_APP_ID:
                 found_live_tv = True
             if app["id"] == tv_state.current_app_id:
-                self._current_source = app["title"]
+                current_source = app["title"]
                 self._source_list[app["title"]] = app
             elif (
                 not conf_sources
@@ -222,7 +223,7 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
             if source["appId"] == LIVE_TV_APP_ID:
                 found_live_tv = True
             if source["appId"] == tv_state.current_app_id:
-                self._current_source = source["label"]
+                current_source = source["label"]
                 self._source_list[source["label"]] = source
             elif (
                 not conf_sources
@@ -231,15 +232,17 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
             ):
                 self._source_list[source["label"]] = source
 
-        # empty list, TV may be off, keep previous list
+        # empty list, TV may be off, keep previous list and source
         if not self._source_list and source_list:
             self._source_list = source_list
+            return
+
         # special handling of live tv since this might
         # not appear in the app or input lists in some cases
-        elif not found_live_tv:
+        if not found_live_tv:
             app = {"id": LIVE_TV_APP_ID, "title": "Live TV"}
             if tv_state.current_app_id == LIVE_TV_APP_ID:
-                self._current_source = app["title"]
+                current_source = app["title"]
                 self._source_list["Live TV"] = app
             elif (
                 not conf_sources
@@ -248,6 +251,8 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
                 or any(word in app["id"] for word in conf_sources)
             ):
                 self._source_list["Live TV"] = app
+
+        self._current_source = current_source
 
     @property
     @override

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -233,6 +233,9 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
             ):
                 self._source_list[source["label"]] = source
 
+        # decided before the live tv insert below can mask an empty update
+        keep_previous_list = not self._source_list and bool(source_list)
+
         # special handling of live tv since this might
         # not appear in the app or input lists in some cases
         if not found_live_tv:
@@ -249,7 +252,7 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
                 self._source_list["Live TV"] = app
 
         # empty list, TV may be off, keep previous list
-        if not self._source_list and source_list:
+        if keep_previous_list:
             self._source_list = source_list
 
     @property

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -74,7 +74,7 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
 
         # Assume that the TV is not paused
         self._paused = False
-        self._current_source = None
+        self._current_source: str | None = None
         self._source_list: dict = {}
 
         self._supported_features = MediaPlayerEntityFeature(0)
@@ -201,16 +201,17 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
         """Update list of sources from current source and apps."""
         tv_state = self._client.tv_state
         source_list = self._source_list
+        current_source = self._current_source
         self._source_list = {}
+        self._current_source = None
         conf_sources = self._sources
-        current_source = None
 
         found_live_tv = False
         for app in tv_state.apps.values():
             if app["id"] == LIVE_TV_APP_ID:
                 found_live_tv = True
             if app["id"] == tv_state.current_app_id:
-                current_source = app["title"]
+                self._current_source = app["title"]
                 self._source_list[app["title"]] = app
             elif (
                 not conf_sources
@@ -224,7 +225,7 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
             if source["appId"] == LIVE_TV_APP_ID:
                 found_live_tv = True
             if source["appId"] == tv_state.current_app_id:
-                current_source = source["label"]
+                self._current_source = source["label"]
                 self._source_list[source["label"]] = source
             elif (
                 not conf_sources
@@ -235,28 +236,28 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
 
         # live tv is the source even when both lists leave it out
         if not found_live_tv and tv_state.current_app_id == LIVE_TV_APP_ID:
-            current_source = "Live TV"
+            self._current_source = "Live TV"
 
         # empty list, TV may be off, keep previous list
         if not self._source_list and source_list:
             self._source_list = source_list
             # only a TV reporting nothing keeps its previous source
             if not tv_state.apps and not tv_state.inputs:
-                return
+                self._current_source = current_source
         # special handling of live tv since this might
         # not appear in the app or input lists in some cases
         elif not found_live_tv:
             app = {"id": LIVE_TV_APP_ID, "title": "Live TV"}
-            if (
-                tv_state.current_app_id == LIVE_TV_APP_ID
-                or not conf_sources
+            if tv_state.current_app_id == LIVE_TV_APP_ID:
+                self._current_source = app["title"]
+                self._source_list["Live TV"] = app
+            elif (
+                not conf_sources
                 or app["id"] in conf_sources
                 or any(word in app["title"] for word in conf_sources)
                 or any(word in app["id"] for word in conf_sources)
             ):
                 self._source_list["Live TV"] = app
-
-        self._current_source = current_source
 
     @property
     @override

--- a/tests/components/webostv/__init__.py
+++ b/tests/components/webostv/__init__.py
@@ -1,5 +1,7 @@
 """Tests for the LG webOS TV integration."""
 
+from typing import Any
+
 from homeassistant.components.webostv.const import DOMAIN
 from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST
 from homeassistant.core import HomeAssistant
@@ -10,7 +12,9 @@ from tests.common import MockConfigEntry
 
 
 async def setup_webostv(
-    hass: HomeAssistant, unique_id: str | None = FAKE_UUID
+    hass: HomeAssistant,
+    unique_id: str | None = FAKE_UUID,
+    options: dict[str, Any] | None = None,
 ) -> MockConfigEntry:
     """Initialize webostv and media_player for tests."""
     entry = MockConfigEntry(
@@ -19,6 +23,7 @@ async def setup_webostv(
             CONF_HOST: HOST,
             CONF_CLIENT_SECRET: CLIENT_KEY,
         },
+        options=options or {},
         title=TV_NAME,
         unique_id=unique_id,
     )

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -571,44 +571,6 @@ async def test_source_cleared_with_filtered_out_sources(
     assert ATTR_INPUT_SOURCE not in hass.states.get(ENTITY_ID).attributes
 
 
-async def test_empty_update_keeps_source_list(hass: HomeAssistant, client) -> None:
-    """Test the previous list survives an update with no apps and no inputs."""
-    await setup_webostv(hass)
-    await client.mock_state_update()
-
-    sources = ["Input01", "Input02", "Live TV"]
-    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE_LIST] == sources
-
-    client.tv_state.apps = {}
-    client.tv_state.inputs = {}
-    await client.mock_state_update()
-
-    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE_LIST] == sources
-
-
-async def test_live_tv_source_missing_from_lists(hass: HomeAssistant, client) -> None:
-    """Test live TV is the source when it is in neither list."""
-    client.tv_state.apps = {
-        "youtube": {
-            "title": "YouTube",
-            "id": "youtube",
-            "largeIcon": "large-icon",
-            "icon": "icon",
-        },
-    }
-    client.tv_state.inputs = {}
-    client.tv_state.current_app_id = "youtube"
-    await setup_webostv(hass, options={CONF_SOURCES: ["Netflix"]})
-    await client.mock_state_update()
-
-    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE] == "YouTube"
-
-    client.tv_state.current_app_id = LIVE_TV_APP_ID
-    await client.mock_state_update()
-
-    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE] == "Live TV"
-
-
 async def test_app_id(hass: HomeAssistant, client) -> None:
     """Test app_id follows the foreground app id reported by the TV."""
     await setup_webostv(hass)

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -571,6 +571,21 @@ async def test_source_cleared_with_filtered_out_sources(
     assert ATTR_INPUT_SOURCE not in hass.states.get(ENTITY_ID).attributes
 
 
+async def test_empty_update_keeps_source_list(hass: HomeAssistant, client) -> None:
+    """Test the previous list survives an update with no apps and no inputs."""
+    await setup_webostv(hass)
+    await client.mock_state_update()
+
+    sources = ["Input01", "Input02", "Live TV"]
+    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE_LIST] == sources
+
+    client.tv_state.apps = {}
+    client.tv_state.inputs = {}
+    await client.mock_state_update()
+
+    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE_LIST] == sources
+
+
 async def test_live_tv_source_missing_from_lists(hass: HomeAssistant, client) -> None:
     """Test live TV is the source when it is in neither list."""
     client.tv_state.apps = {

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -28,6 +28,7 @@ from homeassistant.components.media_player import (
 from homeassistant.components.webostv.const import (
     ATTR_PAYLOAD,
     ATTR_SOUND_OUTPUT,
+    CONF_SOURCES,
     DOMAIN,
     LIVE_TV_APP_ID,
     WebOsTvCommandError,
@@ -551,6 +552,28 @@ async def test_source_unlisted_current_app(hass: HomeAssistant, client) -> None:
     attributes = hass.states.get(ENTITY_ID).attributes
     assert ATTR_INPUT_SOURCE not in attributes
     assert attributes[ATTR_INPUT_SOURCE_LIST] == ["Input01", "Input02", "Live TV"]
+
+
+async def test_source_cleared_with_filtered_out_sources(
+    hass: HomeAssistant, client
+) -> None:
+    """Test source is cleared when configured sources match nothing."""
+    config_entry = await setup_webostv(hass)
+    new_options = config_entry.options.copy()
+    new_options[CONF_SOURCES] = ["Netflix"]
+    hass.config_entries.async_update_entry(config_entry, options=new_options)
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    client.tv_state.inputs = {}
+    await client.mock_state_update()
+
+    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE] == "Live TV"
+
+    client.tv_state.current_app_id = "com.webos.app.home"
+    await client.mock_state_update()
+
+    assert ATTR_INPUT_SOURCE not in hass.states.get(ENTITY_ID).attributes
 
 
 async def test_source_kept_on_empty_update(hass: HomeAssistant, client) -> None:

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -537,6 +537,39 @@ async def test_update_sources_live_tv_find(hass: HomeAssistant, client) -> None:
     assert len(sources) == 1
 
 
+async def test_source_unlisted_current_app(hass: HomeAssistant, client) -> None:
+    """Test source is cleared when the current app is not in the lists."""
+    await setup_webostv(hass)
+    await client.mock_state_update()
+
+    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE] == "Live TV"
+
+    # home screen and screen saver are not in the apps or inputs lists
+    client.tv_state.current_app_id = "com.webos.app.home"
+    await client.mock_state_update()
+
+    attributes = hass.states.get(ENTITY_ID).attributes
+    assert ATTR_INPUT_SOURCE not in attributes
+    assert attributes[ATTR_INPUT_SOURCE_LIST] == ["Input01", "Input02", "Live TV"]
+
+
+async def test_source_kept_on_empty_update(hass: HomeAssistant, client) -> None:
+    """Test source is kept when the TV reports no apps and no inputs."""
+    await setup_webostv(hass)
+    client.tv_state.current_app_id = "app0"
+    await client.mock_state_update()
+
+    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE] == "Input01"
+
+    client.tv_state.apps = {}
+    client.tv_state.inputs = {}
+    await client.mock_state_update()
+
+    attributes = hass.states.get(ENTITY_ID).attributes
+    assert attributes[ATTR_INPUT_SOURCE] == "Input01"
+    assert attributes[ATTR_INPUT_SOURCE_LIST] == ["Input01", "Input02", "Live TV"]
+
+
 async def test_client_disconnected(
     hass: HomeAssistant,
     client,

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -594,23 +594,6 @@ async def test_live_tv_source_missing_from_lists(hass: HomeAssistant, client) ->
     assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE] == "Live TV"
 
 
-async def test_source_kept_on_empty_update(hass: HomeAssistant, client) -> None:
-    """Test source is kept when the TV reports no apps and no inputs."""
-    await setup_webostv(hass)
-    client.tv_state.current_app_id = "app0"
-    await client.mock_state_update()
-
-    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE] == "Input01"
-
-    client.tv_state.apps = {}
-    client.tv_state.inputs = {}
-    await client.mock_state_update()
-
-    attributes = hass.states.get(ENTITY_ID).attributes
-    assert attributes[ATTR_INPUT_SOURCE] == "Input01"
-    assert attributes[ATTR_INPUT_SOURCE_LIST] == ["Input01", "Input02", "Live TV"]
-
-
 async def test_app_id(hass: HomeAssistant, client) -> None:
     """Test app_id follows the foreground app id reported by the TV."""
     await setup_webostv(hass)

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -559,14 +559,8 @@ async def test_source_cleared_with_filtered_out_sources(
     hass: HomeAssistant, client
 ) -> None:
     """Test source is cleared when configured sources match nothing."""
-    config_entry = await setup_webostv(hass)
-    new_options = config_entry.options.copy()
-    new_options[CONF_SOURCES] = ["Netflix"]
-    hass.config_entries.async_update_entry(config_entry, options=new_options)
-    await hass.config_entries.async_reload(config_entry.entry_id)
-    await hass.async_block_till_done()
-
     client.tv_state.inputs = {}
+    await setup_webostv(hass, options={CONF_SOURCES: ["Netflix"]})
     await client.mock_state_update()
 
     assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE] == "Live TV"
@@ -575,6 +569,29 @@ async def test_source_cleared_with_filtered_out_sources(
     await client.mock_state_update()
 
     assert ATTR_INPUT_SOURCE not in hass.states.get(ENTITY_ID).attributes
+
+
+async def test_live_tv_source_missing_from_lists(hass: HomeAssistant, client) -> None:
+    """Test live TV is the source when it is in neither list."""
+    client.tv_state.apps = {
+        "youtube": {
+            "title": "YouTube",
+            "id": "youtube",
+            "largeIcon": "large-icon",
+            "icon": "icon",
+        },
+    }
+    client.tv_state.inputs = {}
+    client.tv_state.current_app_id = "youtube"
+    await setup_webostv(hass, options={CONF_SOURCES: ["Netflix"]})
+    await client.mock_state_update()
+
+    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE] == "YouTube"
+
+    client.tv_state.current_app_id = LIVE_TV_APP_ID
+    await client.mock_state_update()
+
+    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE] == "Live TV"
 
 
 async def test_source_kept_on_empty_update(hass: HomeAssistant, client) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
`media_player.source` kept reporting the last matched app after the TV moved to
something that is not in the apps or inputs lists, such as the home screen or the
screen saver. Playing Netflix and then pressing Home left `source` on `Netflix`
indefinitely, while the set itself reported `com.webos.app.home` over the same
connection.

`_update_sources()` rebuilt `_source_list` from scratch on every update but only
ever assigned `_current_source` inside the branches that matched `current_app_id`,
so an unmatched foreground app left the previous value in place and it was
republished on every state update.

`_current_source` is now reset at the top of the method alongside `_source_list` and
set again whenever a source matches, so an app that matches nothing leaves `source`
absent rather than wrong. The Live TV fallback moved above the list preservation
guard so it still resolves the source when Live TV is missing from both raw lists,
and its synthesized entry lands in the list the same way every other matched source
does.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181358 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
