### PR TITLE
Fix BAF color temperature support on fan-mounted lights

### DIFF
--- a/homeassistant/components/baf/light.py
+++ b/homeassistant/components/baf/light.py
@@ -25,7 +25,12 @@ async def async_setup_entry(
     """Set up BAF lights."""
     device = entry.runtime_data
     if device.has_light:
-        klass = BAFFanLight if device.has_fan else BAFStandaloneLight
+        klass = (
+            BAFColorTempLight
+            if device.light_warmest_color_temperature
+            and device.light_coolest_color_temperature
+            else BAFBrightnessLight
+        )
         async_add_entities([klass(device)])
 
 
@@ -58,24 +63,26 @@ class BAFLight(BAFEntity, LightEntity):
         self._device.light_mode = OffOnAuto.OFF
 
 
-class BAFFanLight(BAFLight):
-    """Representation of a Big Ass Fans light on a fan."""
+class BAFBrightnessLight(BAFLight):
+    """Representation of a Big Ass Fans light without color temperature."""
 
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
     _attr_color_mode = ColorMode.BRIGHTNESS
 
 
-class BAFStandaloneLight(BAFLight):
-    """Representation of a Big Ass Fans light."""
+class BAFColorTempLight(BAFLight):
+    """Representation of a Big Ass Fans light with color temperature."""
 
     _attr_supported_color_modes = {ColorMode.COLOR_TEMP}
     _attr_color_mode = ColorMode.COLOR_TEMP
 
     def __init__(self, device: Device) -> None:
-        """Init a standalone light."""
+        """Init a light with color temperature."""
         super().__init__(device)
-        self._attr_max_color_temp_kelvin = device.light_warmest_color_temperature
-        self._attr_min_color_temp_kelvin = device.light_coolest_color_temperature
+        warmest = device.light_warmest_color_temperature
+        coolest = device.light_coolest_color_temperature
+        self._attr_min_color_temp_kelvin = min(warmest, coolest)
+        self._attr_max_color_temp_kelvin = max(warmest, coolest)
 
     @callback
     @override


### PR DESCRIPTION
## Proposed change

`baf` chooses its light class from whether the device has a fan:

```python
klass = BAFFanLight if device.has_fan else BAFStandaloneLight
```

`BAFFanLight` hardcodes `ColorMode.BRIGHTNESS`, so any light kit attached to a fan is brightness-only regardless of what the hardware can do. This is wrong for tunable-white light kits such as the one on the i6, where color temperature is adjustable in the BAF app but absent in Home Assistant.

Nothing below the integration is missing. `aiobafi6` already exposes `light_color_temperature` (writable), `light_warmest_color_temperature` and `light_coolest_color_temperature`. The protocol has no "is tunable" capability bit — `Capabilities` carries only `has_comfort1`, `has_comfort3` and `has_light` — so the presence of a reported warmest/coolest range is the available signal, and this PR selects on it instead.

This also corrects inverted Kelvin bounds in the color temperature class. The existing code assigns:

```python
self._attr_max_color_temp_kelvin = device.light_warmest_color_temperature
self._attr_min_color_temp_kelvin = device.light_coolest_color_temperature
```

In Kelvin the warmest end is the *lower* number. My i6 fans report warmest=2200 and coolest=6500, which yields min=6500, max=2200. The two changes are not separable: enabling color temperature on these devices without correcting the bounds produces an unusable entity.

`BAFFanLight`/`BAFStandaloneLight` are renamed to `BAFBrightnessLight`/`BAFColorTempLight`, since they now describe capability rather than form factor.

Devices that do not report a color temperature range fall through to brightness-only, which is their current behaviour.

Tested on 5x Big Ass Fans i6 (firmware 3.3.5) running HA core 2026.8.2 with aiobafi6 0.9.0; 3 of the 5 have light kits.

- Before: `supported_color_modes: [brightness]`, no color temperature available.
- After: `supported_color_modes: [color_temp]`, `min_color_temp_kelvin: 2200`, `max_color_temp_kelvin: 6500`.

Verified the read path (device-reported color temperature surfacing as `color_temp_kelvin`) and the write path (`light.turn_on` with `color_temp_kelvin`, with `color_temp_kelvin` + `brightness` together, and driven by Adaptive Lighting). All 86 `baf` entities loaded, none unavailable.

I have not added tests. `tests/components/baf/` currently contains only `test_config_flow.py` — there is no device fixture or `conftest.py` to extend — so covering this would mean building that scaffolding from scratch. Happy to do so if a maintainer would like it as part of this PR.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #138933
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [[development checklist](https://developers.home-assistant.io/docs/development_checklist/)][dev-checklist]
- [x] I have followed the [[perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [[www.home-assistant.io](https://github.com/home-assistant/home-assistant.io)][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [[manifest file](https://developers.home-assistant.io/docs/creating_integration_manifest/)][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [[open pull requests](https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure)][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr