### PR TITLE
Add set_client_name action to TP-Link Omada

### DIFF
--- a/homeassistant/components/tplink_omada/icons.json
+++ b/homeassistant/components/tplink_omada/icons.json
@@ -31,6 +31,9 @@
   "services": {
     "reconnect_client": {
       "service": "mdi:sync"
+    },
+    "set_client_name": {
+      "service": "mdi:rename-box"
     }
   }
 }

--- a/homeassistant/components/tplink_omada/services.py
+++ b/homeassistant/components/tplink_omada/services.py
@@ -168,7 +168,7 @@ async def _resolve_client_controller(
         try:
             await controller.omada_client.get_client(controller_mac)
         except RequestFailed as ex:
-            # The controller reports unknown clients with error code -41011.
+            # -41011 is the controller's "client not found" code (no public accessor).
             if getattr(ex, "_error_code", None) == -41011:
                 continue
             raise HomeAssistantError(

--- a/homeassistant/components/tplink_omada/services.py
+++ b/homeassistant/components/tplink_omada/services.py
@@ -6,7 +6,6 @@ from tplink_omada_client import OmadaClientSettings
 from tplink_omada_client.exceptions import OmadaClientException
 import voluptuous as vol
 
-from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID, ATTR_DEVICE_ID, ATTR_NAME
 from homeassistant.core import HomeAssistant, ServiceCall, callback
@@ -14,7 +13,6 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
-    entity_registry as er,
     selector,
 )
 from homeassistant.helpers.service import async_register_admin_service
@@ -94,48 +92,25 @@ SCHEMA_SET_CLIENT_NAME = vol.Schema(
                 "integration": DOMAIN,
             }
         ),
-        vol.Required(ATTR_DEVICE_ID): selector.DeviceSelector(
-            {
-                "integration": DOMAIN,
-                "entity": [
-                    {
-                        "domain": DEVICE_TRACKER_DOMAIN,
-                        "integration": DOMAIN,
-                    }
-                ],
-            }
-        ),
+        vol.Required(ATTR_DEVICE_ID): selector.DeviceSelector(),
         vol.Required(ATTR_NAME): vol.All(cv.string, vol.Length(min=1)),
     }
 )
 
 
-def _omada_tracker_entry_ids(hass: HomeAssistant, device: dr.DeviceEntry) -> set[str]:
-    """Return the Omada config entries with a device tracker on the device."""
-    omada_entry_ids = {
-        entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN)
-    }
-    return {
-        entity.config_entry_id
-        for entity in er.async_entries_for_device(er.async_get(hass), device.id)
-        if entity.domain == DEVICE_TRACKER_DOMAIN
-        and entity.config_entry_id in omada_entry_ids
-    }
-
-
-def _resolve_client_controller(
+async def _resolve_client_controller(
     call: ServiceCall,
 ) -> tuple[OmadaSiteController, str]:
     """Resolve the controller and MAC of the client referenced by the call."""
     hass = call.hass
 
-    if not hass.config_entries.async_entries(DOMAIN):
+    omada_entries = hass.config_entries.async_entries(DOMAIN)
+    if not omada_entries:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="no_controllers",
         )
 
-    requested_entry: ConfigEntry[OmadaSiteController] | None = None
     if entry_id := call.data.get(ATTR_CONFIG_ENTRY_ID):
         entry = hass.config_entries.async_get_entry(entry_id)
         if not entry:
@@ -148,7 +123,20 @@ def _resolve_client_controller(
                 translation_domain=DOMAIN,
                 translation_key="controller_unavailable",
             )
-        requested_entry = cast(ConfigEntry[OmadaSiteController], entry)
+        controller = cast(ConfigEntry[OmadaSiteController], entry).runtime_data
+    else:
+        if len(omada_entries) > 1:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="controller_ambiguous",
+            )
+        entry = omada_entries[0]
+        if entry.state is not ConfigEntryState.LOADED:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="controller_unavailable",
+            )
+        controller = cast(ConfigEntry[OmadaSiteController], entry).runtime_data
 
     device = dr.async_get(hass).async_get(call.data[ATTR_DEVICE_ID])
     if device is None or not isinstance(device, dr.DeviceEntry):
@@ -158,45 +146,34 @@ def _resolve_client_controller(
             translation_key="client_device_not_found",
         )
 
-    tracker_entry_ids = _omada_tracker_entry_ids(hass, device)
-    if not tracker_entry_ids:
+    mac = next(
+        (
+            connection_id
+            for connection_type, connection_id in device.connections
+            if connection_type == dr.CONNECTION_NETWORK_MAC
+        ),
+        None,
+    )
+    if mac is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="client_device_no_mac",
+        )
+
+    try:
+        await controller.omada_client.get_client(mac)
+    except OmadaClientException as ex:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="client_device_not_tracked",
-        )
+        ) from ex
 
-    if requested_entry is None:
-        entry = next(
-            entry
-            for entry_id in tracker_entry_ids
-            if (entry := hass.config_entries.async_get_entry(entry_id)) is not None
-        )
-        if entry.state is not ConfigEntryState.LOADED:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="controller_unavailable",
-            )
-        controller = cast(ConfigEntry[OmadaSiteController], entry).runtime_data
-    elif requested_entry.entry_id not in tracker_entry_ids:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="controller_mismatch",
-        )
-    else:
-        controller = requested_entry.runtime_data
-
-    for connection_type, connection_id in device.connections:
-        if connection_type == dr.CONNECTION_NETWORK_MAC:
-            return controller, connection_id
-    raise ServiceValidationError(
-        translation_domain=DOMAIN,
-        translation_key="client_device_no_mac",
-    )
+    return controller, mac
 
 
 async def _handle_set_client_name(call: ServiceCall) -> None:
     """Handle the service action to set the name of a network client."""
-    controller, mac = _resolve_client_controller(call)
+    controller, mac = await _resolve_client_controller(call)
     name: str = call.data[ATTR_NAME]
 
     try:

--- a/homeassistant/components/tplink_omada/services.py
+++ b/homeassistant/components/tplink_omada/services.py
@@ -98,6 +98,11 @@ SCHEMA_SET_CLIENT_NAME = vol.Schema(
 )
 
 
+def _controller_mac(mac: str) -> str:
+    """Normalize a registry MAC to the controller's canonical format."""
+    return mac.upper().replace(":", "-")
+
+
 async def _resolve_client_controller(
     call: ServiceCall,
 ) -> tuple[OmadaSiteController, str]:
@@ -159,8 +164,9 @@ async def _resolve_client_controller(
 
     known_macs: list[str] = []
     for mac in macs:
+        controller_mac = _controller_mac(mac)
         try:
-            await controller.omada_client.get_client(mac)
+            await controller.omada_client.get_client(controller_mac)
         except RequestFailed as ex:
             # The controller reports unknown clients with error code -41011.
             if getattr(ex, "_error_code", None) == -41011:
@@ -168,15 +174,15 @@ async def _resolve_client_controller(
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="client_query_failed",
-                translation_placeholders={"mac": mac},
+                translation_placeholders={"mac": controller_mac},
             ) from ex
         except OmadaClientException as ex:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="client_query_failed",
-                translation_placeholders={"mac": mac},
+                translation_placeholders={"mac": controller_mac},
             ) from ex
