### PR TITLE
victron_gx: Bump victron-mqtt to 2026.9.2

### DIFF
--- a/homeassistant/components/victron_gx/button.py
+++ b/homeassistant/components/victron_gx/button.py
@@ -51,6 +51,8 @@ async def async_setup_entry(
 class VictronButton(VictronBaseEntity, ButtonEntity):
     """Implementation of a Victron GX button entity."""
 
+    _follow_metric_availability = False
+
     @callback
     @override
     def _on_update_cb(self, _value: Any) -> None:

--- a/homeassistant/components/victron_gx/device_tracker.py
+++ b/homeassistant/components/victron_gx/device_tracker.py
@@ -1,12 +1,13 @@
 """Support for Victron GX device tracker."""
 
-from typing import Any, override
+from typing import TYPE_CHECKING, override
 
 from victron_mqtt import (
     Device as VictronVenusDevice,
     GpsLocation,
     Metric as VictronVenusMetric,
     MetricKind,
+    MetricValue,
 )
 
 from homeassistant.components.device_tracker import TrackerEntity
@@ -63,11 +64,16 @@ class VictronDeviceTracker(VictronBaseEntity, TrackerEntity):
     ) -> None:
         """Initialize the device tracker."""
         super().__init__(device, metric, device_info, installation_id)
-        self._update_from_location(metric.value)
+        value = metric.value
+        if TYPE_CHECKING:
+            assert value is None or isinstance(value, GpsLocation)
+        self._update_from_location(value)
 
     @callback
     @override
-    def _on_update_cb(self, value: Any) -> None:
+    def _on_update_cb(self, value: MetricValue) -> None:
+        if TYPE_CHECKING:
+            assert value is None or isinstance(value, GpsLocation)
         self._update_from_location(value)
         self.async_write_ha_state()
 

--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -52,6 +52,7 @@ class VictronBaseEntity(Entity):
 
     _attr_should_poll = False
     _attr_has_entity_name = True
+    _follow_metric_availability = True
 
     def __init__(
         self,
@@ -63,6 +64,8 @@ class VictronBaseEntity(Entity):
         """Initialize the entity."""
         self._device = device
         self._metric = metric
+        if self._follow_metric_availability:
+            self._attr_available = metric.available
         self._attr_device_info = device_info
         self._attr_unique_id = f"{installation_id}_{metric.unique_id}"
         self._attr_suggested_display_precision = metric.precision
@@ -116,7 +119,13 @@ class VictronBaseEntity(Entity):
         """Handle the metric update. Must be implemented by subclasses."""
 
     @callback
-    def _on_update(self, _: VictronVenusMetric, value: MetricValue) -> None:
+    def _on_update(self, metric: VictronVenusMetric, value: MetricValue) -> None:
+        if self._follow_metric_availability and not metric.available:
+            if self._attr_available:
+                self._attr_available = False
+                self.async_write_ha_state()
+            return
+        self._attr_available = True
         self._on_update_cb(value)
 
     @override

--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -1,12 +1,13 @@
 """Base entity for entities in victron_gx integration."""
 
 from abc import abstractmethod
-from typing import Any, override
+from typing import override
 
 from victron_mqtt import (
     Device as VictronVenusDevice,
     Metric as VictronVenusMetric,
     MetricType,
+    MetricValue,
 )
 
 from homeassistant.const import EntityCategory
@@ -111,11 +112,11 @@ class VictronBaseEntity(Entity):
 
     @callback
     @abstractmethod
-    def _on_update_cb(self, value: Any) -> None:
+    def _on_update_cb(self, value: MetricValue) -> None:
         """Handle the metric update. Must be implemented by subclasses."""
 
     @callback
-    def _on_update(self, _: VictronVenusMetric, value: Any) -> None:
+    def _on_update(self, _: VictronVenusMetric, value: MetricValue) -> None:
         self._on_update_cb(value)
 
     @override

--- a/homeassistant/components/victron_gx/manifest.json
+++ b/homeassistant/components/victron_gx/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "quality_scale": "platinum",
-  "requirements": ["victron-mqtt==2026.8.4"],
+  "requirements": ["victron-mqtt==2026.9.1"],
   "ssdp": [
     {
       "X_MqttOnLan": "1",

--- a/homeassistant/components/victron_gx/manifest.json
+++ b/homeassistant/components/victron_gx/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "quality_scale": "platinum",
-  "requirements": ["victron-mqtt==2026.9.1"],
+  "requirements": ["victron-mqtt==2026.9.2"],
   "ssdp": [
     {
       "X_MqttOnLan": "1",

--- a/homeassistant/components/victron_gx/number.py
+++ b/homeassistant/components/victron_gx/number.py
@@ -1,12 +1,13 @@
 """Support for Victron GX number entities."""
 
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, override
 
 from victron_mqtt import (
     Device as VictronVenusDevice,
     Metric as VictronVenusMetric,
     MetricKind,
     MetricType,
+    MetricValue,
     WritableMetric as VictronVenusWritableMetric,
 )
 
@@ -77,7 +78,10 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
         """Initialize the number entity."""
         super().__init__(device, metric, device_info, installation_id)
         self._attr_device_class = METRIC_TYPE_TO_DEVICE_CLASS.get(metric.metric_type)
-        self._attr_native_value = metric.value
+        value = metric.value
+        if TYPE_CHECKING:
+            assert value is None or isinstance(value, int | float)
+        self._attr_native_value = value
         if metric.min_value is not None:
             self._attr_native_min_value = metric.min_value
         if metric.max_value is not None:
@@ -93,7 +97,9 @@ class VictronNumber(VictronBaseEntity, NumberEntity):
 
     @callback
     @override
-    def _on_update_cb(self, value: Any) -> None:
+    def _on_update_cb(self, value: MetricValue) -> None:
+        if TYPE_CHECKING:
+            assert value is None or isinstance(value, int | float)
         self._attr_native_value = value
         self.async_write_ha_state()
 

--- a/homeassistant/components/victron_gx/strings.json
+++ b/homeassistant/components/victron_gx/strings.json
@@ -338,6 +338,12 @@
       "hub4_ac_grid_setpoint": {
         "name": "AC grid setpoint"
       },
+      "hub4_max_charge_power": {
+        "name": "Maximum charge power"
+      },
+      "hub4_max_discharge_power": {
+        "name": "Maximum discharge power"
+      },
       "multi_ess_min_soc_limit": {
         "name": "ESS minimum SoC limit"
       },
@@ -346,6 +352,9 @@
       },
       "multiplus_assist_current_boost_factor": {
         "name": "Assist current boost factor"
+      },
+      "pvinverter_power_limit": {
+        "name": "Power limit"
       },
       "solarcharger_charge_current_limit": {
         "name": "[%key:component::victron_gx::common::charge_current_limit%]"
@@ -987,6 +996,18 @@
       "dcload_voltage": {
         "name": "[%key:component::victron_gx::common::voltage%]"
       },
+      "dcsource_current": {
+        "name": "[%key:component::victron_gx::common::current%]"
+      },
+      "dcsource_power": {
+        "name": "[%key:component::victron_gx::common::power%]"
+      },
+      "dcsource_temperature": {
+        "name": "[%key:component::victron_gx::common::temperature%]"
+      },
+      "dcsource_voltage": {
+        "name": "[%key:component::victron_gx::common::voltage%]"
+      },
       "dcsystem_aux_voltage": {
         "name": "Auxiliary voltage"
       },
@@ -1524,6 +1545,21 @@
       },
       "platform_venus_firmware_installed_version": {
         "name": "Installed version"
+      },
+      "platform_venus_firmware_progress": {
+        "name": "Firmware update progress"
+      },
+      "platform_venus_firmware_state": {
+        "name": "Firmware update state",
+        "state": {
+          "checking": "Checking",
+          "downloading_and_installing": "Downloading and installing",
+          "error_during_check": "Error during check",
+          "error_during_update": "Error during update",
+          "idle": "[%key:common::state::idle%]",
+          "rebooting": "Rebooting",
+          "update_file_not_found": "Update file not found"
+        }
       },
       "pvinverter_current_phase": {
         "name": "Current {phase}"

--- a/homeassistant/components/victron_gx/time.py
+++ b/homeassistant/components/victron_gx/time.py
@@ -2,12 +2,13 @@
 
 from datetime import time
 import logging
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, override
 
 from victron_mqtt import (
     Device as VictronVenusDevice,
     Metric as VictronVenusMetric,
     MetricKind,
+    MetricValue,
     WritableMetric as VictronVenusWritableMetric,
 )
 
@@ -58,11 +59,16 @@ class VictronTime(VictronBaseEntity, TimeEntity):
     ) -> None:
         """Initialize the time entity."""
         super().__init__(device, metric, device_info, installation_id)
-        self._attr_native_value = VictronTime.victron_time_to_time(metric.value)
+        value = metric.value
+        if TYPE_CHECKING:
+            assert value is None or isinstance(value, int | float)
+        self._attr_native_value = VictronTime.victron_time_to_time(value)
 
     @callback
     @override
-    def _on_update_cb(self, value: Any) -> None:
+    def _on_update_cb(self, value: MetricValue) -> None:
+        if TYPE_CHECKING:
+            assert value is None or isinstance(value, int | float)
         self._attr_native_value = VictronTime.victron_time_to_time(value)
         self.async_write_ha_state()
 
@@ -81,7 +87,7 @@ class VictronTime(VictronBaseEntity, TimeEntity):
         self._metric.set(total_minutes)
 
     @staticmethod
-    def victron_time_to_time(value: int | None) -> time | None:
+    def victron_time_to_time(value: float | None) -> time | None:
         """Convert minutes since midnight to time object."""
         if value is None:
             return None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3382,7 +3382,7 @@ viaggiatreno_ha==0.2.4
 victron-ble-ha-parser==0.7.0
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.8.4
+victron-mqtt==2026.9.1
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.12

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3382,7 +3382,7 @@ viaggiatreno_ha==0.2.4
 victron-ble-ha-parser==0.7.0
 
 # homeassistant.components.victron_gx
-victron-mqtt==2026.9.1
+victron-mqtt==2026.9.2
 
 # homeassistant.components.victron_remote_monitoring
 victron-vrm==0.1.12

--- a/tests/components/victron_gx/test_device_tracker.py
+++ b/tests/components/victron_gx/test_device_tracker.py
@@ -1,10 +1,13 @@
 """Tests for Victron GX MQTT device trackers."""
 
+from unittest.mock import MagicMock
+
 from victron_mqtt import Hub as VictronVenusHub
 from victron_mqtt.testing import finalize_injection, inject_message
 
 from homeassistant.components.device_tracker import SourceType, TrackingType
 from homeassistant.components.victron_gx.const import DOMAIN
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -122,6 +125,7 @@ async def test_victron_device_tracker(
 
     state = hass.states.get(entity.entity_id)
     assert state is not None
+    assert state.state == STATE_UNKNOWN
     assert state.attributes == {
         "source_type": SourceType.GPS,
         "altitude": None,
@@ -131,3 +135,12 @@ async def test_victron_device_tracker(
         "in_zones": [],
         "tracking_type": TrackingType.POSITION,
     }
+
+    metric = victron_hub.devices["gps_0"].get_metric("gps_location")
+    assert metric is not None
+    metric._keepalive(force_invalidate=True, log_debug=MagicMock())
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/victron_gx/test_number.py
+++ b/tests/components/victron_gx/test_number.py
@@ -1,10 +1,13 @@
 """Tests for Victron GX MQTT number entities."""
 
+from unittest.mock import MagicMock
+
 from victron_mqtt import Hub as VictronVenusHub
 from victron_mqtt.testing import finalize_injection, inject_message
 
 from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.victron_gx.const import DOMAIN
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -96,6 +99,54 @@ async def test_victron_number_update(
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == "58.0"
+
+
+async def test_nullable_number_availability(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test nullable values remain distinct from source unavailability."""
+    victron_hub, mock_config_entry = init_integration
+    topic = f"N/{MOCK_INSTALLATION_ID}/hub4/0/Overrides/MaxChargePower"
+
+    await inject_message(victron_hub, topic, '{"value": 1200.0}')
+    await finalize_injection(victron_hub, disconnect=False)
+    await hass.async_block_till_done()
+
+    entity = next(
+        entity
+        for entity in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+        if entity.translation_key == "hub4_max_charge_power"
+    )
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.state == "1200.0"
+
+    await inject_message(victron_hub, topic, '{"value": null}')
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    metric = victron_hub.devices["hub4_0"].get_metric("hub4_max_charge_power")
+    assert metric is not None
+    metric._keepalive(force_invalidate=True, log_debug=MagicMock())
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    await inject_message(victron_hub, topic, '{"value": 1300.0}')
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity.entity_id)
+    assert state is not None
+    assert state.state == "1300.0"
 
 
 async def test_victron_number_actions(


### PR DESCRIPTION
## Proposed change

Bump `victron-mqtt` library from `2026.8.4` to `2026.9.2` for the `victron_gx` integration.

Changes include:
- Update `victron-mqtt` dependency version in `manifest.json` and requirements files
- Specifically, this version includes the needed support needed to implement firmware update support.
- Update entity translations (`strings.json`) from latest topic definitions
- Minor changes in types as the library is not using ```Any``` for metric values anymore but the new ```MetricValue```. This was just changed here to make linter happy with this change.
- I had to add support for metric availability as in the old victron-mqtt library getting back ```None``` as value meant that the entity is unavailable and now it is tracked via specific new property so without this small tweak this version bump would break that scenario. This change already works for good few weeks on the custom integration and verified by users.

Changelog: https://github.com/tomer-w/victron_mqtt/compare/v2026.8.4...v2026.9.2

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr