### PR TITLE
Fix cloud support package snapshots with verbose logging

### DIFF
--- a/tests/components/cloud/snapshots/test_http_api.ambr
+++ b/tests/components/cloud/snapshots/test_http_api.ambr
@@ -238,7 +238,6 @@
   <details><summary>Logs</summary>
   
   ```logs
-  2025-02-10 12:00:00.000 INFO (MainThread) [hass_nabucasa.iot] This message will be dropped since this test patches MAX_RECORDS
   2025-02-10 12:00:00.000 INFO (MainThread) [hass_nabucasa.iot] Hass nabucasa log
   2025-02-10 12:00:00.000 WARNING (MainThread) [snitun.utils.aiohttp_client] Snitun log
   2025-02-10 12:00:00.000 ERROR (MainThread) [homeassistant.components.cloud.client] Cloud log
@@ -320,7 +319,6 @@
   <details><summary>Logs</summary>
   
   ```logs
-  2025-02-10 12:00:00.000 INFO (MainThread) [hass_nabucasa.iot] This message will be dropped since this test patches MAX_RECORDS
   2025-02-10 12:00:00.000 INFO (MainThread) [hass_nabucasa.iot] Hass nabucasa log
   2025-02-10 12:00:00.000 WARNING (MainThread) [snitun.utils.aiohttp_client] Snitun log
   2025-02-10 12:00:00.000 ERROR (MainThread) [homeassistant.components.cloud.client] Cloud log

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -2925,8 +2925,12 @@ async def test_download_support_package_custom_components_error(
     aioclient_mock: AiohttpClientMocker,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test download support package when async_get_custom_components fails."""
+
+    # Exclude setup logs with nondeterministic timestamps in verbose runs.
+    caplog.set_level(logging.INFO, logger="hass_nabucasa.events.bus")
 
     aioclient_mock.get("https://cloud.bla.com/status", text="")
     aioclient_mock.get(
@@ -3044,8 +3048,12 @@ async def test_download_support_package_integration_load_error(
     aioclient_mock: AiohttpClientMocker,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test download support package when async_get_loaded_integration fails."""
+
+    # Exclude setup logs with nondeterministic timestamps in verbose runs.
+    caplog.set_level(logging.INFO, logger="hass_nabucasa.events.bus")
 
     aioclient_mock.get("https://cloud.bla.com/status", text="")
     aioclient_mock.get(

--- a/tests/components/cloud/test_http_api.py
+++ b/tests/components/cloud/test_http_api.py
@@ -2916,6 +2916,7 @@ async def test_download_support_package(
     assert await req.text() == snapshot
 
 
+@patch("homeassistant.components.cloud.helpers.FixedSizeQueueLogHandler.MAX_RECORDS", 3)
 @pytest.mark.usefixtures("enable_custom_integrations")
 async def test_download_support_package_custom_components_error(
     hass: HomeAssistant,
@@ -2925,12 +2926,8 @@ async def test_download_support_package_custom_components_error(
     aioclient_mock: AiohttpClientMocker,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test download support package when async_get_custom_components fails."""
-
-    # Exclude setup logs with nondeterministic timestamps in verbose runs.
-    caplog.set_level(logging.INFO, logger="hass_nabucasa.events.bus")
 
     aioclient_mock.get("https://cloud.bla.com/status", text="")
     aioclient_mock.get(
@@ -3039,6 +3036,7 @@ async def test_download_support_package_custom_components_error(
     assert await req.text() == snapshot
 
 
+@patch("homeassistant.components.cloud.helpers.FixedSizeQueueLogHandler.MAX_RECORDS", 3)
 @pytest.mark.usefixtures("enable_custom_integrations")
 async def test_download_support_package_integration_load_error(
     hass: HomeAssistant,
@@ -3048,12 +3046,8 @@ async def test_download_support_package_integration_load_error(
     aioclient_mock: AiohttpClientMocker,
     freezer: FrozenDateTimeFactory,
     snapshot: SnapshotAssertion,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test download support package when async_get_loaded_integration fails."""
-
-    # Exclude setup logs with nondeterministic timestamps in verbose runs.
-    caplog.set_level(logging.INFO, logger="hass_nabucasa.events.bus")
 
     aioclient_mock.get("https://cloud.bla.com/status", text="")
     aioclient_mock.get(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Verbose pytest runs add setup DEBUG logs with changing timestamps to two cloud support package snapshots.

I added the missing `MAX_RECORDS = 3` decorators to both error tests to match `test_download_support_package`. Each test's log queue now discards the setup logs and the first explicit log message. Both snapshots contain only the final three deterministic messages.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

All 501 cloud tests pass normally and with `-vvv`. The three support package tests also pass with `-v` and `--log-level=DEBUG`. Ruff, Pylint and the applicable commit hooks pass.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr