### PR TITLE
Bump adext to 0.4.7

### DIFF
--- a/homeassistant/components/alarmdecoder/manifest.json
+++ b/homeassistant/components/alarmdecoder/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["adext", "alarmdecoder"],
-  "requirements": ["adext==0.4.4"]
+  "requirements": ["adext==0.4.7"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -142,7 +142,7 @@ adax==0.4.0
 adb-shell[async]==0.4.4
 
 # homeassistant.components.alarmdecoder
-adext==0.4.4
+adext==0.4.7
 
 # homeassistant.components.adguard
 adguardhome==0.8.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The alarmdecoder integration pins `adext==0.4.4`, which pins `alarmdecoder==1.13.12`. In that version `SocketDevice.read_line()` guards its `select.select()` read loop with `except socket.error`. When the underlying socket goes away, `select.select()` raises `ValueError: file descriptor cannot be a negative integer (-1)` rather than a `socket.error`, so the exception escapes uncaught and kills the reader thread.

Because the thread dies rather than closing cleanly, the library never fires its `on_close` callback, `handle_closed_connection()` in `homeassistant/components/alarmdecoder/__init__.py` is never called, and the integration's existing reconnect path never runs. Entities keep their last values and stay frozen until Home Assistant is restarted, with nothing in the log to say the connection is gone.

`alarmdecoder` 1.13.14 widens that handler to `except (socket.error, ValueError)` and raises `CommError`, which the existing close handling already covers. `adext` 0.4.7 is the release that pins it. Bumping the pin is the entire change; no integration code needs to change.

### Library diff

`adext` 0.4.4...0.4.7 ([source](https://github.com/ajschmidt8/adext)) — the only functional change is the pin it carries. 0.4.5 still pinned 1.13.12 and 0.4.6 moved to 1.13.13, so 0.4.7 is the first release that picks up the fix.

```diff
--- adext-0.4.4/setup.py
+++ adext-0.4.7/setup.py
-    install_requires=["alarmdecoder==1.13.12"],
+    install_requires=["alarmdecoder==1.13.14"],
```

Everything else in that range is README badges and CI workflow files.

`alarmdecoder` [1.13.12...1.13.14](https://github.com/nutechsoftware/alarmdecoder) is three changes in two files:

```diff
--- alarmdecoder/devices/socket_device.py
+++ alarmdecoder/devices/socket_device.py
@@ -339,7 +339,7 @@ read_line()
-        except socket.error as err:
+        except (socket.error, ValueError) as err:
             raise CommError('Error reading from device: {0}'.format(str(err)), err)

--- alarmdecoder/zonetracking.py
+++ alarmdecoder/zonetracking.py
@@ -154,6 +154,7 @@ _update_zone on an existing zone
                     self._update_zone(zone, status=status)
+                    self.zones[zone].expander = True

@@ -169,7 +170,7 @@ iterate over a copy, since _update_zone mutates the list
-                for zone in self._zones_faulted:
+                for zone in self._zones_faulted[:]:
```

The first is the fix for this issue. The other two are zone-tracking corrections: expander zones now keep their flag when updated rather than only when first added, and the faulted-zone clear loop no longer mutates the list it is iterating.

### Testing

The 8 existing alarmdecoder tests pass, and `hassfest` plus the `prek` hooks are clean. I do not have an AlarmDecoder panel, so the reconnect behaviour itself is not verified against hardware — the case for the bump is the library diff above lining up exactly with the traceback in the issue.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176746
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
