### PR TITLE
Deduplicate sleepers within a single SleepIQ bed

### DIFF
--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -182,20 +182,18 @@ def _deduplicate_sleepers(gateway: AsyncSleepIQ) -> None:
 
     The API can return the same sleeper_id more than once per bed, which
     causes entity platforms to create entities with colliding unique IDs.
-    Keep only the first occurrence of each sleeper_id. Sleepers with a
-    falsy sleeper_id (None or empty string) are always kept.
+    Keep only the first occurrence of each effective identity. The key is
+    str(sleeper_id) so that falsy values (None, "") also deduplicate
+    correctly; they produce the same unique-ID prefix downstream.
     """
     for bed in gateway.beds.values():
         seen: set[str] = set()
         filtered: list[SleepIQSleeper] = []
         for sleeper in bed.sleepers:
-            sid = sleeper.sleeper_id
-            if not sid:
-                filtered.append(sleeper)
+            key = str(sleeper.sleeper_id)
+            if key in seen:
                 continue
-            if sid in seen:
-                continue
-            seen.add(sid)
+            seen.add(key)
             filtered.append(sleeper)
         if len(filtered) != len(bed.sleepers):
             _LOGGER.debug(

--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -182,9 +182,9 @@ def _deduplicate_sleepers(gateway: AsyncSleepIQ) -> None:
 
     The API can return the same sleeper_id more than once per bed, which
     causes entity platforms to create entities with colliding unique IDs.
-    Keep only the first occurrence of each effective identity. The key is
-    str(sleeper_id) so that falsy values (None, "") also deduplicate
-    correctly; they produce the same unique-ID prefix downstream.
+    Keep only the first occurrence of each effective identity, keyed by
+    str(sleeper_id) so that falsy values (None, "") are also deduplicated
+    rather than skipped.
     """
     for bed in gateway.beds.values():
         seen: set[str] = set()

--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -8,6 +8,7 @@ from asyncsleepiq import (
     SleepIQAPIException,
     SleepIQBed,
     SleepIQLoginException,
+    SleepIQSleeper,
     SleepIQTimeoutException,
 )
 import voluptuous as vol
@@ -94,6 +95,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SleepIQConfigEntry) -> b
         raise ConfigEntryNotReady(str(err) or "Error reading from SleepIQ API") from err
 
     _filter_duplicate_beds(gateway)
+    _deduplicate_sleepers(gateway)
     await _async_migrate_unique_ids(hass, entry, gateway)
 
     coordinator = SleepIQDataUpdateCoordinator(hass, entry, gateway)
@@ -173,6 +175,36 @@ def _filter_duplicate_beds(gateway: AsyncSleepIQ) -> None:
                     best,
                 )
                 del gateway.beds[bed_id]
+
+
+def _deduplicate_sleepers(gateway: AsyncSleepIQ) -> None:
+    """Remove duplicate sleepers within each bed.
+
+    The API can return the same sleeper_id more than once per bed, which
+    causes entity platforms to create entities with colliding unique IDs.
+    Keep only the first occurrence of each sleeper_id. Sleepers with a
+    falsy sleeper_id (None or empty string) are always kept.
+    """
+    for bed in gateway.beds.values():
+        seen: set[str] = set()
+        filtered: list[SleepIQSleeper] = []
+        for sleeper in bed.sleepers:
+            sid = sleeper.sleeper_id
+            if not sid:
+                filtered.append(sleeper)
+                continue
+            if sid in seen:
+                continue
+            seen.add(sid)
+            filtered.append(sleeper)
+        if len(filtered) != len(bed.sleepers):
+            _LOGGER.debug(
+                "Removed %d duplicate sleeper(s) from bed '%s' (id=%s)",
+                len(bed.sleepers) - len(filtered),
+                bed.name,
+                bed.id,
+            )
+            bed.sleepers = filtered
 
 
 async def _async_migrate_unique_ids(

--- a/tests/components/sleepiq/test_init.py
+++ b/tests/components/sleepiq/test_init.py
@@ -18,6 +18,7 @@ from asyncsleepiq import (
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.sleepiq import _deduplicate_sleepers
 from homeassistant.components.sleepiq.const import DOMAIN, IS_IN_BED, SLEEP_NUMBER
 from homeassistant.components.sleepiq.coordinator import (
     LONGER_UPDATE_INTERVAL,
@@ -25,7 +26,7 @@ from homeassistant.components.sleepiq.coordinator import (
     UPDATE_INTERVAL,
 )
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
-from homeassistant.const import CONF_USERNAME, PRESSURE
+from homeassistant.const import CONF_USERNAME, PRESSURE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -356,3 +357,98 @@ async def test_duplicate_beds_none_sleeper_ids_not_filtered(
     entry = await setup_platform(hass, "sensor")
     assert entry.state is ConfigEntryState.LOADED
     assert "ghost_001" in mock_asyncsleepiq.beds
+
+
+def test_deduplicate_sleepers_removes_duplicates() -> None:
+    """Test that duplicate sleepers with the same sleeper_id are removed."""
+    gateway = MagicMock()
+    bed = create_autospec(SleepIQBed)
+    bed.name = "Test Bed"
+    bed.id = "bed_1"
+
+    sleeper_a = create_autospec(SleepIQSleeper)
+    sleeper_a.sleeper_id = "0"
+    sleeper_a.side = Side.LEFT
+
+    sleeper_b = create_autospec(SleepIQSleeper)
+    sleeper_b.sleeper_id = "0"
+    sleeper_b.side = Side.RIGHT
+
+    bed.sleepers = [sleeper_a, sleeper_b]
+    gateway.beds = {"bed_1": bed}
+
+    _deduplicate_sleepers(gateway)
+
+    assert len(bed.sleepers) == 1
+    assert bed.sleepers[0] is sleeper_a
+
+
+def test_deduplicate_sleepers_keeps_distinct() -> None:
+    """Test that distinct sleeper IDs are preserved and falsy IDs are never deduplicated."""
+    gateway = MagicMock()
+    bed = create_autospec(SleepIQBed)
+    bed.name = "Test Bed"
+    bed.id = "bed_1"
+
+    sleeper_a = create_autospec(SleepIQSleeper)
+    sleeper_a.sleeper_id = SLEEPER_L_ID
+
+    sleeper_b = create_autospec(SleepIQSleeper)
+    sleeper_b.sleeper_id = SLEEPER_R_ID
+
+    # Two sleepers with None IDs should both be kept
+    sleeper_c = create_autospec(SleepIQSleeper)
+    sleeper_c.sleeper_id = None
+
+    sleeper_d = create_autospec(SleepIQSleeper)
+    sleeper_d.sleeper_id = None
+
+    bed.sleepers = [sleeper_a, sleeper_b, sleeper_c, sleeper_d]
+    gateway.beds = {"bed_1": bed}
+
+    _deduplicate_sleepers(gateway)
+
+    assert len(bed.sleepers) == 4
+    assert bed.sleepers[0] is sleeper_a
+    assert bed.sleepers[1] is sleeper_b
+    assert bed.sleepers[2] is sleeper_c
+    assert bed.sleepers[3] is sleeper_d
+
+
+def test_deduplicate_sleepers_empty() -> None:
+    """Test that an empty sleeper list causes no error."""
+    gateway = MagicMock()
+    bed = create_autospec(SleepIQBed)
+    bed.name = "Empty Bed"
+    bed.id = "bed_1"
+    bed.sleepers = []
+    gateway.beds = {"bed_1": bed}
+
+    _deduplicate_sleepers(gateway)
+
+    assert bed.sleepers == []
+
+
+async def test_duplicate_sleepers_no_unique_id_errors(
+    hass: HomeAssistant,
+    mock_asyncsleepiq: MagicMock,
+    mock_bed: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that duplicate sleepers do not produce unique ID errors."""
+    # Add a duplicate of the left sleeper
+    dup_sleeper = create_autospec(SleepIQSleeper)
+    dup_sleeper.side = Side.RIGHT
+    dup_sleeper.name = "Duplicate"
+    dup_sleeper.sleeper_id = SLEEPER_L_ID
+    dup_sleeper.in_bed = False
+    dup_sleeper.sleep_number = 50
+    dup_sleeper.pressure = 1200
+    dup_sleeper.sleep_data = SleepData(
+        duration=0, sleep_score=0, heart_rate=0, respiratory_rate=0, hrv=0
+    )
+    mock_bed.sleepers.append(dup_sleeper)
+
+    entry = await setup_platform(hass, Platform.BINARY_SENSOR)
+    assert entry.state is ConfigEntryState.LOADED
+    assert "does not generate unique IDs" not in caplog.text

--- a/tests/components/sleepiq/test_init.py
+++ b/tests/components/sleepiq/test_init.py
@@ -384,7 +384,7 @@ def test_deduplicate_sleepers_removes_duplicates() -> None:
 
 
 def test_deduplicate_sleepers_keeps_distinct() -> None:
-    """Test that distinct sleeper IDs are preserved and falsy IDs are never deduplicated."""
+    """Test that distinct sleeper IDs are preserved and falsy IDs are deduplicated."""
     gateway = MagicMock()
     bed = create_autospec(SleepIQBed)
     bed.name = "Test Bed"
@@ -396,7 +396,6 @@ def test_deduplicate_sleepers_keeps_distinct() -> None:
     sleeper_b = create_autospec(SleepIQSleeper)
     sleeper_b.sleeper_id = SLEEPER_R_ID
 
-    # Two sleepers with None IDs should both be kept
     sleeper_c = create_autospec(SleepIQSleeper)
     sleeper_c.sleeper_id = None
 
@@ -408,11 +407,10 @@ def test_deduplicate_sleepers_keeps_distinct() -> None:
 
     _deduplicate_sleepers(gateway)
 
-    assert len(bed.sleepers) == 4
+    assert len(bed.sleepers) == 3
     assert bed.sleepers[0] is sleeper_a
     assert bed.sleepers[1] is sleeper_b
     assert bed.sleepers[2] is sleeper_c
-    assert bed.sleepers[3] is sleeper_d
 
 
 def test_deduplicate_sleepers_empty() -> None:

--- a/tests/components/sleepiq/test_init.py
+++ b/tests/components/sleepiq/test_init.py
@@ -402,15 +402,22 @@ def test_deduplicate_sleepers_keeps_distinct() -> None:
     sleeper_d = create_autospec(SleepIQSleeper)
     sleeper_d.sleeper_id = None
 
-    bed.sleepers = [sleeper_a, sleeper_b, sleeper_c, sleeper_d]
+    sleeper_e = create_autospec(SleepIQSleeper)
+    sleeper_e.sleeper_id = ""
+
+    sleeper_f = create_autospec(SleepIQSleeper)
+    sleeper_f.sleeper_id = ""
+
+    bed.sleepers = [sleeper_a, sleeper_b, sleeper_c, sleeper_d, sleeper_e, sleeper_f]
     gateway.beds = {"bed_1": bed}
 
     _deduplicate_sleepers(gateway)
 
-    assert len(bed.sleepers) == 3
+    assert len(bed.sleepers) == 4
     assert bed.sleepers[0] is sleeper_a
     assert bed.sleepers[1] is sleeper_b
     assert bed.sleepers[2] is sleeper_c
+    assert bed.sleepers[3] is sleeper_e
 
 
 def test_deduplicate_sleepers_empty() -> None:

--- a/tests/components/sleepiq/test_init.py
+++ b/tests/components/sleepiq/test_init.py
@@ -434,7 +434,6 @@ async def test_duplicate_sleepers_no_unique_id_errors(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that duplicate sleepers do not produce unique ID errors."""
-    # Add a duplicate of the left sleeper
     dup_sleeper = create_autospec(SleepIQSleeper)
     dup_sleeper.side = Side.RIGHT
     dup_sleeper.name = "Duplicate"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The SleepIQ API can return the same `sleeper_id` on both sides of a bed (typically the `"0"` placeholder for an unassigned side). After #178682 removed duplicate *bed* objects, this remaining duplication within a single bed still produces colliding unique IDs during entity setup:

```
ERROR [homeassistant.components.binary_sensor] Platform sleepiq does not generate unique IDs. ID 0_is_in_bed already exists
ERROR [homeassistant.components.number] Platform sleepiq does not generate unique IDs. ID 0_firmness already exists
ERROR [homeassistant.components.sensor] Platform sleepiq does not generate unique IDs. ID 0_pressure already exists
```

(repeated for sleep_number, sleep_score, sleep_duration, heart_rate, respiratory_rate, hrv)

This adds `_deduplicate_sleepers()` in the same pattern as the existing `_filter_duplicate_beds()`. It keeps only the first occurrence of each `sleeper_id` per bed, using `str(sleeper_id)` as the dedup key so that falsy values (None, empty string) also deduplicate correctly rather than bypassing the check and colliding on their string representation downstream.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #175191
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
