### PR TITLE
Let a Fronius power limit revert when Home Assistant stops

### DIFF
--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -336,13 +336,17 @@ class FroniusSolarNet:
 
     async def _init_modbus_inverter(self, inverter_info: FroniusDeviceInfo) -> None:
         """Set up a Modbus coordinator for an inverter exposing SunSpec MPPT data."""
-        if inverter_info.solar_net_id in [
+        # each coordinator is retried on its own: a device may answer for one
+        # of them and not the other, and recover on a later re-scan
+        needs_readings = inverter_info.solar_net_id not in {
             coordinator.inverter_info.solar_net_id
-            for coordinator in (
-                *self.modbus_inverter_coordinators,
-                *self.modbus_settings_coordinators,
-            )
-        ]:
+            for coordinator in self.modbus_inverter_coordinators
+        }
+        needs_settings = inverter_info.solar_net_id not in {
+            coordinator.inverter_info.solar_net_id
+            for coordinator in self.modbus_settings_coordinators
+        }
+        if not needs_readings and not needs_settings:
             return
         if (unit_id := self._modbus_unit_id(inverter_info.solar_net_id)) is None:
             return
@@ -370,7 +374,7 @@ class FroniusSolarNet:
                 err,
             )
             return
-        if modbus_inverter.mppt is not None:
+        if needs_readings and modbus_inverter.mppt is not None:
             readings = FroniusModbusInverterUpdateCoordinator(
                 hass=self.hass,
                 solar_net=self,
@@ -382,14 +386,16 @@ class FroniusSolarNet:
             )
             if await self._start_modbus_coordinator(readings):
                 self.modbus_inverter_coordinators.append(readings)
-        else:
+        elif needs_readings:
             _LOGGER.debug(
                 "No MPPT model exposed by inverter %s at Modbus unit %s",
                 inverter_info.solar_net_id,
                 unit_id,
             )
 
-        if await self._modbus_control_allowed(modbus_inverter, unit_id):
+        if needs_settings and await self._modbus_control_allowed(
+            modbus_inverter, unit_id
+        ):
             settings = FroniusModbusSettingsUpdateCoordinator(
                 hass=self.hass,
                 solar_net=self,

--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
+    CONF_AUTO_REVERT,
     CONF_MODBUS_PORT,
     DEFAULT_MODBUS_PORT,
     DOMAIN,
@@ -85,6 +86,10 @@ async def async_migrate_entry(hass: HomeAssistant, entry: FroniusConfigEntry) ->
         # add the Modbus port setting
         data = {CONF_MODBUS_PORT: DEFAULT_MODBUS_PORT, **entry.data}
         hass.config_entries.async_update_entry(entry, data=data, minor_version=2)
+    if entry.minor_version < 3:
+        # add the Modbus setpoint fallback setting
+        data = {CONF_AUTO_REVERT: False, **entry.data}
+        hass.config_entries.async_update_entry(entry, data=data, minor_version=3)
     return True
 
 

--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -338,7 +338,10 @@ class FroniusSolarNet:
         """Set up a Modbus coordinator for an inverter exposing SunSpec MPPT data."""
         if inverter_info.solar_net_id in [
             coordinator.inverter_info.solar_net_id
-            for coordinator in self.modbus_inverter_coordinators
+            for coordinator in (
+                *self.modbus_inverter_coordinators,
+                *self.modbus_settings_coordinators,
+            )
         ]:
             return
         if (unit_id := self._modbus_unit_id(inverter_info.solar_net_id)) is None:
@@ -398,6 +401,7 @@ class FroniusSolarNet:
             )
             if await self._start_modbus_coordinator(settings):
                 self.modbus_settings_coordinators.append(settings)
+                await settings.async_start_heartbeat()
 
         _LOGGER.debug(
             "Modbus enabled for inverter %s (UID: %s, unit ID: %s)",

--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -27,7 +27,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
-    CONF_AUTO_REVERT,
+    CONF_AUTO_REVERT_POWER_LIMIT,
     CONF_MODBUS_PORT,
     DEFAULT_MODBUS_PORT,
     DOMAIN,
@@ -88,7 +88,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: FroniusConfigEntry) ->
         hass.config_entries.async_update_entry(entry, data=data, minor_version=2)
     if entry.minor_version < 3:
         # add the Modbus setpoint fallback setting
-        data = {CONF_AUTO_REVERT: False, **entry.data}
+        data = {CONF_AUTO_REVERT_POWER_LIMIT: False, **entry.data}
         hass.config_entries.async_update_entry(entry, data=data, minor_version=3)
     return True
 

--- a/homeassistant/components/fronius/config_flow.py
+++ b/homeassistant/components/fronius/config_flow.py
@@ -7,14 +7,25 @@ from typing import Any, Final, override
 from pyfronius import Fronius, FroniusError
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
 from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from .const import CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT, DOMAIN, FroniusConfigEntryData
+from . import FroniusConfigEntry
+from .const import (
+    CONF_AUTO_REVERT,
+    CONF_MODBUS_PORT,
+    DEFAULT_MODBUS_PORT,
+    DOMAIN,
+    FroniusConfigEntryData,
+)
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -73,6 +84,13 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize flow."""
         self.info: FroniusConfigEntryData
+
+    @staticmethod
+    @callback
+    @override
+    def async_get_options_flow(config_entry: FroniusConfigEntry) -> FroniusOptionsFlow:
+        """Get the options flow for this handler."""
+        return FroniusOptionsFlow()
 
     @override
     async def async_step_user(
@@ -192,6 +210,25 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             description_placeholders={"device": reconfigure_entry.title},
             errors=errors,
+        )
+
+
+class FroniusOptionsFlow(OptionsFlowWithReload):
+    """Handle the Fronius options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage how the inverter handles a setpoint Home Assistant left."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        auto_revert = self.config_entry.options.get(CONF_AUTO_REVERT, False)
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_AUTO_REVERT, default=auto_revert): bool}
+            ),
         )
 
 

--- a/homeassistant/components/fronius/config_flow.py
+++ b/homeassistant/components/fronius/config_flow.py
@@ -7,18 +7,13 @@ from typing import Any, Final, override
 from pyfronius import Fronius, FroniusError
 import voluptuous as vol
 
-from homeassistant.config_entries import (
-    ConfigFlow,
-    ConfigFlowResult,
-    OptionsFlowWithReload,
-)
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
-from . import FroniusConfigEntry
 from .const import (
     CONF_AUTO_REVERT,
     CONF_MODBUS_PORT,
@@ -31,7 +26,13 @@ _LOGGER: Final = logging.getLogger(__name__)
 
 DHCP_REQUEST_DELAY: Final = 60
 
-MODBUS_PORT_SELECTOR: Final = vol.All(vol.Coerce(int), vol.Range(min=1, max=65535))
+# the settings that are not the host - shown when adding and reconfiguring
+SETTINGS_SCHEMA: Final = {
+    vol.Required(CONF_MODBUS_PORT, default=DEFAULT_MODBUS_PORT): vol.All(
+        vol.Coerce(int), vol.Range(min=1, max=65535)
+    ),
+    vol.Required(CONF_AUTO_REVERT, default=False): bool,
+}
 
 
 def create_title(info: FroniusConfigEntryData) -> str:
@@ -43,7 +44,10 @@ def create_title(info: FroniusConfigEntryData) -> str:
 
 
 async def validate_host(
-    hass: HomeAssistant, host: str, modbus_port: int = DEFAULT_MODBUS_PORT
+    hass: HomeAssistant,
+    host: str,
+    modbus_port: int = DEFAULT_MODBUS_PORT,
+    auto_revert: bool = False,
 ) -> tuple[str, FroniusConfigEntryData]:
     """Validate the user input allows us to connect."""
     fronius = Fronius(async_get_clientsession(hass, verify_ssl=False), host)
@@ -59,6 +63,7 @@ async def validate_host(
             host=host,
             is_logger=True,
             modbus_port=modbus_port,
+            auto_revert=auto_revert,
         )
     # Gen24 devices don't provide GetLoggerInfo
     try:
@@ -72,6 +77,7 @@ async def validate_host(
         host=host,
         is_logger=False,
         modbus_port=modbus_port,
+        auto_revert=auto_revert,
     )
 
 
@@ -79,18 +85,11 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Fronius."""
 
     VERSION = 1
-    MINOR_VERSION = 2
+    MINOR_VERSION = 3
 
     def __init__(self) -> None:
         """Initialize flow."""
         self.info: FroniusConfigEntryData
-
-    @staticmethod
-    @callback
-    @override
-    def async_get_options_flow(config_entry: FroniusConfigEntry) -> FroniusOptionsFlow:
-        """Get the options flow for this handler."""
-        return FroniusOptionsFlow()
 
     @override
     async def async_step_user(
@@ -105,6 +104,7 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
                     self.hass,
                     user_input[CONF_HOST],
                     modbus_port=user_input[CONF_MODBUS_PORT],
+                    auto_revert=user_input[CONF_AUTO_REVERT],
                 )
             except CannotConnect:
                 errors["base"] = "cannot_connect"
@@ -119,14 +119,7 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_HOST): str,
-                    vol.Required(
-                        CONF_MODBUS_PORT, default=DEFAULT_MODBUS_PORT
-                    ): MODBUS_PORT_SELECTOR,
-                }
-            ),
+            data_schema=vol.Schema({vol.Required(CONF_HOST): str, **SETTINGS_SCHEMA}),
             errors=errors,
         )
 
@@ -184,6 +177,7 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
                     self.hass,
                     user_input[CONF_HOST],
                     modbus_port=user_input[CONF_MODBUS_PORT],
+                    auto_revert=user_input[CONF_AUTO_REVERT],
                 )
             except CannotConnect:
                 errors["base"] = "cannot_connect"
@@ -196,39 +190,14 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
 
                 return self.async_update_reload_and_abort(reconfigure_entry, data=info)
 
-        host = reconfigure_entry.data[CONF_HOST]
-        modbus_port = reconfigure_entry.data.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT)
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_HOST, default=host): str,
-                    vol.Required(
-                        CONF_MODBUS_PORT, default=modbus_port
-                    ): MODBUS_PORT_SELECTOR,
-                }
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema({vol.Required(CONF_HOST): str, **SETTINGS_SCHEMA}),
+                reconfigure_entry.data,
             ),
             description_placeholders={"device": reconfigure_entry.title},
             errors=errors,
-        )
-
-
-class FroniusOptionsFlow(OptionsFlowWithReload):
-    """Handle the Fronius options."""
-
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Manage how the inverter handles a setpoint Home Assistant left."""
-        if user_input is not None:
-            return self.async_create_entry(data=user_input)
-
-        auto_revert = self.config_entry.options.get(CONF_AUTO_REVERT, False)
-        return self.async_show_form(
-            step_id="init",
-            data_schema=vol.Schema(
-                {vol.Required(CONF_AUTO_REVERT, default=auto_revert): bool}
-            ),
         )
 
 

--- a/homeassistant/components/fronius/config_flow.py
+++ b/homeassistant/components/fronius/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import (
-    CONF_AUTO_REVERT,
+    CONF_AUTO_REVERT_POWER_LIMIT,
     CONF_MODBUS_PORT,
     DEFAULT_MODBUS_PORT,
     DOMAIN,
@@ -31,7 +31,7 @@ SETTINGS_SCHEMA: Final = {
     vol.Required(CONF_MODBUS_PORT, default=DEFAULT_MODBUS_PORT): vol.All(
         vol.Coerce(int), vol.Range(min=1, max=65535)
     ),
-    vol.Required(CONF_AUTO_REVERT, default=False): bool,
+    vol.Required(CONF_AUTO_REVERT_POWER_LIMIT, default=False): bool,
 }
 
 
@@ -47,7 +47,7 @@ async def validate_host(
     hass: HomeAssistant,
     host: str,
     modbus_port: int = DEFAULT_MODBUS_PORT,
-    auto_revert: bool = False,
+    auto_revert_power_limit: bool = False,
 ) -> tuple[str, FroniusConfigEntryData]:
     """Validate the user input allows us to connect."""
     fronius = Fronius(async_get_clientsession(hass, verify_ssl=False), host)
@@ -63,7 +63,7 @@ async def validate_host(
             host=host,
             is_logger=True,
             modbus_port=modbus_port,
-            auto_revert=auto_revert,
+            auto_revert_power_limit=auto_revert_power_limit,
         )
     # Gen24 devices don't provide GetLoggerInfo
     try:
@@ -77,7 +77,7 @@ async def validate_host(
         host=host,
         is_logger=False,
         modbus_port=modbus_port,
-        auto_revert=auto_revert,
+        auto_revert_power_limit=auto_revert_power_limit,
     )
 
 
@@ -104,7 +104,7 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
                     self.hass,
                     user_input[CONF_HOST],
                     modbus_port=user_input[CONF_MODBUS_PORT],
-                    auto_revert=user_input[CONF_AUTO_REVERT],
+                    auto_revert_power_limit=user_input[CONF_AUTO_REVERT_POWER_LIMIT],
                 )
             except CannotConnect:
                 errors["base"] = "cannot_connect"
@@ -177,7 +177,7 @@ class FroniusConfigFlow(ConfigFlow, domain=DOMAIN):
                     self.hass,
                     user_input[CONF_HOST],
                     modbus_port=user_input[CONF_MODBUS_PORT],
-                    auto_revert=user_input[CONF_AUTO_REVERT],
+                    auto_revert_power_limit=user_input[CONF_AUTO_REVERT_POWER_LIMIT],
                 )
             except CannotConnect:
                 errors["base"] = "cannot_connect"

--- a/homeassistant/components/fronius/const.py
+++ b/homeassistant/components/fronius/const.py
@@ -1,5 +1,6 @@
 """Constants for the Fronius integration."""
 
+from datetime import timedelta
 from enum import StrEnum
 from typing import Final, NamedTuple, TypedDict
 
@@ -10,6 +11,12 @@ DOMAIN: Final = "fronius"
 
 CONF_MODBUS_PORT: Final = "modbus_port"
 DEFAULT_MODBUS_PORT: Final = 502
+
+CONF_AUTO_REVERT: Final = "auto_revert"
+# how long the device holds a setpoint after it last received it
+AUTO_REVERT_SECONDS: Final = 3600
+# the setpoint is sent again this often, so a restart has room to spare
+HEARTBEAT_INTERVAL: Final = timedelta(minutes=15)
 
 type SolarNetId = str
 SOLAR_NET_DISCOVERY_NEW: Final = "fronius_discovery_new"

--- a/homeassistant/components/fronius/const.py
+++ b/homeassistant/components/fronius/const.py
@@ -31,6 +31,7 @@ class FroniusConfigEntryData(TypedDict):
     host: str
     is_logger: bool
     modbus_port: int
+    auto_revert: bool
 
 
 class FroniusDeviceInfo(NamedTuple):

--- a/homeassistant/components/fronius/const.py
+++ b/homeassistant/components/fronius/const.py
@@ -12,7 +12,7 @@ DOMAIN: Final = "fronius"
 CONF_MODBUS_PORT: Final = "modbus_port"
 DEFAULT_MODBUS_PORT: Final = 502
 
-CONF_AUTO_REVERT: Final = "auto_revert"
+CONF_AUTO_REVERT_POWER_LIMIT: Final = "auto_revert_power_limit"
 # how long the device holds a setpoint after it last received it
 AUTO_REVERT_SECONDS: Final = 3600
 # the setpoint is sent again this often, so a restart has room to spare
@@ -31,7 +31,7 @@ class FroniusConfigEntryData(TypedDict):
     host: str
     is_logger: bool
     modbus_port: int
-    auto_revert: bool
+    auto_revert_power_limit: bool
 
 
 class FroniusDeviceInfo(NamedTuple):

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -2,10 +2,11 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast, override
 
 from fronius_modbus import (
+    Controls,
     FroniusModbusInverter,
     Mppt,
     SunSpecError,
@@ -18,11 +19,15 @@ from homeassistant.const import Platform
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .binary_sensor import POWER_FLOW_BINARY_SENSOR_DESCRIPTIONS
 from .const import (
+    AUTO_REVERT_SECONDS,
+    CONF_AUTO_REVERT,
     DOMAIN,
+    HEARTBEAT_INTERVAL,
     SOLAR_NET_ID_POWER_FLOW,
     SOLAR_NET_ID_SYSTEM,
     FroniusDeviceInfo,
@@ -286,6 +291,56 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         Platform.SWITCH: MODBUS_SWITCH_ENTITY_DESCRIPTIONS,
     }
 
+    @property
+    def revert_seconds(self) -> int:
+        """Return the fallback period to give the device, 0 for none."""
+        if self.config_entry.options.get(CONF_AUTO_REVERT, False):
+            return AUTO_REVERT_SECONDS
+        return 0
+
+    async def async_start_heartbeat(self) -> None:
+        """Keep an active power limit alive against the device's fallback.
+
+        The device holds a power limit only for as long as it keeps hearing
+        it, so it is sent again well before the period is up. Sending it once
+        here also lets the option take effect on a limit that is already
+        running - clearing the period on the device when it is turned off.
+        """
+        await self._async_resend_power_limit()
+        if not self.revert_seconds:
+            return
+        self.config_entry.async_on_unload(
+            async_track_time_interval(
+                self.hass, self._async_resend_power_limit, HEARTBEAT_INTERVAL
+            )
+        )
+
+    async def _async_resend_power_limit(self, _now: datetime | None = None) -> None:
+        """Send an active power limit again to restart the fallback period.
+
+        Fronius documents the period as restarted by every received Modbus
+        message, but a Gen24 dropped the limit on time while being read every
+        five seconds - only writing the limit again restarts it.
+
+        Nothing to do while no limit is in force: without one there is no
+        period running that could be restarted or cleared.
+        """
+        controls = self.modbus_inverter.controls
+        if (
+            controls is None
+            or not controls.enabled
+            or (limit := controls.power_limit) is None
+        ):
+            return
+        try:
+            await controls.set_power_limit(limit, revert_seconds=self.revert_seconds)
+        except (ModbusError, SunSpecError) as err:
+            self.logger.warning(
+                "Could not send the AC power limit to inverter %s again: %s",
+                self.inverter_info.solar_net_id,
+                err,
+            )
+
     @override
     async def _refresh_components(self) -> None:
         """Refresh the models carrying the writable settings."""
@@ -310,6 +365,10 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         register map before anything is written - the register addresses
         move when the data type setting is changed on the device.
 
+        A device holding a different fallback period than the configured one
+        is corrected first, so an output power limit the user sets reverts on
+        the schedule they chose.
+
         ``enable_field`` names the register that puts a setpoint into effect.
         It is written again after a change, because the device only picks up a
         change to an active mode when the mode is enabled again - but only
@@ -325,6 +384,11 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
             )
         try:
             await component.async_update()
+            if (
+                isinstance(component, Controls)
+                and component.revert_seconds != self.revert_seconds
+            ):
+                await component.write("revert_seconds", self.revert_seconds)
             await component.write(field, value)
             if enable_field is not None and getattr(component, enable_field):
                 await component.write(enable_field, True)

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -302,18 +302,34 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         """Keep an active power limit alive against the device's fallback.
 
         The device holds a power limit only for as long as it keeps hearing
-        it, so it is sent again well before the period is up. Sending it once
-        here also lets the option take effect on a limit that is already
-        running - clearing the period on the device when it is turned off.
+        it, so with the option on the limit is sent again well before the
+        period is up.
         """
-        await self._async_resend_power_limit()
         if not self.revert_seconds:
+            await self._async_clear_revert_period()
             return
+        await self._async_resend_power_limit()
         self.config_entry.async_on_unload(
             async_track_time_interval(
                 self.hass, self._async_resend_power_limit, HEARTBEAT_INTERVAL
             )
         )
+
+    async def _async_clear_revert_period(self) -> None:
+        """Take back a period left on the device when the option is turned off.
+
+        A device that was never configured for one here is left alone: what
+        it holds then came from somewhere else, and dropping it would take
+        away another controller's safety net.
+        """
+        controls = self.modbus_inverter.controls
+        if (
+            CONF_AUTO_REVERT not in self.config_entry.options
+            or controls is None
+            or not controls.revert_seconds
+        ):
+            return
+        await self._async_resend_power_limit()
 
     async def _async_resend_power_limit(self, _now: datetime | None = None) -> None:
         """Send an active power limit again to restart the fallback period.
@@ -323,17 +339,22 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         five seconds - only writing the limit again restarts it.
 
         Nothing to do while no limit is in force: without one there is no
-        period running that could be restarted or cleared.
+        period running that could be restarted or cleared. That is decided on
+        a fresh read, so a limit released on the device since the last poll
+        is not taken back here.
         """
         controls = self.modbus_inverter.controls
-        if (
-            controls is None
-            or not controls.enabled
-            or (limit := controls.power_limit) is None
-        ):
+        if controls is None:
             return
         try:
-            await controls.set_power_limit(limit, revert_seconds=self.revert_seconds)
+            await controls.async_update()
+            if not controls.enabled or (limit := controls.power_limit) is None:
+                return
+            # the same registers `set_power_limit` writes - but that one would
+            # enable the limit, and this may only refresh a running one
+            await controls.write("revert_seconds", self.revert_seconds)
+            await controls.write("power_limit", limit)
+            await controls.write("enabled", True)
         except (ModbusError, SunSpecError) as err:
             self.logger.warning(
                 "Could not send the AC power limit to inverter %s again: %s",

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -16,10 +16,10 @@ from modbus_connection import ModbusError
 from pyfronius import BadStatusError, FroniusError
 
 from homeassistant.const import Platform
-from homeassistant.core import callback
+from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .binary_sensor import POWER_FLOW_BINARY_SENSOR_DESCRIPTIONS
@@ -291,10 +291,12 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         Platform.SWITCH: MODBUS_SWITCH_ENTITY_DESCRIPTIONS,
     }
 
+    _heartbeat_unsub: CALLBACK_TYPE | None = None
+
     @property
     def revert_seconds(self) -> int:
         """Return the fallback period to give the device, 0 for none."""
-        if self.config_entry.options.get(CONF_AUTO_REVERT, False):
+        if self.config_entry.data[CONF_AUTO_REVERT]:
             return AUTO_REVERT_SECONDS
         return 0
 
@@ -302,36 +304,47 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         """Keep an active power limit alive against the device's fallback.
 
         The device holds a power limit only for as long as it keeps hearing
-        it, so with the option on the limit is sent again well before the
-        period is up.
+        it, so with the setting on the limit is sent again well before the
+        period is up - starting right away, because the device may have been
+        counting down while Home Assistant was not running.
         """
-        if not self.revert_seconds:
-            await self._async_clear_revert_period()
+        self.config_entry.async_on_unload(self._async_cancel_heartbeat)
+        if self.revert_seconds:
+            await self._async_send_heartbeat()
             return
-        await self._async_resend_power_limit()
-        self.config_entry.async_on_unload(
-            async_track_time_interval(
-                self.hass, self._async_resend_power_limit, HEARTBEAT_INTERVAL
-            )
-        )
-
-    async def _async_clear_revert_period(self) -> None:
-        """Take back a period left on the device when the option is turned off.
-
-        A device that was never configured for one here is left alone: what
-        it holds then came from somewhere else, and dropping it would take
-        away another controller's safety net.
-        """
+        # take back only a period this integration could have set - any other
+        # came from somewhere else, and dropping it would take away another
+        # controller's safety net
         controls = self.modbus_inverter.controls
-        if (
-            CONF_AUTO_REVERT not in self.config_entry.options
-            or controls is None
-            or not controls.revert_seconds
-        ):
-            return
-        await self._async_resend_power_limit()
+        if controls is not None and controls.revert_seconds == AUTO_REVERT_SECONDS:
+            await self._async_resend_power_limit()
 
-    async def _async_resend_power_limit(self, _now: datetime | None = None) -> None:
+    async def _async_send_heartbeat(self, _now: datetime | None = None) -> None:
+        """Send the limit again and line up the next beat."""
+        self._heartbeat_unsub = None
+        await self._async_resend_power_limit()
+        self._async_update_heartbeat()
+
+    @callback
+    def _async_update_heartbeat(self) -> None:
+        """Beat only while there is a limit to keep alive."""
+        controls = self.modbus_inverter.controls
+        if not self.revert_seconds or controls is None or not controls.enabled:
+            self._async_cancel_heartbeat()
+            return
+        if self._heartbeat_unsub is None:
+            self._heartbeat_unsub = async_call_later(
+                self.hass, HEARTBEAT_INTERVAL, self._async_send_heartbeat
+            )
+
+    @callback
+    def _async_cancel_heartbeat(self) -> None:
+        """Drop a pending beat."""
+        if self._heartbeat_unsub is not None:
+            self._heartbeat_unsub()
+            self._heartbeat_unsub = None
+
+    async def _async_resend_power_limit(self) -> None:
         """Send an active power limit again to restart the fallback period.
 
         Fronius documents the period as restarted by every received Modbus
@@ -361,6 +374,13 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
                 self.inverter_info.solar_net_id,
                 err,
             )
+
+    @override
+    async def _async_update_data(self) -> dict[SolarNetId, Any]:
+        """Refresh the settings and keep the heartbeat in step with them."""
+        data = await super()._async_update_data()
+        self._async_update_heartbeat()
+        return data
 
     @override
     async def _refresh_components(self) -> None:
@@ -419,6 +439,8 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
                 translation_key="modbus_write_failed",
                 translation_placeholders={"error": str(err)},
             ) from err
+        # the write restarted the device's period, so the beat starts over
+        self._async_cancel_heartbeat()
         # not debounced: the entity should settle on what the device reports
         # back, and writes are rare and user initiated
         await self.async_refresh()

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -1,6 +1,7 @@
 """DataUpdateCoordinators for the Fronius integration."""
 
 from abc import ABC, abstractmethod
+import asyncio
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast, override
@@ -292,6 +293,13 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
     }
 
     _heartbeat_unsub: CALLBACK_TYPE | None = None
+    _heartbeat_stopped = False
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Set up a coordinator that also writes to the device."""
+        super().__init__(*args, **kwargs)
+        # the heartbeat and a user's write must not interleave on the device
+        self._device_lock = asyncio.Lock()
 
     @property
     def revert_seconds(self) -> int:
@@ -308,7 +316,9 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         period is up - starting right away, because the device may have been
         counting down while Home Assistant was not running.
         """
-        self.config_entry.async_on_unload(self._async_cancel_heartbeat)
+        self.config_entry.async_on_unload(self._async_stop_heartbeat)
+        # the first refresh may have scheduled a beat already
+        self._async_cancel_heartbeat()
         if self.revert_seconds:
             await self._async_send_heartbeat()
             return
@@ -329,13 +339,24 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
     def _async_update_heartbeat(self) -> None:
         """Beat only while there is a limit to keep alive."""
         controls = self.modbus_inverter.controls
-        if not self.revert_seconds or controls is None or not controls.enabled:
+        if (
+            self._heartbeat_stopped
+            or not self.revert_seconds
+            or controls is None
+            or not controls.enabled
+        ):
             self._async_cancel_heartbeat()
             return
         if self._heartbeat_unsub is None:
             self._heartbeat_unsub = async_call_later(
                 self.hass, HEARTBEAT_INTERVAL, self._async_send_heartbeat
             )
+
+    @callback
+    def _async_stop_heartbeat(self) -> None:
+        """Stop beating for good, even from a beat that is under way."""
+        self._heartbeat_stopped = True
+        self._async_cancel_heartbeat()
 
     @callback
     def _async_cancel_heartbeat(self) -> None:
@@ -360,14 +381,15 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         if controls is None:
             return
         try:
-            await controls.async_update()
-            if not controls.enabled or (limit := controls.power_limit) is None:
-                return
-            # the same registers `set_power_limit` writes - but that one would
-            # enable the limit, and this may only refresh a running one
-            await controls.write("revert_seconds", self.revert_seconds)
-            await controls.write("power_limit", limit)
-            await controls.write("enabled", True)
+            async with self._device_lock:
+                await controls.async_update()
+                if not controls.enabled or (limit := controls.power_limit) is None:
+                    return
+                # the same registers `set_power_limit` writes - but that one
+                # would enable the limit, and this may only refresh a running one
+                await controls.write("revert_seconds", self.revert_seconds)
+                await controls.write("power_limit", limit)
+                await controls.write("enabled", True)
         except (ModbusError, SunSpecError) as err:
             self.logger.warning(
                 "Could not send the AC power limit to inverter %s again: %s",
@@ -424,15 +446,16 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
                 translation_key="modbus_model_unavailable",
             )
         try:
-            await component.async_update()
-            if (
-                isinstance(component, Controls)
-                and component.revert_seconds != self.revert_seconds
-            ):
-                await component.write("revert_seconds", self.revert_seconds)
-            await component.write(field, value)
-            if enable_field is not None and getattr(component, enable_field):
-                await component.write(enable_field, True)
+            async with self._device_lock:
+                await component.async_update()
+                if (
+                    isinstance(component, Controls)
+                    and component.revert_seconds != self.revert_seconds
+                ):
+                    await component.write("revert_seconds", self.revert_seconds)
+                await component.write(field, value)
+                if enable_field is not None and getattr(component, enable_field):
+                    await component.write(enable_field, True)
         except (ModbusError, SunSpecError) as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -300,13 +300,13 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         super().__init__(*args, **kwargs)
         # the heartbeat and a user's write must not interleave on the device
         self._device_lock = asyncio.Lock()
-
-    @property
-    def revert_seconds(self) -> int:
-        """Return the fallback period to give the device, 0 for none."""
-        if self.config_entry.data[CONF_AUTO_REVERT_POWER_LIMIT]:
-            return AUTO_REVERT_SECONDS
-        return 0
+        # the fallback period to give the device, 0 for none - changing the
+        # setting reloads the entry, so it is fixed for this coordinator
+        self._revert_seconds = (
+            AUTO_REVERT_SECONDS
+            if self.config_entry.data[CONF_AUTO_REVERT_POWER_LIMIT]
+            else 0
+        )
 
     async def async_start_heartbeat(self) -> None:
         """Keep an active power limit alive against the device's fallback.
@@ -319,7 +319,7 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         self.config_entry.async_on_unload(self._async_stop_heartbeat)
         # the first refresh may have scheduled a beat already
         self._async_cancel_heartbeat()
-        if self.revert_seconds:
+        if self._revert_seconds:
             await self._async_send_heartbeat()
             return
         # take back only a period this integration could have set - any other
@@ -341,7 +341,7 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         controls = self.modbus_inverter.controls
         if (
             self._heartbeat_stopped
-            or not self.revert_seconds
+            or not self._revert_seconds
             or controls is None
             or not controls.enabled
         ):
@@ -387,7 +387,7 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
                     return
                 # the same registers `set_power_limit` writes - but that one
                 # would enable the limit, and this may only refresh a running one
-                await controls.write("revert_seconds", self.revert_seconds)
+                await controls.write("revert_seconds", self._revert_seconds)
                 await controls.write("power_limit", limit)
                 await controls.write("enabled", True)
         except (ModbusError, SunSpecError) as err:
@@ -450,9 +450,9 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
                 await component.async_update()
                 if (
                     isinstance(component, Controls)
-                    and component.revert_seconds != self.revert_seconds
+                    and component.revert_seconds != self._revert_seconds
                 ):
-                    await component.write("revert_seconds", self.revert_seconds)
+                    await component.write("revert_seconds", self._revert_seconds)
                 await component.write(field, value)
                 if enable_field is not None and getattr(component, enable_field):
                     await component.write(enable_field, True)

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -321,13 +321,6 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         self._async_cancel_heartbeat()
         if self._revert_seconds:
             await self._async_send_heartbeat()
-            return
-        # take back only a period this integration could have set - any other
-        # came from somewhere else, and dropping it would take away another
-        # controller's safety net
-        controls = self.modbus_inverter.controls
-        if controls is not None and controls.revert_seconds == AUTO_REVERT_SECONDS:
-            await self._async_resend_power_limit()
 
     async def _async_send_heartbeat(self, _now: datetime | None = None) -> None:
         """Send the limit again and line up the next beat."""
@@ -402,7 +395,22 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
         """Refresh the settings and keep the heartbeat in step with them."""
         data = await super()._async_update_data()
         self._async_update_heartbeat()
+        if not self._revert_seconds:
+            await self._async_clear_revert_period()
         return data
+
+    async def _async_clear_revert_period(self) -> None:
+        """Take back a period this integration left on the device.
+
+        Only one it could have set is taken back - any other came from
+        somewhere else, and dropping it would take away another controller's
+        safety net. Done from the refresh so that a write that fails is
+        tried again while the device holds a period it should not.
+        """
+        controls = self.modbus_inverter.controls
+        if controls is None or controls.revert_seconds != AUTO_REVERT_SECONDS:
+            return
+        await self._async_resend_power_limit()
 
     @override
     async def _refresh_components(self) -> None:

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .binary_sensor import POWER_FLOW_BINARY_SENSOR_DESCRIPTIONS
 from .const import (
     AUTO_REVERT_SECONDS,
-    CONF_AUTO_REVERT,
+    CONF_AUTO_REVERT_POWER_LIMIT,
     DOMAIN,
     HEARTBEAT_INTERVAL,
     SOLAR_NET_ID_POWER_FLOW,
@@ -304,7 +304,7 @@ class FroniusModbusSettingsUpdateCoordinator(FroniusModbusCoordinatorBase):
     @property
     def revert_seconds(self) -> int:
         """Return the fallback period to give the device, 0 for none."""
-        if self.config_entry.data[CONF_AUTO_REVERT]:
+        if self.config_entry.data[CONF_AUTO_REVERT_POWER_LIMIT]:
             return AUTO_REVERT_SECONDS
         return 0
 

--- a/homeassistant/components/fronius/quality_scale.yaml
+++ b/homeassistant/components/fronius/quality_scale.yaml
@@ -43,10 +43,7 @@ rules:
     comment: |
       This integration does not provide additional actions.
   config-entry-unloading: done
-  docs-configuration-parameters:
-    status: exempt
-    comment: |
-      This integration does not provide configuration options.
+  docs-configuration-parameters: done
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done

--- a/homeassistant/components/fronius/quality_scale.yaml
+++ b/homeassistant/components/fronius/quality_scale.yaml
@@ -43,7 +43,10 @@ rules:
     comment: |
       This integration does not provide additional actions.
   config-entry-unloading: done
-  docs-configuration-parameters: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: |
+      This integration does not provide configuration options.
   docs-installation-parameters: done
   entity-unavailable: done
   integration-owner: done

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -466,7 +466,7 @@
           "auto_revert": "Revert the AC power limit if Home Assistant stops"
         },
         "data_description": {
-          "auto_revert": "The inverter drops the AC power limit an hour after it last received it, and returns to its own settings. Home Assistant sends the limit again every 15 minutes, so this only takes effect once Home Assistant has really stopped. Battery setpoints are not affected - the inverter supports no timeout for them."
+          "auto_revert": "The inverter drops the AC power limit an hour after it last received it, and returns to its own settings. Home Assistant sends the limit again every 15 minutes, so this only takes effect once it stops sending - because Home Assistant is down, or because the integration was removed. Battery setpoints are not affected - the inverter supports no timeout for them."
         },
         "description": "These settings apply to controlling the inverter over Modbus."
       }

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -17,10 +17,12 @@
       },
       "reconfigure": {
         "data": {
+          "auto_revert": "[%key:component::fronius::config::step::user::data::auto_revert%]",
           "host": "[%key:common::config_flow::data::host%]",
           "modbus_port": "[%key:component::fronius::config::step::user::data::modbus_port%]"
         },
         "data_description": {
+          "auto_revert": "[%key:component::fronius::config::step::user::data_description::auto_revert%]",
           "host": "[%key:component::fronius::config::step::user::data_description::host%]",
           "modbus_port": "[%key:component::fronius::config::step::user::data_description::modbus_port%]"
         },
@@ -28,10 +30,12 @@
       },
       "user": {
         "data": {
+          "auto_revert": "Revert the AC power limit if Home Assistant stops",
           "host": "[%key:common::config_flow::data::host%]",
           "modbus_port": "Modbus port"
         },
         "data_description": {
+          "auto_revert": "The inverter drops the AC power limit an hour after it last received it, and returns to its own settings. Home Assistant sends the limit again every 15 minutes, so this only takes effect once it stops sending - because Home Assistant is down, or because the integration was removed. Battery setpoints are not affected - the inverter supports no timeout for them.",
           "host": "The IP address or hostname of your Fronius device.",
           "modbus_port": "Port of the device's Modbus TCP interface. Only used when Modbus is enabled on the device's web interface."
         },
@@ -457,19 +461,6 @@
     },
     "update_failed": {
       "message": "An error occurred while attempting to fetch data: {fronius_error}"
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "data": {
-          "auto_revert": "Revert the AC power limit if Home Assistant stops"
-        },
-        "data_description": {
-          "auto_revert": "The inverter drops the AC power limit an hour after it last received it, and returns to its own settings. Home Assistant sends the limit again every 15 minutes, so this only takes effect once it stops sending - because Home Assistant is down, or because the integration was removed. Battery setpoints are not affected - the inverter supports no timeout for them."
-        },
-        "description": "These settings apply to controlling the inverter over Modbus."
-      }
     }
   }
 }

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -73,7 +73,7 @@
         "name": "Grid export tariff"
       },
       "co2_factor": {
-        "name": "CO\u2082 factor"
+        "name": "CO₂ factor"
       },
       "current_ac": {
         "name": "AC current"
@@ -176,8 +176,8 @@
           "hardware_id_problem": "Hardware ID problem",
           "hid_range_error": "HID range error",
           "initialisation_error_file_system_error_on_usb": "Initialization error in file system on USB flash drive",
-          "initialisation_error_usb_flash_drive_not_supported": "Initialization error \u2013 USB flash drive is not supported",
-          "initialisation_error_usb_stick_over_current": "Initialization error \u2013 Overcurrent on USB stick",
+          "initialisation_error_usb_flash_drive_not_supported": "Initialization error – USB flash drive is not supported",
+          "initialisation_error_usb_stick_over_current": "Initialization error – Overcurrent on USB stick",
           "insulation_error_on_solar_panels": "Insulation error on the solar panels",
           "insulation_fault": "Insulation fault",
           "insulation_measurement_triggered": "Insulation measurement triggered",
@@ -457,6 +457,19 @@
     },
     "update_failed": {
       "message": "An error occurred while attempting to fetch data: {fronius_error}"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "auto_revert": "Revert the AC power limit if Home Assistant stops"
+        },
+        "data_description": {
+          "auto_revert": "The inverter drops the AC power limit an hour after it last received it, and returns to its own settings. Home Assistant sends the limit again every 15 minutes, so this only takes effect once Home Assistant has really stopped. Battery setpoints are not affected - the inverter supports no timeout for them."
+        },
+        "description": "These settings apply to controlling the inverter over Modbus."
+      }
     }
   }
 }

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -17,12 +17,12 @@
       },
       "reconfigure": {
         "data": {
-          "auto_revert": "[%key:component::fronius::config::step::user::data::auto_revert%]",
+          "auto_revert_power_limit": "[%key:component::fronius::config::step::user::data::auto_revert_power_limit%]",
           "host": "[%key:common::config_flow::data::host%]",
           "modbus_port": "[%key:component::fronius::config::step::user::data::modbus_port%]"
         },
         "data_description": {
-          "auto_revert": "[%key:component::fronius::config::step::user::data_description::auto_revert%]",
+          "auto_revert_power_limit": "[%key:component::fronius::config::step::user::data_description::auto_revert_power_limit%]",
           "host": "[%key:component::fronius::config::step::user::data_description::host%]",
           "modbus_port": "[%key:component::fronius::config::step::user::data_description::modbus_port%]"
         },
@@ -30,12 +30,12 @@
       },
       "user": {
         "data": {
-          "auto_revert": "Revert the AC power limit if Home Assistant stops",
+          "auto_revert_power_limit": "Revert the AC power limit if Home Assistant stops",
           "host": "[%key:common::config_flow::data::host%]",
           "modbus_port": "Modbus port"
         },
         "data_description": {
-          "auto_revert": "The inverter drops the AC power limit an hour after it last received it, and returns to its own settings. Home Assistant sends the limit again every 15 minutes, so this only takes effect once it stops sending - because Home Assistant is down, or because the integration was removed. Battery setpoints are not affected - the inverter supports no timeout for them.",
+          "auto_revert_power_limit": "The inverter drops the AC power limit an hour after it last received it, and returns to its own settings. Home Assistant sends the limit again every 15 minutes, so this only takes effect once it stops sending - because Home Assistant is down, or because the integration was removed. Battery setpoints are not affected - the inverter supports no timeout for them.",
           "host": "The IP address or hostname of your Fronius device.",
           "modbus_port": "Port of the device's Modbus TCP interface. Only used when Modbus is enabled on the device's web interface."
         },

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -22,7 +22,7 @@ async def setup_fronius_integration(
     is_logger: bool = True,
     unique_id: str = MOCK_UID,
     modbus_port: int | None = None,
-    options: dict[str, Any] | None = None,
+    auto_revert: bool = False,
 ) -> ConfigEntry:
     """Create the Fronius integration.
 
@@ -37,8 +37,8 @@ async def setup_fronius_integration(
             CONF_HOST: MOCK_HOST,
             "is_logger": is_logger,
             **({"modbus_port": modbus_port} if modbus_port is not None else {}),
+            **({"auto_revert": True} if auto_revert else {}),
         },
-        options=options or {},
         minor_version=1 if modbus_port is None else 2,
     )
     entry.add_to_hass(hass)

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -22,6 +22,7 @@ async def setup_fronius_integration(
     is_logger: bool = True,
     unique_id: str = MOCK_UID,
     modbus_port: int | None = None,
+    options: dict[str, Any] | None = None,
 ) -> ConfigEntry:
     """Create the Fronius integration.
 
@@ -37,6 +38,7 @@ async def setup_fronius_integration(
             "is_logger": is_logger,
             **({"modbus_port": modbus_port} if modbus_port is not None else {}),
         },
+        options=options or {},
         minor_version=1 if modbus_port is None else 2,
     )
     entry.add_to_hass(hass)

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -22,7 +22,7 @@ async def setup_fronius_integration(
     is_logger: bool = True,
     unique_id: str = MOCK_UID,
     modbus_port: int | None = None,
-    auto_revert: bool = False,
+    auto_revert_power_limit: bool = False,
 ) -> ConfigEntry:
     """Create the Fronius integration.
 
@@ -37,7 +37,7 @@ async def setup_fronius_integration(
             CONF_HOST: MOCK_HOST,
             "is_logger": is_logger,
             **({"modbus_port": modbus_port} if modbus_port is not None else {}),
-            **({"auto_revert": True} if auto_revert else {}),
+            **({"auto_revert_power_limit": True} if auto_revert_power_limit else {}),
         },
         minor_version=1 if modbus_port is None else 2,
     )

--- a/tests/components/fronius/snapshots/test_diagnostics.ambr
+++ b/tests/components/fronius/snapshots/test_diagnostics.ambr
@@ -3,6 +3,7 @@
   dict({
     'config_entry': dict({
       'data': dict({
+        'auto_revert': False,
         'host': 'http://fronius',
         'is_logger': True,
         'modbus_port': 502,
@@ -12,7 +13,7 @@
       }),
       'domain': 'fronius',
       'entry_id': 'f1e2b9837e8adaed6fa682acaa216fd8',
-      'minor_version': 2,
+      'minor_version': 3,
       'options': dict({
       }),
       'pref_disable_new_entities': False,
@@ -381,6 +382,7 @@
   dict({
     'config_entry': dict({
       'data': dict({
+        'auto_revert': False,
         'host': 'http://fronius',
         'is_logger': False,
         'modbus_port': 502,
@@ -390,7 +392,7 @@
       }),
       'domain': 'fronius',
       'entry_id': 'f1e2b9837e8adaed6fa682acaa216fd8',
-      'minor_version': 2,
+      'minor_version': 3,
       'options': dict({
       }),
       'pref_disable_new_entities': False,

--- a/tests/components/fronius/snapshots/test_diagnostics.ambr
+++ b/tests/components/fronius/snapshots/test_diagnostics.ambr
@@ -3,7 +3,7 @@
   dict({
     'config_entry': dict({
       'data': dict({
-        'auto_revert': False,
+        'auto_revert_power_limit': False,
         'host': 'http://fronius',
         'is_logger': True,
         'modbus_port': 502,
@@ -382,7 +382,7 @@
   dict({
     'config_entry': dict({
       'data': dict({
-        'auto_revert': False,
+        'auto_revert_power_limit': False,
         'host': 'http://fronius',
         'is_logger': False,
         'modbus_port': 502,

--- a/tests/components/fronius/test_config_flow.py
+++ b/tests/components/fronius/test_config_flow.py
@@ -6,7 +6,7 @@ from pyfronius import FroniusError
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.fronius.const import CONF_AUTO_REVERT, DOMAIN
+from homeassistant.components.fronius.const import DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -64,6 +64,7 @@ async def assert_finish_flow_with_logger(hass: HomeAssistant, flow_id: str) -> N
         "host": "10.9.8.1",
         "is_logger": True,
         "modbus_port": 502,
+        "auto_revert": False,
     }
     assert result["result"].unique_id == "123.4567"
 
@@ -122,6 +123,7 @@ async def test_form_with_inverter(hass: HomeAssistant) -> None:
             {
                 "host": "10.9.1.1",
                 "modbus_port": 1502,
+                "auto_revert": True,
             },
         )
         await hass.async_block_till_done()
@@ -132,6 +134,7 @@ async def test_form_with_inverter(hass: HomeAssistant) -> None:
         "host": "10.9.1.1",
         "is_logger": False,
         "modbus_port": 1502,
+        "auto_revert": True,
     }
     assert result2["result"].unique_id == "1234567"
 
@@ -256,6 +259,7 @@ async def test_config_flow_already_configured(
         "host": old_host,  # not updated from config flow - only from reconfigure flow
         "is_logger": True,
         "modbus_port": 502,  # added by migration
+        "auto_revert": False,  # added by migration
     }
 
 
@@ -283,6 +287,7 @@ async def test_dhcp(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) ->
         "host": MOCK_DHCP_DATA.ip,
         "is_logger": True,
         "modbus_port": 502,
+        "auto_revert": False,
     }
     assert result["result"].unique_id == "123.4567"
 
@@ -373,6 +378,7 @@ async def test_reconfigure(hass: HomeAssistant) -> None:
         "host": new_host,
         "is_logger": False,
         "modbus_port": 1502,
+        "auto_revert": False,
     }
 
 
@@ -467,25 +473,3 @@ async def test_reconfigure_to_different_device(hass: HomeAssistant) -> None:
     await assert_abort_flow_with_logger(
         hass, result["flow_id"], reason="unique_id_mismatch"
     )
-
-
-async def test_options_flow(hass: HomeAssistant) -> None:
-    """Test turning on the fallback for setpoints."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="123.4567890",
-        data={CONF_HOST: "10.1.2.3", "is_logger": True},
-    )
-    entry.add_to_hass(hass)
-
-    result = await hass.config_entries.options.async_init(entry.entry_id)
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "init"
-
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"], {CONF_AUTO_REVERT: True}
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert entry.options == {CONF_AUTO_REVERT: True}

--- a/tests/components/fronius/test_config_flow.py
+++ b/tests/components/fronius/test_config_flow.py
@@ -6,7 +6,7 @@ from pyfronius import FroniusError
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.fronius.const import DOMAIN
+from homeassistant.components.fronius.const import CONF_AUTO_REVERT, DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -467,3 +467,25 @@ async def test_reconfigure_to_different_device(hass: HomeAssistant) -> None:
     await assert_abort_flow_with_logger(
         hass, result["flow_id"], reason="unique_id_mismatch"
     )
+
+
+async def test_options_flow(hass: HomeAssistant) -> None:
+    """Test turning on the fallback for setpoints."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="123.4567890",
+        data={CONF_HOST: "10.1.2.3", "is_logger": True},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {CONF_AUTO_REVERT: True}
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options == {CONF_AUTO_REVERT: True}

--- a/tests/components/fronius/test_config_flow.py
+++ b/tests/components/fronius/test_config_flow.py
@@ -64,7 +64,7 @@ async def assert_finish_flow_with_logger(hass: HomeAssistant, flow_id: str) -> N
         "host": "10.9.8.1",
         "is_logger": True,
         "modbus_port": 502,
-        "auto_revert": False,
+        "auto_revert_power_limit": False,
     }
     assert result["result"].unique_id == "123.4567"
 
@@ -123,7 +123,7 @@ async def test_form_with_inverter(hass: HomeAssistant) -> None:
             {
                 "host": "10.9.1.1",
                 "modbus_port": 1502,
-                "auto_revert": True,
+                "auto_revert_power_limit": True,
             },
         )
         await hass.async_block_till_done()
@@ -134,7 +134,7 @@ async def test_form_with_inverter(hass: HomeAssistant) -> None:
         "host": "10.9.1.1",
         "is_logger": False,
         "modbus_port": 1502,
-        "auto_revert": True,
+        "auto_revert_power_limit": True,
     }
     assert result2["result"].unique_id == "1234567"
 
@@ -259,7 +259,7 @@ async def test_config_flow_already_configured(
         "host": old_host,  # not updated from config flow - only from reconfigure flow
         "is_logger": True,
         "modbus_port": 502,  # added by migration
-        "auto_revert": False,  # added by migration
+        "auto_revert_power_limit": False,  # added by migration
     }
 
 
@@ -287,7 +287,7 @@ async def test_dhcp(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) ->
         "host": MOCK_DHCP_DATA.ip,
         "is_logger": True,
         "modbus_port": 502,
-        "auto_revert": False,
+        "auto_revert_power_limit": False,
     }
     assert result["result"].unique_id == "123.4567"
 
@@ -378,7 +378,7 @@ async def test_reconfigure(hass: HomeAssistant) -> None:
         "host": new_host,
         "is_logger": False,
         "modbus_port": 1502,
-        "auto_revert": False,
+        "auto_revert_power_limit": False,
     }
 
 

--- a/tests/components/fronius/test_init.py
+++ b/tests/components/fronius/test_init.py
@@ -42,13 +42,14 @@ async def test_unload_config_entry(
 async def test_migrate_config_entry(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
-    """Test migration adds the default Modbus port to old config entries."""
+    """Test migration adds the Modbus settings to old config entries."""
     mock_responses(aioclient_mock)
     entry = await setup_fronius_integration(hass)
 
     assert entry.version == 1
-    assert entry.minor_version == 2
+    assert entry.minor_version == 3
     assert entry.data["modbus_port"] == 502
+    assert entry.data["auto_revert"] is False
 
 
 async def test_logger_error(

--- a/tests/components/fronius/test_init.py
+++ b/tests/components/fronius/test_init.py
@@ -49,7 +49,7 @@ async def test_migrate_config_entry(
     assert entry.version == 1
     assert entry.minor_version == 3
     assert entry.data["modbus_port"] == 502
-    assert entry.data["auto_revert"] is False
+    assert entry.data["auto_revert_power_limit"] is False
 
 
 async def test_logger_error(

--- a/tests/components/fronius/test_modbus.py
+++ b/tests/components/fronius/test_modbus.py
@@ -5,21 +5,33 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from fronius_modbus.testing import MpptModuleSpec, build_sunspec_map
-from modbus_connection.mock import MockModbusConnection
+from modbus_connection import ModbusConnectionError
+from modbus_connection.mock import MockModbusConnection, WriteEvent
 import pytest
 
-from homeassistant.components.fronius.const import SOLAR_NET_RESCAN_TIMER
+from homeassistant.components.fronius.const import (
+    AUTO_REVERT_SECONDS,
+    CONF_AUTO_REVERT,
+    HEARTBEAT_INTERVAL,
+    SOLAR_NET_RESCAN_TIMER,
+)
 from homeassistant.components.fronius.coordinator import (
     FroniusModbusInverterUpdateCoordinator,
 )
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import Platform
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import mock_responses, setup_fronius_integration
 
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 # module names as reported by real GEN24 hybrid inverters
@@ -35,6 +47,9 @@ GEN24_HYBRID_MODULES = [
         id_str="StDisCha 4", current=12, voltage=3990, power=480, energy=150_000
     ),
 ]
+
+POWER_LIMIT = "number.gen24_storage_ac_power_limit"
+POWER_LIMITING = "switch.gen24_storage_ac_power_limiting"
 
 
 def assert_state(
@@ -250,6 +265,7 @@ async def test_no_mppt_model(
     aioclient_mock: AiohttpClientMocker,
     mock_fronius_modbus: MockModbusConnection,
     entity_registry: er.EntityRegistry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test a SunSpec device without MPPT model still gets its controls.
 
@@ -276,6 +292,13 @@ async def test_no_mppt_model(
     # no MPPT sensors, but the controls and their derived values are there
     assert not [entry for entry in modbus_entities if "mppt" in entry.unique_id]
     assert "number" in {entry.domain for entry in modbus_entities}
+
+    freezer.tick(timedelta(minutes=SOLAR_NET_RESCAN_TIMER, seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # the re-scan finds the controls already set up
+    assert len(config_entry.runtime_data.modbus_settings_coordinators) == 1
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -451,3 +474,192 @@ async def test_control_refused_creates_no_control_entities(
         )
         if entry.domain == "number"
     ]
+
+
+async def _setup_with_controls(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    connection: MockModbusConnection,
+    options: dict[str, bool] | None = None,
+) -> MockConfigEntry:
+    """Set up an inverter that accepts control writes."""
+    connection.for_unit(1).holding.update(
+        build_sunspec_map(GEN24_HYBRID_MODULES, storage_wcha_max=12800)
+    )
+    mock_responses(aioclient_mock, fixture_set="gen24_storage")
+    with patch(
+        "homeassistant.components.fronius.PLATFORMS",
+        [Platform.NUMBER, Platform.SWITCH],
+    ):
+        return await setup_fronius_integration(
+            hass, is_logger=False, unique_id="12345678", options=options
+        )
+
+
+async def _turn_on_power_limit(hass: HomeAssistant, limit: float) -> None:
+    """Set the AC power limit and put it into effect."""
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: POWER_LIMIT, ATTR_VALUE: limit},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: POWER_LIMITING},
+        blocking=True,
+    )
+
+
+async def test_limit_carries_the_configured_fallback_period(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test the inverter is told when to revert a limit Home Assistant set."""
+    config_entry = await _setup_with_controls(
+        hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+    )
+    controls = config_entry.runtime_data.modbus_settings_coordinators[
+        0
+    ].modbus_inverter.controls
+
+    await _turn_on_power_limit(hass, 60)
+
+    assert_state(hass, POWER_LIMIT, 60.0)
+    assert controls.enabled is True
+    assert controls.revert_seconds == AUTO_REVERT_SECONDS
+
+
+async def test_active_limit_is_sent_again_before_it_reverts(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test an active limit is refreshed, so only an outage lets it revert."""
+    config_entry = await _setup_with_controls(
+        hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+    )
+    controls = config_entry.runtime_data.modbus_settings_coordinators[
+        0
+    ].modbus_inverter.controls
+    await _turn_on_power_limit(hass, 60)
+
+    writes: list[WriteEvent] = []
+    mock_fronius_modbus.for_unit(1).on_write(writes.append)
+    freezer.tick(HEARTBEAT_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # the fallback period, the limit and the enable register that arms it
+    assert len(writes) == 3
+    assert controls.power_limit == 60
+    assert controls.enabled is True
+
+
+async def test_heartbeat_leaves_a_released_limit_released(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the heartbeat doesn't take control back that the user handed over.
+
+    While no limit is in force there is no period counting down either, so
+    the inverter is left to whatever source it fell back to.
+    """
+    config_entry = await _setup_with_controls(
+        hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+    )
+    controls = config_entry.runtime_data.modbus_settings_coordinators[
+        0
+    ].modbus_inverter.controls
+    assert controls.enabled is False
+
+    writes: list[WriteEvent] = []
+    mock_fronius_modbus.for_unit(1).on_write(writes.append)
+    freezer.tick(HEARTBEAT_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert not writes
+    assert controls.enabled is False
+
+
+async def test_limit_without_a_fallback_period_is_left_alone(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a limit is not refreshed while the inverter is not to revert it."""
+    config_entry = await _setup_with_controls(hass, aioclient_mock, mock_fronius_modbus)
+    controls = config_entry.runtime_data.modbus_settings_coordinators[
+        0
+    ].modbus_inverter.controls
+    await _turn_on_power_limit(hass, 60)
+    assert controls.revert_seconds == 0
+
+    writes: list[WriteEvent] = []
+    mock_fronius_modbus.for_unit(1).on_write(writes.append)
+    freezer.tick(timedelta(hours=9))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert not writes
+
+
+async def test_clearing_the_fallback_period_frees_a_running_limit(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test a limit stops reverting as soon as the fallback period is off.
+
+    The inverter would otherwise keep counting down the period it was given
+    with the limit, and drop it once Home Assistant stops refreshing it.
+    """
+    config_entry = await _setup_with_controls(
+        hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+    )
+    await _turn_on_power_limit(hass, 60)
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    with patch(
+        "homeassistant.components.fronius.PLATFORMS",
+        [Platform.NUMBER, Platform.SWITCH],
+    ):
+        await hass.config_entries.options.async_configure(
+            result["flow_id"], {CONF_AUTO_REVERT: False}
+        )
+        await hass.async_block_till_done()
+
+    assert config_entry.options == {CONF_AUTO_REVERT: False}
+    coordinator = config_entry.runtime_data.modbus_settings_coordinators[0]
+    await coordinator.async_refresh()
+    controls = coordinator.modbus_inverter.controls
+    assert controls.enabled is True
+    assert controls.revert_seconds == 0
+
+
+async def test_a_failed_resend_of_the_limit_is_logged(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test an inverter gone quiet while a limit is kept alive doesn't raise."""
+    await _setup_with_controls(
+        hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+    )
+    await _turn_on_power_limit(hass, 60)
+    mock_fronius_modbus.for_unit(1).fail_requests(ModbusConnectionError("gone"))
+
+    freezer.tick(HEARTBEAT_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert "Could not send the AC power limit" in caplog.text

--- a/tests/components/fronius/test_modbus.py
+++ b/tests/components/fronius/test_modbus.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
+from fronius_modbus import Mppt
 from fronius_modbus.testing import MpptModuleSpec, build_sunspec_map
 from modbus_connection import ModbusConnectionError
 from modbus_connection.mock import MockModbusConnection, WriteEvent
@@ -663,3 +664,84 @@ async def test_a_failed_resend_of_the_limit_is_logged(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     assert "Could not send the AC power limit" in caplog.text
+
+
+async def test_unconfigured_device_is_left_alone(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+) -> None:
+    """Test a setup without the option touching nothing but the write probe.
+
+    Whatever period such a device holds was put there by something else, so
+    clearing it would take away another controller's safety net.
+    """
+    config_entry = await _setup_with_controls(hass, aioclient_mock, mock_fronius_modbus)
+    await _turn_on_power_limit(hass, 60)
+
+    writes: list[WriteEvent] = []
+    mock_fronius_modbus.for_unit(1).on_write(writes.append)
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # only the write access probe, the limit itself is not sent again
+    assert len(writes) == 1
+
+
+async def test_heartbeat_leaves_a_limit_released_on_the_device_released(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the heartbeat decides on a fresh read, not on the last poll.
+
+    Something else may release the limit between two polls - the heartbeat
+    must not take that back.
+    """
+    config_entry = await _setup_with_controls(
+        hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+    )
+    controls = config_entry.runtime_data.modbus_settings_coordinators[
+        0
+    ].modbus_inverter.controls
+    await _turn_on_power_limit(hass, 60)
+
+    await controls.write("enabled", False)
+    # the write leaves the coordinator's picture of the device behind
+    assert controls.enabled is True
+
+    freezer.tick(HEARTBEAT_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert controls.enabled is False
+
+
+async def test_readings_recover_when_only_the_controls_came_up(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a re-scan still adds the MPPT data after it failed once.
+
+    The two coordinators are independent: one of them answering is no reason
+    to stop retrying the other.
+    """
+    with patch.object(
+        Mppt, "async_update", side_effect=ModbusConnectionError("no answer")
+    ):
+        config_entry = await _setup_with_controls(
+            hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+        )
+        assert not config_entry.runtime_data.modbus_inverter_coordinators
+        assert config_entry.runtime_data.modbus_settings_coordinators
+
+    freezer.tick(timedelta(minutes=SOLAR_NET_RESCAN_TIMER, seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert config_entry.runtime_data.modbus_inverter_coordinators
+    # the settings coordinator that was already up is not added a second time
+    assert len(config_entry.runtime_data.modbus_settings_coordinators) == 1

--- a/tests/components/fronius/test_modbus.py
+++ b/tests/components/fronius/test_modbus.py
@@ -1,10 +1,11 @@
 """Tests for the Fronius Modbus TCP (SunSpec) support."""
 
+import asyncio
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
-from fronius_modbus import Mppt
+from fronius_modbus import Controls, Mppt
 from fronius_modbus.testing import MpptModuleSpec, build_sunspec_map
 from modbus_connection import ModbusConnectionError
 from modbus_connection.mock import MockModbusConnection, WriteEvent
@@ -789,3 +790,92 @@ async def test_readings_recover_when_only_the_controls_came_up(
     assert config_entry.runtime_data.modbus_inverter_coordinators
     # the settings coordinator that was already up is not added a second time
     assert len(config_entry.runtime_data.modbus_settings_coordinators) == 1
+
+
+async def test_unloading_stops_the_heartbeat(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test no beat outlives the config entry.
+
+    A limit that is already in force when the entry is set up schedules a
+    beat during the first refresh, before the heartbeat is started.
+    """
+    config_entry = await _setup_with_controls(
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
+    )
+    await _turn_on_power_limit(hass, 60)
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    unit = mock_fronius_modbus.for_unit(1)
+    unit.read_events.clear()
+    freezer.tick(HEARTBEAT_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert not unit.read_events
+
+
+async def test_heartbeat_does_not_undo_a_write_it_overlaps(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a beat under way cannot re-assert a limit the user just released."""
+    config_entry = await _setup_with_controls(
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
+    )
+    coordinator = config_entry.runtime_data.modbus_settings_coordinators[0]
+    controls = coordinator.modbus_inverter.controls
+    # silence the pollers and drain what they had scheduled, so that the beat
+    # is the only thing reading the device
+    for poller in (
+        *config_entry.runtime_data.modbus_inverter_coordinators,
+        *config_entry.runtime_data.modbus_settings_coordinators,
+    ):
+        poller.update_interval = None
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    await _turn_on_power_limit(hass, 60)
+
+    writing = asyncio.Event()
+    release = asyncio.Event()
+    original_write = Controls.write
+
+    async def blocking_write(self: Controls, field: str, value: float | bool) -> None:
+        """Hold the beat after it decided the limit is still in force."""
+        if not writing.is_set():
+            writing.set()
+            await release.wait()
+        await original_write(self, field, value)
+
+    with patch.object(Controls, "write", blocking_write):
+        freezer.tick(HEARTBEAT_INTERVAL + timedelta(seconds=1))
+        async_fire_time_changed(hass)
+        await writing.wait()
+
+        switched_off = hass.async_create_task(
+            hass.services.async_call(
+                SWITCH_DOMAIN,
+                SERVICE_TURN_OFF,
+                {ATTR_ENTITY_ID: POWER_LIMITING},
+                blocking=True,
+            )
+        )
+        for _ in range(10):
+            await asyncio.sleep(0)
+        release.set()
+        await switched_off
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # what the device holds, not what the last refresh happened to leave behind
+    await controls.async_update()
+    assert controls.enabled is False

--- a/tests/components/fronius/test_modbus.py
+++ b/tests/components/fronius/test_modbus.py
@@ -26,11 +26,17 @@ from homeassistant.components.number import (
 )
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, Platform
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_HOST,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import mock_responses, setup_fronius_integration
+from . import MOCK_HOST, mock_responses, setup_fronius_integration
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -481,7 +487,7 @@ async def _setup_with_controls(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     connection: MockModbusConnection,
-    options: dict[str, bool] | None = None,
+    auto_revert: bool = False,
 ) -> MockConfigEntry:
     """Set up an inverter that accepts control writes."""
     connection.for_unit(1).holding.update(
@@ -493,7 +499,7 @@ async def _setup_with_controls(
         [Platform.NUMBER, Platform.SWITCH],
     ):
         return await setup_fronius_integration(
-            hass, is_logger=False, unique_id="12345678", options=options
+            hass, is_logger=False, unique_id="12345678", auto_revert=auto_revert
         )
 
 
@@ -520,7 +526,7 @@ async def test_limit_carries_the_configured_fallback_period(
 ) -> None:
     """Test the inverter is told when to revert a limit Home Assistant set."""
     config_entry = await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
     )
     controls = config_entry.runtime_data.modbus_settings_coordinators[
         0
@@ -541,7 +547,7 @@ async def test_active_limit_is_sent_again_before_it_reverts(
 ) -> None:
     """Test an active limit is refreshed, so only an outage lets it revert."""
     config_entry = await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
     )
     controls = config_entry.runtime_data.modbus_settings_coordinators[
         0
@@ -572,7 +578,7 @@ async def test_heartbeat_leaves_a_released_limit_released(
     the inverter is left to whatever source it fell back to.
     """
     config_entry = await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
     )
     controls = config_entry.runtime_data.modbus_settings_coordinators[
         0
@@ -612,37 +618,75 @@ async def test_limit_without_a_fallback_period_is_left_alone(
     assert not writes
 
 
-async def test_clearing_the_fallback_period_frees_a_running_limit(
+async def test_turning_the_setting_off_frees_a_running_limit(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     mock_fronius_modbus: MockModbusConnection,
 ) -> None:
-    """Test a limit stops reverting as soon as the fallback period is off.
+    """Test a limit stops reverting as soon as the setting is turned off.
 
     The inverter would otherwise keep counting down the period it was given
     with the limit, and drop it once Home Assistant stops refreshing it.
     """
     config_entry = await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
     )
     await _turn_on_power_limit(hass, 60)
 
-    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await config_entry.start_reconfigure_flow(hass)
     with patch(
         "homeassistant.components.fronius.PLATFORMS",
         [Platform.NUMBER, Platform.SWITCH],
     ):
-        await hass.config_entries.options.async_configure(
-            result["flow_id"], {CONF_AUTO_REVERT: False}
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: MOCK_HOST, CONF_AUTO_REVERT: False}
         )
         await hass.async_block_till_done()
 
-    assert config_entry.options == {CONF_AUTO_REVERT: False}
+    assert config_entry.data[CONF_AUTO_REVERT] is False
     coordinator = config_entry.runtime_data.modbus_settings_coordinators[0]
     await coordinator.async_refresh()
     controls = coordinator.modbus_inverter.controls
     assert controls.enabled is True
     assert controls.revert_seconds == 0
+
+
+async def test_heartbeat_stops_with_the_limit(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test no beat is left running once the limit is switched off."""
+    config_entry = await _setup_with_controls(
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
+    )
+    # silence the pollers and let the runs they had scheduled drain, so that
+    # anything reaching the device from here on is the heartbeat
+    for coordinator in (
+        *config_entry.runtime_data.modbus_inverter_coordinators,
+        *config_entry.runtime_data.modbus_settings_coordinators,
+    ):
+        coordinator.update_interval = None
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    await _turn_on_power_limit(hass, 60)
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: POWER_LIMITING},
+        blocking=True,
+    )
+
+    unit = mock_fronius_modbus.for_unit(1)
+    unit.read_events.clear()
+    freezer.tick(HEARTBEAT_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert not unit.read_events
 
 
 async def test_a_failed_resend_of_the_limit_is_logged(
@@ -654,7 +698,7 @@ async def test_a_failed_resend_of_the_limit_is_logged(
 ) -> None:
     """Test an inverter gone quiet while a limit is kept alive doesn't raise."""
     await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
     )
     await _turn_on_power_limit(hass, 60)
     mock_fronius_modbus.for_unit(1).fail_requests(ModbusConnectionError("gone"))
@@ -700,7 +744,7 @@ async def test_heartbeat_leaves_a_limit_released_on_the_device_released(
     must not take that back.
     """
     config_entry = await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
     )
     controls = config_entry.runtime_data.modbus_settings_coordinators[
         0
@@ -733,7 +777,7 @@ async def test_readings_recover_when_only_the_controls_came_up(
         Mppt, "async_update", side_effect=ModbusConnectionError("no answer")
     ):
         config_entry = await _setup_with_controls(
-            hass, aioclient_mock, mock_fronius_modbus, options={CONF_AUTO_REVERT: True}
+            hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
         )
         assert not config_entry.runtime_data.modbus_inverter_coordinators
         assert config_entry.runtime_data.modbus_settings_coordinators

--- a/tests/components/fronius/test_modbus.py
+++ b/tests/components/fronius/test_modbus.py
@@ -883,3 +883,51 @@ async def test_heartbeat_does_not_undo_a_write_it_overlaps(
     # what the device holds, not what the last refresh happened to leave behind
     await controls.async_update()
     assert controls.enabled is False
+
+
+async def test_clearing_the_period_is_tried_again(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    mock_fronius_modbus: MockModbusConnection,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a write that fails while taking a period back is repeated.
+
+    Losing that one write would leave the inverter counting down to drop a
+    limit the user asked to keep.
+    """
+    config_entry = await _setup_with_controls(
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert_power_limit=True
+    )
+    await _turn_on_power_limit(hass, 60)
+    original_write = Controls.write
+    failed = False
+
+    async def write_once_refused(self: Controls, field: str, value: float | bool):
+        """Refuse the first attempt at the period, then behave."""
+        nonlocal failed
+        if field == "revert_seconds" and not failed:
+            failed = True
+            raise ModbusConnectionError("no answer")
+        await original_write(self, field, value)
+
+    result = await config_entry.start_reconfigure_flow(hass)
+    with patch.object(Controls, "write", write_once_refused):
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: MOCK_HOST, CONF_AUTO_REVERT_POWER_LIMIT: False},
+        )
+        await hass.async_block_till_done()
+
+    coordinator = config_entry.runtime_data.modbus_settings_coordinators[0]
+    controls = coordinator.modbus_inverter.controls
+    assert failed
+    await controls.async_update()
+    assert controls.revert_seconds == AUTO_REVERT_SECONDS
+
+    freezer.tick(timedelta(minutes=5, seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    await controls.async_update()
+    assert controls.revert_seconds == 0

--- a/tests/components/fronius/test_modbus.py
+++ b/tests/components/fronius/test_modbus.py
@@ -13,7 +13,7 @@ import pytest
 
 from homeassistant.components.fronius.const import (
     AUTO_REVERT_SECONDS,
-    CONF_AUTO_REVERT,
+    CONF_AUTO_REVERT_POWER_LIMIT,
     HEARTBEAT_INTERVAL,
     SOLAR_NET_RESCAN_TIMER,
 )
@@ -488,7 +488,7 @@ async def _setup_with_controls(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     connection: MockModbusConnection,
-    auto_revert: bool = False,
+    auto_revert_power_limit: bool = False,
 ) -> MockConfigEntry:
     """Set up an inverter that accepts control writes."""
     connection.for_unit(1).holding.update(
@@ -500,7 +500,10 @@ async def _setup_with_controls(
         [Platform.NUMBER, Platform.SWITCH],
     ):
         return await setup_fronius_integration(
-            hass, is_logger=False, unique_id="12345678", auto_revert=auto_revert
+            hass,
+            is_logger=False,
+            unique_id="12345678",
+            auto_revert_power_limit=auto_revert_power_limit,
         )
 
 
@@ -527,7 +530,7 @@ async def test_limit_carries_the_configured_fallback_period(
 ) -> None:
     """Test the inverter is told when to revert a limit Home Assistant set."""
     config_entry = await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert_power_limit=True
     )
     controls = config_entry.runtime_data.modbus_settings_coordinators[
         0
@@ -548,7 +551,7 @@ async def test_active_limit_is_sent_again_before_it_reverts(
 ) -> None:
     """Test an active limit is refreshed, so only an outage lets it revert."""
     config_entry = await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert_power_limit=True
     )
     controls = config_entry.runtime_data.modbus_settings_coordinators[
         0
@@ -579,7 +582,7 @@ async def test_heartbeat_leaves_a_released_limit_released(
     the inverter is left to whatever source it fell back to.
     """
     config_entry = await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert_power_limit=True
     )
     controls = config_entry.runtime_data.modbus_settings_coordinators[
         0
@@ -630,7 +633,7 @@ async def test_turning_the_setting_off_frees_a_running_limit(
     with the limit, and drop it once Home Assistant stops refreshing it.
     """
     config_entry = await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert_power_limit=True
     )
     await _turn_on_power_limit(hass, 60)
 
@@ -640,11 +643,12 @@ async def test_turning_the_setting_off_frees_a_running_limit(
         [Platform.NUMBER, Platform.SWITCH],
     ):
         await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: MOCK_HOST, CONF_AUTO_REVERT: False}
+            result["flow_id"],
+            {CONF_HOST: MOCK_HOST, CONF_AUTO_REVERT_POWER_LIMIT: False},
         )
         await hass.async_block_till_done()
 
-    assert config_entry.data[CONF_AUTO_REVERT] is False
+    assert config_entry.data[CONF_AUTO_REVERT_POWER_LIMIT] is False
     coordinator = config_entry.runtime_data.modbus_settings_coordinators[0]
     await coordinator.async_refresh()
     controls = coordinator.modbus_inverter.controls
@@ -660,7 +664,7 @@ async def test_heartbeat_stops_with_the_limit(
 ) -> None:
     """Test no beat is left running once the limit is switched off."""
     config_entry = await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert_power_limit=True
     )
     # silence the pollers and let the runs they had scheduled drain, so that
     # anything reaching the device from here on is the heartbeat
@@ -699,7 +703,7 @@ async def test_a_failed_resend_of_the_limit_is_logged(
 ) -> None:
     """Test an inverter gone quiet while a limit is kept alive doesn't raise."""
     await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert_power_limit=True
     )
     await _turn_on_power_limit(hass, 60)
     mock_fronius_modbus.for_unit(1).fail_requests(ModbusConnectionError("gone"))
@@ -745,7 +749,7 @@ async def test_heartbeat_leaves_a_limit_released_on_the_device_released(
     must not take that back.
     """
     config_entry = await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert_power_limit=True
     )
     controls = config_entry.runtime_data.modbus_settings_coordinators[
         0
@@ -778,7 +782,7 @@ async def test_readings_recover_when_only_the_controls_came_up(
         Mppt, "async_update", side_effect=ModbusConnectionError("no answer")
     ):
         config_entry = await _setup_with_controls(
-            hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
+            hass, aioclient_mock, mock_fronius_modbus, auto_revert_power_limit=True
         )
         assert not config_entry.runtime_data.modbus_inverter_coordinators
         assert config_entry.runtime_data.modbus_settings_coordinators
@@ -804,7 +808,7 @@ async def test_unloading_stops_the_heartbeat(
     beat during the first refresh, before the heartbeat is started.
     """
     config_entry = await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert_power_limit=True
     )
     await _turn_on_power_limit(hass, 60)
     await hass.config_entries.async_reload(config_entry.entry_id)
@@ -830,7 +834,7 @@ async def test_heartbeat_does_not_undo_a_write_it_overlaps(
 ) -> None:
     """Test a beat under way cannot re-assert a limit the user just released."""
     config_entry = await _setup_with_controls(
-        hass, aioclient_mock, mock_fronius_modbus, auto_revert=True
+        hass, aioclient_mock, mock_fronius_modbus, auto_revert_power_limit=True
     )
     coordinator = config_entry.runtime_data.modbus_settings_coordinators[0]
     controls = coordinator.modbus_inverter.controls


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Adds a setting to the Fronius config flow: **Revert the AC power limit if Home Assistant stops**. It is offered when the integration is set up and in the reconfigure flow, next to the Modbus port; existing entries get it added by a migration.

A setpoint written over Modbus stays on the inverter until it is changed - including while Home Assistant is shut down or unreachable. The SunSpec Immediate Controls model (123) has a register for that case, `WMaxLimPct_RvrtTms`: the inverter drops the limit when it hasn't been sent it for that long and hands control back to its own priority list. With the setting on, the integration writes an hour into it and re-sends an active limit every 15 minutes, so the hour only ever runs out once Home Assistant has really stopped - a restart or a short outage has plenty of room to spare. The heartbeat schedules itself one beat at a time: it starts when a limit is put in force, restarts whenever the limit is written, and stops when the limit is switched off, so nothing is sent while there is nothing to keep alive.

Details worth knowing for the review:

- **The heartbeat is necessary.** Fronius documents the timer as restarted by *every received Modbus message*, which would make the regular polling enough. Measured against a Gen24 (firmware 1.40.9-1), it is not: a limit read every five seconds still reverted after exactly its 60 second period. Only writing the limit again restarts it. The docstring records this so it doesn't get "simplified" away later.
- **AC power limit only.** The storage model's equivalent register, `InOutWRte_RvrtTms` (124), is documented by Fronius as `R` / *Not supported*, so the battery setpoints cannot auto-revert. The option's description says so.
- **The heartbeat never takes control back.** While no limit is in force there is no period counting down either, so it returns without touching the device - a limit the user released with the switch stays released.
- **A switch, not a period picker.** The register accepts up to 8 hours, but a single well-chosen value is easier to explain and covers what the option is for: getting the inverter back to its own settings when nothing is sending the limit any more. That is an outage - and just as much a deliberate removal of the integration, which otherwise leaves the last limit in force with nothing left to take it back.

Also included: a device that exposes the controls model but no MPPT model got a second settings coordinator on every hourly re-scan, because the re-scan guard only looked at the MPPT coordinators. With the heartbeat that would have meant duplicate writes to the inverter, so the two coordinators are now tracked separately and each retried on its own.

That last part makes #181402 more likely to be hit: a settings coordinator can now come up on a re-scan while the readings coordinator is already there, and the platforms only learn about coordinators found after setup once that PR is in. Merging #181402 first and rebasing this one avoids the window - the two touch the same lines in `_init_modbus_inverter`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47915
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
