### PR TITLE
Restore the last HVAC mode when turning on Matter thermostats

### DIFF
--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -27,6 +27,7 @@ from homeassistant.components.climate import (
 from homeassistant.const import ATTR_TEMPERATURE, Platform, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 
 from .entity import MatterEntity, MatterEntityDescription
 from .helpers import MatterConfigEntry
@@ -207,7 +208,19 @@ class MatterClimateEntityDescription(ClimateEntityDescription, MatterEntityDescr
     """Describe Matter Climate entities."""
 
 
-class MatterClimate(MatterEntity, ClimateEntity):
+@dataclass
+class MatterClimateExtraStoredData(ExtraStoredData):
+    """Store the last running mode separately from the current device state."""
+
+    last_hvac_mode: HVACMode
+
+    @override
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dict representation of the stored data."""
+        return {"last_hvac_mode": self.last_hvac_mode}
+
+
+class MatterClimate(MatterEntity, ClimateEntity, RestoreEntity):
     """Representation of a Matter climate entity."""
 
     _attr_temperature_unit: str = UnitOfTemperature.CELSIUS
@@ -216,6 +229,7 @@ class MatterClimate(MatterEntity, ClimateEntity):
     _attr_preset_mode: str | None = None
     _attr_preset_modes: list[str] | None = None
     _feature_map: int | None = None
+    _last_hvac_mode: HVACMode | None = None
 
     _platform_translation_key = "thermostat"
 
@@ -229,6 +243,36 @@ class MatterClimate(MatterEntity, ClimateEntity):
         self._preset_handle_by_name: dict[str, bytes | None] = {}
         self._preset_name_by_handle: dict[bytes | None, str] = {}
         super().__init__(*args, **kwargs)
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Restore the last running mode without changing the device state."""
+        await super().async_added_to_hass()
+        if self._last_hvac_mode is not None:
+            return
+        if (extra_data := await self.async_get_last_extra_data()) is None:
+            return
+        last_hvac_mode = extra_data.as_dict().get("last_hvac_mode")
+        if last_hvac_mode in self.hvac_modes and last_hvac_mode != HVACMode.OFF:
+            self._last_hvac_mode = HVACMode(last_hvac_mode)
+
+    @property
+    @override
+    def extra_restore_state_data(self) -> MatterClimateExtraStoredData | None:
+        """Return the last running mode for restoration."""
+        if self._last_hvac_mode is None:
+            return None
+        return MatterClimateExtraStoredData(self._last_hvac_mode)
+
+    @override
+    async def async_turn_on(self) -> None:
+        """Turn on using the last supported running mode."""
+        if self.hvac_mode != HVACMode.OFF:
+            return
+        if self._last_hvac_mode is not None and self._last_hvac_mode in self.hvac_modes:
+            await self.async_set_hvac_mode(self._last_hvac_mode)
+            return
+        await super().async_turn_on()
 
     @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
@@ -348,6 +392,11 @@ class MatterClimate(MatterEntity, ClimateEntity):
         self._update_presets()
 
         self._update_hvac_mode_and_action()
+        if (
+            self._attr_hvac_mode != HVACMode.OFF
+            and self._attr_hvac_mode in self.hvac_modes
+        ):
+            self._last_hvac_mode = self._attr_hvac_mode
         self._update_target_temperatures()
         self._update_temperature_limits()
 

--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -269,10 +269,15 @@ class MatterClimate(MatterEntity, ClimateEntity, RestoreEntity):
         """Turn on using the last supported running mode."""
         if self.hvac_mode != HVACMode.OFF:
             return
+        has_dedicated_power = (
+            self.get_matter_attribute_value(clusters.OnOff.Attributes.OnOff) is False
+        )
         if self._last_hvac_mode is not None and self._last_hvac_mode in self.hvac_modes:
             await self.async_set_hvac_mode(self._last_hvac_mode)
-            return
-        await super().async_turn_on()
+        else:
+            await super().async_turn_on()
+        if has_dedicated_power:
+            await self.send_device_command(clusters.OnOff.Commands.On())
 
     @override
     async def async_set_temperature(self, **kwargs: Any) -> None:

--- a/homeassistant/components/matter/climate.py
+++ b/homeassistant/components/matter/climate.py
@@ -364,6 +364,9 @@ class MatterClimate(MatterEntity, ClimateEntity, RestoreEntity):
             value=system_mode_value,
             matter_attribute=clusters.Thermostat.Attributes.SystemMode,
         )
+        # Dedicated power can keep the reported HVAC mode off after a mode write.
+        if hvac_mode != HVACMode.OFF:
+            self._last_hvac_mode = hvac_mode
         # we need to optimistically update the attribute's value here
         # to prevent a race condition when adjusting the mode and temperature
         # in the same call

--- a/tests/components/matter/test_climate.py
+++ b/tests/components/matter/test_climate.py
@@ -15,15 +15,20 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from .common import (
     set_node_attribute,
+    setup_integration_with_node_fixture,
     snapshot_matter_entities,
     trigger_subscription_callback,
 )
+
+from tests.common import mock_restore_cache_with_extra_data
+
+THERMOSTAT_ENTITY_ID = "climate.longan_link_hvac"
 
 
 @pytest.mark.usefixtures("matter_devices")
@@ -775,3 +780,183 @@ async def test_thermostat_with_null_local_temperature(
     state = hass.states.get("climate.longan_link_hvac")
     assert state
     assert state.attributes["current_temperature"] is None
+
+
+@pytest.mark.parametrize("node_fixture", ["longan_link_thermostat"])
+@pytest.mark.parametrize(
+    ("system_mode", "hvac_mode"),
+    [
+        pytest.param(1, HVACMode.HEAT_COOL, id="auto"),
+        pytest.param(3, HVACMode.COOL, id="cool"),
+        pytest.param(4, HVACMode.HEAT, id="heat"),
+    ],
+)
+async def test_turn_on_restores_reported_mode(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+    system_mode: int,
+    hvac_mode: HVACMode,
+) -> None:
+    """Only turn_on restores the mode reported before an external shutdown."""
+    set_node_attribute(matter_node, 1, 513, 28, system_mode)
+    await trigger_subscription_callback(hass, matter_client)
+    set_node_attribute(matter_node, 1, 513, 28, 0)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get(THERMOSTAT_ENTITY_ID)
+    assert state
+    assert state.state == HVACMode.OFF
+    matter_client.write_attribute.assert_not_called()
+    matter_client.send_device_command.assert_not_called()
+
+    await hass.services.async_call(
+        "climate", "turn_on", {"entity_id": THERMOSTAT_ENTITY_ID}, blocking=True
+    )
+
+    matter_client.write_attribute.assert_called_once_with(
+        node_id=matter_node.node_id, attribute_path="1/513/28", value=system_mode
+    )
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(THERMOSTAT_ENTITY_ID)
+    assert state
+    assert state.state == hvac_mode
+
+
+@pytest.mark.parametrize("node_fixture", ["longan_link_thermostat"])
+@pytest.mark.parametrize(
+    "attributes", [{"1/513/28": 1}, {"1/513/28": 3}, {"1/513/28": 4}]
+)
+@pytest.mark.usefixtures("matter_node")
+async def test_turn_on_keeps_running_mode(
+    hass: HomeAssistant, matter_client: MagicMock
+) -> None:
+    """Turning on an already running thermostat does not send commands."""
+    initial_state = hass.states.get(THERMOSTAT_ENTITY_ID)
+    assert initial_state
+    await hass.services.async_call(
+        "climate", "turn_on", {"entity_id": THERMOSTAT_ENTITY_ID}, blocking=True
+    )
+    matter_client.write_attribute.assert_not_called()
+    matter_client.send_device_command.assert_not_called()
+    state = hass.states.get(THERMOSTAT_ENTITY_ID)
+    assert state
+    assert state.state == initial_state.state
+
+
+@pytest.mark.parametrize("node_fixture", ["longan_link_thermostat"])
+async def test_turn_on_after_reload(
+    hass: HomeAssistant, matter_client: MagicMock, matter_node: MatterNode
+) -> None:
+    """Reload keeps the thermostat off until turn_on restores its previous mode."""
+    await hass.services.async_call(
+        "climate", "turn_off", {"entity_id": THERMOSTAT_ENTITY_ID}, blocking=True
+    )
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(THERMOSTAT_ENTITY_ID)
+    assert state
+    assert state.state == HVACMode.OFF
+    matter_client.write_attribute.reset_mock()
+
+    entry = hass.config_entries.async_entries("matter")[0]
+    assert await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(THERMOSTAT_ENTITY_ID)
+    assert state
+    assert state.state == HVACMode.OFF
+    matter_client.write_attribute.assert_not_called()
+    matter_client.send_device_command.assert_not_called()
+    await hass.services.async_call(
+        "climate", "turn_on", {"entity_id": THERMOSTAT_ENTITY_ID}, blocking=True
+    )
+    matter_client.write_attribute.assert_called_once_with(
+        node_id=matter_node.node_id, attribute_path="1/513/28", value=3
+    )
+
+
+@pytest.mark.parametrize(
+    ("stored_mode", "system_mode", "expected_mode"),
+    [
+        pytest.param("cool", 0, 3, id="restore-cool"),
+        pytest.param("heat", 0, 4, id="restore-heat"),
+        pytest.param("heat_cool", 0, 1, id="restore-auto"),
+        pytest.param(None, 0, 1, id="no-history"),
+        pytest.param("off", 0, 1, id="off-history"),
+        pytest.param("invalid", 0, 1, id="invalid-history"),
+        pytest.param("fan_only", 0, 1, id="unsupported-history"),
+        pytest.param("heat", 3, 3, id="live-mode-takes-precedence"),
+    ],
+)
+async def test_turn_on_restored_history(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    stored_mode: str | None,
+    system_mode: int,
+    expected_mode: int,
+) -> None:
+    """Stored history never overrides device state or sends commands on setup."""
+    mock_restore_cache_with_extra_data(
+        hass,
+        [(State(THERMOSTAT_ENTITY_ID, HVACMode.OFF), {"last_hvac_mode": stored_mode})],
+    )
+    matter_node = await setup_integration_with_node_fixture(
+        hass, "longan_link_thermostat", matter_client, {"1/513/28": system_mode}
+    )
+    matter_client.write_attribute.assert_not_called()
+    matter_client.send_device_command.assert_not_called()
+
+    # An external shutdown must not overwrite the last running mode.
+    set_node_attribute(matter_node, 1, 513, 28, 0)
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(THERMOSTAT_ENTITY_ID)
+    assert state
+    assert state.state == HVACMode.OFF
+    matter_client.write_attribute.assert_not_called()
+
+    await hass.services.async_call(
+        "climate", "turn_on", {"entity_id": THERMOSTAT_ENTITY_ID}, blocking=True
+    )
+    matter_client.write_attribute.assert_called_once_with(
+        node_id=matter_node.node_id, attribute_path="1/513/28", value=expected_mode
+    )
+
+
+@pytest.mark.parametrize("node_fixture", ["longan_link_thermostat"])
+async def test_turn_on_after_supported_modes_change(
+    hass: HomeAssistant, matter_client: MagicMock, matter_node: MatterNode
+) -> None:
+    """Fall back when a previously used mode is no longer supported."""
+    set_node_attribute(matter_node, 1, 513, 28, 0)
+    set_node_attribute(
+        matter_node, 1, 513, 65532, clusters.Thermostat.Bitmaps.Feature.kHeating
+    )
+    await trigger_subscription_callback(hass, matter_client)
+    matter_client.write_attribute.assert_not_called()
+
+    await hass.services.async_call(
+        "climate", "turn_on", {"entity_id": THERMOSTAT_ENTITY_ID}, blocking=True
+    )
+    matter_client.write_attribute.assert_called_once_with(
+        node_id=matter_node.node_id, attribute_path="1/513/28", value=4
+    )
+
+
+@pytest.mark.parametrize("node_fixture", ["longan_link_thermostat"])
+async def test_explicit_mode_overrides_history(
+    hass: HomeAssistant, matter_client: MagicMock, matter_node: MatterNode
+) -> None:
+    """An explicit mode command is not replaced by the remembered cooling mode."""
+    await hass.services.async_call(
+        "climate", "turn_off", {"entity_id": THERMOSTAT_ENTITY_ID}, blocking=True
+    )
+    matter_client.write_attribute.reset_mock()
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": THERMOSTAT_ENTITY_ID, "hvac_mode": HVACMode.HEAT},
+        blocking=True,
+    )
+    matter_client.write_attribute.assert_called_once_with(
+        node_id=matter_node.node_id, attribute_path="1/513/28", value=4
+    )

--- a/tests/components/matter/test_climate.py
+++ b/tests/components/matter/test_climate.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, call
 
 from chip.clusters import Objects as clusters
 from matter_server.client.models.node import MatterNode
+from matter_server.common.errors import MatterError
 from matter_server.common.helpers.util import create_attribute_path_from_attribute
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -16,7 +17,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, State
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from .common import (
@@ -29,6 +30,7 @@ from .common import (
 from tests.common import mock_restore_cache_with_extra_data
 
 THERMOSTAT_ENTITY_ID = "climate.longan_link_hvac"
+ROOM_AC_ENTITY_ID = "climate.room_airconditioner"
 
 
 @pytest.mark.usefixtures("matter_devices")
@@ -959,4 +961,87 @@ async def test_explicit_mode_overrides_history(
     )
     matter_client.write_attribute.assert_called_once_with(
         node_id=matter_node.node_id, attribute_path="1/513/28", value=4
+    )
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_room_airconditioner"])
+@pytest.mark.parametrize("attributes", [{"1/6/0": True, "1/513/28": 4}])
+@pytest.mark.parametrize(
+    ("hvac_mode", "system_mode"),
+    [
+        pytest.param(HVACMode.COOL, 3, id="cool"),
+        pytest.param(HVACMode.HEAT_COOL, 1, id="auto"),
+        pytest.param(HVACMode.DRY, 8, id="dry"),
+        pytest.param(HVACMode.FAN_ONLY, 7, id="fan-only"),
+    ],
+)
+async def test_turn_on_uses_mode_selected_with_power_off(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+    hvac_mode: HVACMode,
+    system_mode: int,
+) -> None:
+    """An explicit mode selected while power is off replaces the remembered mode."""
+    set_node_attribute(matter_node, 1, 6, 0, False)
+    await trigger_subscription_callback(hass, matter_client)
+    matter_client.write_attribute.assert_not_called()
+
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": ROOM_AC_ENTITY_ID, "hvac_mode": hvac_mode},
+        blocking=True,
+    )
+    matter_client.write_attribute.assert_called_once_with(
+        node_id=matter_node.node_id, attribute_path="1/513/28", value=system_mode
+    )
+    await trigger_subscription_callback(hass, matter_client)
+    state = hass.states.get(ROOM_AC_ENTITY_ID)
+    assert state
+    assert state.state == HVACMode.OFF
+    matter_client.send_device_command.assert_not_called()
+    matter_client.write_attribute.reset_mock()
+
+    await hass.services.async_call(
+        "climate", "turn_on", {"entity_id": ROOM_AC_ENTITY_ID}, blocking=True
+    )
+    matter_client.write_attribute.assert_called_once_with(
+        node_id=matter_node.node_id, attribute_path="1/513/28", value=system_mode
+    )
+    matter_client.send_device_command.assert_called_once_with(
+        node_id=matter_node.node_id, endpoint_id=1, command=clusters.OnOff.Commands.On()
+    )
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_room_airconditioner"])
+@pytest.mark.parametrize("attributes", [{"1/6/0": True, "1/513/28": 4}])
+async def test_failed_mode_write_keeps_previous_mode(
+    hass: HomeAssistant, matter_client: MagicMock, matter_node: MatterNode
+) -> None:
+    """A failed mode write while power is off does not change the remembered mode."""
+    set_node_attribute(matter_node, 1, 6, 0, False)
+    await trigger_subscription_callback(hass, matter_client)
+    matter_client.write_attribute.side_effect = MatterError("Mode write failed")
+    with pytest.raises(HomeAssistantError, match="Mode write failed"):
+        await hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {"entity_id": ROOM_AC_ENTITY_ID, "hvac_mode": HVACMode.COOL},
+            blocking=True,
+        )
+    matter_client.write_attribute.assert_called_once_with(
+        node_id=matter_node.node_id, attribute_path="1/513/28", value=3
+    )
+    matter_client.send_device_command.assert_not_called()
+    matter_client.write_attribute.reset_mock(side_effect=True)
+
+    await hass.services.async_call(
+        "climate", "turn_on", {"entity_id": ROOM_AC_ENTITY_ID}, blocking=True
+    )
+    matter_client.write_attribute.assert_called_once_with(
+        node_id=matter_node.node_id, attribute_path="1/513/28", value=4
+    )
+    matter_client.send_device_command.assert_called_once_with(
+        node_id=matter_node.node_id, endpoint_id=1, command=clusters.OnOff.Commands.On()
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Matter climate entities now resume their last supported non-off HVAC mode when turned on from Home Assistant, including through dashboard controls and voice commands. For example, an air conditioner turned off while cooling will resume cooling when turned on again. Calling `climate.turn_on` on an already running entity now leaves its mode unchanged.

Previously, entities without a dedicated turn-on implementation selected a mode using Home Assistant's default priority: heat/cool, then heat, then cool. Automations or scripts that relied on that behavior should explicitly call `climate.set_hvac_mode` with the desired mode instead of relying on `climate.turn_on`.

If no previous supported mode is available, the existing fallback behavior is retained. This change applies only to the Matter integration.

This PR was tested with Aqara Hub M3 (bridged IR AC), SwitchBot Hub 2 (bridged IR AC), and Virtual Room AC created by Google MVD.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Restore the last supported non-off HVAC mode when a Matter climate entity receives `climate.turn_on`.

Air conditioners are often used primarily for cooling. For compatibility with controllers, some manufacturers expose their air conditioners as Matter Thermostat devices rather than Room Air Conditioner devices. In this setup, Home Assistant may offer both heating and cooling without an automatic heat/cool mode. Its default turn-on implementation then chooses heating, even if the device was cooling before it was switched off. This makes dashboard quick toggles and voice commands unexpectedly change the operating mode.

Matter 1.6's Thermostat cluster provides a writable `SystemMode`, but no standard configuration for a default turn-on mode or command to resume the last non-off mode. Writing `SystemMode` changes the current mode; it does not configure what a later generic turn-on action should do. See the [Matter 1.6 Thermostat definition](https://github.com/project-chip/connectedhomeip/blob/master/data_model/1.6/clusters/Thermostat.xml).

This follows patterns already used by other Core integrations: Z-Wave JS restores the mode saved before shutdown when native resume is unavailable, KNX remembers modes reported by the device, and Samsung Infrared persists the last non-off mode using extra restore data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
