### PR TITLE
Add l/min unit mapping to nibe_heatpump sensors

### DIFF
--- a/homeassistant/components/nibe_heatpump/sensor.py
+++ b/homeassistant/components/nibe_heatpump/sensor.py
@@ -164,6 +164,13 @@ UNIT_DESCRIPTIONS = {
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
     ),
+    "l/min": SensorEntityDescription(
+        key="l/min",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
+    ),
     "m³/h": SensorEntityDescription(
         key="m³/h",
         entity_category=EntityCategory.DIAGNOSTIC,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `nibe` library gained a new unit string `l/min` in 2.24.0. `UNIT_DESCRIPTIONS` in `nibe_heatpump/sensor.py` only knows `l/m`, so `UNIT_DESCRIPTIONS.get(coil.unit)` returns `None` and affected sensors fall through to the fallback branch in `Sensor.__init__`: no `device_class`, no `state_class`, and the raw unit string passed through as free text.

For users this appears as a repairs issue after upgrading to 2026.9:

> We have generated statistics for 'S735 Flow sensor (BF1)' (sensor.flow_sensor_bf1_30041) in the past, but it no longer has a state class, therefore we cannot track long term statistics for it anymore.

Root cause chain:

- yozik04/nibe#296 ("[S735 fw 4.10.5] Update CSV, JSON", released in 2.24.0) changed register `30041` from `unit: "l/m"` to `unit: "l/min"`.
- #177987 bumped nibe to 2.24.0 for 2026.9.
- The mapping key was never added, so the entity silently lost its device class and state class, breaking long-term statistics continuity.

This PR adds `l/min` alongside the existing `l/m` key with the same `SensorEntityDescription`. `l/m` is intentionally kept: 15 model definitions in nibe 2.24.0 still use it (f1145_f1245, f1155_f1255, f1345, f1355, f730, f750, s1155_s1255, s1156_s1256, s2125, s320_s325, s330_s332, smo40, vvm225_vvm320_vvm325, vvm310_vvm500, vvms325).

Models fixed by this change (all files using `l/min` in nibe 2.24.0): `s735`, `smos40`, `vvms320`, `vvms320_vvms325`, `vvms500`. The last four already used `l/min` before 2.24.0, so they have been missing the state class for longer; only S735 surfaces a visible repair, because only a unit *rename* on an entity with existing statistics triggers the dialog.

Because `UnitOfVolumeFlowRate.LITERS_PER_MINUTE` is unchanged, existing long-term statistics reconnect to the same entity without a unit conversion conflict — no data loss, provided users have not already deleted the statistics via the repair dialog.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

This is a regression introduced in 2026.9, so it may be worth considering for a 2026.9.x patch release.

Core PR that introduced the regression: #177987
Related dependency change: https://github.com/yozik04/nibe/pull/296

Note on scope: the lookup falls back silently, so any future unit string the library adds degrades entities without any signal. Other unit strings currently unmapped in the S735 table are `%`, `DM`, `days` and `rpm` — `"%RH"` is mapped but plain `"%"` is not. That is a pre-existing gap and deliberately not addressed here to keep this a minimal regression fix.

Per the AI policy: the diff was drafted with AI assistance and reviewed by me before submission.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr