### PR TITLE
Replace device_id tuple with string in rfxtrx

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -5,7 +5,7 @@ import binascii
 from collections.abc import Callable, Mapping
 import copy
 import logging
-from typing import Any, NamedTuple, cast
+from typing import Any, NamedTuple, Self, cast
 
 import RFXtrx as rfxtrxmod
 
@@ -58,13 +58,13 @@ class DeviceTuple(NamedTuple):
     subtype: str
     id_string: str
 
-    @staticmethod
-    def from_unique_id(unique_id: str) -> DeviceTuple:
+    @classmethod
+    def from_unique_id(cls, unique_id: str) -> Self:
         """Construct a device tuple from a unique id."""
         data = unique_id.split("_")
         if len(data) != 3:
             raise ValueError(f"Invalid device unique id: {unique_id}")
-        return DeviceTuple(data[0], data[1], data[2])
+        return cls(data[0], data[1], data[2])
 
     @property
     def unique_id(self) -> str:
@@ -356,7 +356,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate an old config entry."""
     version = entry.version
 
-    _LOGGER.debug("Migrating from version %s", version)
+    _LOGGER.debug("Migrating from version %s.%s", entry.version, entry.minor_version)
 
     if version == 1:
         # Convert from old tuple based device identifiers to standard string
@@ -384,7 +384,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         version = 2
         hass.config_entries.async_update_entry(entry, version=version)
 
-    _LOGGER.debug("Migration to version %s successful", version)
+    _LOGGER.debug(
+        "Migration to version %s.%s successful", entry.version, entry.minor_version
+    )
     return True
 
 

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -483,18 +483,29 @@ def get_device_tuple_from_device(
     return DeviceTuple(f"{device.packettype:x}", f"{device.subtype:x}", id_string)
 
 
-def get_device_tuple_from_identifiers(
+def get_device_tuples_from_identifiers(
     identifiers: set[tuple[str, str]],
-) -> DeviceTuple | None:
-    """Calculate the device tuple from a device entry."""
+) -> list[DeviceTuple]:
+    """Calculate the device tuples from a device entry."""
+    device_tuples = []
     for identifier in identifiers:
         if identifier[0] != DOMAIN:
             continue
         try:
-            return DeviceTuple.from_unique_id(identifier[1])
+            device_tuples.append(DeviceTuple.from_unique_id(identifier[1]))
         except ValueError as err:
             _LOGGER.debug("%s", err)
-    return None
+    return device_tuples
+
+
+def get_device_tuple_from_identifiers(
+    identifiers: set[tuple[str, str]],
+) -> DeviceTuple | None:
+    """Calculate the first device tuple from a device entry."""
+    device_tuples = get_device_tuples_from_identifiers(identifiers)
+    if not device_tuples:
+        return None
+    return device_tuples[0]
 
 
 async def async_remove_config_entry_device(

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -58,6 +58,19 @@ class DeviceTuple(NamedTuple):
     subtype: str
     id_string: str
 
+    @staticmethod
+    def from_unique_id(unique_id: str) -> DeviceTuple:
+        """Construct a device tuple from a unique id."""
+        data = unique_id.split("_")
+        if len(data) != 3:
+            raise ValueError(f"Invalid device unique id: {unique_id}")
+        return DeviceTuple(data[0], data[1], data[2])
+
+    @property
+    def unique_id(self) -> str:
+        """Unique identifier of this device tuple."""
+        return f"{self.packettype}_{self.subtype}_{self.id_string}"
+
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -144,7 +157,7 @@ def _get_device_lookup(
     for event_code, event_config in devices.items():
         if (event := get_rfx_object(event_code)) is None:
             continue
-        device_id = get_device_id(
+        device_id = get_device_tuple_from_device(
             event.device, data_bits=event_config.get(CONF_DATA_BITS)
         )
         lookup[device_id] = event_config
@@ -189,7 +202,7 @@ async def async_setup_internal(hass: HomeAssistant, entry: ConfigEntry) -> None:
         _LOGGER.debug("Receive RFXCOM event: %s", event_data)
 
         data_bits = get_device_data_bits(event.device, devices)
-        device_id = get_device_id(event.device, data_bits=data_bits)
+        device_id = get_device_tuple_from_device(event.device, data_bits=data_bits)
 
         if device_id not in devices:
             if config[CONF_AUTOMATIC_ADD]:
@@ -202,7 +215,7 @@ async def async_setup_internal(hass: HomeAssistant, entry: ConfigEntry) -> None:
             pt2262_devices.add(event.device.id_string)
 
         device_entry = device_registry.async_get_device_by_identifier(
-            (DOMAIN, *device_id),  # type: ignore[arg-type]
+            (DOMAIN, device_id.unique_id),
             entry.entry_id,
         )
         if device_entry:
@@ -309,7 +322,7 @@ async def async_setup_platform_entry(
         if not supported(event):
             continue
 
-        device_id = get_device_id(
+        device_id = get_device_tuple_from_device(
             event.device, data_bits=entity_info.get(CONF_DATA_BITS)
         )
         if device_id in device_ids:
@@ -337,6 +350,42 @@ async def async_setup_platform_entry(
         config_entry.async_on_unload(
             async_dispatcher_connect(hass, SIGNAL_EVENT, _update)
         )
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate an old config entry."""
+    version = entry.version
+
+    _LOGGER.debug("Migrating from version %s", version)
+
+    if version == 1:
+        # Convert from old tuple based device identifiers to standard string
+
+        device_registry = dr.async_get(hass)
+        for device_entry in dr.async_entries_for_config_entry(
+            device_registry, entry.entry_id
+        ):
+            identifiers = set()
+            for identifier in device_entry.identifiers:
+                if identifier[0] == DOMAIN and len(cast(tuple, identifier)) == 4:
+                    legacy_identifier = cast(tuple[str, str, str, str], identifier)
+                    identifier = (
+                        DOMAIN,
+                        DeviceTuple(
+                            packettype=legacy_identifier[1],
+                            subtype=legacy_identifier[2],
+                            id_string=legacy_identifier[3],
+                        ).unique_id,
+                    )
+                identifiers.add(identifier)
+            device_registry.async_update_device(
+                device_entry.id, new_identifiers=identifiers
+            )
+        version = 2
+        hass.config_entries.async_update_entry(entry, version=version)
+
+    _LOGGER.debug("Migration to version %s successful", version)
+    return True
 
 
 def get_rfx_object(packetid: str) -> rfxtrxmod.RFXtrxEvent | None:
@@ -384,7 +433,7 @@ def get_device_data_bits(
     if device.packettype == DEVICE_PACKET_TYPE_LIGHTING4:
         for device_id, entity_config in devices.items():
             bits = entity_config.get(CONF_DATA_BITS)
-            if get_device_id(device, bits) == device_id:
+            if get_device_tuple_from_device(device, bits) == device_id:
                 data_bits = bits
                 break
     return data_bits
@@ -419,7 +468,7 @@ def find_possible_pt2262_device(device_ids: set[str], device_id: str) -> str | N
     return None
 
 
-def get_device_id(
+def get_device_tuple_from_device(
     device: rfxtrxmod.RFXtrxDevice, data_bits: int | None = None
 ) -> DeviceTuple:
     """Calculate a device id for device."""
@@ -438,12 +487,14 @@ def get_device_tuple_from_identifiers(
     identifiers: set[tuple[str, str]],
 ) -> DeviceTuple | None:
     """Calculate the device tuple from a device entry."""
-    identifier = next((x for x in identifiers if x[0] == DOMAIN and len(x) == 4), None)
-    if not identifier:
-        return None
-    # work around legacy identifier, being a multi tuple value
-    identifier2 = cast(tuple[str, str, str, str], identifier)
-    return DeviceTuple(identifier2[1], identifier2[2], identifier2[3])
+    for identifier in identifiers:
+        if identifier[0] != DOMAIN:
+            continue
+        try:
+            return DeviceTuple.from_unique_id(identifier[1])
+        except ValueError as err:
+            _LOGGER.debug("%s", err)
+    return None
 
 
 async def async_remove_config_entry_device(

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -39,7 +39,7 @@ from homeassistant.helpers.typing import VolDictType
 from . import (
     DOMAIN,
     DeviceTuple,
-    get_device_id,
+    get_device_tuple_from_device,
     get_device_tuple_from_identifiers,
     get_rfx_object,
 )
@@ -180,7 +180,7 @@ class RfxtrxOptionsFlow(OptionsFlow):
         if user_input is not None:
             devices: dict[str, dict[str, Any] | None] = {}
             device: dict[str, Any]
-            device_id = get_device_id(
+            device_id = get_device_tuple_from_device(
                 self._selected_device_object.device,
                 data_bits=user_input.get(CONF_DATA_BITS),
             )
@@ -325,8 +325,8 @@ class RfxtrxOptionsFlow(OptionsFlow):
         old_device_data = self._get_device_data(old_device)
         new_device_data = self._get_device_data(replace_device)
 
-        old_device_id = "_".join(x for x in old_device_data[CONF_DEVICE_ID])
-        new_device_id = "_".join(x for x in new_device_data[CONF_DEVICE_ID])
+        old_device_id = old_device_data[CONF_DEVICE_ID].unique_id
+        new_device_id = new_device_data[CONF_DEVICE_ID].unique_id
 
         entity_registry = er.async_get(self.hass)
         entity_entries = er.async_entries_for_device(
@@ -414,12 +414,14 @@ class RfxtrxOptionsFlow(OptionsFlow):
 
     def _can_add_device(self, new_rfx_obj: rfxtrxmod.RFXtrxEvent) -> bool:
         """Check if device does not already exist."""
-        new_device_id = get_device_id(new_rfx_obj.device)
+        new_device_id = get_device_tuple_from_device(new_rfx_obj.device)
         for packet_id, entity_info in self.config_entry.data[CONF_DEVICES].items():
             rfx_obj = get_rfx_object(packet_id)
             assert rfx_obj
 
-            device_id = get_device_id(rfx_obj.device, entity_info.get(CONF_DATA_BITS))
+            device_id = get_device_tuple_from_device(
+                rfx_obj.device, entity_info.get(CONF_DATA_BITS)
+            )
             if new_device_id == device_id:
                 return False
 
@@ -493,7 +495,7 @@ class RfxtrxOptionsFlow(OptionsFlow):
 class RfxtrxConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for RFXCOM RFXtrx."""
 
-    VERSION = 1
+    VERSION = 2
 
     @override
     async def async_step_user(

--- a/homeassistant/components/rfxtrx/entity.py
+++ b/homeassistant/components/rfxtrx/entity.py
@@ -14,14 +14,6 @@ from . import DeviceTuple
 from .const import ATTR_EVENT, COMMAND_GROUP_LIST, DATA_RFXOBJECT, DOMAIN, SIGNAL_EVENT
 
 
-def _get_identifiers_from_device_tuple(
-    device_tuple: DeviceTuple,
-) -> set[tuple[str, str]]:
-    """Calculate the device identifier from a device tuple."""
-    # work around legacy identifier, being a multi tuple value
-    return {(DOMAIN, *device_tuple)}  # type: ignore[arg-type]
-
-
 class RfxtrxEntity(RestoreEntity):
     """Represents a Rfxtrx device.
 
@@ -42,11 +34,11 @@ class RfxtrxEntity(RestoreEntity):
     ) -> None:
         """Initialize the device."""
         self._attr_device_info = DeviceInfo(
-            identifiers=_get_identifiers_from_device_tuple(device_id),
+            identifiers={(DOMAIN, device_id.unique_id)},
             model=device.type_string,
             name=f"{device.type_string} {device_id.id_string}",
         )
-        self._attr_unique_id = "_".join(x for x in device_id)
+        self._attr_unique_id = device_id.unique_id
         self._device = device
         self._event = event
         self._device_id = device_id

--- a/homeassistant/components/rfxtrx/sensor.py
+++ b/homeassistant/components/rfxtrx/sensor.py
@@ -289,7 +289,7 @@ class RfxtrxSensor(RfxtrxEntity, SensorEntity):
         """Initialize the sensor."""
         super().__init__(device, device_id, event=event)
         self.entity_description = entity_description
-        self._attr_unique_id = "_".join(x for x in (*device_id, entity_description.key))
+        self._attr_unique_id = f"{device_id.unique_id}_{entity_description.key}"
 
     @override
     async def async_added_to_hass(self) -> None:

--- a/tests/components/rfxtrx/__init__.py
+++ b/tests/components/rfxtrx/__init__.py
@@ -1,1 +1,3 @@
 """Tests for the rfxtrx component."""
+
+ENTRY_VERSION = 2

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -13,6 +13,8 @@ from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
+from . import ENTRY_VERSION
+
 from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
@@ -37,6 +39,23 @@ def create_rfx_test_cfg(
     }
 
 
+def create_rfx_test_entry(
+    device="abcd",
+    automatic_add=False,
+    protocols=None,
+    devices=None,
+    host=None,
+    port=None,
+):
+    """Create rfxtrx config entry."""
+    entry_data = create_rfx_test_cfg(
+        device, automatic_add, protocols, devices, host, port
+    )
+    return MockConfigEntry(
+        domain="rfxtrx", unique_id=DOMAIN, data=entry_data, version=ENTRY_VERSION
+    )
+
+
 async def setup_rfx_test_cfg(
     hass: HomeAssistant,
     device="abcd",
@@ -47,7 +66,7 @@ async def setup_rfx_test_cfg(
     port=None,
 ):
     """Construct a rfxtrx config entry."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         device=device,
         automatic_add=automatic_add,
         devices=devices,
@@ -55,7 +74,6 @@ async def setup_rfx_test_cfg(
         host=host,
         port=port,
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
     mock_entry.supports_remove_device = True
     mock_entry.add_to_hass(hass)
 

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -2,14 +2,13 @@
 
 import pytest
 
-from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import ATTR_EVENT
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
 
-from .conftest import create_rfx_test_cfg
+from .conftest import create_rfx_test_entry
 
-from tests.common import MockConfigEntry, mock_restore_cache
+from tests.common import mock_restore_cache
 
 EVENT_SMOKE_DETECTOR_PANIC = "08200300a109000670"
 EVENT_SMOKE_DETECTOR_NO_PANIC = "08200300a109000770"
@@ -25,9 +24,7 @@ EVENT_AC_118CDEA_2_ON = "0b1100100118cdea02010f70"
 
 async def test_one(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 sensor."""
-    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f230010f71": {}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices={"0b1100cd0213c7f230010f71": {}})
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -41,7 +38,7 @@ async def test_one(hass: HomeAssistant, rfxtrx) -> None:
 
 async def test_one_pt2262(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 PT2262 sensor."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "0913000022670e013970": {
                 "data_bits": 4,
@@ -50,8 +47,6 @@ async def test_one_pt2262(hass: HomeAssistant, rfxtrx) -> None:
             }
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -74,11 +69,9 @@ async def test_one_pt2262(hass: HomeAssistant, rfxtrx) -> None:
 
 async def test_pt2262_unconfigured(hass: HomeAssistant, rfxtrx) -> None:
     """Test with discovery for PT2262."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={"0913000022670e013970": {}, "09130000226707013970": {}}
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -107,9 +100,7 @@ async def test_state_restore(hass: HomeAssistant, rfxtrx, state, event) -> None:
 
     mock_restore_cache(hass, [State(entity_id, state, attributes={ATTR_EVENT: event})])
 
-    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f230010f71": {}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices={"0b1100cd0213c7f230010f71": {}})
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -120,15 +111,13 @@ async def test_state_restore(hass: HomeAssistant, rfxtrx, state, event) -> None:
 
 async def test_several(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "0b1100cd0213c7f230010f71": {},
             "0b1100100118cdea02010f70": {},
             "0b1100100118cdea03010f70": {},
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -188,9 +177,9 @@ async def test_off_delay_restore(hass: HomeAssistant, rfxtrx) -> None:
         ],
     )
 
-    entry_data = create_rfx_test_cfg(devices={EVENT_AC_118CDEA_2_ON: {"off_delay": 5}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(
+        devices={EVENT_AC_118CDEA_2_ON: {"off_delay": 5}}
+    )
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -204,11 +193,9 @@ async def test_off_delay_restore(hass: HomeAssistant, rfxtrx) -> None:
 
 async def test_off_delay(hass: HomeAssistant, rfxtrx, timestep) -> None:
     """Test with discovery."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={"0b1100100118cdea02010f70": {"off_delay": 5}}
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -296,7 +283,7 @@ async def test_light(hass: HomeAssistant, rfxtrx_automatic) -> None:
 
 async def test_pt2262_duplicate_id(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 sensor."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "0913000022670e013970": {
                 "data_bits": 4,
@@ -310,8 +297,6 @@ async def test_pt2262_duplicate_id(hass: HomeAssistant, rfxtrx) -> None:
             },
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -12,6 +12,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
+from . import ENTRY_VERSION
+
 from tests.common import MockConfigEntry
 
 SOME_PROTOCOLS = ["ac", "arc"]
@@ -285,6 +287,7 @@ async def test_options_global(hass: HomeAssistant) -> None:
             "devices": {},
         },
         unique_id=DOMAIN,
+        version=ENTRY_VERSION,
     )
     with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
         result = await start_options_flow(hass, entry)
@@ -320,6 +323,7 @@ async def test_no_protocols(hass: HomeAssistant) -> None:
             "devices": {},
         },
         unique_id=DOMAIN,
+        version=ENTRY_VERSION,
     )
     with patch("homeassistant.components.rfxtrx.async_setup_entry", return_value=True):
         result = await start_options_flow(hass, entry)
@@ -354,6 +358,7 @@ async def test_options_add_device(hass: HomeAssistant) -> None:
             "devices": {},
         },
         unique_id=DOMAIN,
