### PR TITLE
Add Tuya EV charger (qccdz) fixture

### DIFF
--- a/tests/components/tuya/fixtures/qccdz_dsmsam7xpb3ht7rl.json
+++ b/tests/components/tuya/fixtures/qccdz_dsmsam7xpb3ht7rl.json
@@ -1,0 +1,157 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "EV Charger",
+  "category": "qccdz",
+  "product_id": "dsmsam7xpb3ht7rl",
+  "product_name": "EV Charger",
+  "online": true,
+  "sub": false,
+  "time_zone": "+03:00",
+  "active_time": "2026-09-04T09:07:25+00:00",
+  "create_time": "2026-09-04T09:07:25+00:00",
+  "update_time": "2026-09-04T09:07:25+00:00",
+  "function": {
+    "charge_cur_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "A",
+        "min": 1,
+        "max": 255,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "work_mode": {
+      "type": "Enum",
+      "value": {
+        "range": [
+          "charge_now",
+          "charge_pct",
+          "charge_energy",
+          "charge_schedule"
+        ]
+      }
+    },
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    }
+  },
+  "status_range": {
+    "forward_energy_total": {
+      "type": "Integer",
+      "value": {
+        "unit": "kW·h",
+        "min": 0,
+        "max": 99999999,
+        "scale": 2,
+        "step": 1
+      },
+      "report_type": "minux"
+    },
+    "work_state": {
+      "type": "Enum",
+      "value": {
+        "range": [
+          "charger_free",
+          "charger_insert",
+          "charger_free_fault",
+          "charger_wait",
+          "charger_charging",
+          "charger_pause",
+          "charger_end",
+          "charger_fault"
+        ]
+      },
+      "report_type": null
+    },
+    "charge_cur_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "A",
+        "min": 1,
+        "max": 255,
+        "scale": 0,
+        "step": 1
+      },
+      "report_type": null
+    },
+    "sigle_phase_power": {
+      "type": "Integer",
+      "value": {
+        "unit": "kW",
+        "min": 0,
+        "max": 99999999,
+        "scale": 3,
+        "step": 1
+      },
+      "report_type": null
+    },
+    "power_total": {
+      "type": "Integer",
+      "value": {
+        "unit": "kW",
+        "min": 0,
+        "max": 99999999,
+        "scale": 3,
+        "step": 1
+      },
+      "report_type": null
+    },
+    "work_mode": {
+      "type": "Enum",
+      "value": {
+        "range": [
+          "charge_now",
+          "charge_pct",
+          "charge_energy",
+          "charge_schedule"
+        ]
+      },
+      "report_type": null
+    },
+    "switch": {
+      "type": "Boolean",
+      "value": {},
+      "report_type": null
+    },
+    "temp_current": {
+      "type": "Integer",
+      "value": {
+        "unit": "℃",
+        "min": -40,
+        "max": 200,
+        "scale": 0,
+        "step": 1
+      },
+      "report_type": null
+    },
+    "charge_energy_once": {
+      "type": "Integer",
+      "value": {
+        "unit": "kW·h",
+        "min": 0,
+        "max": 999999,
+        "scale": 2,
+        "step": 1
+      },
+      "report_type": null
+    }
+  },
+  "status": {
+    "forward_energy_total": 20,
+    "work_state": "charger_free",
+    "charge_cur_set": 10,
+    "sigle_phase_power": 0,
+    "power_total": 0,
+    "work_mode": "charge_now",
+    "switch": false,
+    "temp_current": 24,
+    "charge_energy_once": 0
+  },
+  "set_up": true,
+  "support_local": true
+}

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -5639,6 +5639,36 @@
     'via_device_id': None,
   })
 # ---
+# name: test_device_registry[lr7th3bpx7masmsdzdccq]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tuya',
+        'lr7th3bpx7masmsdzdccq',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Tuya',
+    'model': 'EV Charger',
+    'model_id': 'dsmsam7xpb3ht7rl',
+    'name': 'EV Charger',
+    'name_by_user': None,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
 # name: test_device_registry[m2gpwqz5xb4chzqubdnz]
   DeviceRegistryEntrySnapshot({
     'area_id': None,

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -4235,6 +4235,56 @@
     'state': 'off',
   })
 # ---
+# name: test_platform_setup_and_discovery[switch.ev_charger_switch-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.ev_charger_switch',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Switch',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Switch',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'switch',
+    'unique_id': 'tuya.lr7th3bpx7masmsdzdccqswitch',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.ev_charger_switch-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'EV Charger Switch',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.ev_charger_switch',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_platform_setup_and_discovery[switch.fakkel_veranda_socket_1-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([


### PR DESCRIPTION
## Proposed change

Add the diagnostics fixture for a Tuya `qccdz` EV charger (product `dsmsam7xpb3ht7rl`,
"EV Charger") together with the snapshots it affects today: the device registry entry
and the existing `qccdz` switch.

The device reports `work_state`, `forward_energy_total`, `charge_energy_once`,
`sigle_phase_power`, `power_total`, `temp_current`, `charge_cur_set` and `work_mode`,
none of which are exposed yet. Follow-up PRs add them per platform (sensor, number,
select) on top of this fixture, as requested in #181453 review.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #136207, #117729
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
