### PR TITLE
Fix easyEnergy price period count sensor semantics

### DIFF
--- a/homeassistant/components/easyenergy/sensor.py
+++ b/homeassistant/components/easyenergy/sensor.py
@@ -12,13 +12,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import (
-    CURRENCY_EURO,
-    PERCENTAGE,
-    UnitOfEnergy,
-    UnitOfTime,
-    UnitOfVolume,
-)
+from homeassistant.const import CURRENCY_EURO, PERCENTAGE, UnitOfEnergy, UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -182,14 +176,12 @@ SENSORS: tuple[EasyEnergySensorEntityDescription, ...] = (
         key="hours_priced_equal_or_lower",
         translation_key="hours_priced_equal_or_lower",
         service_type="today_energy_usage",
-        native_unit_of_measurement=UnitOfTime.HOURS,
         value_fn=lambda data: data.energy_today.periods_priced_equal_or_lower,
     ),
     EasyEnergySensorEntityDescription(
         key="hours_priced_equal_or_higher",
         translation_key="hours_priced_equal_or_higher",
         service_type="today_energy_return",
-        native_unit_of_measurement=UnitOfTime.HOURS,
         value_fn=lambda data: data.energy_today.return_periods_priced_equal_or_higher,
     ),
 )

--- a/homeassistant/components/easyenergy/strings.json
+++ b/homeassistant/components/easyenergy/strings.json
@@ -24,10 +24,10 @@
         "name": "Time of highest price - today"
       },
       "hours_priced_equal_or_higher": {
-        "name": "Hours priced equal or higher than current - today"
+        "name": "Periods priced equal or higher than current - today"
       },
       "hours_priced_equal_or_lower": {
-        "name": "Hours priced equal or lower than current - today"
+        "name": "Periods priced equal or lower than current - today"
       },
       "lowest_price_time": {
         "name": "Time of lowest price - today"

--- a/tests/components/easyenergy/test_sensor.py
+++ b/tests/components/easyenergy/test_sensor.py
@@ -1,8 +1,9 @@
 """Tests for the sensors provided by the easyEnergy integration."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock
 
-from easyenergy import EasyEnergyNoDataError
+from easyenergy import EasyEnergyNoDataError, Electricity
 import pytest
 
 from homeassistant.components.easyenergy.const import DOMAIN
@@ -29,8 +30,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 @pytest.mark.freeze_time("2026-04-19 13:00:00+00:00")
@@ -128,7 +130,7 @@ async def test_energy_usage_today(
     assert not device_entry.model
     assert not device_entry.sw_version
 
-    # Usage hours priced equal or lower sensor
+    # Usage periods priced equal or lower sensor
     state = hass.states.get(
         "sensor.easyenergy_today_energy_usage_hours_priced_equal_or_lower"
     )
@@ -141,9 +143,10 @@ async def test_energy_usage_today(
         entry.unique_id == f"{entry_id}_today_energy_usage_hours_priced_equal_or_lower"
     )
     assert state.state == "2"
+    assert ATTR_UNIT_OF_MEASUREMENT not in state.attributes
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME) == "Energy market price"
-        " - Usage Hours priced equal or lower than current - today"
+        " - Usage Periods priced equal or lower than current - today"
     )
     assert ATTR_DEVICE_CLASS not in state.attributes
 
@@ -243,7 +246,7 @@ async def test_energy_return_today(
     assert not device_entry.model
     assert not device_entry.sw_version
 
-    # Return hours priced equal or higher sensor
+    # Return periods priced equal or higher sensor
     state = hass.states.get(
         "sensor.easyenergy_today_energy_return_hours_priced_equal_or_higher"
     )
@@ -257,9 +260,10 @@ async def test_energy_return_today(
         == f"{entry_id}_today_energy_return_hours_priced_equal_or_higher"
     )
     assert state.state == "23"
+    assert ATTR_UNIT_OF_MEASUREMENT not in state.attributes
     assert (
         state.attributes.get(ATTR_FRIENDLY_NAME) == "Energy market price"
-        " - Return Hours priced equal or higher than current - today"
+        " - Return Periods priced equal or higher than current - today"
     )
     assert ATTR_DEVICE_CLASS not in state.attributes
 
@@ -321,3 +325,59 @@ async def test_no_gas_today(
     state = hass.states.get("sensor.easyenergy_today_gas_current_hour_price")
     assert state
     assert state.state == STATE_UNKNOWN
+
+
+@pytest.mark.freeze_time("2026-04-19 00:00:00+00:00")
+@pytest.mark.parametrize(
+    ("minutes", "granularity"),
+    [
+        pytest.param(60, "hour", id="hourly"),
+        pytest.param(15, "quarter", id="quarter-hourly"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("sensor", "expected_state"),
+    [
+        pytest.param("usage_hours_priced_equal_or_lower", "3", id="usage"),
+        pytest.param("return_hours_priced_equal_or_higher", "2", id="return"),
+    ],
+)
+async def test_price_period_counts(
+    hass: HomeAssistant,
+    mock_easyenergy: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    minutes: int,
+    granularity: str,
+    sensor: str,
+    expected_state: str,
+) -> None:
+    """Test inclusive counts for distinct usage and return prices at any interval size."""
+    data = await async_load_json_object_fixture(hass, "today_energy.json", DOMAIN)
+    start = dt_util.utcnow()
+    interval = timedelta(minutes=minutes)
+    prices = [
+        {
+            **data["prices"][0],
+            "from": (start + index * interval).isoformat(),
+            "until": (start + (index + 1) * interval).isoformat(),
+            "granularity": granularity,
+            "priceIncVat": usage_price,
+            "invoicePrice": return_price,
+        }
+        for index, (usage_price, return_price) in enumerate(
+            [(0.2, 0.3), (-0.1, 0.1), (0.2, 0.3), (0.4, 0.2)]
+        )
+    ]
+    mock_easyenergy.energy_prices.return_value = Electricity.from_dict(
+        prices, price_key="priceIncVat", return_price_key="invoicePrice"
+    )
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"sensor.easyenergy_today_energy_{sensor}")
+    assert state
+    assert state.state == expected_state
+    assert ATTR_UNIT_OF_MEASUREMENT not in state.attributes
+    assert ATTR_DEVICE_CLASS not in state.attributes
+    assert ATTR_STATE_CLASS not in state.attributes


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The easyEnergy sensors `hours_priced_equal_or_lower` and `hours_priced_equal_or_higher`, now named "Periods priced …", no longer expose the `h` unit of measurement. Their values count price periods, not durations in hours.

Update any templates or dashboard cards that depend on these sensors' `unit_of_measurement` attribute to handle unitless counts. Numeric values, entity IDs, and unique IDs remain unchanged. Automations that compare only the numeric sensor values require no changes.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The two `hours_priced_equal_or_*` sensors expose counts from python-easyenergy, but currently label them as hours. Remove `UnitOfTime.HOURS` and rename their translated display names to “Periods priced …”. No device class applies: these values count today's periods whose usage price is at or below the current usage price, or whose return price is at or above the current return price. The library counts matching intervals without weighting their duration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #181378
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
