### PR TITLE
Handle 2FA-required errors separately from password errors in iCloud

### DIFF
--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from pyicloud import PyiCloudService
 from pyicloud.exceptions import (
+    PyiCloudAuthRequiredException,
     PyiCloudFailedLoginException,
     PyiCloudNoDevicesException,
     PyiCloudServiceNotActivatedException,
@@ -115,27 +116,36 @@ class IcloudAccount:
             )
 
         except PyiCloudFailedLoginException:
-            self.api = None
-            # Login failed which means credentials/2fa need to be updated.
-            _LOGGER.error(
-                (
-                    "Your iCloud account for '%s' is no longer working; Go to the "
-                    "Integrations menu and click on Configure on the discovered Apple "
-                    "iCloud card to login again"
-                ),
-                self._config_entry.data[CONF_USERNAME],
-            )
+            # PyiCloudService authenticates while constructing, so this means
+            # the stored password was rejected. A 2FA challenge does not raise
+            # here; it sets requires_2fa on the service and is handled below.
+            self._handle_auth_required(requires_2fa=False)
+            return
 
-            self._require_reauth()
+        except PyiCloudAuthRequiredException:
+            # self.api was never assigned, so there is no service to ask
+            # whether a code is what is missing. Treat it as a login failure.
+            self._handle_auth_required(requires_2fa=False)
             return
 
         if self.api.requires_2fa:
-            self._require_reauth()
+            self._handle_auth_required(requires_2fa=True)
             return
 
         try:
             # Gets device owners infos
             user_info = self.api.devices.user_info