-        known_macs.append(mac)
+        known_macs.append(controller_mac)
 
     if len(known_macs) == 1:
         return controller, known_macs[0]

--- a/homeassistant/components/tplink_omada/services.py
+++ b/homeassistant/components/tplink_omada/services.py
@@ -20,9 +20,6 @@ from homeassistant.helpers.service import async_register_admin_service
 from .const import DOMAIN
 from .controller import OmadaSiteController
 
-SERVICE_RECONNECT_CLIENT = "reconnect_client"
-SERVICE_SET_CLIENT_NAME = "set_client_name"
-
 ATTR_MAC = "mac"
 
 
@@ -57,18 +54,6 @@ def _get_controller(call: ServiceCall) -> OmadaSiteController:
     return entry.runtime_data
 
 
-SCHEMA_RECONNECT_CLIENT = vol.Schema(
-    {
-        vol.Optional(ATTR_CONFIG_ENTRY_ID): selector.ConfigEntrySelector(
-            {
-                "integration": DOMAIN,
-            }
-        ),
-        vol.Required(ATTR_MAC): cv.string,
-    }
-)
-
-
 async def _handle_reconnect_client(call: ServiceCall) -> None:
     """Handle the service action to force reconnection of a network client."""
     controller = _get_controller(call)
@@ -85,19 +70,6 @@ async def _handle_reconnect_client(call: ServiceCall) -> None:
         ) from ex
 
 
-SCHEMA_SET_CLIENT_NAME = vol.Schema(
-    {
-        vol.Optional(ATTR_CONFIG_ENTRY_ID): selector.ConfigEntrySelector(
-            {
-                "integration": DOMAIN,
-            }
-        ),
-        vol.Required(ATTR_DEVICE_ID): selector.DeviceSelector(),
-        vol.Required(ATTR_NAME): vol.All(cv.string, vol.Length(min=1)),
-    }
-)
-
-
 def _controller_mac(mac: str) -> str:
     """Normalize a registry MAC to the controller's canonical format."""
     return mac.upper().replace(":", "-")
@@ -109,39 +81,18 @@ async def _resolve_client_controller(
     """Resolve the controller and MAC of the client referenced by the call."""
     hass = call.hass
 
-    omada_entries = hass.config_entries.async_entries(DOMAIN)
-    if not omada_entries:
+    entry = hass.config_entries.async_get_entry(call.data[ATTR_CONFIG_ENTRY_ID])
+    if not entry or entry.domain != DOMAIN:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
-            translation_key="no_controllers",
+            translation_key="controller_not_found",
         )
-
-    if entry_id := call.data.get(ATTR_CONFIG_ENTRY_ID):
-        entry = hass.config_entries.async_get_entry(entry_id)
-        if not entry or entry.domain != DOMAIN:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="controller_not_found",
-            )
-        if entry.state is not ConfigEntryState.LOADED:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="controller_unavailable",
-            )
-        controller = cast(ConfigEntry[OmadaSiteController], entry).runtime_data
-    else:
-        if len(omada_entries) > 1:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="controller_ambiguous",
-            )
-        entry = omada_entries[0]
-        if entry.state is not ConfigEntryState.LOADED:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="controller_unavailable",
-            )
-        controller = cast(ConfigEntry[OmadaSiteController], entry).runtime_data
+    if entry.state is not ConfigEntryState.LOADED:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="controller_unavailable",
+        )
+    controller = cast(ConfigEntry[OmadaSiteController], entry).runtime_data
 
     device = dr.async_get(hass).async_get(call.data[ATTR_DEVICE_ID])
     if device is None or not isinstance(device, dr.DeviceEntry):
@@ -212,30 +163,39 @@ async def _handle_set_client_name(call: ServiceCall) -> None:
         ) from ex
 
 
-SERVICES = [
-    (
-        SERVICE_RECONNECT_CLIENT,
-        SCHEMA_RECONNECT_CLIENT,
-        _handle_reconnect_client,
-        False,
-    ),
-    (
-        SERVICE_SET_CLIENT_NAME,
-        SCHEMA_SET_CLIENT_NAME,
-        _handle_set_client_name,
-        True,
-    ),
-]
-
-
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Set up the services for the TP-Link Omada integration."""
 
-    for service_name, schema, handler, admin_only in SERVICES:
-        if admin_only:
-            async_register_admin_service(
-                hass, DOMAIN, service_name, handler, schema=schema
-            )
-        else:
-            hass.services.async_register(DOMAIN, service_name, handler, schema=schema)
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        "set_client_name",
+        _handle_set_client_name,
+        schema=vol.Schema(
+            {
+                vol.Required(ATTR_CONFIG_ENTRY_ID): selector.ConfigEntrySelector(
+                    {
+                        "integration": DOMAIN,
+                    }
+                ),
+                vol.Required(ATTR_DEVICE_ID): selector.DeviceSelector(),
+                vol.Required(ATTR_NAME): vol.All(cv.string, vol.Length(min=1)),
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "reconnect_client",
+        _handle_reconnect_client,
+        schema=vol.Schema(
+            {
+                vol.Optional(ATTR_CONFIG_ENTRY_ID): selector.ConfigEntrySelector(
+                    {
+                        "integration": DOMAIN,
+                    }
+                ),
+                vol.Required(ATTR_MAC): cv.string,
+            }
+        ),
+    )

--- a/homeassistant/components/tplink_omada/services.py
+++ b/homeassistant/components/tplink_omada/services.py
@@ -2,19 +2,26 @@
 
 from typing import cast
 
+from tplink_omada_client import OmadaClientSettings
 from tplink_omada_client.exceptions import OmadaClientException
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-from homeassistant.const import ATTR_CONFIG_ENTRY_ID
+from homeassistant.const import ATTR_CONFIG_ENTRY_ID, ATTR_DEVICE_ID, ATTR_NAME
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import config_validation as cv, selector
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    selector,
+)
+from homeassistant.helpers.service import async_register_admin_service
 
 from .const import DOMAIN
 from .controller import OmadaSiteController
 
 SERVICE_RECONNECT_CLIENT = "reconnect_client"
+SERVICE_SET_CLIENT_NAME = "set_client_name"
 
 ATTR_MAC = "mac"
 
@@ -78,8 +85,71 @@ async def _handle_reconnect_client(call: ServiceCall) -> None:
         ) from ex
 
 
+SCHEMA_SET_CLIENT_NAME = vol.Schema(
+    {
+        vol.Optional(ATTR_CONFIG_ENTRY_ID): selector.ConfigEntrySelector(
+            {
+                "integration": DOMAIN,
+            }
+        ),
+        vol.Required(ATTR_DEVICE_ID): selector.DeviceSelector(
+            {
+                "integration": DOMAIN,
+            }
+        ),
+        vol.Required(ATTR_NAME): vol.All(cv.string, vol.Length(min=1)),
+    }
+)
+
+
+def _get_client_mac(call: ServiceCall) -> str:
+    """Return the network MAC address of the device referenced by the call."""
+    device = dr.async_get(call.hass).async_get(call.data[ATTR_DEVICE_ID])
+    if device is None or not isinstance(device, dr.DeviceEntry):
+        # Child devices carry no connections to resolve a MAC from.
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="client_device_not_found",
+        )
+    for connection_type, connection_id in device.connections:
+        if connection_type == dr.CONNECTION_NETWORK_MAC:
+            return connection_id
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="client_device_no_mac",
+    )
+
+
+async def _handle_set_client_name(call: ServiceCall) -> None:
+    """Handle the service action to set the name of a network client."""
+    controller = _get_controller(call)
+
+    mac = _get_client_mac(call)
+    name: str = call.data[ATTR_NAME]
+
+    try:
+        await controller.omada_client.update_client(mac, OmadaClientSettings(name=name))
+    except OmadaClientException as ex:
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="set_client_name_failed",
+            translation_placeholders={"mac": mac},
+        ) from ex
+
+
 SERVICES = [
-    (SERVICE_RECONNECT_CLIENT, SCHEMA_RECONNECT_CLIENT, _handle_reconnect_client)
+    (
+        SERVICE_RECONNECT_CLIENT,
+        SCHEMA_RECONNECT_CLIENT,
+        _handle_reconnect_client,
+        False,
+    ),
+    (
+        SERVICE_SET_CLIENT_NAME,
+        SCHEMA_SET_CLIENT_NAME,
+        _handle_set_client_name,
+        True,
+    ),
 ]
 
 
@@ -87,5 +157,10 @@ SERVICES = [
 def async_setup_services(hass: HomeAssistant) -> None:
     """Set up the services for the TP-Link Omada integration."""
 
-    for service_name, schema, handler in SERVICES:
-        hass.services.async_register(DOMAIN, service_name, handler, schema=schema)
+    for service_name, schema, handler, admin_only in SERVICES:
+        if admin_only:
+            async_register_admin_service(
+                hass, DOMAIN, service_name, handler, schema=schema
+            )
+        else:
+            hass.services.async_register(DOMAIN, service_name, handler, schema=schema)

--- a/homeassistant/components/tplink_omada/services.py
+++ b/homeassistant/components/tplink_omada/services.py
@@ -6,6 +6,7 @@ from tplink_omada_client import OmadaClientSettings
 from tplink_omada_client.exceptions import OmadaClientException
 import voluptuous as vol
 
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID, ATTR_DEVICE_ID, ATTR_NAME
 from homeassistant.core import HomeAssistant, ServiceCall, callback
@@ -13,6 +14,7 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
+    entity_registry as er,
     selector,
 )
 from homeassistant.helpers.service import async_register_admin_service
@@ -95,6 +97,12 @@ SCHEMA_SET_CLIENT_NAME = vol.Schema(
         vol.Required(ATTR_DEVICE_ID): selector.DeviceSelector(
             {
                 "integration": DOMAIN,
+                "entity": [
+                    {
+                        "domain": DEVICE_TRACKER_DOMAIN,
+                        "integration": DOMAIN,
+                    }
+                ],
             }
         ),
         vol.Required(ATTR_NAME): vol.All(cv.string, vol.Length(min=1)),
@@ -102,18 +110,84 @@ SCHEMA_SET_CLIENT_NAME = vol.Schema(
 )
 
 
-def _get_client_mac(call: ServiceCall) -> str:
-    """Return the network MAC address of the device referenced by the call."""
-    device = dr.async_get(call.hass).async_get(call.data[ATTR_DEVICE_ID])
+def _omada_tracker_entry_ids(hass: HomeAssistant, device: dr.DeviceEntry) -> set[str]:
+    """Return the Omada config entries with a device tracker on the device."""
+    omada_entry_ids = {
+        entry.entry_id for entry in hass.config_entries.async_entries(DOMAIN)
+    }
+    return {
+        entity.config_entry_id
+        for entity in er.async_entries_for_device(er.async_get(hass), device.id)
+        if entity.domain == DEVICE_TRACKER_DOMAIN
+        and entity.config_entry_id in omada_entry_ids
+    }
+
+
+def _resolve_client_controller(
+    call: ServiceCall,
+) -> tuple[OmadaSiteController, str]:
+    """Resolve the controller and MAC of the client referenced by the call."""
+    hass = call.hass
+
+    if not hass.config_entries.async_entries(DOMAIN):
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="no_controllers",
+        )
+
+    requested_entry: ConfigEntry[OmadaSiteController] | None = None
+    if entry_id := call.data.get(ATTR_CONFIG_ENTRY_ID):
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if not entry:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="controller_not_found",
+            )
+        if entry.state is not ConfigEntryState.LOADED:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="controller_unavailable",
+            )
+        requested_entry = cast(ConfigEntry[OmadaSiteController], entry)
+
+    device = dr.async_get(hass).async_get(call.data[ATTR_DEVICE_ID])
     if device is None or not isinstance(device, dr.DeviceEntry):
         # Child devices carry no connections to resolve a MAC from.
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="client_device_not_found",
         )
+
+    tracker_entry_ids = _omada_tracker_entry_ids(hass, device)
+    if not tracker_entry_ids:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="client_device_not_tracked",
+        )
+
+    if requested_entry is None:
+        entry = next(
+            entry
+            for entry_id in tracker_entry_ids
+            if (entry := hass.config_entries.async_get_entry(entry_id)) is not None
+        )
+        if entry.state is not ConfigEntryState.LOADED:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="controller_unavailable",
+            )
+        controller = cast(ConfigEntry[OmadaSiteController], entry).runtime_data
+    elif requested_entry.entry_id not in tracker_entry_ids:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="controller_mismatch",
+        )
+    else:
+        controller = requested_entry.runtime_data
+
     for connection_type, connection_id in device.connections:
         if connection_type == dr.CONNECTION_NETWORK_MAC:
-            return connection_id
+            return controller, connection_id
     raise ServiceValidationError(
         translation_domain=DOMAIN,
         translation_key="client_device_no_mac",
@@ -122,9 +196,7 @@ def _get_client_mac(call: ServiceCall) -> str:
 
 async def _handle_set_client_name(call: ServiceCall) -> None:
     """Handle the service action to set the name of a network client."""
-    controller = _get_controller(call)
-
-    mac = _get_client_mac(call)
+    controller, mac = _resolve_client_controller(call)
     name: str = call.data[ATTR_NAME]
 
     try:

--- a/homeassistant/components/tplink_omada/services.py
+++ b/homeassistant/components/tplink_omada/services.py
@@ -3,7 +3,7 @@
 from typing import cast
 
 from tplink_omada_client import OmadaClientSettings
-from tplink_omada_client.exceptions import OmadaClientException
+from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
@@ -113,7 +113,7 @@ async def _resolve_client_controller(
 
     if entry_id := call.data.get(ATTR_CONFIG_ENTRY_ID):
         entry = hass.config_entries.async_get_entry(entry_id)
-        if not entry:
+        if not entry or entry.domain != DOMAIN:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="controller_not_found",
@@ -146,29 +146,49 @@ async def _resolve_client_controller(
             translation_key="client_device_not_found",
         )
 
-    mac = next(
-        (
-            connection_id
-            for connection_type, connection_id in device.connections
-            if connection_type == dr.CONNECTION_NETWORK_MAC
-        ),
-        None,
-    )
-    if mac is None:
+    macs = [
+        connection_id
+        for connection_type, connection_id in device.connections
+        if connection_type == dr.CONNECTION_NETWORK_MAC
+    ]
+    if not macs:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="client_device_no_mac",
         )
 
-    try:
-        await controller.omada_client.get_client(mac)
-    except OmadaClientException as ex:
+    known_macs: list[str] = []
+    for mac in macs:
+        try:
+            await controller.omada_client.get_client(mac)
+        except RequestFailed as ex:
+            # The controller reports unknown clients with error code -41011.
+            if getattr(ex, "_error_code", None) == -41011:
+                continue
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="client_query_failed",
+                translation_placeholders={"mac": mac},
+            ) from ex
+        except OmadaClientException as ex:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="client_query_failed",
+                translation_placeholders={"mac": mac},
+            ) from ex
+        known_macs.append(mac)
+
+    if len(known_macs) == 1:
+        return controller, known_macs[0]
+    if not known_macs:
         raise ServiceValidationError(
             translation_domain=DOMAIN,
             translation_key="client_device_not_tracked",
-        ) from ex
-
-    return controller, mac
+        )
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="client_mac_ambiguous",
+    )
 
 
 async def _handle_set_client_name(call: ServiceCall) -> None:

--- a/homeassistant/components/tplink_omada/services.yaml
+++ b/homeassistant/components/tplink_omada/services.yaml
@@ -9,3 +9,18 @@ reconnect_client:
       example: "01-23-45-67-89-AB"
       selector:
         text:
+set_client_name:
+  fields:
+    config_entry_id:
+      selector:
+        config_entry:
+          integration: tplink_omada
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: tplink_omada
+    name:
+      required: true
+      selector:
+        text:

--- a/homeassistant/components/tplink_omada/services.yaml
+++ b/homeassistant/components/tplink_omada/services.yaml
@@ -19,10 +19,6 @@ set_client_name:
       required: true
       selector:
         device:
-          integration: tplink_omada
-          entity:
-            - domain: device_tracker
-              integration: tplink_omada
     name:
       required: true
       selector:

--- a/homeassistant/components/tplink_omada/services.yaml
+++ b/homeassistant/components/tplink_omada/services.yaml
@@ -20,6 +20,9 @@ set_client_name:
       selector:
         device:
           integration: tplink_omada
+          entity:
+            - domain: device_tracker
+              integration: tplink_omada
     name:
       required: true
       selector:

--- a/homeassistant/components/tplink_omada/services.yaml
+++ b/homeassistant/components/tplink_omada/services.yaml
@@ -12,6 +12,7 @@ reconnect_client:
 set_client_name:
   fields:
     config_entry_id:
+      required: true
       selector:
         config_entry:
           integration: tplink_omada

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -118,6 +118,12 @@
     "client_device_not_found": {
       "message": "The selected device was not found."
     },
+    "client_device_not_tracked": {
+      "message": "The selected device is not a network client tracked by the Omada integration."
+    },
+    "controller_mismatch": {
+      "message": "The selected device is not a client of the specified Omada controller."
+    },
     "controller_not_found": {
       "message": "Specified TP-Link Omada controller not found"
     },

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -127,9 +127,6 @@
     "client_query_failed": {
       "message": "Failed to query client with MAC {mac} from the Omada controller."
     },
-    "controller_ambiguous": {
-      "message": "Multiple Omada controllers found. Specify the controller to use."
-    },
     "controller_not_found": {
       "message": "Specified TP-Link Omada controller not found"
     },

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -112,6 +112,12 @@
     "cannot_connect": {
       "message": "Omada controller could not be reached."
     },
+    "client_device_no_mac": {
+      "message": "The selected device has no network MAC address associated with it."
+    },
+    "client_device_not_found": {
+      "message": "The selected device was not found."
+    },
     "controller_not_found": {
       "message": "Specified TP-Link Omada controller not found"
     },
@@ -129,6 +135,9 @@
     },
     "reconnect_failed": {
       "message": "Failed to reconnect client with MAC {mac}"
+    },
+    "set_client_name_failed": {
+      "message": "Failed to set client name for device with MAC {mac}"
     },
     "switch_action_failed": {
       "message": "Failed to update the switch."
@@ -154,6 +163,24 @@
         }
       },
       "name": "Reconnect wireless client"
+    },
+    "set_client_name": {
+      "description": "Sets the name of a client on the Omada network.",
+      "fields": {
+        "config_entry_id": {
+          "description": "The instance of the Omada integration to which the client is connected.",
+          "name": "Omada controller"
+        },
+        "device_id": {
+          "description": "The device whose client name will be set.",
+          "name": "Device"
+        },
+        "name": {
+          "description": "New name for the client.",
+          "name": "Name"
+        }
+      },
+      "name": "Set client name"
     }
   }
 }

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -121,6 +121,12 @@
     "client_device_not_tracked": {
       "message": "The selected device is not a network client of the Omada controller."
     },
+    "client_mac_ambiguous": {
+      "message": "The selected device has multiple network addresses on the Omada controller. Select a different device."
+    },
+    "client_query_failed": {
+      "message": "Failed to query client with MAC {mac} from the Omada controller."
+    },
     "controller_ambiguous": {
       "message": "Multiple Omada controllers found. Specify the controller to use."
     },

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -119,10 +119,10 @@
       "message": "The selected device was not found."
     },
     "client_device_not_tracked": {
-      "message": "The selected device is not a network client tracked by the Omada integration."
+      "message": "The selected device is not a network client of the Omada controller."
     },
-    "controller_mismatch": {
-      "message": "The selected device is not a client of the specified Omada controller."
+    "controller_ambiguous": {
+      "message": "Multiple Omada controllers found. Specify the controller to use."
     },
     "controller_not_found": {
       "message": "Specified TP-Link Omada controller not found"

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -109,6 +109,7 @@ async def mock_omada_site_client(hass: HomeAssistant) -> AsyncGenerator[AsyncMoc
     site_client.get_known_clients.return_value = async_empty()
     site_client.get_connected_clients.return_value = async_empty()
     site_client.reconnect_client = AsyncMock()
+    site_client.update_client = AsyncMock()
     return site_client
 
 

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -108,6 +108,7 @@ async def mock_omada_site_client(hass: HomeAssistant) -> AsyncGenerator[AsyncMoc
 
     site_client.get_known_clients.return_value = async_empty()
     site_client.get_connected_clients.return_value = async_empty()
+    site_client.get_client = AsyncMock()
     site_client.reconnect_client = AsyncMock()
     site_client.update_client = AsyncMock()
     return site_client

--- a/tests/components/tplink_omada/test_services.py
+++ b/tests/components/tplink_omada/test_services.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from tplink_omada_client import OmadaClientSettings
-from tplink_omada_client.exceptions import OmadaClientException
+from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
 import voluptuous as vol
 
 from homeassistant.components.tplink_omada.const import DOMAIN
@@ -183,6 +183,17 @@ def _add_foreign_device(hass: HomeAssistant, mac: str) -> str:
     device = dr.async_get(hass).async_get_or_create(
         config_entry_id=foreign_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, mac)},
+    )
+    return device.id
+
+
+def _add_multi_mac_device(
+    hass: HomeAssistant, config_entry: MockConfigEntry, macs: list[str]
+) -> str:
+    """Register a device with multiple network MAC connections."""
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, mac) for mac in macs},
     )
     return device.id
 
@@ -445,7 +456,7 @@ async def test_service_set_client_name_non_client_device(
     mac = "aa:bb:cc:dd:ee:ff"
     device_id = _add_client_device(hass, mock_config_entry, mac)
 
-    mock_omada_site_client.get_client.side_effect = OmadaClientException
+    mock_omada_site_client.get_client.side_effect = RequestFailed(-41011, "not found")
     with pytest.raises(ServiceValidationError) as err:
         await hass.services.async_call(
             DOMAIN,
@@ -521,3 +532,125 @@ async def test_service_set_client_name_foreign_device(
     mock_omada_site_client.update_client.assert_awaited_once_with(
         mac, OmadaClientSettings(name="Ting sensor")
     )
+
+
+async def test_service_set_client_name_foreign_controller_entry(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name with a non-Omada config entry raises an error."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    foreign_entry = MockConfigEntry(domain="sonos", unique_id="foreign_entry")
+    foreign_entry.add_to_hass(hass)
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_client_name",
+            {
+                "config_entry_id": foreign_entry.entry_id,
+                "device_id": "device1",
+                "name": "Ting sensor",
+            },
+            blocking=True,
+        )
+    assert err.value.translation_key == "controller_not_found"
+    assert err.value.translation_domain == DOMAIN
+
+    mock_omada_site_client.update_client.assert_not_awaited()
+
+
+async def test_service_set_client_name_single_known_mac(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name resolves a device with multiple MACs to the tracked one."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    client_mac = "aa:bb:cc:dd:ee:ff"
+    other_mac = "11:22:33:44:55:66"
+    device_id = _add_multi_mac_device(hass, mock_config_entry, [client_mac, other_mac])
+
+    async def get_client(mac: str) -> MagicMock:
+        if mac == other_mac:
+            raise RequestFailed(-41011, "not found")
+        return MagicMock()
+
+    mock_omada_site_client.get_client.side_effect = get_client
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_client_name",
+        {"device_id": device_id, "name": "Ting sensor"},
+        blocking=True,
+    )
+
+    mock_omada_site_client.update_client.assert_awaited_once_with(
+        client_mac, OmadaClientSettings(name="Ting sensor")
+    )
+
+
+async def test_service_set_client_name_multiple_known_macs(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name with multiple tracked MACs raises an ambiguity error."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_id = _add_multi_mac_device(
+        hass, mock_config_entry, ["aa:bb:cc:dd:ee:ff", "11:22:33:44:55:66"]
+    )
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_client_name",
+            {"device_id": device_id, "name": "Ting sensor"},
+            blocking=True,
+        )
+    assert err.value.translation_key == "client_mac_ambiguous"
+    assert err.value.translation_domain == DOMAIN
+
+    mock_omada_site_client.update_client.assert_not_awaited()
+
+
+async def test_service_set_client_name_query_failed_raises_homeassistanterror(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name surfaces a controller failure querying the client."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mac = "aa:bb:cc:dd:ee:ff"
+    device_id = _add_client_device(hass, mock_config_entry, mac)
+
+    mock_omada_site_client.get_client.side_effect = RequestFailed(-30109, "boom")
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_client_name",
+            {"device_id": device_id, "name": "Ting sensor"},
+            blocking=True,
+        )
+    assert err.value.translation_key == "client_query_failed"
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_placeholders == {"mac": mac}
+
+    mock_omada_site_client.update_client.assert_not_awaited()

--- a/tests/components/tplink_omada/test_services.py
+++ b/tests/components/tplink_omada/test_services.py
@@ -406,7 +406,11 @@ async def test_service_set_client_name_empty_name_rejected(
         await hass.services.async_call(
             DOMAIN,
             "set_client_name",
-            {"device_id": device_id, "name": ""},
+            {
+                "config_entry_id": mock_config_entry.entry_id,
+                "device_id": device_id,
+                "name": "",
+            },
             blocking=True,
         )
 

--- a/tests/components/tplink_omada/test_services.py
+++ b/tests/components/tplink_omada/test_services.py
@@ -250,7 +250,8 @@ async def test_service_set_client_name(
     )
 
     mock_omada_site_client.update_client.assert_awaited_once_with(
-        mac, OmadaClientSettings(name="Ting sensor")
+        mac.upper().replace(":", "-"),
+        OmadaClientSettings(name="Ting sensor"),
     )
 
 
@@ -276,7 +277,8 @@ async def test_service_set_client_name_without_config_entry_id(
     )
 
     mock_omada_site_client.update_client.assert_awaited_once_with(
-        mac, OmadaClientSettings(name="Ting sensor")
+        mac.upper().replace(":", "-"),
+        OmadaClientSettings(name="Ting sensor"),
     )
 
 
@@ -410,10 +412,11 @@ async def test_service_set_client_name_failed_raises_homeassistanterror(
         )
     assert err.value.translation_key == "set_client_name_failed"
     assert err.value.translation_domain == DOMAIN
-    assert err.value.translation_placeholders == {"mac": mac}
+    assert err.value.translation_placeholders == {"mac": mac.upper().replace(":", "-")}
 
     mock_omada_site_client.update_client.assert_awaited_once_with(
-        mac, OmadaClientSettings(name="Ting sensor")
+        mac.upper().replace(":", "-"),
+        OmadaClientSettings(name="Ting sensor"),
     )
 
 
@@ -528,9 +531,12 @@ async def test_service_set_client_name_foreign_device(
         blocking=True,
     )
 
-    mock_omada_site_client.get_client.assert_awaited_once_with(mac)
+    mock_omada_site_client.get_client.assert_awaited_once_with(
+        mac.upper().replace(":", "-")
+    )
     mock_omada_site_client.update_client.assert_awaited_once_with(
-        mac, OmadaClientSettings(name="Ting sensor")
+        mac.upper().replace(":", "-"),
+        OmadaClientSettings(name="Ting sensor"),
     )
 
 
@@ -581,7 +587,7 @@ async def test_service_set_client_name_single_known_mac(
     device_id = _add_multi_mac_device(hass, mock_config_entry, [client_mac, other_mac])
 
     async def get_client(mac: str) -> MagicMock:
-        if mac == other_mac:
+        if mac == other_mac.upper().replace(":", "-"):
             raise RequestFailed(-41011, "not found")
         return MagicMock()
 
@@ -595,7 +601,8 @@ async def test_service_set_client_name_single_known_mac(
     )
 
     mock_omada_site_client.update_client.assert_awaited_once_with(
-        client_mac, OmadaClientSettings(name="Ting sensor")
+        client_mac.upper().replace(":", "-"),
+        OmadaClientSettings(name="Ting sensor"),
     )
 
 
@@ -651,6 +658,6 @@ async def test_service_set_client_name_query_failed_raises_homeassistanterror(
         )
     assert err.value.translation_key == "client_query_failed"
     assert err.value.translation_domain == DOMAIN
-    assert err.value.translation_placeholders == {"mac": mac}
+    assert err.value.translation_placeholders == {"mac": mac.upper().replace(":", "-")}
 
     mock_omada_site_client.update_client.assert_not_awaited()

--- a/tests/components/tplink_omada/test_services.py
+++ b/tests/components/tplink_omada/test_services.py
@@ -11,7 +11,7 @@ from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.components.tplink_omada.services import async_setup_services
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -168,19 +168,44 @@ async def test_service_reconnect_failed_raises_homeassistanterror(
 def _add_client_device(
     hass: HomeAssistant, config_entry: MockConfigEntry, mac: str
 ) -> str:
-    """Register a device with a network MAC connection for the given entry."""
+    """Register a device with a network MAC connection and tracker entity."""
     device = dr.async_get(hass).async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, mac)},
+    )
+    er.async_get(hass).async_get_or_create(
+        "device_tracker",
+        DOMAIN,
+        f"scanner_{config_entry.entry_id}_{mac}",
+        config_entry=config_entry,
+        device_id=device.id,
     )
     return device.id
 
 
 def _add_device_without_mac(hass: HomeAssistant, config_entry: MockConfigEntry) -> str:
-    """Register a device without a network MAC connection for the given entry."""
+    """Register a device with a tracker entity but no network MAC connection."""
     device = dr.async_get(hass).async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "no-mac-device")},
+    )
+    er.async_get(hass).async_get_or_create(
+        "device_tracker",
+        DOMAIN,
+        "scanner_no_mac",
+        config_entry=config_entry,
+        device_id=device.id,
+    )
+    return device.id
+
+
+def _add_non_client_device(
+    hass: HomeAssistant, config_entry: MockConfigEntry, mac: str
+) -> str:
+    """Register a device with a network MAC connection but no tracker entity."""
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)},
     )
     return device.id
 
@@ -416,5 +441,72 @@ async def test_service_set_client_name_empty_name_rejected(
             {"device_id": device_id, "name": ""},
             blocking=True,
         )
+
+    mock_omada_site_client.update_client.assert_not_awaited()
+
+
+async def test_service_set_client_name_non_client_device(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name with a non-client device raises ServiceValidationError."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mac = "aa:bb:cc:dd:ee:ff"
+    device_id = _add_non_client_device(hass, mock_config_entry, mac)
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_client_name",
+            {"device_id": device_id, "name": "Ting sensor"},
+            blocking=True,
+        )
+    assert err.value.translation_key == "client_device_not_tracked"
+    assert err.value.translation_domain == DOMAIN
+
+    mock_omada_site_client.update_client.assert_not_awaited()
+
+
+async def test_service_set_client_name_controller_mismatch(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name with a device from another controller raises an error."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    other_entry = MockConfigEntry(
+        title="Other Omada Controller",
+        domain=DOMAIN,
+        unique_id="54321",
+    )
+    other_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(other_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mac = "aa:bb:cc:dd:ee:ff"
+    device_id = _add_client_device(hass, other_entry, mac)
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_client_name",
+            {
+                "config_entry_id": mock_config_entry.entry_id,
+                "device_id": device_id,
+                "name": "Ting sensor",
+            },
+            blocking=True,
+        )
+    assert err.value.translation_key == "controller_mismatch"
+    assert err.value.translation_domain == DOMAIN
 
     mock_omada_site_client.update_client.assert_not_awaited()

--- a/tests/components/tplink_omada/test_services.py
+++ b/tests/components/tplink_omada/test_services.py
@@ -11,7 +11,7 @@ from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.components.tplink_omada.services import async_setup_services
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
@@ -168,44 +168,30 @@ async def test_service_reconnect_failed_raises_homeassistanterror(
 def _add_client_device(
     hass: HomeAssistant, config_entry: MockConfigEntry, mac: str
 ) -> str:
-    """Register a device with a network MAC connection and tracker entity."""
+    """Register a device with a network MAC connection."""
     device = dr.async_get(hass).async_get_or_create(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, mac)},
     )
-    er.async_get(hass).async_get_or_create(
-        "device_tracker",
-        DOMAIN,
-        f"scanner_{config_entry.entry_id}_{mac}",
-        config_entry=config_entry,
-        device_id=device.id,
+    return device.id
+
+
+def _add_foreign_device(hass: HomeAssistant, mac: str) -> str:
+    """Register a device owned by another integration with a network MAC."""
+    foreign_entry = MockConfigEntry(domain="sonos", unique_id="foreign")
+    foreign_entry.add_to_hass(hass)
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=foreign_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)},
     )
     return device.id
 
 
 def _add_device_without_mac(hass: HomeAssistant, config_entry: MockConfigEntry) -> str:
-    """Register a device with a tracker entity but no network MAC connection."""
+    """Register a device without a network MAC connection."""
     device = dr.async_get(hass).async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "no-mac-device")},
-    )
-    er.async_get(hass).async_get_or_create(
-        "device_tracker",
-        DOMAIN,
-        "scanner_no_mac",
-        config_entry=config_entry,
-        device_id=device.id,
-    )
-    return device.id
-
-
-def _add_non_client_device(
-    hass: HomeAssistant, config_entry: MockConfigEntry, mac: str
-) -> str:
-    """Register a device with a network MAC connection but no tracker entity."""
-    device = dr.async_get(hass).async_get_or_create(
-        config_entry_id=config_entry.entry_id,
-        connections={(dr.CONNECTION_NETWORK_MAC, mac)},
     )
     return device.id
 
@@ -457,8 +443,9 @@ async def test_service_set_client_name_non_client_device(
     await hass.async_block_till_done()
 
     mac = "aa:bb:cc:dd:ee:ff"
-    device_id = _add_non_client_device(hass, mock_config_entry, mac)
+    device_id = _add_client_device(hass, mock_config_entry, mac)
 
+    mock_omada_site_client.get_client.side_effect = OmadaClientException
     with pytest.raises(ServiceValidationError) as err:
         await hass.services.async_call(
             DOMAIN,
@@ -472,13 +459,13 @@ async def test_service_set_client_name_non_client_device(
     mock_omada_site_client.update_client.assert_not_awaited()
 
 
-async def test_service_set_client_name_controller_mismatch(
+async def test_service_set_client_name_controller_ambiguous(
     hass: HomeAssistant,
     mock_omada_site_client: MagicMock,
     mock_omada_client: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test set client name with a device from another controller raises an error."""
+    """Test set client name without a controller raises an error with multiple entries."""
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -492,21 +479,45 @@ async def test_service_set_client_name_controller_mismatch(
     await hass.config_entries.async_setup(other_entry.entry_id)
     await hass.async_block_till_done()
 
-    mac = "aa:bb:cc:dd:ee:ff"
-    device_id = _add_client_device(hass, other_entry, mac)
-
     with pytest.raises(ServiceValidationError) as err:
         await hass.services.async_call(
             DOMAIN,
             "set_client_name",
-            {
-                "config_entry_id": mock_config_entry.entry_id,
-                "device_id": device_id,
-                "name": "Ting sensor",
-            },
+            {"device_id": "device1", "name": "Ting sensor"},
             blocking=True,
         )
-    assert err.value.translation_key == "controller_mismatch"
+    assert err.value.translation_key == "controller_ambiguous"
     assert err.value.translation_domain == DOMAIN
 
     mock_omada_site_client.update_client.assert_not_awaited()
+
+
+async def test_service_set_client_name_foreign_device(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name with a device owned by another integration."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mac = "aa:bb:cc:dd:ee:ff"
+    device_id = _add_foreign_device(hass, mac)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_client_name",
+        {
+            "config_entry_id": mock_config_entry.entry_id,
+            "device_id": device_id,
+            "name": "Ting sensor",
+        },
+        blocking=True,
+    )
+
+    mock_omada_site_client.get_client.assert_awaited_once_with(mac)
+    mock_omada_site_client.update_client.assert_awaited_once_with(
+        mac, OmadaClientSettings(name="Ting sensor")
+    )

--- a/tests/components/tplink_omada/test_services.py
+++ b/tests/components/tplink_omada/test_services.py
@@ -3,12 +3,15 @@
 from unittest.mock import MagicMock
 
 import pytest
+from tplink_omada_client import OmadaClientSettings
 from tplink_omada_client.exceptions import OmadaClientException
+import voluptuous as vol
 
 from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.components.tplink_omada.services import async_setup_services
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
@@ -160,3 +163,258 @@ async def test_service_reconnect_failed_raises_homeassistanterror(
     assert err.value.translation_placeholders == {"mac": mac}
 
     mock_omada_site_client.reconnect_client.assert_awaited_once_with(mac)
+
+
+def _add_client_device(
+    hass: HomeAssistant, config_entry: MockConfigEntry, mac: str
+) -> str:
+    """Register a device with a network MAC connection for the given entry."""
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)},
+    )
+    return device.id
+
+
+def _add_device_without_mac(hass: HomeAssistant, config_entry: MockConfigEntry) -> str:
+    """Register a device without a network MAC connection for the given entry."""
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "no-mac-device")},
+    )
+    return device.id
+
+
+async def test_service_set_client_name_no_config_entries(
+    hass: HomeAssistant,
+) -> None:
+    """Test set client name service raises error when no config entries exist."""
+    async_setup_services(hass)
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_client_name",
+            {"device_id": "device1", "name": "Ting sensor"},
+            blocking=True,
+        )
+    assert err.value.translation_key == "no_controllers"
+    assert err.value.translation_domain == DOMAIN
+
+
+async def test_service_set_client_name(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setting the name of a client."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mac = "aa:bb:cc:dd:ee:ff"
+    device_id = _add_client_device(hass, mock_config_entry, mac)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_client_name",
+        {
+            "config_entry_id": mock_config_entry.entry_id,
+            "device_id": device_id,
+            "name": "Ting sensor",
+        },
+        blocking=True,
+    )
+
+    mock_omada_site_client.update_client.assert_awaited_once_with(
+        mac, OmadaClientSettings(name="Ting sensor")
+    )
+
+
+async def test_service_set_client_name_without_config_entry_id(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name without config_entry_id uses first loaded entry."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mac = "aa:bb:cc:dd:ee:ff"
+    device_id = _add_client_device(hass, mock_config_entry, mac)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_client_name",
+        {"device_id": device_id, "name": "Ting sensor"},
+        blocking=True,
+    )
+
+    mock_omada_site_client.update_client.assert_awaited_once_with(
+        mac, OmadaClientSettings(name="Ting sensor")
+    )
+
+
+async def test_service_set_client_name_invalid_config_entry_id(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name with invalid config entry raises ServiceValidationError."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_client_name",
+            {
+                "config_entry_id": "invalid_entry_id",
+                "device_id": "device1",
+                "name": "Ting sensor",
+            },
+            blocking=True,
+        )
+    assert err.value.translation_key == "controller_not_found"
+    assert err.value.translation_domain == DOMAIN
+
+
+async def test_service_set_client_name_entry_not_loaded(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name raises error when entry is not loaded."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    unloaded_entry = MockConfigEntry(
+        title="Unloaded Omada Controller",
+        domain=DOMAIN,
+        unique_id="67890",
+    )
+    unloaded_entry.add_to_hass(hass)
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_client_name",
+            {
+                "config_entry_id": unloaded_entry.entry_id,
+                "device_id": "device1",
+                "name": "Ting sensor",
+            },
+            blocking=True,
+        )
+    assert err.value.translation_key == "controller_unavailable"
+    assert err.value.translation_domain == DOMAIN
+
+
+async def test_service_set_client_name_unknown_device(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name with an unknown device raises ServiceValidationError."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_client_name",
+            {"device_id": "nonexistent_device", "name": "Ting sensor"},
+            blocking=True,
+        )
+    assert err.value.translation_key == "client_device_not_found"
+    assert err.value.translation_domain == DOMAIN
+
+
+async def test_service_set_client_name_device_without_mac(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name with a device without a MAC raises ServiceValidationError."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_id = _add_device_without_mac(hass, mock_config_entry)
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_client_name",
+            {"device_id": device_id, "name": "Ting sensor"},
+            blocking=True,
+        )
+    assert err.value.translation_key == "client_device_no_mac"
+    assert err.value.translation_domain == DOMAIN
+
+
+async def test_service_set_client_name_failed_raises_homeassistanterror(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name raises correct exception on controller failure."""
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mac = "aa:bb:cc:dd:ee:ff"
+    device_id = _add_client_device(hass, mock_config_entry, mac)
+
+    mock_omada_site_client.update_client.side_effect = OmadaClientException
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_client_name",
+            {"device_id": device_id, "name": "Ting sensor"},
+            blocking=True,
+        )
+    assert err.value.translation_key == "set_client_name_failed"
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_placeholders == {"mac": mac}
+
+    mock_omada_site_client.update_client.assert_awaited_once_with(
+        mac, OmadaClientSettings(name="Ting sensor")
+    )
+
+
+async def test_service_set_client_name_empty_name_rejected(
+    hass: HomeAssistant,
+    mock_omada_site_client: MagicMock,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test set client name with an empty name is rejected by the schema."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mac = "aa:bb:cc:dd:ee:ff"
+    device_id = _add_client_device(hass, mock_config_entry, mac)
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_client_name",
+            {"device_id": device_id, "name": ""},
+            blocking=True,
+        )
+
+    mock_omada_site_client.update_client.assert_not_awaited()

--- a/tests/components/tplink_omada/test_services.py
+++ b/tests/components/tplink_omada/test_services.py
@@ -207,23 +207,6 @@ def _add_device_without_mac(hass: HomeAssistant, config_entry: MockConfigEntry) 
     return device.id
 
 
-async def test_service_set_client_name_no_config_entries(
-    hass: HomeAssistant,
-) -> None:
-    """Test set client name service raises error when no config entries exist."""
-    async_setup_services(hass)
-
-    with pytest.raises(ServiceValidationError) as err:
-        await hass.services.async_call(
-            DOMAIN,
-            "set_client_name",
-            {"device_id": "device1", "name": "Ting sensor"},
-            blocking=True,
-        )
-    assert err.value.translation_key == "no_controllers"
-    assert err.value.translation_domain == DOMAIN
-
-
 async def test_service_set_client_name(
     hass: HomeAssistant,
     mock_omada_site_client: MagicMock,
@@ -246,33 +229,6 @@ async def test_service_set_client_name(
             "device_id": device_id,
             "name": "Ting sensor",
         },
-        blocking=True,
-    )
-
-    mock_omada_site_client.update_client.assert_awaited_once_with(
-        mac.upper().replace(":", "-"),
-        OmadaClientSettings(name="Ting sensor"),
-    )
-
-
-async def test_service_set_client_name_without_config_entry_id(
-    hass: HomeAssistant,
-    mock_omada_site_client: MagicMock,
-    mock_omada_client: MagicMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test set client name without config_entry_id uses first loaded entry."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    mac = "aa:bb:cc:dd:ee:ff"
-    device_id = _add_client_device(hass, mock_config_entry, mac)
-
-    await hass.services.async_call(
-        DOMAIN,
-        "set_client_name",
-        {"device_id": device_id, "name": "Ting sensor"},
         blocking=True,
     )
 
@@ -356,7 +312,11 @@ async def test_service_set_client_name_unknown_device(
         await hass.services.async_call(
             DOMAIN,
             "set_client_name",
-            {"device_id": "nonexistent_device", "name": "Ting sensor"},
+            {
+                "config_entry_id": mock_config_entry.entry_id,
+                "device_id": "nonexistent_device",
+                "name": "Ting sensor",
+            },
             blocking=True,
         )
     assert err.value.translation_key == "client_device_not_found"
@@ -380,7 +340,11 @@ async def test_service_set_client_name_device_without_mac(
         await hass.services.async_call(
             DOMAIN,
             "set_client_name",
-            {"device_id": device_id, "name": "Ting sensor"},
+            {
+                "config_entry_id": mock_config_entry.entry_id,
+                "device_id": device_id,
+                "name": "Ting sensor",
+            },
             blocking=True,
         )
     assert err.value.translation_key == "client_device_no_mac"
@@ -407,7 +371,11 @@ async def test_service_set_client_name_failed_raises_homeassistanterror(
         await hass.services.async_call(
             DOMAIN,
             "set_client_name",
-            {"device_id": device_id, "name": "Ting sensor"},
+            {
+                "config_entry_id": mock_config_entry.entry_id,
+                "device_id": device_id,
+                "name": "Ting sensor",
+            },
             blocking=True,
         )
     assert err.value.translation_key == "set_client_name_failed"
@@ -464,43 +432,14 @@ async def test_service_set_client_name_non_client_device(
         await hass.services.async_call(
             DOMAIN,
             "set_client_name",
-            {"device_id": device_id, "name": "Ting sensor"},
+            {
+                "config_entry_id": mock_config_entry.entry_id,
+                "device_id": device_id,
+                "name": "Ting sensor",
+            },
             blocking=True,
         )
     assert err.value.translation_key == "client_device_not_tracked"
-    assert err.value.translation_domain == DOMAIN
-
-    mock_omada_site_client.update_client.assert_not_awaited()
-
-
-async def test_service_set_client_name_controller_ambiguous(
-    hass: HomeAssistant,
-    mock_omada_site_client: MagicMock,
-    mock_omada_client: MagicMock,
-    mock_config_entry: MockConfigEntry,
-) -> None:
-    """Test set client name without a controller raises an error with multiple entries."""
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    other_entry = MockConfigEntry(
-        title="Other Omada Controller",
-        domain=DOMAIN,
-        unique_id="54321",
-    )
-    other_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(other_entry.entry_id)
-    await hass.async_block_till_done()
-
-    with pytest.raises(ServiceValidationError) as err:
-        await hass.services.async_call(
-            DOMAIN,
-            "set_client_name",
-            {"device_id": "device1", "name": "Ting sensor"},
-            blocking=True,
-        )
-    assert err.value.translation_key == "controller_ambiguous"
     assert err.value.translation_domain == DOMAIN
 
     mock_omada_site_client.update_client.assert_not_awaited()
@@ -596,7 +535,11 @@ async def test_service_set_client_name_single_known_mac(
     await hass.services.async_call(
         DOMAIN,
         "set_client_name",
-        {"device_id": device_id, "name": "Ting sensor"},
+        {
+            "config_entry_id": mock_config_entry.entry_id,
+            "device_id": device_id,
+            "name": "Ting sensor",
+        },
         blocking=True,
     )
 
@@ -625,7 +568,11 @@ async def test_service_set_client_name_multiple_known_macs(
         await hass.services.async_call(
             DOMAIN,
             "set_client_name",
-            {"device_id": device_id, "name": "Ting sensor"},
+            {
+                "config_entry_id": mock_config_entry.entry_id,
+                "device_id": device_id,
+                "name": "Ting sensor",
+            },
             blocking=True,
         )
     assert err.value.translation_key == "client_mac_ambiguous"
@@ -653,7 +600,11 @@ async def test_service_set_client_name_query_failed_raises_homeassistanterror(
         await hass.services.async_call(
             DOMAIN,
             "set_client_name",
-            {"device_id": device_id, "name": "Ting sensor"},
+            {
+                "config_entry_id": mock_config_entry.entry_id,
+                "device_id": device_id,
+                "name": "Ting sensor",
+            },
             blocking=True,
         )
     assert err.value.translation_key == "client_query_failed"


### PR DESCRIPTION
## Breaking change

No breaking change.

## Proposed change

Adds a `set_client_name` action to the TP-Link Omada integration. The action sets the name of a network client on the Omada controller, so the friendly name appears in the Omada client list. The client MAC address is resolved from the selected device's network connection in the device registry, so the action targets a device instead of requiring a raw MAC address.

The action is registered as an admin-only service since it modifies controller configuration. Errors use translated messages following the existing `exceptions` translation pattern in the integration.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47933
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
