### PR TITLE
Read the Peblar meter history

### DIFF
--- a/homeassistant/components/peblar/icons.json
+++ b/homeassistant/components/peblar/icons.json
@@ -97,6 +97,9 @@
     "delete_vehicle_token": {
       "service": "mdi:car-off"
     },
+    "get_meter_history": {
+      "service": "mdi:history"
+    },
     "list_rfid_tokens": {
       "service": "mdi:card-account-details"
     },

--- a/homeassistant/components/peblar/services.py
+++ b/homeassistant/components/peblar/services.py
@@ -12,7 +12,13 @@ from peblar import (
 )
 import voluptuous as vol
 
-from homeassistant.const import ATTR_CONFIG_ENTRY_ID, CONF_ALIAS, CONF_DESCRIPTION
+from homeassistant.const import (
+    ATTR_CONFIG_ENTRY_ID,
+    CONF_AFTER,
+    CONF_ALIAS,
+    CONF_BEFORE,
+    CONF_DESCRIPTION,
+)
 from homeassistant.core import (
     HomeAssistant,
     ServiceCall,
@@ -26,6 +32,8 @@ from homeassistant.helpers.service import (
     async_get_config_entry,
     async_register_admin_service,
 )
+from homeassistant.util import dt as dt_util
+from homeassistant.util.json import JsonValueType
 
 from .const import CONF_EVCC_ID, CONF_UID, DOMAIN
 from .coordinator import PeblarConfigEntry
@@ -35,10 +43,18 @@ SERVICE_AUTHORIZE_CHARGE_SESSION = "authorize_charge_session"
 SERVICE_ADD_VEHICLE_TOKEN = "add_vehicle_token"
 SERVICE_DELETE_RFID_TOKEN = "delete_rfid_token"
 SERVICE_DELETE_VEHICLE_TOKEN = "delete_vehicle_token"
+SERVICE_GET_METER_HISTORY = "get_meter_history"
 SERVICE_LIST_RFID_TOKENS = "list_rfid_tokens"
 SERVICE_LIST_VEHICLE_TOKENS = "list_vehicle_tokens"
 
 CHARGER_SCHEMA = vol.Schema({vol.Required(ATTR_CONFIG_ENTRY_ID): str})
+
+METER_HISTORY_SCHEMA = CHARGER_SCHEMA.extend(
+    {
+        vol.Optional(CONF_AFTER): cv.datetime,
+        vol.Optional(CONF_BEFORE): cv.datetime,
+    }
+)
 
 TOKEN_SCHEMA = CHARGER_SCHEMA.extend({vol.Required(CONF_UID): str})
 ADD_TOKEN_SCHEMA = TOKEN_SCHEMA.extend({vol.Required(CONF_DESCRIPTION): str})
@@ -57,6 +73,12 @@ AUTHORIZE_SCHEMA = vol.All(
     ),
     cv.has_at_least_one_key(CONF_UID, CONF_DESCRIPTION),
 )
+
+
+def _get_peblar(hass: HomeAssistant, entry_id: str) -> Peblar:
+    """Return the client for a charger, whatever hardware it carries."""
+    entry: PeblarConfigEntry = async_get_config_entry(hass, DOMAIN, entry_id)
+    return entry.runtime_data.user_configuration_coordinator.peblar
 
 
 def _get_rfid_peblar(hass: HomeAssistant, entry_id: str) -> Peblar:
@@ -213,6 +235,62 @@ def async_setup_services(hass: HomeAssistant) -> None:
                 name=call.data.get(CONF_DESCRIPTION),
             )
 