+        except (PyiCloudFailedLoginException, PyiCloudAuthRequiredException) as err:
+            # Reading the devices refreshes the session, and a stored token
+            # that iCloud has since invalidated is only rejected here, not
+            # while logging in. Ask for reauth so the user has something to
+            # act on, and still raise: the fetch timer is only armed at the
+            # end of update_devices(), so returning here would leave an entry
+            # that is loaded and never polls again.
+            self._handle_auth_required(
+                requires_2fa=self.api is not None and self.api.requires_2fa
+            )
+            raise ConfigEntryNotReady from err
         except (
             PyiCloudServiceNotActivatedException,
             PyiCloudNoDevicesException,
@@ -160,6 +170,32 @@ class IcloudAccount:
 
         self._devices = {}
         self.update_devices()
+
+    def _handle_auth_required(self, requires_2fa: bool) -> None:
+        """Report why authentication failed and start the reauth flow."""
+        if requires_2fa:
+            # Keep the API around: the reauth flow reuses this session to send
+            # and validate the 2FA code rather than asking for the password
+            # again. Dropping it would send the user back to the setup form.
+            _LOGGER.warning(
+                (
+                    "2FA authentication required for '%s'; go to the Integrations "
+                    "menu and click on Configure on the discovered Apple iCloud "
+                    "card to enter your verification code"
+                ),
+                self._config_entry.data[CONF_USERNAME],
+            )
+        else:
+            self.api = None
+            _LOGGER.error(
+                (
+                    "Your iCloud account for '%s' is no longer working; Go to the "
+                    "Integrations menu and click on Configure on the discovered Apple "
+                    "iCloud card to login again"
+                ),
+                self._config_entry.data[CONF_USERNAME],
+            )
+        self._require_reauth()
 
     def update_devices(self) -> None:
         """Update iCloud devices."""

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -65,15 +65,13 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-# pyicloud only raises PyiCloud2FARequiredException for a 409 whose body is JSON
-# with authType == "hsa2". Every other authentication rejection falls through to
-# Session._raise_error(), which rewrites the reason to "Authentication required
-# for Account." and raises a plain PyiCloudAPIResponseException carrying the HTTP
-# status in .code. The status is therefore what has to be inspected, not the type.
+# Most authentication rejections arrive as a plain PyiCloudAPIResponseException
+# carrying the HTTP status in .code, so the status is what has to be inspected
+# rather than the exception type.
 #
-# GENERAL_AUTH_ERROR (500) is excluded on purpose: pyicloud groups it with the
+# GENERAL_AUTH_ERROR (500) is left out on purpose: pyicloud groups it with the
 # authentication statuses, but a 500 is just as likely to be a transient iCloud
-# failure, and asking the user to reauthenticate for those would be wrong.
+# failure, and asking the user to log in again for those would be wrong.
 _AUTH_REQUIRED_STATUSES = frozenset(
     {
         AppleAuthError.TWO_FACTOR_REQUIRED,
@@ -117,6 +115,8 @@ class IcloudAccount:
         self._icloud_dir = icloud_dir
 
         self.api: PyiCloudService | None = None
+        # Read by the reauth flow when api.requires_2fa cannot be trusted.
+        self.requires_verification_code = False
         self._owner_fullname: str | None = None
         self._family_members_fullname: dict[str, str] = {}
         self._devices: dict[str, IcloudDevice] = {}
@@ -144,27 +144,33 @@ class IcloudAccount:
         except PyiCloudFailedLoginException:
             # PyiCloudService authenticates while constructing, so this means
             # the stored password was rejected.
-            self._handle_auth_required(requires_2fa=False)
+            self._handle_auth_required(two_factor=False, keep_session=False)
             return
 
-        except PyiCloud2FARequiredException, PyiCloudAuthRequiredException:
+        except PyiCloud2FARequiredException:
             # A 2FA challenge can also surface as an exception here rather than
             # as requires_2fa, because authenticate() raises out of
-            # _get_mfa_auth_options() before the flag is set. Either way
-            # self.api was never assigned, so there is no session for the reauth
+            # _get_mfa_auth_options() before the flag is set. self.api was
+            # never assigned either way, so there is no session for the reauth
             # flow to send a code through; ask for the password, which starts a
             # fresh login and re-issues the challenge.
-            self._handle_auth_required(requires_2fa=False)
+            self._handle_auth_required(two_factor=True, keep_session=False)
+            return
+
+        except PyiCloudAuthRequiredException:
+            # iCloud rejected the session rather than issuing a challenge, so
+            # this is a login to redo, not a code to enter.
+            self._handle_auth_required(two_factor=False, keep_session=False)
             return
 
         except PyiCloudAPIResponseException as err:
             if not _is_auth_error(err):
                 raise
-            self._handle_auth_required(requires_2fa=False)
+            self._handle_auth_required(two_factor=False, keep_session=False)
             return
 
         if self.api.requires_2fa:
-            self._handle_auth_required(requires_2fa=True)
+            self._handle_auth_required(two_factor=True, keep_session=True)
             return
 
         try:
@@ -175,7 +181,7 @@ class IcloudAccount:
             # the devices rather than while logging in, and does not set
             # requires_2fa for it, so ask for a code explicitly. The session is
             # kept so the reauth flow can send the code through it.
-            self._handle_auth_required(requires_2fa=True)
+            self._handle_auth_required(two_factor=True, keep_session=True)
             raise ConfigEntryNotReady from err
         except (PyiCloudFailedLoginException, PyiCloudAuthRequiredException) as err:
             # Reading the devices refreshes the session, and a stored token
@@ -184,9 +190,8 @@ class IcloudAccount:
             # act on, and still raise: the fetch timer is only armed at the
             # end of update_devices(), so returning here would leave an entry
             # that is loaded and never polls again.
-            self._handle_auth_required(
-                requires_2fa=self.api is not None and self.api.requires_2fa
-            )
+            challenged = self.api is not None and self.api.requires_2fa
+            self._handle_auth_required(two_factor=challenged, keep_session=challenged)
             raise ConfigEntryNotReady from err
         except (
             PyiCloudServiceNotActivatedException,
@@ -203,7 +208,7 @@ class IcloudAccount:
             # Drop the session instead of keeping it for a code: it has just
             # failed to refresh, so a reauth flow sending a code through it
             # would fail as well.
-            self._handle_auth_required(requires_2fa=False)
+            self._handle_auth_required(two_factor=False, keep_session=False)
             raise ConfigEntryNotReady from err
 
         if user_info is None:
@@ -223,12 +228,20 @@ class IcloudAccount:
         self._devices = {}
         self.update_devices()
 
-    def _handle_auth_required(self, requires_2fa: bool) -> None:
-        """Report why authentication failed and start the reauth flow."""
-        if requires_2fa:
-            # Keep the API around: the reauth flow reuses this session to send
-            # and validate the 2FA code rather than asking for the password
-            # again. Dropping it would send the user back to the setup form.
+    def _handle_auth_required(self, *, two_factor: bool, keep_session: bool) -> None:
+        """Report why authentication failed and start the reauth flow.
+
+        two_factor says what iCloud asked for, keep_session whether there is a
+        session to ask through: a 2FA challenge raised before the session was
+        established leaves nothing to send a code over, so the user has to log
+        in again even though a code is what iCloud wants.
+        """
+        if not keep_session:
+            # Without a session the reauth flow goes to the password form,
+            # which starts a fresh login and re-issues any challenge.
+            self.api = None
+
+        if two_factor and keep_session:
             _LOGGER.warning(
                 (
                     "2FA authentication required for '%s'; go to the Integrations "
@@ -237,8 +250,16 @@ class IcloudAccount:
                 ),
                 self._config_entry.data[CONF_USERNAME],
             )
+        elif two_factor:
+            _LOGGER.warning(
+                (
+                    "2FA authentication required for '%s'; go to the Integrations "
+                    "menu and click on Configure on the discovered Apple iCloud "
+                    "card to login again"
+                ),
+                self._config_entry.data[CONF_USERNAME],
+            )
         else:
-            self.api = None
             _LOGGER.error(
                 (
                     "Your iCloud account for '%s' is no longer working; Go to the "
@@ -247,6 +268,11 @@ class IcloudAccount:
                 ),
                 self._config_entry.data[CONF_USERNAME],
             )
+
+        # A challenge raised by a request pyicloud does not route through
+        # authenticate() never sets api.requires_2fa, which is what the reauth
+        # flow reads to decide whether to ask for a code.
+        self.requires_verification_code = two_factor and keep_session
         self._require_reauth()
 
     def update_devices(self) -> None:

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -6,7 +6,10 @@ import operator
 from typing import TYPE_CHECKING, Any
 
 from pyicloud import PyiCloudService
+from pyicloud.const import AppleAuthError
 from pyicloud.exceptions import (
+    PyiCloud2FARequiredException,
+    PyiCloudAPIResponseException,
     PyiCloudAuthRequiredException,
     PyiCloudFailedLoginException,
     PyiCloudNoDevicesException,
@@ -61,6 +64,29 @@ if TYPE_CHECKING:
     from .media_source import PhotoCache
 
 _LOGGER = logging.getLogger(__name__)
+
+# pyicloud only raises PyiCloud2FARequiredException for a 409 whose body is JSON
+# with authType == "hsa2". Every other authentication rejection falls through to
+# Session._raise_error(), which rewrites the reason to "Authentication required
+# for Account." and raises a plain PyiCloudAPIResponseException carrying the HTTP
+# status in .code. The status is therefore what has to be inspected, not the type.
+#
+# GENERAL_AUTH_ERROR (500) is excluded on purpose: pyicloud groups it with the
+# authentication statuses, but a 500 is just as likely to be a transient iCloud
+# failure, and asking the user to reauthenticate for those would be wrong.
+_AUTH_REQUIRED_STATUSES = frozenset(
+    {
+        AppleAuthError.TWO_FACTOR_REQUIRED,
+        AppleAuthError.LOGIN_TOKEN_EXPIRED,
+        AppleAuthError.FIND_MY_REAUTH_REQUIRED,
+    }
+)
+
+
+def _is_auth_error(err: PyiCloudAPIResponseException) -> bool:
+    """Return True if the account has to authenticate again to recover."""
+    return isinstance(err.code, int) and err.code in _AUTH_REQUIRED_STATUSES
+
 
 type IcloudConfigEntry = ConfigEntry[IcloudAccount]
 
@@ -117,14 +143,23 @@ class IcloudAccount:
 
         except PyiCloudFailedLoginException:
             # PyiCloudService authenticates while constructing, so this means
-            # the stored password was rejected. A 2FA challenge does not raise
-            # here; it sets requires_2fa on the service and is handled below.
+            # the stored password was rejected.
             self._handle_auth_required(requires_2fa=False)
             return
 
-        except PyiCloudAuthRequiredException:
-            # self.api was never assigned, so there is no service to ask
-            # whether a code is what is missing. Treat it as a login failure.
+        except PyiCloud2FARequiredException, PyiCloudAuthRequiredException:
+            # A 2FA challenge can also surface as an exception here rather than
+            # as requires_2fa, because authenticate() raises out of
+            # _get_mfa_auth_options() before the flag is set. Either way
+            # self.api was never assigned, so there is no session for the reauth
+            # flow to send a code through; ask for the password, which starts a
+            # fresh login and re-issues the challenge.
+            self._handle_auth_required(requires_2fa=False)
+            return
+
+        except PyiCloudAPIResponseException as err:
+            if not _is_auth_error(err):
+                raise
             self._handle_auth_required(requires_2fa=False)
             return
 
@@ -135,6 +170,13 @@ class IcloudAccount:
         try:
             # Gets device owners infos
             user_info = self.api.devices.user_info
+        except PyiCloud2FARequiredException as err:
+            # iCloud issues the challenge when the session is refreshed to read
+            # the devices rather than while logging in, and does not set
+            # requires_2fa for it, so ask for a code explicitly. The session is
+            # kept so the reauth flow can send the code through it.
+            self._handle_auth_required(requires_2fa=True)
+            raise ConfigEntryNotReady from err
         except (PyiCloudFailedLoginException, PyiCloudAuthRequiredException) as err:
             # Reading the devices refreshes the session, and a stored token
             # that iCloud has since invalidated is only rejected here, not
@@ -152,6 +194,16 @@ class IcloudAccount:
             PyiCloudServiceUnavailable,
         ) as err:
             _LOGGER.error("No iCloud device found")
+            raise ConfigEntryNotReady from err
+        except PyiCloudAPIResponseException as err:
+            # Has to stay below the clause above: PyiCloudServiceNotActivatedException
+            # is a subclass of this one and would otherwise never be reached.
+            if not _is_auth_error(err):
+                raise
+            # Drop the session instead of keeping it for a code: it has just
+            # failed to refresh, so a reauth flow sending a code through it
+            # would fail as well.
+            self._handle_auth_required(requires_2fa=False)
             raise ConfigEntryNotReady from err
 
         if user_info is None:

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -53,9 +53,22 @@ class IcloudFlowHandler(ConfigFlow, domain=DOMAIN):
 
         self._trusted_device = None
         self._verification_code = None
+        self._forced_2fa = False
 
         self._existing_entry_data: dict[str, Any] | None = None
         self._description_placeholders: dict[str, str] | None = None
+
+    @property
+    def _requires_2fa(self) -> bool:
+        """Return True when a 2FA code is what this flow has to collect.
+
+        iCloud can raise a challenge from a request pyicloud does not route
+        through authenticate(), which leaves api.requires_2fa false while a
+        code is outstanding. The account records that case, and the flow has
+        to honour it both when routing to the code form and when validating
+        what is entered there.
+        """
+        return self._forced_2fa or bool(self.api and self.api.requires_2fa)
 
     def _show_setup_form(self, user_input=None, errors=None, step_id="user"):
         """Show the setup form to the user."""
@@ -159,7 +172,7 @@ class IcloudFlowHandler(ConfigFlow, domain=DOMAIN):
                 errors = {CONF_PASSWORD: "invalid_auth"}
                 return self._show_setup_form(user_input, errors, step_id)
 
-        if self.api.requires_2fa:
+        if self._requires_2fa:
             return await self.async_step_verification_code()
 
         if self.api.requires_2sa:
@@ -221,12 +234,17 @@ class IcloudFlowHandler(ConfigFlow, domain=DOMAIN):
         self._description_placeholders = {"username": entry_data[CONF_USERNAME]}
 
         # Get the API from the existing entry runtime data
-        self.api = self._get_reauth_entry().runtime_data.api
+        account = self._get_reauth_entry().runtime_data
+        self.api = account.api
 
         # If the API is None, it means the existing entry was never successfully authenticated,
         # so we need to show the setup form again to get the password.
         if self.api is None:
             return self._show_setup_form(step_id="reauth_confirm")
+
+        # Only meaningful together with the session it was raised on, which is
+        # why it is read here rather than before the check above.
+        self._forced_2fa = account.requires_verification_code
 
         # If the API is not None, it means the existing entry was successfully authenticated before,
         # so we can proceed to the reauth_confirm step to trigger 2FA challenge.
@@ -327,7 +345,7 @@ class IcloudFlowHandler(ConfigFlow, domain=DOMAIN):
         self._verification_code = user_input[CONF_VERIFICATION_CODE]
 
         try:
-            if self.api.requires_2fa:
+            if self._requires_2fa:
                 if not await self.hass.async_add_executor_job(
                     self.api.validate_2fa_code, self._verification_code
                 ):
@@ -348,10 +366,14 @@ class IcloudFlowHandler(ConfigFlow, domain=DOMAIN):
             self._verification_code = None
             errors["base"] = "validate_verification_code"
 
-            if self.api.requires_2fa:
+            if self._requires_2fa:
                 return await self.async_step_verification_code(errors=errors)
 
             return await self.async_step_trusted_device(errors=errors)
+
+        # The challenge is answered; leaving this set would route the login
+        # that follows straight back to this form.
+        self._forced_2fa = False
 
         return await self.async_step_user(
             {

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING, Any, override
 
 from pyicloud import PyiCloudService
 from pyicloud.exceptions import (
+    PyiCloud2FARequiredException,
+    PyiCloudAPIResponseException,
+    PyiCloudAuthRequiredException,
     PyiCloudException,
     PyiCloudFailedLoginException,
     PyiCloudNoDevicesException,
@@ -170,6 +173,23 @@ class IcloudFlowHandler(ConfigFlow, domain=DOMAIN):
                 _LOGGER.error("Error logging into iCloud service: %s", error)
                 self.api = None
                 errors = {CONF_PASSWORD: "invalid_auth"}
+                return self._show_setup_form(user_input, errors, step_id)
+            except (
+                PyiCloud2FARequiredException,
+                PyiCloudAuthRequiredException,
+                PyiCloudAPIResponseException,
+            ) as error:
+                # PyiCloudService validates the stored session while it is
+                # constructed, so a session iCloud is rejecting fails here
+                # before the password is tried. Report it rather than letting
+                # it escape the flow.
+                _LOGGER.error(
+                    "Stored iCloud session for %s was rejected: %s",
+                    self._username,
+                    error,
+                )
+                self.api = None
+                errors = {"base": "unknown"}
                 return self._show_setup_form(user_input, errors, step_id)
 
         if self._requires_2fa:

--- a/homeassistant/components/icloud/strings.json
+++ b/homeassistant/components/icloud/strings.json
@@ -8,6 +8,7 @@
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "send_verification_code": "Failed to send verification code",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
       "validate_verification_code": "Failed to verify your verification code, try again"
     },
     "step": {

--- a/tests/components/icloud/test_init.py
+++ b/tests/components/icloud/test_init.py
@@ -1,9 +1,13 @@
 """Tests for the iCloud config flow."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
-from pyicloud.exceptions import PyiCloudFailedLoginException
+from pyicloud.exceptions import (
+    PyiCloudAuthRequiredException,
+    PyiCloudFailedLoginException,
+)
 import pytest
+from requests import Response
 
 from homeassistant.components.icloud.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -42,9 +46,21 @@ def mock_controller_2fa_service_failed():
         yield service_mock
 
 
+@pytest.fixture(name="service_auth_required")
+def mock_controller_auth_required_service():
+    """Mock a service that reports the session needs authenticating again."""
+    with patch(
+        "homeassistant.components.icloud.account.PyiCloudService"
+    ) as service_mock:
+        service_mock.side_effect = PyiCloudAuthRequiredException(
+            USERNAME, Mock(spec=Response)
+        )
+        yield service_mock
+
+
 @pytest.mark.usefixtures("service_2fa")
-async def test_setup_2fa(hass: HomeAssistant) -> None:
-    """Test that 2FA login triggers reauth flow."""
+async def test_setup_2fa(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
+    """Test that a 2FA challenge starts reauth and is not reported as a bad password."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
     )
@@ -60,12 +76,19 @@ async def test_setup_2fa(hass: HomeAssistant) -> None:
     in_progress_flows = hass.config_entries.flow.async_progress()
     assert len(in_progress_flows) == 1
     assert in_progress_flows[0]["context"]["unique_id"] == config_entry.unique_id
+    assert "2FA authentication required" in caplog.text
+    assert "no longer working" not in caplog.text
+
+    # The reauth flow reuses this session to send and validate the code, so it
+    # has to survive the challenge.
     assert config_entry.runtime_data.api is not None
 
 
 @pytest.mark.usefixtures("service_2fa_failed")
-async def test_setup_password_failed(hass: HomeAssistant) -> None:
-    """Test that invalid login triggers reauth flow."""
+async def test_setup_password_failed(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a rejected password is reported as such, not as a 2FA prompt."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
     )
@@ -81,6 +104,8 @@ async def test_setup_password_failed(hass: HomeAssistant) -> None:
     in_progress_flows = hass.config_entries.flow.async_progress()
     assert len(in_progress_flows) == 1
     assert in_progress_flows[0]["context"]["unique_id"] == config_entry.unique_id
+    assert "no longer working" in caplog.text
+    assert "2FA authentication required" not in caplog.text
     assert config_entry.runtime_data.api is None
 
 
@@ -99,3 +124,75 @@ async def test_unique_id_set_on_setup(hass: HomeAssistant) -> None:
 
     assert config_entry.unique_id == USERNAME
     assert config_entry.state is ConfigEntryState.LOADED
+
+
+@pytest.mark.usefixtures("service_auth_required")
+async def test_setup_auth_required(hass: HomeAssistant) -> None:
+    """Test that an auth-required login failure starts reauth."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    in_progress_flows = hass.config_entries.flow.async_progress()
+    assert len(in_progress_flows) == 1
+    assert in_progress_flows[0]["context"]["unique_id"] == config_entry.unique_id
+
+
+async def test_auth_required_on_first_fetch_is_retried(
+    hass: HomeAssistant, service_2fa: Mock
+) -> None:
+    """Test that losing the session before the first fetch is retried.
+
+    The fetch timer is only armed once update_devices() completes, so an entry
+    that gives up here would stay loaded and never poll again.
+    """
+    service_2fa.return_value.requires_2fa = False
+    type(service_2fa.return_value).devices = PropertyMock(
+        side_effect=PyiCloudAuthRequiredException(USERNAME, Mock(spec=Response))
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # SETUP_RETRY, so Home Assistant retries with backoff instead of leaving a
+    # loaded entry that never polls.
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_invalid_token_on_first_fetch_starts_reauth(
+    hass: HomeAssistant, service_2fa: Mock
+) -> None:
+    """Test that a token rejected on the first fetch asks the user to log in.
+
+    iCloud only rejects a stale stored token when the session is refreshed to
+    read the devices, so this surfaces after a successful looking login.
+    """
+    service_2fa.return_value.requires_2fa = False
+    type(service_2fa.return_value).devices = PropertyMock(
+        side_effect=PyiCloudFailedLoginException("Invalid authentication token.")
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert [
+        flow
+        for flow in hass.config_entries.flow.async_progress()
+        if flow["context"]["source"] == "reauth"
+    ]

--- a/tests/components/icloud/test_init.py
+++ b/tests/components/icloud/test_init.py
@@ -19,6 +19,7 @@ from homeassistant.components.icloud.config_flow import (
 )
 from homeassistant.components.icloud.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -403,3 +404,42 @@ async def test_2fa_required_exception_at_login_starts_reauth(
         for flow in hass.config_entries.flow.async_progress()
         if flow["context"]["source"] == "reauth"
     ]
+
+
+async def test_password_reauth_reports_a_rejected_session(
+    hass: HomeAssistant, service_auth_required: Mock
+) -> None:
+    """Test that a session iCloud keeps rejecting does not break the flow.
+
+    PyiCloudService validates the persisted session while it is constructed,
+    so the password form runs into the same rejection before the password is
+    ever tried. The user has to be told, not shown an unknown error.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    flows = [
+        flow
+        for flow in hass.config_entries.flow.async_progress()
+        if flow["context"]["source"] == "reauth"
+    ]
+    assert len(flows) == 1
+    assert flows[0]["step_id"] == "reauth_confirm"
+
+    # The stored session is what iCloud is rejecting, so constructing the
+    # service from the reauth form runs into it again.
+    with patch(
+        "homeassistant.components.icloud.config_flow.PyiCloudService",
+        side_effect=PyiCloudAuthRequiredException(USERNAME, Mock(spec=Response)),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flows[0]["flow_id"], {CONF_PASSWORD: "new-password"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "unknown"}

--- a/tests/components/icloud/test_init.py
+++ b/tests/components/icloud/test_init.py
@@ -13,13 +13,32 @@ from pyicloud.exceptions import (
 import pytest
 from requests import Response
 
+from homeassistant.components.icloud.config_flow import (
+    CONF_REQUEST_NEW_CODE,
+    CONF_VERIFICATION_CODE,
+)
 from homeassistant.components.icloud.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
-from .const import MOCK_CONFIG, USERNAME
+from .const import DEVICE, MOCK_CONFIG, USER_INFO, USERNAME
 
 from tests.common import MockConfigEntry
+
+
+class MockDevice(dict):
+    """Device payload that answers status() with itself, as pyicloud does."""
+
+    def status(self, fields):
+        """Return every requested field, as AppleDevice.status does."""
+        return self
+
+
+class MockDevices(list):
+    """Devices response that also carries the account's user info."""
+
+    user_info = USER_INFO
 
 
 @pytest.fixture(name="service_2fa")
@@ -209,12 +228,23 @@ async def test_2fa_required_exception_on_first_fetch_starts_reauth(
 
     The challenge arrives when the session is refreshed to read the devices,
     which raises instead of setting requires_2fa, so the exception is the only
-    signal that a code is what is missing.
+    signal that a code is what is missing. The reauth flow has to be told, or
+    it reads api.requires_2fa, finds it false and never asks for the code.
     """
     service_2fa.return_value.requires_2fa = False
-    type(service_2fa.return_value).devices = PropertyMock(
+    service_2fa.return_value.requires_2sa = False
+    devices = PropertyMock(
         side_effect=PyiCloud2FARequiredException(USERNAME, Mock(spec=Response))
     )
+    type(service_2fa.return_value).devices = devices
+
+    def validate_2fa_code(code: str) -> bool:
+        """Clear the challenge, as entering a valid code does."""
+        devices.side_effect = None
+        devices.return_value = MockDevices([MockDevice(DEVICE)])
+        return True
+
+    service_2fa.return_value.validate_2fa_code = Mock(side_effect=validate_2fa_code)
 
     config_entry = MockConfigEntry(
         domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
@@ -225,11 +255,26 @@ async def test_2fa_required_exception_on_first_fetch_starts_reauth(
     await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
-    assert [
+    flows = [
         flow
         for flow in hass.config_entries.flow.async_progress()
         if flow["context"]["source"] == "reauth"
     ]
+    assert len(flows) == 1
+    assert flows[0]["step_id"] == "verification_code"
+
+    # The code goes through the session that was kept, not down the
+    # two-step-verification path that a false requires_2fa would select.
+    result = await hass.config_entries.flow.async_configure(
+        flows[0]["flow_id"],
+        {CONF_VERIFICATION_CODE: "123456", CONF_REQUEST_NEW_CODE: False},
+    )
+    await hass.async_block_till_done()
+
+    service_2fa.return_value.validate_2fa_code.assert_called_once_with("123456")
+    service_2fa.return_value.validate_verification_code.assert_not_called()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/icloud/test_init.py
+++ b/tests/components/icloud/test_init.py
@@ -2,9 +2,13 @@
 
 from unittest.mock import Mock, PropertyMock, patch
 
+from pyicloud.const import AppleAuthError
 from pyicloud.exceptions import (
+    PyiCloud2FARequiredException,
+    PyiCloudAPIResponseException,
     PyiCloudAuthRequiredException,
     PyiCloudFailedLoginException,
+    PyiCloudServiceNotActivatedException,
 )
 import pytest
 from requests import Response
@@ -191,6 +195,164 @@ async def test_invalid_token_on_first_fetch_starts_reauth(
     await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert [
+        flow
+        for flow in hass.config_entries.flow.async_progress()
+        if flow["context"]["source"] == "reauth"
+    ]
+
+
+async def test_2fa_required_exception_on_first_fetch_starts_reauth(
+    hass: HomeAssistant, service_2fa: Mock
+) -> None:
+    """Test that a 2FA challenge raised by the first fetch asks for a code.
+
+    The challenge arrives when the session is refreshed to read the devices,
+    which raises instead of setting requires_2fa, so the exception is the only
+    signal that a code is what is missing.
+    """
+    service_2fa.return_value.requires_2fa = False
+    type(service_2fa.return_value).devices = PropertyMock(
+        side_effect=PyiCloud2FARequiredException(USERNAME, Mock(spec=Response))
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert [
+        flow
+        for flow in hass.config_entries.flow.async_progress()
+        if flow["context"]["source"] == "reauth"
+    ]
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        AppleAuthError.TWO_FACTOR_REQUIRED,
+        AppleAuthError.LOGIN_TOKEN_EXPIRED,
+        AppleAuthError.FIND_MY_REAUTH_REQUIRED,
+    ],
+)
+async def test_auth_response_on_first_fetch_starts_reauth(
+    hass: HomeAssistant, service_2fa: Mock, status: AppleAuthError
+) -> None:
+    """Test that an authentication status on the first fetch starts reauth.
+
+    pyicloud only raises a dedicated exception for a 409 carrying an hsa2 body.
+    Any other rejection arrives as a plain PyiCloudAPIResponseException, so the
+    status has to be inspected rather than the exception type.
+    """
+    service_2fa.return_value.requires_2fa = False
+    type(service_2fa.return_value).devices = PropertyMock(
+        side_effect=PyiCloudAPIResponseException(
+            "Authentication required for Account.", status
+        )
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert [
+        flow
+        for flow in hass.config_entries.flow.async_progress()
+        if flow["context"]["source"] == "reauth"
+    ]
+
+
+async def test_other_api_error_on_first_fetch_does_not_start_reauth(
+    hass: HomeAssistant, service_2fa: Mock
+) -> None:
+    """Test that a non-authentication API error does not ask the user to log in.
+
+    Reauthenticating cannot fix a server-side failure, so prompting for it would
+    send the user after credentials that are not the problem.
+    """
+    service_2fa.return_value.requires_2fa = False
+    type(service_2fa.return_value).devices = PropertyMock(
+        side_effect=PyiCloudAPIResponseException("Service temporarily unavailable", 503)
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not [
+        flow
+        for flow in hass.config_entries.flow.async_progress()
+        if flow["context"]["source"] == "reauth"
+    ]
+
+
+async def test_service_not_activated_is_not_treated_as_auth_error(
+    hass: HomeAssistant, service_2fa: Mock
+) -> None:
+    """Test that an inactive iCloud service does not ask the user to log in.
+
+    PyiCloudServiceNotActivatedException subclasses PyiCloudAPIResponseException,
+    so it has to keep being handled as a missing service rather than falling
+    into the authentication handling.
+    """
+    service_2fa.return_value.requires_2fa = False
+    type(service_2fa.return_value).devices = PropertyMock(
+        side_effect=PyiCloudServiceNotActivatedException("Not activated", 400)
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert not [
+        flow
+        for flow in hass.config_entries.flow.async_progress()
+        if flow["context"]["source"] == "reauth"
+    ]
+
+
+async def test_2fa_required_exception_at_login_starts_reauth(
+    hass: HomeAssistant,
+) -> None:
+    """Test that a 2FA challenge raised while logging in starts reauth.
+
+    authenticate() can raise out of the MFA options request before requires_2fa
+    is ever set, leaving no service to ask what is missing.
+    """
+    with patch(
+        "homeassistant.components.icloud.account.PyiCloudService"
+    ) as service_mock:
+        service_mock.side_effect = PyiCloud2FARequiredException(
+            USERNAME, Mock(spec=Response)
+        )
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", unique_id=USERNAME
+        )
+        config_entry.add_to_hass(hass)
+
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
     assert [
         flow
         for flow in hass.config_entries.flow.async_progress()


### PR DESCRIPTION
## Proposed change

A 2FA challenge and a rejected password both end up in the same error path during setup, so a routine 2FA re-challenge is reported to the user as "your iCloud account is no longer working" — pointing them at the password instead of the verification code.

This reports the two cases separately, and keeps the authenticated session when the account only needs a code. That part matters beyond the wording: `async_step_reauth` reads `self.api = self._get_reauth_entry().runtime_data.api` and, when it is `None`, falls back to `_show_setup_form()` to ask for the password again. Dropping the session on a 2FA challenge would therefore send the user back to re-enter a password that was never wrong, instead of straight to the code entry.

It also handles the session being rejected between logging in and the first device fetch. Reading `api.devices` refreshes the session, and a stored token that iCloud has since invalidated is only rejected at that point rather than while logging in — surfacing as `PyiCloudFailedLoginException: Invalid authentication token.`, as `PyiCloudAuthRequiredException`, or as an authentication status on a plain response. Previously all of them escaped as an unhandled traceback with no reauth flow started, so the user got a failed entry and nothing to act on.

Setup separates the two kinds of failure. A rejection only the user can clear raises `ConfigEntryAuthFailed`, so Home Assistant starts the reauth flow and stops re-attempting a login that cannot succeed until they have finished it. iCloud failing rather than refusing — a non-authentication status, no devices, service unavailable — raises `ConfigEntryNotReady` and is retried with backoff. An earlier revision of this description said the authentication path retried with `ConfigEntryNotReady` as well; that was changed during review, and this paragraph now matches the code.

The config flow needed the same treatment at the same request. It read `api.devices` after a login it had already treated as successful, with no handling for a rejection there, so the step ended on the unhandled exception with no way back to the password and no code entry. A challenge now keeps its session and goes to the verification code step; any other rejection is reported on the form, and only a session iCloud is actually refusing is dropped, so an outage does not cost the trust token.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Supersedes #169005, which was closed by the stale bot rather than on review. Rebuilt as a single commit on current `dev`.

On #169005 it was asked whether this duplicated #169001. That was a fair reading of the old branches — the polling-loop branch carried the 2FA message split as well. The two are now cleanly separated: this PR only classifies the setup-time error, and #181389 only keeps the fetch timer alive. They touch the same file but not the same behaviour.

The existing `test_setup_2fa` continues to assert that the session survives a 2FA challenge, which is what keeps the reauth flow going straight to code entry.

This needs the `bugfix` label for the `required-labels` check to pass — I cannot add it myself.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository: #182389 and #182375.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