+        version=ENTRY_VERSION,
     )
     result = await start_options_flow(hass, entry)
 
@@ -416,6 +421,7 @@ async def test_options_add_duplicate_device(hass: HomeAssistant) -> None:
             "devices": {"0b1100cd0213c7f230010f71": {}},
         },
         unique_id=DOMAIN,
+        version=ENTRY_VERSION,
     )
     entry.add_to_hass(hass)
 
@@ -458,6 +464,7 @@ async def test_options_replace_sensor_device(
             },
         },
         unique_id=DOMAIN,
+        version=ENTRY_VERSION,
     )
     await start_options_flow(hass, entry)
 
@@ -508,7 +515,7 @@ async def test_options_replace_sensor_device(
         (
             elem.id
             for elem in device_entries
-            if next(iter(elem.identifiers))[1:] == ("52", "1", "f0:04")
+            if next(iter(elem.identifiers))[1] == "52_1_f0:04"
         ),
         None,
     )
@@ -516,7 +523,7 @@ async def test_options_replace_sensor_device(
         (
             elem.id
             for elem in device_entries
-            if next(iter(elem.identifiers))[1:] == ("52", "1", "23:04")
+            if next(iter(elem.identifiers))[1] == "52_1_23:04"
         ),
         None,
     )
@@ -620,6 +627,7 @@ async def test_options_replace_control_device(
             },
         },
         unique_id=DOMAIN,
+        version=ENTRY_VERSION,
     )
     await start_options_flow(hass, entry)
 
@@ -642,7 +650,7 @@ async def test_options_replace_control_device(
         (
             elem.id
             for elem in device_entries
-            if next(iter(elem.identifiers))[1:] == ("11", "0", "118cdea:2")
+            if next(iter(elem.identifiers))[1] == "11_0_118cdea:2"
         ),
         None,
     )
@@ -650,7 +658,7 @@ async def test_options_replace_control_device(
         (
             elem.id
             for elem in device_entries
-            if next(iter(elem.identifiers))[1:] == ("11", "0", "1118cdea:2")
+            if next(iter(elem.identifiers))[1] == "11_0_1118cdea:2"
         ),
         None,
     )
@@ -715,6 +723,7 @@ async def test_options_add_and_configure_device(
             "devices": {},
         },
         unique_id=DOMAIN,
+        version=ENTRY_VERSION,
     )
     result = await start_options_flow(hass, entry)
 
@@ -823,6 +832,7 @@ async def test_options_configure_rfy_cover_device(
             "devices": {},
         },
         unique_id=DOMAIN,
+        version=ENTRY_VERSION,
     )
     result = await start_options_flow(hass, entry)
 

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -4,20 +4,17 @@ from unittest.mock import call
 
 import pytest
 
-from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 
-from .conftest import create_rfx_test_cfg
+from .conftest import create_rfx_test_entry
 
-from tests.common import MockConfigEntry, mock_restore_cache
+from tests.common import mock_restore_cache
 
 
 async def test_one_cover(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 cover."""
-    entry_data = create_rfx_test_cfg(devices={"0b1400cd0213c7f20d010f51": {}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices={"0b1400cd0213c7f20d010f51": {}})
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -62,9 +59,7 @@ async def test_state_restore(hass: HomeAssistant, rfxtrx, state) -> None:
 
     mock_restore_cache(hass, [State(entity_id, state)])
 
-    entry_data = create_rfx_test_cfg(devices={"0b1400cd0213c7f20d010f51": {}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices={"0b1400cd0213c7f20d010f51": {}})
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -75,15 +70,13 @@ async def test_state_restore(hass: HomeAssistant, rfxtrx, state) -> None:
 
 async def test_several_covers(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3 covers."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "0b1400cd0213c7f20d010f51": {},
             "0A1400ADF394AB010D0060": {},
             "09190000009ba8010100": {},
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -122,14 +115,12 @@ async def test_discover_covers(hass: HomeAssistant, rfxtrx_automatic) -> None:
 
 async def test_duplicate_cover(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 2 duplicate covers."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "0b1400cd0213c7f20d010f51": {},
             "0b1400cd0213c7f20d010f50": {},
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -143,7 +134,7 @@ async def test_duplicate_cover(hass: HomeAssistant, rfxtrx) -> None:
 
 async def test_rfy_cover(hass: HomeAssistant, rfxtrx) -> None:
     """Test Rfy venetian blind covers."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "071a000001020301": {
                 "venetian_blind_mode": "Unknown",
@@ -155,8 +146,6 @@ async def test_rfy_cover(hass: HomeAssistant, rfxtrx) -> None:
             "0c1a0000010203030000000000": {"venetian_blind_mode": "EU"},
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -13,27 +13,23 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
-from .conftest import create_rfx_test_cfg
+from .conftest import create_rfx_test_entry
 
-from tests.common import MockConfigEntry, async_get_device_automations
+from tests.common import async_get_device_automations
 
 
 class DeviceTestData(NamedTuple):
     """Test data linked to a device."""
 
     code: str
-    device_identifier: tuple[str, str, str, str]
+    device_identifier: tuple[str, str]
 
 
-DEVICE_LIGHTING_1 = DeviceTestData("0710002a45050170", ("rfxtrx", "10", "0", "E5"))
+DEVICE_LIGHTING_1 = DeviceTestData("0710002a45050170", ("rfxtrx", "10_0_E5"))
 
-DEVICE_BLINDS_1 = DeviceTestData(
-    "09190000009ba8010100", ("rfxtrx", "19", "0", "009ba8:1")
-)
+DEVICE_BLINDS_1 = DeviceTestData("09190000009ba8010100", ("rfxtrx", "19_0_009ba8:1"))
 
-DEVICE_TEMPHUM_1 = DeviceTestData(
-    "0a52080705020095220269", ("rfxtrx", "52", "8", "05:02")
-)
+DEVICE_TEMPHUM_1 = DeviceTestData("0a52080705020095220269", ("rfxtrx", "52_8_05:02"))
 
 
 @pytest.mark.parametrize("device", [DEVICE_LIGHTING_1, DEVICE_TEMPHUM_1])
@@ -42,17 +38,13 @@ async def test_device_test_data(rfxtrx, device: DeviceTestData) -> None:
     pkt: RFXtrx.lowlevel.Packet = RFXtrx.lowlevel.parse(bytearray.fromhex(device.code))
     assert device.device_identifier == (
         "rfxtrx",
-        f"{pkt.packettype:x}",
-        f"{pkt.subtype:x}",
-        pkt.id_string,
+        f"{pkt.packettype:x}_{pkt.subtype:x}_{pkt.id_string}",
     )
 
 
 async def setup_entry(hass: HomeAssistant, devices: dict[str, Any]) -> MockConfigEntry:
     """Construct a config setup."""
-    entry_data = create_rfx_test_cfg(devices=devices)
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices=devices)
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -15,7 +15,7 @@ from homeassistant.setup import async_setup_component
 
 from .conftest import create_rfx_test_entry
 
-from tests.common import async_get_device_automations
+from tests.common import MockConfigEntry, async_get_device_automations
 
 
 class DeviceTestData(NamedTuple):
@@ -82,18 +82,6 @@ async def test_get_actions(
     """Test we get the expected actions from a rfxtrx."""
     mock_entry = await setup_entry(hass, {device.code: {}})
 
-    device_entry = device_registry.async_get_device_by_identifier(
-        device.device_identifier, mock_entry.entry_id
-    )
-    assert device_entry
-
-    # Add alternate identifiers, to make sure we can handle future formats
-    identifiers: list[str] = list(*device_entry.identifiers)
-    device_registry.async_update_device(
-        device_entry.id,
-        new_identifiers=device_entry.identifiers
-        | {(identifiers[0], "_".join(identifiers[1:]))},
-    )
     device_entry = device_registry.async_get_device_by_identifier(
         device.device_identifier, mock_entry.entry_id
     )

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -12,33 +12,29 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
-from .conftest import create_rfx_test_cfg
+from .conftest import create_rfx_test_entry
 
-from tests.common import (
-    MockConfigEntry,
-    async_get_device_automations,
-    async_mock_service,
-)
+from tests.common import async_get_device_automations, async_mock_service
 
 
 class EventTestData(NamedTuple):
     """Test data linked to a device."""
 
     code: str
-    device_identifier: tuple[str, str, str, str]
+    device_identifier: tuple[str, str]
     type: str
     subtype: str
 
 
-DEVICE_LIGHTING_1 = ("rfxtrx", "10", "0", "E5")
+DEVICE_LIGHTING_1 = ("rfxtrx", "10_0_E5")
 EVENT_LIGHTING_1 = EventTestData("0710002a45050170", DEVICE_LIGHTING_1, "command", "On")
 
-DEVICE_ROLLERTROL_1 = ("rfxtrx", "19", "0", "009ba8:1")
+DEVICE_ROLLERTROL_1 = ("rfxtrx", "19_0_009ba8:1")
 EVENT_ROLLERTROL_1 = EventTestData(
     "09190000009ba8010100", DEVICE_ROLLERTROL_1, "command", "Down"
 )
 
-DEVICE_FIREALARM_1 = ("rfxtrx", "20", "3", "a10900:32")
+DEVICE_FIREALARM_1 = ("rfxtrx", "20_3_a10900:32")
 EVENT_FIREALARM_1 = EventTestData(
     "08200300a109000670", DEVICE_FIREALARM_1, "status", "Panic"
 )
@@ -46,9 +42,7 @@ EVENT_FIREALARM_1 = EventTestData(
 
 async def setup_entry(hass: HomeAssistant, devices: dict[str, Any]) -> MockConfigEntry:
     """Construct a config setup."""
-    entry_data = create_rfx_test_cfg(devices=devices)
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices=devices)
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -14,7 +14,11 @@ from homeassistant.setup import async_setup_component
 
 from .conftest import create_rfx_test_entry
 
-from tests.common import async_get_device_automations, async_mock_service
+from tests.common import (
+    MockConfigEntry,
+    async_get_device_automations,
+    async_mock_service,
+)
 
 
 class EventTestData(NamedTuple):
@@ -82,18 +86,6 @@ async def test_get_triggers(
     """Test we get the expected triggers from a rfxtrx."""
     mock_entry = await setup_entry(hass, {event.code: {}})
 
-    device_entry = device_registry.async_get_device_by_identifier(
-        event.device_identifier, mock_entry.entry_id
-    )
-    assert device_entry
-
-    # Add alternate identifiers, to make sure we can handle future formats
-    identifiers: list[str] = list(event.device_identifier)
-    device_registry.async_update_device(
-        device_entry.id,
-        new_identifiers=device_entry.identifiers
-        | {(identifiers[0], "_".join(identifiers[1:]))},
-    )
     device_entry = device_registry.async_get_device_by_identifier(
         event.device_identifier, mock_entry.entry_id
     )

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -256,7 +256,8 @@ async def test_migrate_entry(
         },
     )
 
-    await entry.async_migrate(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
     assert dict(entry.data) == {
         "device": "abcd",

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -218,7 +218,9 @@ async def test_reconnect(rfxtrx, hass: HomeAssistant) -> None:
     rfxtrx.connect.call_count = 2
 
 
-async def test_migrate_entry(hass: HomeAssistant) -> None:
+async def test_migrate_entry(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
     """Test successful migration of entry data."""
     legacy_config = {
         "device": "abcd",
@@ -240,15 +242,14 @@ async def test_migrate_entry(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    registry = dr.async_get(hass)
-    device_1 = registry.async_get_or_create(
+    device_1 = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={
             (DOMAIN, "11", "0", "213c7f2:16"),
             ("dummy", "id"),
         },
     )
-    device_2 = registry.async_get_or_create(
+    device_2 = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={
             (DOMAIN, "16", "0", "00:90"),
@@ -273,13 +274,13 @@ async def test_migrate_entry(hass: HomeAssistant) -> None:
     }
     assert entry.version == 2
 
-    device_1 = registry.async_get(device_1.id)
+    device_1 = device_registry.async_get(device_1.id)
     assert device_1.identifiers == {
         (DOMAIN, "11_0_213c7f2:16"),
         ("dummy", "id"),
     }
 
-    device_2 = registry.async_get(device_2.id)
+    device_2 = device_registry.async_get(device_2.id)
     assert device_2.identifiers == {
         (DOMAIN, "16_0_00:90"),
     }

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -4,7 +4,8 @@ from unittest.mock import ANY, call
 
 import RFXtrx as rfxtrxmod
 
-from homeassistant.components.rfxtrx.const import DOMAIN, EVENT_RFXTRX_EVENT
+from homeassistant.components.rfxtrx import DOMAIN, DeviceTuple
+from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
@@ -12,6 +13,7 @@ from homeassistant.setup import async_setup_component
 
 from .conftest import setup_rfx_test_cfg
 
+from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
 
 SOME_PROTOCOLS = ["ac", "arc"]
@@ -45,12 +47,12 @@ async def test_fire_event(
     await rfxtrx.signal("0716000100900970")
 
     device_id_1 = device_registry.async_get_device_by_identifier(
-        ("rfxtrx", "11", "0", "213c7f2:16"), mock_entry.entry_id
+        ("rfxtrx", "11_0_213c7f2:16"), mock_entry.entry_id
     )
     assert device_id_1
 
     device_id_2 = device_registry.async_get_device_by_identifier(
-        ("rfxtrx", "16", "0", "00:90"), mock_entry.entry_id
+        ("rfxtrx", "16_0_00:90"), mock_entry.entry_id
     )
     assert device_id_2
 
@@ -97,16 +99,16 @@ async def test_ws_device_remove(
     """Test removing a device through device registry."""
     assert await async_setup_component(hass, "config", {})
 
-    device_id = ["11", "0", "213c7f2:16"]
+    device_tuple = DeviceTuple("11", "0", "213c7f2:16")
     mock_entry = await setup_rfx_test_cfg(
         hass,
         devices={
-            "0b1100cd0213c7f210010f51": {"fire_event": True, "device_id": device_id},
+            "0b1100cd0213c7f210010f51": {"fire_event": True, "device_id": device_tuple},
         },
     )
 
     device_entry = device_registry.async_get_device_by_identifier(
-        ("rfxtrx", *device_id), mock_entry.entry_id
+        ("rfxtrx", device_tuple.unique_id), mock_entry.entry_id
     )
     assert device_entry
 
@@ -118,7 +120,7 @@ async def test_ws_device_remove(
     # Verify device entry is removed
     assert (
         device_registry.async_get_device_by_identifier(
-            ("rfxtrx", *device_id), mock_entry.entry_id
+            ("rfxtrx", device_tuple.unique_id), mock_entry.entry_id
         )
         is None
     )
@@ -214,3 +216,70 @@ async def test_reconnect(rfxtrx, hass: HomeAssistant) -> None:
 
     assert config_entry.state is ConfigEntryState.LOADED
     rfxtrx.connect.call_count = 2
+
+
+async def test_migrate_entry(hass: HomeAssistant) -> None:
+    """Test successful migration of entry data."""
+    legacy_config = {
+        "device": "abcd",
+        "host": None,
+        "port": None,
+        "automatic_add": True,
+        "protocols": [],
+        "devices": {
+            "0b1100cd0213c7f210010f51": {
+                "fire_event": True,
+                "device_id": ["11", "0", "213c7f2:16"],
+            },
+            "0716000100900970": {},
+        },
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, unique_id=DOMAIN, data=legacy_config, version=1
+    )
+    entry.add_to_hass(hass)
+
+    registry = dr.async_get(hass)
+    device_1 = registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={
+            (DOMAIN, "11", "0", "213c7f2:16"),
+            ("dummy", "id"),
+        },
+    )
+    device_2 = registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={
+            (DOMAIN, "16", "0", "00:90"),
+        },
+    )
+
+    await entry.async_migrate(hass)
+
+    assert dict(entry.data) == {
+        "device": "abcd",
+        "host": None,
+        "port": None,
+        "automatic_add": True,
+        "protocols": [],
+        "devices": {
+            "0b1100cd0213c7f210010f51": {
+                "fire_event": True,
+                "device_id": ["11", "0", "213c7f2:16"],
+            },
+            "0716000100900970": {},
+        },
+    }
+    assert entry.version == 2
+
+    device_1 = registry.async_get(device_1.id)
+    assert device_1.identifiers == {
+        (DOMAIN, "11_0_213c7f2:16"),
+        ("dummy", "id"),
+    }
+
+    device_2 = registry.async_get(device_2.id)
+    assert device_2.identifiers == {
+        (DOMAIN, "16_0_00:90"),
+    }

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -5,20 +5,17 @@ from unittest.mock import call
 import pytest
 
 from homeassistant.components.light import ATTR_BRIGHTNESS
-from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
 
-from .conftest import create_rfx_test_cfg
+from .conftest import create_rfx_test_entry
 
-from tests.common import MockConfigEntry, mock_restore_cache
+from tests.common import mock_restore_cache
 
 
 async def test_one_light(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 light."""
-    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f210020f51": {}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices={"0b1100cd0213c7f210020f51": {}})
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -102,9 +99,7 @@ async def test_state_restore(hass: HomeAssistant, rfxtrx, state, brightness) -> 
         hass, [State(entity_id, state, attributes={ATTR_BRIGHTNESS: brightness})]
     )
 
-    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f210020f51": {}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices={"0b1100cd0213c7f210020f51": {}})
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -116,15 +111,13 @@ async def test_state_restore(hass: HomeAssistant, rfxtrx, state, brightness) -> 
 
 async def test_several_lights(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3 lights."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "0b1100cd0213c7f230020f71": {},
             "0b1100100118cdea02020f70": {},
             "0b1100101118cdea02050f70": {},
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import ATTR_EVENT
 from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
@@ -12,16 +11,14 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, State
 
-from .conftest import create_rfx_test_cfg
+from .conftest import create_rfx_test_entry
 
-from tests.common import MockConfigEntry, mock_restore_cache
+from tests.common import mock_restore_cache
 
 
 async def test_default_config(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 0 sensor."""
-    entry_data = create_rfx_test_cfg(devices={})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices={})
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -32,9 +29,7 @@ async def test_default_config(hass: HomeAssistant, rfxtrx) -> None:
 
 async def test_one_sensor(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 sensor."""
-    entry_data = create_rfx_test_cfg(devices={"0a52080705020095220269": {}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices={"0a52080705020095220269": {}})
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -61,9 +56,7 @@ async def test_state_restore(hass: HomeAssistant, rfxtrx, state, event) -> None:
 
     mock_restore_cache(hass, [State(entity_id, state, attributes={ATTR_EVENT: event})])
 
-    entry_data = create_rfx_test_cfg(devices={"0a520801070100b81b0279": {}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices={"0a520801070100b81b0279": {}})
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -74,9 +67,7 @@ async def test_state_restore(hass: HomeAssistant, rfxtrx, state, event) -> None:
 
 async def test_one_sensor_no_datatype(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 sensor."""
-    entry_data = create_rfx_test_cfg(devices={"0a52080705020095220269": {}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices={"0a52080705020095220269": {}})
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -121,14 +112,12 @@ async def test_one_sensor_no_datatype(hass: HomeAssistant, rfxtrx) -> None:
 
 async def test_several_sensors(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3 sensors."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "0a52080705020095220269": {},
             "0a520802060100ff0e0269": {},
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -268,14 +257,12 @@ async def test_discover_sensor(hass: HomeAssistant, rfxtrx_automatic) -> None:
 
 async def test_update_of_sensors(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3 sensors."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "0a52080705020095220269": {},
             "0a520802060100ff0e0269": {},
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -312,7 +299,7 @@ async def test_update_of_sensors(hass: HomeAssistant, rfxtrx) -> None:
 
 async def test_rssi_sensor(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 sensor."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "0913000022670e013b70": {
                 "data_bits": 4,
@@ -322,8 +309,6 @@ async def test_rssi_sensor(hass: HomeAssistant, rfxtrx) -> None:
             "0b1100cd0213c7f230010f71": {},
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)

--- a/tests/components/rfxtrx/test_siren.py
+++ b/tests/components/rfxtrx/test_siren.py
@@ -2,21 +2,16 @@
 
 from unittest.mock import call
 
-from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.core import HomeAssistant
 
-from .conftest import create_rfx_test_cfg
-
-from tests.common import MockConfigEntry
+from .conftest import create_rfx_test_entry
 
 
 async def test_one_chime(hass: HomeAssistant, rfxtrx, timestep) -> None:
     """Test with 1 entity."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={"0a16000000000000000000": {"off_delay": 2.0}}
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     entity_id = "siren.byron_sx_00_00"
@@ -68,9 +63,9 @@ async def test_one_chime(hass: HomeAssistant, rfxtrx, timestep) -> None:
 
 async def test_one_security1(hass: HomeAssistant, rfxtrx, timestep) -> None:
     """Test with 1 entity."""
-    entry_data = create_rfx_test_cfg(devices={"08200300a109000670": {"off_delay": 2.0}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(
+        devices={"08200300a109000670": {"off_delay": 2.0}}
+    )
     mock_entry.add_to_hass(hass)
 
     entity_id = "siren.kd101_smoke_detector_a10900_32"

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -9,9 +9,9 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
 
-from .conftest import create_rfx_test_cfg
+from .conftest import create_rfx_test_entry
 
-from tests.common import MockConfigEntry, mock_restore_cache
+from tests.common import mock_restore_cache
 
 EVENT_RFY_ENABLE_SUN_AUTO = "0C1a0000030101011300000003"
 EVENT_RFY_DISABLE_SUN_AUTO = "0C1a0000030101011400000003"
@@ -19,9 +19,7 @@ EVENT_RFY_DISABLE_SUN_AUTO = "0C1a0000030101011400000003"
 
 async def test_one_switch(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 switch."""
-    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f210010f51": {}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices={"0b1100cd0213c7f210010f51": {}})
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -54,7 +52,7 @@ async def test_one_switch(hass: HomeAssistant, rfxtrx) -> None:
 
 async def test_one_pt2262_switch(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 PT2262 switch."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "0913000022670e013970": {
                 "data_bits": 4,
@@ -63,8 +61,6 @@ async def test_one_pt2262_switch(hass: HomeAssistant, rfxtrx) -> None:
             }
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -103,9 +99,7 @@ async def test_state_restore(hass: HomeAssistant, rfxtrx, state) -> None:
 
     mock_restore_cache(hass, [State(entity_id, state)])
 
-    entry_data = create_rfx_test_cfg(devices={"0b1100cd0213c7f210010f51": {}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices={"0b1100cd0213c7f210010f51": {}})
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -116,15 +110,13 @@ async def test_state_restore(hass: HomeAssistant, rfxtrx, state) -> None:
 
 async def test_several_switches(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3 switches."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "0b1100cd0213c7f230010f71": {},
             "0b1100100118cdea02010f70": {},
             "0b1100101118cdea02010f70": {},
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -148,14 +140,12 @@ async def test_several_switches(hass: HomeAssistant, rfxtrx) -> None:
 
 async def test_switch_events(hass: HomeAssistant, rfxtrx) -> None:
     """Event test with 2 switches."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "0b1100cd0213c7f205010f51": {},
             "0b1100cd0213c7f210010f51": {},
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -204,7 +194,7 @@ async def test_switch_events(hass: HomeAssistant, rfxtrx) -> None:
 
 async def test_pt2262_switch_events(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 1 PT2262 switch."""
-    entry_data = create_rfx_test_cfg(
+    mock_entry = create_rfx_test_entry(
         devices={
             "0913000022670e013970": {
                 "data_bits": 4,
@@ -213,8 +203,6 @@ async def test_pt2262_switch_events(hass: HomeAssistant, rfxtrx) -> None:
             }
         }
     )
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
@@ -274,9 +262,7 @@ async def test_discover_rfy_sun_switch(hass: HomeAssistant, rfxtrx_automatic) ->
 
 async def test_unknown_event_code(hass: HomeAssistant, rfxtrx) -> None:
     """Test with 3 switches."""
-    entry_data = create_rfx_test_cfg(devices={"1234567890": {}})
-    mock_entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data=entry_data)
-
+    mock_entry = create_rfx_test_entry(devices={"1234567890": {}})
     mock_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_entry.entry_id)


### PR DESCRIPTION
Replace the legacy method of storing separate tuple fields in device identifers and just store a single string instead.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replace the 4 part device identifiers with normal 2 part device identifiers. This is a one time migration on update with config entry major version update.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/180697
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
