### PR TITLE
Bump teslemetry-stream to 0.13.1

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -901,11 +901,6 @@ async def async_setup_stream(
 ) -> None:
     """Set up the stream for a vehicle."""
     await vehicle.stream_vehicle.get_config()
-    entry.async_create_background_task(
-        hass,
-        vehicle.stream_vehicle.prefer_typed(True),
-        f"Prefer typed for {vehicle.vin}",
-    )
 
     entry.async_on_unload(
         vehicle.stream_vehicle.listen_Version(

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -18,7 +18,7 @@ from tesla_fleet_api.exceptions import (
 )
 from tesla_fleet_api.tesla import EnergySiteRouter
 from tesla_fleet_api.teslemetry import EnergySite, Teslemetry
-from teslemetry_stream import TeslemetryStream
+from teslemetry_stream import TeslemetryStream, TeslemetryStreamAuthenticationError
 from teslemetry_stream.const import SseTopic
 
 from homeassistant.components.application_credentials import (
@@ -681,7 +681,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                     create_handle_energy_stream_connection(energysites)
                 )
             )
-        entry.async_create_background_task(hass, stream.listen(), "Teslemetry Stream")
+
+        async def listen() -> None:
+            """Listen to the stream, prompting reauth if the token is rejected."""
+            try:
+                await stream.listen()
+            except TeslemetryStreamAuthenticationError:
+                entry.async_start_reauth(hass)
+
+        entry.async_create_background_task(hass, listen(), "Teslemetry Stream")
 
     return True
 

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -12,6 +12,6 @@
   "requirements": [
     "aiopowerwall==0.2.0",
     "tesla-fleet-api==1.12.1",
-    "teslemetry-stream==0.10.0"
+    "teslemetry-stream==0.13.1"
   ]
 }

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -3,10 +3,11 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, override
+from typing import override
 
 from tesla_fleet_api import firmware_at_least
 from teslemetry_stream import TeslemetryStream, TeslemetryStreamVehicle
+from teslemetry_stream.const import CreditsEvent
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -1992,13 +1993,9 @@ class TeslemetryCreditQuotaSensor(RestoreSensor):
 
         self.async_on_remove(self.stream.listen_Credits(self._async_update))
 
-    def _async_update(self, credits: dict[str, Any]) -> None:
+    def _async_update(self, credits: CreditsEvent) -> None:
         """Handle updated data from the stream."""
-        quota = credits.get("quota")
-        if not isinstance(quota, dict):
-            return
-
-        fraction = quota.get("fraction")
+        fraction = credits.quota.get("fraction")
         if not isinstance(fraction, (float, int)) or isinstance(fraction, bool):
             return
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3242,7 +3242,7 @@ tesla-powerwall==0.5.3
 tesla-wall-connector==1.2.0
 
 # homeassistant.components.teslemetry
-teslemetry-stream==0.10.0
+teslemetry-stream==0.13.1
 
 # homeassistant.components.tessie
 tessie-api==0.1.3

--- a/tests/components/teslemetry/conftest.py
+++ b/tests/components/teslemetry/conftest.py
@@ -172,7 +172,7 @@ def mock_add_listener():
         def unsubscribe() -> None:
             return
 
-        def side_effect(callback, filters):
+        def side_effect(callback, filters, internal=False):
             mock_add_listener.listeners.append((callback, filters))
             return unsubscribe
 

--- a/tests/components/teslemetry/snapshots/test_diagnostics.ambr
+++ b/tests/components/teslemetry/snapshots/test_diagnostics.ambr
@@ -590,7 +590,6 @@
           'config': dict({
             'fields': dict({
             }),
-            'prefer_typed': None,
           }),
         }),
       }),

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -25,6 +25,7 @@ from tesla_fleet_api.exceptions import (
 )
 from tesla_fleet_api.tesla import EnergySiteRouter
 from tesla_fleet_api.teslemetry import EnergySite
+from teslemetry_stream import TeslemetryStreamAuthenticationError
 
 from homeassistant.components.teslemetry import (
     STREAM_TOPICS,
@@ -1239,6 +1240,23 @@ async def test_get_access_token_rate_limited_after_setup_is_not_fatal(
     await hass.async_block_till_done()
 
     assert not hass.config_entries.flow.async_progress()
+
+
+async def test_stream_rejected_token_starts_reauth(
+    hass: HomeAssistant,
+    mock_stream_listen: AsyncMock,
+) -> None:
+    """Test the stream listener starts reauth when the token is rejected."""
+    mock_stream_listen.side_effect = TeslemetryStreamAuthenticationError
+
+    await setup_platform(hass)
+    await hass.async_block_till_done()
+
+    flows = hass.config_entries.flow.async_progress()
+    assert any(
+        flow["handler"] == DOMAIN and flow["context"].get("source") == "reauth"
+        for flow in flows
+    )
 
 
 SITE_ID = 123456

--- a/tests/components/teslemetry/test_sensor.py
+++ b/tests/components/teslemetry/test_sensor.py
@@ -176,10 +176,15 @@ async def test_sensors_streaming(
     )
     await hass.async_block_till_done()
 
-    # Balance-only credit events should not clear quota usage.
+    # A credit event without quota data should not clear quota usage.
     mock_add_listener.send(
         {
-            "credits": {"balance": 1980},
+            "credits": {
+                "type": "wake_up",
+                "cost": 0,
+                "name": "wake_up",
+                "balance": 1980,
+            },
             "createdAt": "2024-10-04T10:45:18.537Z",
         }
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps `teslemetry-stream` from 0.10.0 to 0.13.1.

For users, the visible benefit is quieter logs: a clean end of the stream (for
example during a server deploy) is now an INFO-level reconnect instead of a
`WARNING`, so the recurring "Stream ended by server" warning no longer appears.

The library also changed shape between these versions, so a few adaptations ride
along to keep the integration correct against 0.13.1:

- Typed events are the default now, so the `prefer_typed` background-task setup
  (removed upstream in 0.10.1) is gone.
- `listen_Credits` hands its callback a `CreditsEvent` dataclass instead of a
  dict, so the credit-quota sensor reads `quota` as an attribute.
- `listen()` raises `TeslemetryStreamAuthenticationError` on a 401/403 instead
  of retrying, so the stream listener now catches it and starts reauth rather
  than letting the background task die silently.

Library diff: https://github.com/Teslemetry/teslemetry_stream/compare/v0.10.0...v0.13.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