+    async def _handle_get_meter_history(call: ServiceCall) -> ServiceResponse:
+        entry_id = call.data[ATTR_CONFIG_ENTRY_ID]
+        peblar = _get_peblar(hass, entry_id)
+
+        # A naive moment is read by the charger as its own local time, which
+        # is not necessarily the one Home Assistant runs in. Both bounds are
+        # anchored here instead, the way the datetime platform does it.
+        after = call.data.get(CONF_AFTER)
+        before = call.data.get(CONF_BEFORE)
+        async with _handle_peblar_errors(hass, entry_id):
+            history = await peblar.meter_history(
+                start=None if after is None else dt_util.as_utc(after),
+                stop=None if before is None else dt_util.as_utc(before),
+            )
+
+        sessions: list[JsonValueType] = []
+        for index, session in enumerate(history.session):
+            # The session that is running has no end yet, and so no energy
+            # total to report for it either.
+            end_energy_kwh = None
+            end_time = None
+            energy_kwh = None
+            if (end_energy := session.session_end_energy_mwh) is not None:
+                end_energy_kwh = end_energy / 1000000
+                energy_kwh = (end_energy - session.session_start_energy_mwh) / 1000000
+            if session.session_end_time is not None:
+                end_time = dt_util.utc_from_timestamp(
+                    session.session_end_time
+                ).isoformat()
+            sessions.append(
+                {
+                    "session_number": session.session_number,
+                    CONF_UID: session.auth_token,
+                    "start_time": dt_util.utc_from_timestamp(
+                        session.session_start_time
+                    ).isoformat(),
+                    "end_time": end_time,
+                    "start_energy_kwh": session.session_start_energy_mwh / 1000000,
+                    "end_energy_kwh": end_energy_kwh,
+                    "energy_kwh": energy_kwh,
+                    "checksum": session.checksum,
+                    # The charger checks each record against its own checksum
+                    # and reports the outcomes as a list of their own. A
+                    # charger that returns fewer of those than it returns
+                    # sessions leaves the rest unanswered, rather than
+                    # unreported.
+                    "corrupted": (
+                        history.corrupted_session[index]
+                        if index < len(history.corrupted_session)
+                        else None
+                    ),
+                }
+            )
+
+        return {"corrupted": history.corrupted, "sessions": sessions}
+
     async def _handle_list_vehicle_tokens(call: ServiceCall) -> ServiceResponse:
         entry_id = call.data[ATTR_CONFIG_ENTRY_ID]
         peblar = _get_autocharge_peblar(hass, entry_id)
@@ -290,4 +368,12 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_AUTHORIZE_CHARGE_SESSION,
         _handle_authorize_charge_session,
         schema=AUTHORIZE_SCHEMA,
+    )
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_GET_METER_HISTORY,
+        _handle_get_meter_history,
+        schema=METER_HISTORY_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
     )

--- a/homeassistant/components/peblar/services.yaml
+++ b/homeassistant/components/peblar/services.yaml
@@ -83,3 +83,17 @@ authorize_charge_session:
     description:
       selector:
         text:
+
+get_meter_history:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: peblar
+    after:
+      selector:
+        datetime:
+    before:
+      selector:
+        datetime:

--- a/homeassistant/components/peblar/strings.json
+++ b/homeassistant/components/peblar/strings.json
@@ -308,6 +308,24 @@
       },
       "name": "Delete autocharge vehicle"
     },
+    "get_meter_history": {
+      "description": "Returns the charging sessions the charger's certified meter has recorded, including the token each session was authorized with.",
+      "fields": {
+        "after": {
+          "description": "Only return sessions that started at or after this moment.",
+          "name": "After"
+        },
+        "before": {
+          "description": "Only return sessions that started at or before this moment.",
+          "name": "Before"
+        },
+        "config_entry_id": {
+          "description": "The Peblar EV charger to read the meter history from.",
+          "name": "Peblar EV charger"
+        }
+      },
+      "name": "Get meter history"
+    },
     "list_rfid_tokens": {
       "description": "Returns the RFID tokens configured in the charger's standalone authorization list.",
       "fields": {

--- a/tests/components/peblar/conftest.py
+++ b/tests/components/peblar/conftest.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from peblar import (
     PeblarEVInterface,
     PeblarMeter,
+    PeblarMeterHistory,
     PeblarSystem,
     PeblarSystemInformation,
     PeblarUserConfiguration,
@@ -79,6 +80,9 @@ def mock_peblar(request: pytest.FixtureRequest) -> Generator[MagicMock]:
         )
         peblar.system_information.return_value = PeblarSystemInformation.from_dict(
             system_information
+        )
+        peblar.meter_history.return_value = PeblarMeterHistory.from_json(
+            load_fixture("meter_history.json", DOMAIN)
         )
 
         # The event stream parks here until the entry unloads, the way a

--- a/tests/components/peblar/fixtures/meter_history.json
+++ b/tests/components/peblar/fixtures/meter_history.json
@@ -1,0 +1,32 @@
+{
+  "Corrupted": false,
+  "CorruptedSession": [true, false],
+  "MetaData": {
+    "MeterHash": "0ac1e2b3c4d5e6f7",
+    "MeterVersion": "1.0.0",
+    "MidCertified": true,
+    "ProductPn": "PBLR-0000",
+    "ProductSn": "23-45-A4O-MOF",
+    "TimeZone": "Europe/Amsterdam"
+  },
+  "Session": [
+    {
+      "AuthToken": "AA:BB:CC:DD",
+      "Checksum": 42,
+      "SessionNumber": 1,
+      "SessionStartEnergymWh": 1000000,
+      "SessionStartTime": 1769083200,
+      "SessionEndEnergymWh": 8500000,
+      "SessionEndTime": 1769108400
+    },
+    {
+      "AuthToken": null,
+      "Checksum": 43,
+      "SessionNumber": 2,
+      "SessionStartEnergymWh": 8500000,
+      "SessionStartTime": 1769169600,
+      "SessionEndEnergymWh": null,
+      "SessionEndTime": null
+    }
+  ]
+}

--- a/tests/components/peblar/test_services.py
+++ b/tests/components/peblar/test_services.py
@@ -1,5 +1,6 @@
 """Tests for the Peblar integration services."""
 
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -20,6 +21,7 @@ from homeassistant.components.peblar.services import (
     SERVICE_AUTHORIZE_CHARGE_SESSION,
     SERVICE_DELETE_RFID_TOKEN,
     SERVICE_DELETE_VEHICLE_TOKEN,
+    SERVICE_GET_METER_HISTORY,
     SERVICE_LIST_RFID_TOKENS,
     SERVICE_LIST_VEHICLE_TOKENS,
 )
@@ -170,8 +172,19 @@ SERVICE_CALLS: list[tuple[str, str, dict[str, Any]]] = [
     (SERVICE_DELETE_RFID_TOKEN, "delete_rfid_token", {"uid": "AA:BB:CC:DD"}),
 ]
 
+# The services that answer over the same error handling, whether or not
+# they touch the RFID list.
+FAILING_SERVICE_CALLS: list[tuple[str, str, dict[str, Any]]] = [
+    *SERVICE_CALLS,
+    (SERVICE_GET_METER_HISTORY, "meter_history", {}),
+]
 
-@pytest.mark.parametrize(("service", "method_name", "service_data"), SERVICE_CALLS)
+RESPONDING_SERVICES = {SERVICE_LIST_RFID_TOKENS, SERVICE_GET_METER_HISTORY}
+
+
+@pytest.mark.parametrize(
+    ("service", "method_name", "service_data"), FAILING_SERVICE_CALLS
+)
 @pytest.mark.parametrize(
     ("error", "translation_key"),
     [
@@ -198,7 +211,7 @@ async def test_service_communication_error(
             service,
             {"config_entry_id": init_integration.entry_id, **service_data},
             blocking=True,
-            return_response=service == "list_rfid_tokens",
+            return_response=service in RESPONDING_SERVICES,
         )
 
     assert excinfo.value.translation_domain == DOMAIN
@@ -206,7 +219,9 @@ async def test_service_communication_error(
     assert excinfo.value.translation_placeholders == {"error": str(error)}
 
 
-@pytest.mark.parametrize(("service", "method_name", "service_data"), SERVICE_CALLS)
+@pytest.mark.parametrize(
+    ("service", "method_name", "service_data"), FAILING_SERVICE_CALLS
+)
 async def test_service_authentication_error(
     hass: HomeAssistant,
     mock_peblar: MagicMock,
@@ -227,7 +242,7 @@ async def test_service_authentication_error(
             service,
             {"config_entry_id": init_integration.entry_id, **service_data},
             blocking=True,
-            return_response=service == "list_rfid_tokens",
+            return_response=service in RESPONDING_SERVICES,
         )
 
     assert excinfo.value.translation_domain == DOMAIN
@@ -502,3 +517,134 @@ async def test_authorize_charge_session_is_refused(
     assert excinfo.value.translation_domain == DOMAIN
     assert excinfo.value.translation_key == translation_key
     mock_peblar.rest_api.return_value.authorize_charge_session.assert_not_called()
+
+
+async def test_get_meter_history(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test the meter history comes back as sessions.
+
+    The second session in the fixture is the one still running: it has no
+    end, and so no energy total to report for it either.
+    """
+    result = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_METER_HISTORY,
+        {"config_entry_id": init_integration.entry_id},
+        blocking=True,
+        return_response=True,
+    )
+
+    assert result == {
+        "corrupted": False,
+        "sessions": [
+            {
+                "session_number": 1,
+                "uid": "AA:BB:CC:DD",
+                "start_time": "2026-01-22T12:00:00+00:00",
+                "end_time": "2026-01-22T19:00:00+00:00",
+                "start_energy_kwh": 1.0,
+                "end_energy_kwh": 8.5,
+                "energy_kwh": 7.5,
+                "checksum": 42,
+                "corrupted": True,
+            },
+            {
+                "session_number": 2,
+                "uid": None,
+                "start_time": "2026-01-23T12:00:00+00:00",
+                "end_time": None,
+                "start_energy_kwh": 8.5,
+                "end_energy_kwh": None,
+                "energy_kwh": None,
+                "checksum": 43,
+                "corrupted": False,
+            },
+        ],
+    }
+    mock_peblar.meter_history.assert_called_once_with(start=None, stop=None)
+
+
+async def test_get_meter_history_without_every_checksum_outcome(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test a session the charger returned no checksum outcome for.
+
+    The outcomes come back as a list of their own, so a charger that
+    returns fewer of them than it returns sessions leaves the last ones
+    unanswered.
+    """
+    mock_peblar.meter_history.return_value.corrupted_session = [False]
+
+    result = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_METER_HISTORY,
+        {"config_entry_id": init_integration.entry_id},
+        blocking=True,
+        return_response=True,
+    )
+
+    assert [session["corrupted"] for session in result["sessions"]] == [False, None]
+
+
+@pytest.mark.parametrize("mock_peblar", [{"HwHasRfid": False}], indirect=True)
+async def test_get_meter_history_needs_no_rfid_reader(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test the meter records every session, tokens or no tokens."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_METER_HISTORY,
+        {"config_entry_id": init_integration.entry_id},
+        blocking=True,
+        return_response=True,
+    )
+
+    mock_peblar.meter_history.assert_called_once_with(start=None, stop=None)
+
+
+@pytest.mark.parametrize(
+    ("after", "before"),
+    [
+        ("2026-01-22T13:00:00+01:00", "2026-01-23T13:00:00+01:00"),
+        ("2026-01-22 13:00:00", "2026-01-23 13:00:00"),
+    ],
+    ids=["with offset", "naive"],
+)
+async def test_get_meter_history_time_range(
+    hass: HomeAssistant,
+    mock_peblar: MagicMock,
+    init_integration: MockConfigEntry,
+    after: str,
+    before: str,
+) -> None:
+    """Test both ends of the range reach the charger, as UTC.
+
+    A moment without an offset is the one the user typed into the
+    frontend, so it is read in Home Assistant's own timezone rather than
+    handed to the charger for it to interpret.
+    """
+    await hass.config.async_set_time_zone("Europe/Amsterdam")
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_GET_METER_HISTORY,
+        {
+            "config_entry_id": init_integration.entry_id,
+            "after": after,
+            "before": before,
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    mock_peblar.meter_history.assert_called_once_with(
+        start=datetime(2026, 1, 22, 12, tzinfo=UTC),
+        stop=datetime(2026, 1, 23, 12, tzinfo=UTC),
+    )


### PR DESCRIPTION
## Breaking change

## Proposed change

Peblar chargers with a certified meter keep their own session log, separate from
the energy sensors. Each record holds the meter reading at both ends of a
session, the token the session was authorized with, and the charger's own
verdict on whether the record still matches its checksum.

That log is what you need to bill someone: a neighbour who charges at your
charger on their own RFID token, or a company car whose employer reimburses per
session. The energy sensors cannot answer that, because they do not know who was
charging.

`peblar==2.0.0` already reads the log through `meter_history()`. This adds the
service that hands it to the user:

```yaml
action: peblar.get_meter_history
data:
  config_entry_id: 01JQ7EXAMPLE
  after: "2026-01-01 00:00:00"
  before: "2026-02-01 00:00:00"
```

Both bounds are optional, and the charger returns everything it kept when
neither is given. A moment typed without an offset is read in Home Assistant's
timezone and converted before the call, because the charger otherwise reads it
in its own.

Every session comes back with its start and end, the meter reading at each end in
kWh, the difference between them, the token, and the charger's own verdict on
whether the record still matches its checksum. The session that is still running
has no end yet, so it reports `null` for its end time and its energy.

The service asks nothing of the hardware. A charger without an RFID reader still
has a meter, and that meter still logs every session.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47932
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr