### PR TITLE
Add charging mode select to Silla Prism

### DIFF
--- a/homeassistant/components/silla_prism/const.py
+++ b/homeassistant/components/silla_prism/const.py
@@ -6,7 +6,7 @@ from homeassistant.const import Platform
 
 DOMAIN: Final = "silla_prism"
 
-PLATFORMS: Final = [Platform.SENSOR]
+PLATFORMS: Final = [Platform.SELECT, Platform.SENSOR]
 
 CONF_BASE_TOPIC: Final = "base_topic"
 

--- a/homeassistant/components/silla_prism/coordinator.py
+++ b/homeassistant/components/silla_prism/coordinator.py
@@ -39,7 +39,7 @@ class PrismCoordinator(DataUpdateCoordinator[PrismStatus]):
         """Initialize the coordinator."""
         super().__init__(hass, _LOGGER, config_entry=entry, name=DOMAIN)
         self.base_topic: str = entry.data[CONF_BASE_TOPIC]
-        self.device = PrismDevice(self.base_topic)
+        self.device = PrismDevice(self.base_topic, publish=self._async_publish)
         self.device.on_status_update = self._on_status_update
         self.device.on_hello = self._on_hello
 
@@ -59,6 +59,10 @@ class PrismCoordinator(DataUpdateCoordinator[PrismStatus]):
     async def _async_update_data(self) -> PrismStatus:
         """Return the accumulated state (populated by retained messages)."""
         return self.device.status
+
+    async def _async_publish(self, topic: str, payload: str) -> None:
+        """Publish a command built by the library."""
+        await mqtt.async_publish(self.hass, topic, payload)
 
     @callback
     def _message_received(self, msg: ReceiveMessage) -> None:

--- a/homeassistant/components/silla_prism/select.py
+++ b/homeassistant/components/silla_prism/select.py
@@ -1,0 +1,54 @@
+"""Select platform for the Silla Prism integration."""
+
+from typing import override
+
+from pysillaprism import SETTABLE_MODES
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import PORT
+from .coordinator import PrismConfigEntry, PrismCoordinator
+from .entity import PrismEntity
+
+PARALLEL_UPDATES = 0
+
+OPTION_TO_MODE = {mode.name.lower(): mode for mode in SETTABLE_MODES}
+MODE_TO_OPTION = {mode: option for option, mode in OPTION_TO_MODE.items()}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PrismConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Prism select entities."""
+    async_add_entities([PrismModeSelect(entry.runtime_data)])
+
+
+class PrismModeSelect(PrismEntity, SelectEntity):
+    """Charging mode selector (Solar/Normal/Pause)."""
+
+    _attr_translation_key = "charging_mode"
+    _attr_options = list(OPTION_TO_MODE)
+
+    def __init__(self, coordinator: PrismCoordinator) -> None:
+        """Initialize the select entity."""
+        super().__init__(coordinator, "charging_mode")
+
+    @property
+    @override
+    def current_option(self) -> str | None:
+        """Return the current mode, or None when it is not user-settable.
+
+        Prism also reports a load-balancing pause, which cannot be selected
+        back; it surfaces on the status sensor instead.
+        """
+        mode = self.coordinator.device.status.port(PORT).mode
+        return MODE_TO_OPTION.get(mode) if mode is not None else None
+
+    @override
+    async def async_select_option(self, option: str) -> None:
+        """Change the charging mode."""
+        await self.coordinator.device.set_mode(OPTION_TO_MODE[option], PORT)

--- a/homeassistant/components/silla_prism/strings.json
+++ b/homeassistant/components/silla_prism/strings.json
@@ -28,6 +28,16 @@
     }
   },
   "entity": {
+    "select": {
+      "charging_mode": {
+        "name": "Charging mode",
+        "state": {
+          "normal": "[%key:common::state::normal%]",
+          "pause": "[%key:common::state::paused%]",
+          "solar": "Solar"
+        }
+      }
+    },
     "sensor": {
       "error": {
         "name": "Error",

--- a/tests/components/silla_prism/__init__.py
+++ b/tests/components/silla_prism/__init__.py
@@ -1,5 +1,9 @@
 """Tests for the Silla Prism integration."""
 
+from unittest.mock import patch
+
+from homeassistant.components.silla_prism.const import PLATFORMS
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .const import RETAINED_BURST
@@ -7,10 +11,17 @@ from .const import RETAINED_BURST
 from tests.common import MockConfigEntry, async_fire_mqtt_message
 
 
-async def setup_integration(hass: HomeAssistant, entry: MockConfigEntry) -> None:
-    """Set up the Silla Prism integration."""
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+async def setup_integration(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    platforms: list[Platform] | None = None,
+) -> None:
+    """Set up the Silla Prism integration, optionally limited to some platforms."""
+    with patch(
+        "homeassistant.components.silla_prism.PLATFORMS", platforms or PLATFORMS
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
 
 async def fire_burst(hass: HomeAssistant) -> None:

--- a/tests/components/silla_prism/snapshots/test_select.ambr
+++ b/tests/components/silla_prism/snapshots/test_select.ambr
@@ -1,0 +1,62 @@
+# serializer version: 1
+# name: test_selects[select.silla_prism_charging_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'solar',
+        'normal',
+        'pause',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.silla_prism_charging_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charging mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Charging mode',
+    'platform': 'silla_prism',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'charging_mode',
+    'unique_id': 'prism_charging_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_selects[select.silla_prism_charging_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Silla Prism Charging mode',
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'solar',
+        'normal',
+        'pause',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.silla_prism_charging_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'normal',
+  })
+# ---

--- a/tests/components/silla_prism/test_select.py
+++ b/tests/components/silla_prism/test_select.py
@@ -1,0 +1,96 @@
+"""Test the Silla Prism selects."""
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import fire_burst, setup_integration
+
+from tests.common import MockConfigEntry, async_fire_mqtt_message, snapshot_platform
+from tests.typing import MqttMockHAClient
+
+CHARGING_MODE_ENTITY_ID = "select.silla_prism_charging_mode"
+MODE_TOPIC = "prism/1/mode"
+SET_MODE_TOPIC = "prism/1/command/set_mode"
+
+
+async def test_selects(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the selects."""
+    await setup_integration(hass, mock_config_entry, [Platform.SELECT])
+    await fire_burst(hass)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("option", "payload"),
+    [("solar", "1"), ("normal", "2"), ("pause", "3")],
+)
+async def test_select_option(
+    hass: HomeAssistant,
+    mqtt_mock: MqttMockHAClient,
+    mock_config_entry: MockConfigEntry,
+    option: str,
+    payload: str,
+) -> None:
+    """Test that selecting a mode publishes the matching command."""
+    await setup_integration(hass, mock_config_entry)
+    await fire_burst(hass)
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: CHARGING_MODE_ENTITY_ID, ATTR_OPTION: option},
+        blocking=True,
+    )
+
+    mqtt_mock.async_publish.assert_called_once_with(
+        SET_MODE_TOPIC, payload, 0, False, message_expiry_interval=None
+    )
+
+
+@pytest.mark.usefixtures("mqtt_mock")
+async def test_mode_updates(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that the selected mode follows the reported one."""
+    await setup_integration(hass, mock_config_entry)
+    await fire_burst(hass)
+
+    assert hass.states.get(CHARGING_MODE_ENTITY_ID).state == "normal"
+
+    async_fire_mqtt_message(hass, MODE_TOPIC, "1")
+    await hass.async_block_till_done()
+
+    assert hass.states.get(CHARGING_MODE_ENTITY_ID).state == "solar"
+
+
+@pytest.mark.usefixtures("mqtt_mock")
+async def test_mode_not_selectable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that a mode Prism cannot be put back into reads as unknown."""
+    await setup_integration(hass, mock_config_entry)
+    await fire_burst(hass)
+
+    # Load balancing suspended the session: reported, but not user-settable.
+    async_fire_mqtt_message(hass, MODE_TOPIC, "7")
+    await hass.async_block_till_done()
+
+    assert hass.states.get(CHARGING_MODE_ENTITY_ID).state == STATE_UNKNOWN

--- a/tests/components/silla_prism/test_sensor.py
+++ b/tests/components/silla_prism/test_sensor.py
@@ -6,7 +6,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import STATE_UNKNOWN
+from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -33,7 +33,7 @@ async def test_sensors(
 ) -> None:
     """Test the sensors."""
     freezer.move_to("2026-01-01 00:00:00+00:00")
-    await setup_integration(hass, mock_config_entry)
+    await setup_integration(hass, mock_config_entry, [Platform.SENSOR])
     await fire_burst(hass)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The initial Silla Prism PR (#176785) was reduced to a single platform for review, with the controls left as follow-ups. This is the first of them: the charging mode select.

The Prism publishes the port operating mode on a retained topic and accepts a `set_mode` command on the matching command topic, so the select reads its state from the accumulated status and writes back through the library's command builders. To make that possible, the coordinator now passes a publish callback to `PrismDevice`, mapping it onto `mqtt.async_publish`. That callback is the plumbing every remaining control platform will reuse.

Only Solar, Normal and Pause are user-settable. The Prism also reports a fourth mode when its own load balancing suspends the session; it cannot be selected back, so `current_option` returns `None` and the entity reads as unknown while it lasts. The port state remains visible on the status sensor throughout.

The shared test helper gained an optional platform list, since `snapshot_platform` requires a single loaded platform and the integration now sets up two.

No library change is needed: `pysillaprism` 0.2.0 already exposes the command surface.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #176785
- Link to documentation pull request: home-assistant/home-assistant.io#47928
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
