### PR TITLE
Handle errors in easyEnergy price actions

### DIFF
--- a/homeassistant/components/easyenergy/services.py
+++ b/homeassistant/components/easyenergy/services.py
@@ -5,7 +5,9 @@ from enum import StrEnum
 from functools import partial
 from typing import Final
 
+from aiohttp import ClientError
 from easyenergy import (
+    EasyEnergyError,
     Electricity,
     ElectricityGranularity,
     ElectricityPriceType,
@@ -23,7 +25,7 @@ from homeassistant.core import (
     SupportsResponse,
     callback,
 )
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import selector, service
 from homeassistant.util import dt as dt_util
 
@@ -192,21 +194,33 @@ async def __get_prices(
     prices: list[dict[str, float | datetime]]
 
     if service_price_type == ServicePriceType.GAS:
-        data = await coordinator.easyenergy.gas_prices(
-            start_date=start_date,
-            end_date=end_date,
-            vat=vat,
-        )
+        try:
+            data = await coordinator.easyenergy.gas_prices(
+                start_date=start_date,
+                end_date=end_date,
+                vat=vat,
+            )
+        except (EasyEnergyError, ClientError, TimeoutError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="fetch_prices_error",
+            ) from err
         prices = __select_prices(
             data, call.data[ATTR_PRICE_TYPE] == ElectricityPriceType.INVOICE.value
         )
     else:
-        data = await coordinator.easyenergy.energy_prices(
-            start_date=start_date,
-            end_date=end_date,
-            granularity=ElectricityGranularity(call.data[ATTR_GRANULARITY]),
-            vat=vat,
-        )
+        try:
+            data = await coordinator.easyenergy.energy_prices(
+                start_date=start_date,
+                end_date=end_date,
+                granularity=ElectricityGranularity(call.data[ATTR_GRANULARITY]),
+                vat=vat,
+            )
+        except (EasyEnergyError, ClientError, TimeoutError) as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="fetch_prices_error",
+            ) from err
 
         if service_price_type == ServicePriceType.ENERGY_USAGE:
             prices = __select_prices(

--- a/homeassistant/components/easyenergy/services.py
+++ b/homeassistant/components/easyenergy/services.py
@@ -5,7 +5,6 @@ from enum import StrEnum
 from functools import partial
 from typing import Final
 
-from aiohttp import ClientError
 from easyenergy import (
     EasyEnergyError,
     Electricity,
@@ -200,7 +199,7 @@ async def __get_prices(
                 end_date=end_date,
                 vat=vat,
             )
-        except (EasyEnergyError, ClientError, TimeoutError) as err:
+        except EasyEnergyError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="fetch_prices_error",
@@ -216,7 +215,7 @@ async def __get_prices(
                 granularity=ElectricityGranularity(call.data[ATTR_GRANULARITY]),
                 vat=vat,
             )
-        except (EasyEnergyError, ClientError, TimeoutError) as err:
+        except EasyEnergyError as err:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="fetch_prices_error",

--- a/homeassistant/components/easyenergy/strings.json
+++ b/homeassistant/components/easyenergy/strings.json
@@ -50,6 +50,9 @@
     "connection_error": {
       "message": "Error communicating with the easyEnergy API."
     },
+    "fetch_prices_error": {
+      "message": "Error fetching prices from the easyEnergy API."
+    },
     "invalid_date": {
       "message": "Invalid date provided. Got {date}"
     }

--- a/tests/components/easyenergy/test_services.py
+++ b/tests/components/easyenergy/test_services.py
@@ -3,7 +3,14 @@
 from datetime import date
 from unittest.mock import MagicMock
 
-from easyenergy import ElectricityGranularity, VatOption
+from aiohttp import ClientPayloadError
+from easyenergy import (
+    EasyEnergyConnectionError,
+    EasyEnergyError,
+    EasyEnergyNoDataError,
+    ElectricityGranularity,
+    VatOption,
+)
 import pytest
 from syrupy.assertion import SnapshotAssertion
 import voluptuous as vol
@@ -18,7 +25,7 @@ from homeassistant.components.easyenergy.services import (
     GAS_SERVICE_NAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from tests.common import MockConfigEntry
 
@@ -459,6 +466,7 @@ async def test_service_validation_config_entry_not_found(
 async def test_service_validation_invalid_date(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    mock_easyenergy: MagicMock,
     service: str,
     date_field: str,
     date_value: str,
@@ -470,6 +478,8 @@ async def test_service_validation_invalid_date(
     }
     if service != ENERGY_RETURN_SERVICE_NAME:
         service_data["incl_vat"] = True
+
+    mock_easyenergy.reset_mock()
 
     with pytest.raises(ServiceValidationError) as err:
         await hass.services.async_call(
@@ -483,3 +493,60 @@ async def test_service_validation_invalid_date(
     assert str(err.value) == f"Invalid date provided. Got {date_value}"
     assert err.value.translation_key == "invalid_date"
     assert err.value.translation_placeholders == {"date": date_value}
+    mock_easyenergy.gas_prices.assert_not_awaited()
+    mock_easyenergy.energy_prices.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    ("service", "method", "service_data"),
+    [
+        (GAS_SERVICE_NAME, "gas_prices", {"incl_vat": True}),
+        (ENERGY_USAGE_SERVICE_NAME, "energy_prices", {"incl_vat": True}),
+        (ENERGY_RETURN_SERVICE_NAME, "energy_prices", {}),
+    ],
+)
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(
+            EasyEnergyError("Unexpected response", {"response": "raw API data"}),
+            id="api_error",
+        ),
+        pytest.param(
+            EasyEnergyConnectionError("Connection failed"), id="connection_error"
+        ),
+        pytest.param(EasyEnergyNoDataError("No prices found"), id="no_data"),
+        pytest.param(ClientPayloadError("Incomplete response"), id="response_error"),
+        pytest.param(TimeoutError("Response timed out"), id="timeout"),
+    ],
+)
+async def test_service_api_error(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_easyenergy: MagicMock,
+    service: str,
+    method: str,
+    service_data: dict[str, bool],
+    exception: Exception,
+) -> None:
+    """Test API failures raise translated execution errors for every action."""
+    mock_method = getattr(mock_easyenergy, method)
+    mock_method.reset_mock()
+    mock_method.side_effect = exception
+
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            {ATTR_CONFIG_ENTRY: mock_config_entry.entry_id} | service_data,
+            blocking=True,
+            return_response=True,
+        )
+
+    assert not isinstance(err.value, ServiceValidationError)
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "fetch_prices_error"
+    assert str(err.value) == "Error fetching prices from the easyEnergy API"
+    assert err.value.__cause__ is exception
+    mock_method.assert_awaited_once()

--- a/tests/components/easyenergy/test_services.py
+++ b/tests/components/easyenergy/test_services.py
@@ -3,7 +3,6 @@
 from datetime import date
 from unittest.mock import MagicMock
 
-from aiohttp import ClientPayloadError
 from easyenergy import (
     EasyEnergyConnectionError,
     EasyEnergyError,
@@ -517,8 +516,6 @@ async def test_service_validation_invalid_date(
             EasyEnergyConnectionError("Connection failed"), id="connection_error"
         ),
         pytest.param(EasyEnergyNoDataError("No prices found"), id="no_data"),
-        pytest.param(ClientPayloadError("Incomplete response"), id="response_error"),
-        pytest.param(TimeoutError("Response timed out"), id="timeout"),
     ],
 )
 async def test_service_api_error(
@@ -528,7 +525,7 @@ async def test_service_api_error(
     service: str,
     method: str,
     service_data: dict[str, bool],
-    exception: Exception,
+    exception: EasyEnergyError,
 ) -> None:
     """Test API failures raise translated execution errors for every action."""
     mock_method = getattr(mock_easyenergy, method)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The easyEnergy price actions currently let library exceptions escape when fetching prices fails. Catch `EasyEnergyError` and its subclasses and raise a translated `HomeAssistantError`, preserving the original exception as the cause. Existing invalid-input errors remain `ServiceValidationError`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #181378
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
