### PR TITLE
Drop the unknown-app sentinel from vizio app_name on non-app inputs

### DIFF
--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -208,12 +208,17 @@ class VizioDevice(VizioEntity, MediaPlayerEntity):
                     else ()
                 ),
             )
-            # find_app_name returns None on a catalog miss; the app_name state
-            # attribute contract expects the UNKNOWN_APP sentinel instead
+            # A catalog miss only warrants the UNKNOWN_APP sentinel on the app
+            # input; HDMI and the like report a config that is never an app.
             if app_name == NO_APP_RUNNING:
                 self._attr_app_name = None
             elif app_name is None:
-                self._attr_app_name = UNKNOWN_APP
+                self._attr_app_name = (
+                    UNKNOWN_APP
+                    if self._current_input is not None
+                    and is_app_input(self._current_input)
+                    else None
+                )
             else:
                 self._attr_app_name = app_name
 

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -855,14 +855,45 @@ async def test_apps_update(
                 assert len(apps) == len(APP_RECORDS)
 
 
+@pytest.mark.parametrize(
+    ("entry_data", "app_config", "expected_app_name"),
+    [
+        pytest.param(
+            MOCK_USER_VALID_TV_CONFIG,
+            UNKNOWN_APP_CONFIG_OBJ,
+            None,
+            id="unknown_config_hides_app_name",
+        ),
+        pytest.param(
+            MOCK_TV_WITH_ADDITIONAL_APPS_CONFIG,
+            CUSTOM_CONFIG_OBJ,
+            ADDITIONAL_APP_CONFIG["name"],
+            id="additional_config_keeps_mapped_name",
+        ),
+    ],
+)
 @pytest.mark.usefixtures("vizio_connect", "vizio_update_with_apps_on_input")
 async def test_vizio_update_with_apps_on_input(
-    hass: HomeAssistant, mock_tv_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    entry_data: dict[str, Any],
+    app_config: AppConfig,
+    expected_app_name: str | None,
 ) -> None:
-    """Test a vizio TV with apps that is on a TV input."""
-    await setup_integration(hass, mock_tv_config_entry)
+    """Test a vizio TV with apps that is on a TV input.
+
+    The device reports an app config even on HDMI. An unrecognized one must
+    not surface as the unknown-app sentinel, while a name mapped through
+    additional_configs is deliberate user configuration and is kept.
+    """
+    config_entry = MockConfigEntry(domain=DOMAIN, data=entry_data, unique_id=UNIQUE_ID)
+    with patch(
+        "homeassistant.components.vizio.Vizio.get_current_app_config",
+        return_value=app_config,
+    ):
+        await setup_integration(hass, config_entry)
     attr = _get_attr_and_assert_base_attr(hass, MediaPlayerDeviceClass.TV, STATE_ON)
-    # app ID should not be in the attributes
+    assert attr[ATTR_INPUT_SOURCE] == CURRENT_INPUT
+    assert attr.get("app_name") == expected_app_name
     assert "app_id" not in attr
 
 


### PR DESCRIPTION
## Proposed change

Vizio TVs report an app config from `/app/current` even while on an HDMI (or any other non-app) input, and that config is never in the app catalog. `find_app_name` therefore misses and the media player set its `app_name` attribute to the `_UNKNOWN_APP` sentinel on every TV input, while `source` correctly showed the HDMI input. The `app_id` attribute was already suppressed off the app input, so the sentinel carried no information there.

With this change a catalog miss only produces `_UNKNOWN_APP` when the current input is the app input, where `app_id` then exposes the config so users can add it to `additional_configs`. On other inputs the attribute is dropped. A name that does resolve is still reported on any input, including one a user has mapped to an HDMI pseudo-app config through `additional_configs`, which keeps the behavior #66424 restored for #65612 after #64025 hid the attribute unconditionally.

`test_vizio_update_with_apps_on_input` is now parametrized over both cases: an unrecognized config on HDMI yields no `app_name`, and an `additional_configs` mapping on HDMI keeps the mapped name.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #176368
- This PR is related to issue: #63859, #65612
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
