### PR TITLE
Add announce support to HEOS

### DIFF
--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -1,5 +1,6 @@
 """Denon HEOS Media Player."""
 
+import asyncio
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
 import dataclasses
@@ -25,6 +26,7 @@ from pyheos.util import mediauri as heos_source
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
+    ATTR_MEDIA_ANNOUNCE,
     ATTR_MEDIA_ENQUEUE,
     BrowseError,
     BrowseMedia,
@@ -183,13 +185,179 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             serial_number=player.serial,  # Only available for some models
             sw_version=player.version,
         )
+        # Announcement state tracking
+        self._announce_restore_state: dict[str, Any] | None = None
+        self._announce_in_progress: bool = False
+        self._announce_completed: bool = False
         super().__init__(coordinator, context=player.player_id)
 
     async def _player_update(self, event: str) -> None:
         """Handle player attribute updated."""
         if event == heos_const.EVENT_PLAYER_NOW_PLAYING_PROGRESS:
             self._media_position_updated_at = utcnow()
+        
+        # Check for announcement completion
+        if self._announce_in_progress and event == heos_const.EVENT_PLAYER_STATE_CHANGED:
+            await self._check_announcement_completion()
+        
         self._handle_coordinator_update()
+
+    async def _play_announcement(self, media_id: str, kwargs: dict[str, Any]) -> None:
+        """Play an announcement with pause/resume functionality."""
+        # Reset completion flag for new announcement
+        self._announce_completed = False
+        
+        # Check if we should save and restore state
+        if self._player.state == PlayState.PLAY:
+            self._announce_restore_state = self._snapshot_state()
+            self._announce_restore_state["tts_url"] = media_id
+            _LOGGER.debug("Saving state for announcement: %s", self._announce_restore_state)
+            
+            # Pause the current playback
+            await self._player.pause()
+            # Give the pause command time to take effect
+            await asyncio.sleep(0.5)
+        
+        # Mark announcement as in progress
+        self._announce_in_progress = True
+        
+        # Set volume if specified in extra
+        extra = kwargs.get("extra", {})
+        if "volume" in extra:
+            try:
+                volume_level = float(extra["volume"]) / 100
+                await self._player.set_volume(int(volume_level * 100))
+            except (ValueError, TypeError) as err:
+                _LOGGER.warning("Invalid volume level for announcement: %s", err)
+        
+        # Play the announcement
+        await self._player.play_url(media_id)
+
+    def _snapshot_state(self) -> dict[str, Any]:
+        """Snapshot the current player state for restoration after announcement."""
+        return {
+            "was_playing": self._player.state == PlayState.PLAY,
+            "volume": self._player.volume,
+            "is_muted": self._player.is_muted,
+            "repeat": self._player.repeat,
+            "shuffle": self._player.shuffle,
+            "media_id": self._player.now_playing_media.media_id,
+            "tts_url": None,
+        }
+
+    async def _restore_state(self) -> None:
+        """Restore the player state after announcement completion."""
+        if not self._announce_restore_state:
+            return
+        
+        state = self._announce_restore_state
+        _LOGGER.debug("Restoring state after announcement: %s", state)
+        
+        try:
+            # Remove TTS from queue if it was added
+            if state["tts_url"]:
+                # Small delay to ensure HEOS has processed the state change
+                await asyncio.sleep(0.2)
+                await self._remove_tts_from_queue(state["tts_url"])
+            
+            # Restore volume
+            await self._player.set_volume(state["volume"])
+            
+            # Restore mute state
+            if state["is_muted"] != self._player.is_muted:
+                await self._player.set_mute(state["is_muted"])
+            
+            # Restore play mode
+            await self._player.set_play_mode(state["repeat"], state["shuffle"])
+            
+            # Resume playback if it was playing before
+            if state["was_playing"]:
+                # Check if we're still on the TTS track - if so, skip it
+                current_media_id = self._player.now_playing_media.media_id
+                if current_media_id == state.get("tts_url"):
+                    try:
+                        _LOGGER.debug("Still on TTS track, skipping to next")
+                        await self._player.play_next()
+                    except HeosError as err:
+                        _LOGGER.debug("Could not skip TTS track: %s", err)
+                        # Fallback to just play
+                        await self._player.play()
+                else:
+                    # Already moved to next track or different media, just ensure we're playing
+                    if self._player.state != PlayState.PLAY:
+                        _LOGGER.debug("Not on TTS track, ensuring playback continues")
+                        await self._player.play()
+            
+            _LOGGER.debug("State restoration completed")
+        except HeosError as err:
+            _LOGGER.error("Error restoring state after announcement: %s", err)
+        finally:
+            # Clear the announcement state
+            self._announce_restore_state = None
+            self._announce_in_progress = False
+            self._announce_completed = False
+
+    async def _remove_tts_from_queue(self, tts_url: str) -> None:
+        """Remove TTS URL from the queue if it was added."""
+        try:
+            # Get current queue after TTS
+            queue_after = await self._player.get_queue()
+            _LOGGER.debug("Queue after TTS: %d items", len(queue_after))
+            
+            # Find all "Url Stream" items (based on the log analysis)
+            tts_queue_ids = []
+            for item in queue_after:
+                # Check for the exact TTS characteristics from the logs
+                if (hasattr(item, 'song') and item.song == "Url Stream" and
+                    hasattr(item, 'album') and item.album == "Url Stream" and
+                    hasattr(item, 'artist') and item.artist == "Url Stream"):
+                    tts_queue_ids.append(item.queue_id)
+                    _LOGGER.debug(
+                        "Found TTS Url Stream item: queue_id=%s, song=%s, media_id=%s",
+                        item.queue_id, item.song, getattr(item, 'media_id', 'N/A')
+                    )
+            
+            # Remove TTS items from queue
+            if tts_queue_ids:
+                _LOGGER.debug("Removing TTS Url Stream items from queue: %s", tts_queue_ids)
+                await self._player.remove_from_queue(tts_queue_ids)
+            else:
+                _LOGGER.debug("No TTS Url Stream items found to remove")
+                
+        except HeosError as err:
+            _LOGGER.warning("Could not remove TTS from queue: %s", err)
+
+    async def _check_announcement_completion(self) -> None:
+        """Check if the announcement has completed and restore state."""
+        # Prevent multiple restoration attempts
+        if self._announce_completed:
+            return
+            
+        if not self._announce_in_progress or not self._announce_restore_state:
+            return
+        
+        # Wait a moment to ensure the state change is processed
+        await asyncio.sleep(0.5)
+        
+        # Check if announcement has completed
+        current_media_id = self._player.now_playing_media.media_id
+        tts_url = self._announce_restore_state.get("tts_url")
+        
+        # Simple completion detection: if we're not playing the TTS URL anymore
+        # This handles both cases where TTS stops or moves to next track
+        if current_media_id != tts_url:
+            # Give it a moment to ensure this is a permanent state change
+            await asyncio.sleep(0.3)
+            
+            # Double-check the state is stable
+            if self._player.now_playing_media.media_id != tts_url:
+                # Mark as completed to prevent multiple triggers
+                self._announce_completed = True
+                _LOGGER.debug(
+                    "Announcement completed - was playing TTS, now playing: %s, state: %s",
+                    current_media_id, self._player.state
+                )
+                await self._restore_state()
 
     @callback
     @override
@@ -301,6 +469,9 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
         """Play a piece of media."""
+        # Handle announce parameter for TTS announcements
+        announce = kwargs.get(ATTR_MEDIA_ANNOUNCE, False)
+        
         if heos_source.is_media_uri(media_id):
             media, _data = heos_source.from_media_uri(media_id)
             if not isinstance(media, MediaItem):
@@ -320,6 +491,11 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
 
         if media_type in {MediaType.URL, MediaType.MUSIC}:
             media_id = async_process_play_media_url(self.hass, media_id)
+
+            # Handle announcement mode
+            if announce:
+                await self._play_announcement(media_id, kwargs)
+                return
 
             await self._player.play_url(media_id)
             return

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -1,28 +1,14 @@
 """Denon HEOS Media Player."""
 
 import asyncio
+import dataclasses
+import logging
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
-import dataclasses
 from datetime import datetime
 from functools import reduce, wraps
-import logging
 from operator import ior
 from typing import Any, Final, override
-
-from pyheos import (
-    AddCriteriaType,
-    ControlType,
-    HeosError,
-    HeosPlayer,
-    MediaItem,
-    MediaMusicSource,
-    MediaType as HeosMediaType,
-    PlayState,
-    RepeatType,
-    const as heos_const,
-)
-from pyheos.util import mediauri as heos_source
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
@@ -47,6 +33,23 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.dt import utcnow
+from pyheos import (
+    AddCriteriaType,
+    ControlType,
+    HeosError,
+    HeosPlayer,
+    MediaItem,
+    MediaMusicSource,
+    PlayState,
+    RepeatType,
+)
+from pyheos import (
+    MediaType as HeosMediaType,
+)
+from pyheos import (
+    const as heos_const,
+)
+from pyheos.util import mediauri as heos_source
 
 from . import services
 from .const import DOMAIN
@@ -138,14 +141,14 @@ type _FuncType[**_P, _R] = Callable[_P, Awaitable[_R]]
 type _ReturnFuncType[**_P, _R] = Callable[_P, Coroutine[Any, Any, _R]]
 
 
-def catch_action_error[**_P, _R](
+def catch_action_error[**P, R](
     action: str,
-) -> Callable[[_FuncType[_P, _R]], _ReturnFuncType[_P, _R]]:
+) -> Callable[[_FuncType[P, R]], _ReturnFuncType[P, R]]:
     """Return decorator that catches errors and raises HomeAssistantError."""
 
-    def decorator(func: _FuncType[_P, _R]) -> _ReturnFuncType[_P, _R]:
+    def decorator(func: _FuncType[P, R]) -> _ReturnFuncType[P, R]:
         @wraps(func)
-        async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             try:
                 return await func(*args, **kwargs)
             except (HeosError, ValueError) as ex:
@@ -189,6 +192,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self._announce_restore_state: dict[str, Any] | None = None
         self._announce_in_progress: bool = False
         self._announce_completed: bool = False
+        self._announce_completion_task: asyncio.Task[None] | None = None
         super().__init__(coordinator, context=player.player_id)
 
     async def _player_update(self, event: str) -> None:
@@ -196,14 +200,27 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         if event == heos_const.EVENT_PLAYER_NOW_PLAYING_PROGRESS:
             self._media_position_updated_at = utcnow()
         
-        # Check for announcement completion
-        if self._announce_in_progress and event == heos_const.EVENT_PLAYER_STATE_CHANGED:
-            await self._check_announcement_completion()
+        # Check for announcement completion in the background so this event
+        # callback does not delay coordinator updates.
+        if (
+            self._announce_in_progress
+            and event == heos_const.EVENT_PLAYER_STATE_CHANGED
+            and (
+                self._announce_completion_task is None
+                or self._announce_completion_task.done()
+            )
+        ):
+            self._announce_completion_task = self.hass.async_create_task(
+                self._check_announcement_completion()
+            )
         
         self._handle_coordinator_update()
 
     async def _play_announcement(self, media_id: str, kwargs: dict[str, Any]) -> None:
         """Play an announcement with pause/resume functionality."""
+        if self._announce_completion_task and not self._announce_completion_task.done():
+            self._announce_completion_task.cancel()
+
         # Reset completion flag for new announcement
         self._announce_completed = False
         
@@ -211,7 +228,9 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         if self._player.state == PlayState.PLAY:
             self._announce_restore_state = self._snapshot_state()
             self._announce_restore_state["tts_url"] = media_id
-            _LOGGER.debug("Saving state for announcement: %s", self._announce_restore_state)
+            LOGGER.debug(
+                "Saving state for announcement: %s", self._announce_restore_state
+            )
             
             # Pause the current playback
             await self._player.pause()
@@ -282,11 +301,10 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                         _LOGGER.debug("Could not skip TTS track: %s", err)
                         # Fallback to just play
                         await self._player.play()
-                else:
-                    # Already moved to next track or different media, just ensure we're playing
-                    if self._player.state != PlayState.PLAY:
-                        _LOGGER.debug("Not on TTS track, ensuring playback continues")
-                        await self._player.play()
+                # Already moved to next track or different media, just ensure we're playing
+                elif self._player.state != PlayState.PLAY:
+                    _LOGGER.debug("Not on TTS track, ensuring playback continues")
+                    await self._player.play()
             
             _LOGGER.debug("State restoration completed")
         except HeosError as err:
@@ -308,18 +326,27 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             tts_queue_ids = []
             for item in queue_after:
                 # Check for the exact TTS characteristics from the logs
-                if (hasattr(item, 'song') and item.song == "Url Stream" and
-                    hasattr(item, 'album') and item.album == "Url Stream" and
-                    hasattr(item, 'artist') and item.artist == "Url Stream"):
+                if (
+                    hasattr(item, "song")
+                    and item.song == "Url Stream"
+                    and hasattr(item, "album")
+                    and item.album == "Url Stream"
+                    and hasattr(item, "artist")
+                    and item.artist == "Url Stream"
+                ):
                     tts_queue_ids.append(item.queue_id)
                     _LOGGER.debug(
                         "Found TTS Url Stream item: queue_id=%s, song=%s, media_id=%s",
-                        item.queue_id, item.song, getattr(item, 'media_id', 'N/A')
+                        item.queue_id,
+                        item.song,
+                        getattr(item, "media_id", "N/A"),
                     )
             
             # Remove TTS items from queue
             if tts_queue_ids:
-                _LOGGER.debug("Removing TTS Url Stream items from queue: %s", tts_queue_ids)
+                _LOGGER.debug(
+                    "Removing TTS Url Stream items from queue: %s", tts_queue_ids
+                )
                 await self._player.remove_from_queue(tts_queue_ids)
             else:
                 _LOGGER.debug("No TTS Url Stream items found to remove")
@@ -355,7 +382,8 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 self._announce_completed = True
                 _LOGGER.debug(
                     "Announcement completed - was playing TTS, now playing: %s, state: %s",
-                    current_media_id, self._player.state
+                    current_media_id,
+                    self._player.state,
                 )
                 await self._restore_state()
 

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -18,13 +18,9 @@ from pyheos import (
     HeosPlayer,
     MediaItem,
     MediaMusicSource,
+    MediaType as HeosMediaType,
     PlayState,
     RepeatType,
-)
-from pyheos import (
-    MediaType as HeosMediaType,
-)
-from pyheos import (
     const as heos_const,
 )
 from pyheos.util import mediauri as heos_source
@@ -71,6 +67,7 @@ BASE_SUPPORTED_FEATURES = (
     | MediaPlayerEntityFeature.GROUPING
     | MediaPlayerEntityFeature.BROWSE_MEDIA
     | MediaPlayerEntityFeature.MEDIA_ENQUEUE
+    | MediaPlayerEntityFeature.MEDIA_ANNOUNCE
 )
 
 PLAY_STATE_TO_STATE = {
@@ -196,6 +193,9 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self._announce_completed: bool = False
         self._announce_completion_task: asyncio.Task[None] | None = None
         self._announce_lock = asyncio.Lock()
+        self._announce_media_signature: dict[str, Any] | None = None
+        self._announce_started: bool = False
+        self._announce_start_time: datetime | None = None
         super().__init__(coordinator, context=player.player_id)
 
     async def _player_update(self, event: str) -> None:
@@ -232,6 +232,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             self._announce_completed = False
             self._announce_restore_state = self._snapshot_state()
             self._announce_restore_state["tts_url"] = media_id
+            self._announce_restore_state["queue_ids_before"] = None
             try:
                 queue_before = await self._player.get_queue()
             except HeosError as err:
@@ -252,22 +253,33 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 # Give the pause command time to take effect.
                 await asyncio.sleep(0.5)
 
-            self._announce_in_progress = True
-
             # Set volume if specified in extra. HEOS expects a percentage,
             # while Home Assistant volume values are normalized to 0..1.
             extra = kwargs.get("extra", {})
-            if "volume" in extra:
-                volume = float(extra["volume"])
-                if not math.isfinite(volume) or not 0 <= volume <= 100:
-                    raise ValueError("Announcement volume must be between 0 and 100")
-                volume_percent = round(volume * 100 if volume <= 1 else volume)
+            if (volume_percent := self._parse_announcement_volume(extra)) is not None:
                 await self._player.set_volume(volume_percent)
 
             await self._player.play_url(media_id)
+            self._announce_in_progress = True
+            self._announce_started = False
+            self._announce_media_signature = None
+            self._announce_start_time = utcnow()
+            self.hass.async_create_task(self._capture_announcement_signature())
         except asyncio.CancelledError:
-            self._clear_announcement_state()
-            self._announce_lock.release()
+            if self._announce_restore_state:
+                restore_task = self.hass.async_create_task(self._restore_state())
+                try:
+                    await asyncio.shield(restore_task)
+                except asyncio.CancelledError:
+                    pass
+                except Exception as err:
+                    _LOGGER.warning(
+                        "Could not restore state after announcement cancellation: %s",
+                        err,
+                    )
+            else:
+                self._clear_announcement_state()
+                self._announce_lock.release()
             raise
         except Exception:
             if self._announce_restore_state:
@@ -275,6 +287,64 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             else:
                 self._announce_lock.release()
             raise
+
+    async def _capture_announcement_signature(self) -> None:
+        """Capture the actual HEOS media signature for the announcement."""
+        for _ in range(8):
+            await asyncio.sleep(0.25)
+            if not self._announce_in_progress or not self._announce_restore_state:
+                return
+
+            current_media = self._player.now_playing_media
+            if not self._is_announcement_media(
+                current_media, self._announce_restore_state["tts_url"]
+            ):
+                continue
+
+            self._announce_media_signature = self._media_signature(current_media)
+            self._announce_started = True
+            _LOGGER.debug(
+                "Captured announcement media signature: %s",
+                self._announce_media_signature,
+            )
+            break
+
+        if not self._announce_in_progress or not self._announce_start_time:
+            return
+        elapsed = (utcnow() - self._announce_start_time).total_seconds()
+        if elapsed < 2.0:
+            await asyncio.sleep(2.0 - elapsed)
+        await self._check_announcement_completion()
+
+    @staticmethod
+    def _media_signature(media: Any) -> dict[str, Any]:
+        """Return the HEOS fields used to identify the current media."""
+        return {
+            "media_id": media.media_id,
+            "song": getattr(media, "song", None),
+            "album": getattr(media, "album", None),
+            "artist": getattr(media, "artist", None),
+        }
+
+    @staticmethod
+    def _is_announcement_media(media: Any, tts_url: str) -> bool:
+        """Return whether HEOS reports the requested URL announcement."""
+        return media.media_id == tts_url or (
+            media.song == "Url Stream"
+            and media.album == "Url Stream"
+            and media.artist == "Url Stream"
+        )
+
+    @staticmethod
+    def _parse_announcement_volume(extra: dict[str, Any]) -> int | None:
+        """Convert an announcement volume to the HEOS percentage scale."""
+        if "volume" not in extra:
+            return None
+
+        volume = float(extra["volume"])
+        if not math.isfinite(volume) or not 0 <= volume <= 100:
+            raise ValueError("Announcement volume must be between 0 and 100")
+        return round(volume * 100 if volume <= 1 else volume)
 
     def _snapshot_state(self) -> dict[str, Any]:
         """Snapshot the current player state for restoration after announcement."""
@@ -293,60 +363,75 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         """Restore the player state after announcement completion."""
         if not self._announce_restore_state:
             return
-        
+
         state = self._announce_restore_state
         _LOGGER.debug("Restoring state after announcement: %s", state)
-        
+
         try:
-            # Remove TTS from queue if it was added
+            # Remove TTS from queue if it was added.
             if state["tts_url"]:
-                # Small delay to ensure HEOS has processed the state change
                 await asyncio.sleep(0.2)
                 await self._remove_tts_from_queue(
                     state["tts_url"], state["queue_ids_before"]
                 )
-            
-            # Restore volume
-            await self._player.set_volume(state["volume"])
-            
-            # Restore mute state
-            if state["is_muted"] != self._player.is_muted:
-                await self._player.set_mute(state["is_muted"])
-            
-            # Restore play mode
-            await self._player.set_play_mode(state["repeat"], state["shuffle"])
-            
-            # Restore the playback state from before the announcement.
-            if state["play_state"] == PlayState.PLAY:
-                # Check if we're still on the TTS track - if so, skip it
-                current_media_id = self._player.now_playing_media.media_id
-                if current_media_id == state.get("tts_url"):
-                    try:
-                        _LOGGER.debug("Still on TTS track, skipping to next")
-                        await self._player.play_next()
-                    except HeosError as err:
-                        _LOGGER.debug("Could not skip TTS track: %s", err)
-                        # Fallback to just play
+
+            # Restore independent settings even when an earlier command fails.
+            try:
+                await self._player.set_volume(state["volume"])
+            except HeosError as err:
+                _LOGGER.warning(
+                    "Could not restore volume after announcement: %s", err
+                )
+
+            try:
+                if state["is_muted"] != self._player.is_muted:
+                    await self._player.set_mute(state["is_muted"])
+            except HeosError as err:
+                _LOGGER.warning(
+                    "Could not restore mute state after announcement: %s", err
+                )
+
+            try:
+                await self._player.set_play_mode(state["repeat"], state["shuffle"])
+            except HeosError as err:
+                _LOGGER.warning(
+                    "Could not restore play mode after announcement: %s", err
+                )
+
+            try:
+                # Restore the playback state from before the announcement.
+                if state["play_state"] == PlayState.PLAY:
+                    current_media_id = self._player.now_playing_media.media_id
+                    if current_media_id == state.get("tts_url"):
+                        try:
+                            _LOGGER.debug("Still on TTS track, skipping to next")
+                            await self._player.play_next()
+                        except HeosError as err:
+                            _LOGGER.debug("Could not skip TTS track: %s", err)
+                            await self._player.play()
+                    elif self._player.state != PlayState.PLAY:
+                        _LOGGER.debug("Not on TTS track, ensuring playback continues")
                         await self._player.play()
-                # Already moved to next track or different media; ensure playback.
-                elif self._player.state != PlayState.PLAY:
-                    _LOGGER.debug("Not on TTS track, ensuring playback continues")
-                    await self._player.play()
-            elif state["play_state"] == PlayState.PAUSE:
-                if self._player.state != PlayState.PAUSE:
-                    await self._player.pause()
-            elif state["play_state"] == PlayState.STOP:
-                if self._player.state != PlayState.STOP:
-                    await self._player.stop()
-            
+                elif state["play_state"] == PlayState.PAUSE:
+                    if self._player.state != PlayState.PAUSE:
+                        await self._player.pause()
+                elif state["play_state"] == PlayState.STOP:
+                    if self._player.state != PlayState.STOP:
+                        await self._player.stop()
+            except HeosError as err:
+                _LOGGER.warning(
+                    "Could not restore playback after announcement: %s", err
+                )
+
             _LOGGER.debug("State restoration completed")
-        except HeosError as err:
-            _LOGGER.error("Error restoring state after announcement: %s", err)
         finally:
             # Clear the announcement state
             self._announce_restore_state = None
             self._announce_in_progress = False
             self._announce_completed = False
+            self._announce_media_signature = None
+            self._announce_started = False
+            self._announce_start_time = None
             self._announce_lock.release()
 
     def _clear_announcement_state(self) -> None:
@@ -354,6 +439,9 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self._announce_restore_state = None
         self._announce_in_progress = False
         self._announce_completed = False
+        self._announce_media_signature = None
+        self._announce_started = False
+        self._announce_start_time = None
 
     async def _remove_tts_from_queue(
         self, tts_url: str, queue_ids_before: set[int] | None
@@ -373,10 +461,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             # Match only the URL created by this announcement.
             tts_queue_ids = []
             for item in queue_after:
-                if (
-                    item.media_id == tts_url
-                    and item.queue_id not in queue_ids_before
-                ):
+                if item.media_id == tts_url and item.queue_id not in queue_ids_before:
                     tts_queue_ids.append(item.queue_id)
                     _LOGGER.debug(
                         "Found TTS Url Stream item: queue_id=%s, song=%s, media_id=%s",
@@ -399,40 +484,73 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
 
     async def _check_announcement_completion(self) -> None:
         """Check if the announcement has completed and restore state."""
-        # Prevent multiple restoration attempts
         if self._announce_completed:
             return
-            
+
         if not self._announce_in_progress or not self._announce_restore_state:
             return
-        
-        # Wait a moment to ensure the state change is processed
+
+        restore_state = self._announce_restore_state
+        tts_url = restore_state["tts_url"]
+
+        # Ignore startup events for two seconds so the pre-announcement media
+        # cannot be mistaken for a completed announcement.
+        if self._announce_start_time:
+            elapsed = (utcnow() - self._announce_start_time).total_seconds()
+            if elapsed < 2.0 and not self._announce_started:
+                return
+
         await asyncio.sleep(0.5)
-        
-        # Check if announcement has completed
-        current_media_id = self._player.now_playing_media.media_id
-        tts_url = self._announce_restore_state.get("tts_url")
-        
-        # Completion is signaled either by moving to another media item or by
-        # leaving the playing state while the TTS item remains current.
-        if current_media_id != tts_url or self._player.state != PlayState.PLAY:
-            # Give it a moment to ensure this is a permanent state change
-            await asyncio.sleep(0.3)
-            
-            # Double-check the state is stable
-            if (
-                self._player.now_playing_media.media_id != tts_url
-                or self._player.state != PlayState.PLAY
-            ):
-                # Mark as completed to prevent multiple triggers
-                self._announce_completed = True
-                _LOGGER.debug(
-                    "Announcement completed - was playing TTS, now playing: %s, "
-                    "state: %s",
-                    current_media_id,
-                    self._player.state,
-                )
-                await self._restore_state()
+
+        if (
+            not self._announce_in_progress
+            or self._announce_restore_state is not restore_state
+        ):
+            return
+
+        current_media = self._player.now_playing_media
+        current_state = self._player.state
+        signature = self._announce_media_signature
+        media_changed = False
+
+        if signature:
+            current_signature = self._media_signature(current_media)
+            media_changed = current_signature != signature
+        else:
+            # Fallback after the grace period if HEOS never exposed a
+            # signature for the URL stream.
+            media_changed = not self._is_announcement_media(current_media, tts_url)
+
+        is_completed = media_changed or current_state in (
+            PlayState.STOP,
+            PlayState.PAUSE,
+        )
+        if not is_completed:
+            return
+
+        await asyncio.sleep(0.3)
+        if (
+            not self._announce_in_progress
+            or self._announce_restore_state is not restore_state
+        ):
+            return
+
+        current_media = self._player.now_playing_media
+        current_state = self._player.state
+        if signature:
+            is_stable = self._media_signature(current_media) != signature
+        else:
+            is_stable = not self._is_announcement_media(current_media, tts_url)
+        is_stable = is_stable or current_state in (PlayState.STOP, PlayState.PAUSE)
+
+        if is_stable:
+            self._announce_completed = True
+            _LOGGER.debug(
+                "Announcement completed - now playing: %s, state: %s",
+                current_media.media_id,
+                current_state,
+            )
+            await self._restore_state()
 
     @callback
     @override

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -1,14 +1,33 @@
 """Denon HEOS Media Player."""
 
 import asyncio
-import dataclasses
-import logging
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from contextlib import suppress
+import dataclasses
 from datetime import datetime
 from functools import reduce, wraps
+import logging
+import math
 from operator import ior
 from typing import Any, Final, override
+
+from pyheos import (
+    AddCriteriaType,
+    ControlType,
+    HeosError,
+    HeosPlayer,
+    MediaItem,
+    MediaMusicSource,
+    PlayState,
+    RepeatType,
+)
+from pyheos import (
+    MediaType as HeosMediaType,
+)
+from pyheos import (
+    const as heos_const,
+)
+from pyheos.util import mediauri as heos_source
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
@@ -33,23 +52,6 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.dt import utcnow
-from pyheos import (
-    AddCriteriaType,
-    ControlType,
-    HeosError,
-    HeosPlayer,
-    MediaItem,
-    MediaMusicSource,
-    PlayState,
-    RepeatType,
-)
-from pyheos import (
-    MediaType as HeosMediaType,
-)
-from pyheos import (
-    const as heos_const,
-)
-from pyheos.util import mediauri as heos_source
 
 from . import services
 from .const import DOMAIN
@@ -193,6 +195,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self._announce_in_progress: bool = False
         self._announce_completed: bool = False
         self._announce_completion_task: asyncio.Task[None] | None = None
+        self._announce_lock = asyncio.Lock()
         super().__init__(coordinator, context=player.player_id)
 
     async def _player_update(self, event: str) -> None:
@@ -204,7 +207,11 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         # callback does not delay coordinator updates.
         if (
             self._announce_in_progress
-            and event == heos_const.EVENT_PLAYER_STATE_CHANGED
+            and event
+            in {
+                heos_const.EVENT_PLAYER_NOW_PLAYING_CHANGED,
+                heos_const.EVENT_PLAYER_STATE_CHANGED,
+            }
             and (
                 self._announce_completion_task is None
                 or self._announce_completion_task.done()
@@ -218,44 +225,62 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
 
     async def _play_announcement(self, media_id: str, kwargs: dict[str, Any]) -> None:
         """Play an announcement with pause/resume functionality."""
-        if self._announce_completion_task and not self._announce_completion_task.done():
-            self._announce_completion_task.cancel()
-
-        # Reset completion flag for new announcement
-        self._announce_completed = False
-        
-        # Check if we should save and restore state
-        if self._player.state == PlayState.PLAY:
+        # Serialize announcements so a new request cannot replace the state
+        # being used by an earlier announcement's completion task.
+        await self._announce_lock.acquire()
+        try:
+            self._announce_completed = False
             self._announce_restore_state = self._snapshot_state()
             self._announce_restore_state["tts_url"] = media_id
+            try:
+                queue_before = await self._player.get_queue()
+            except HeosError as err:
+                _LOGGER.warning(
+                    "Could not snapshot the queue before announcement: %s", err
+                )
+                self._announce_restore_state["queue_ids_before"] = None
+            else:
+                self._announce_restore_state["queue_ids_before"] = {
+                    item.queue_id for item in queue_before
+                }
             _LOGGER.debug(
                 "Saving state for announcement: %s", self._announce_restore_state
             )
-            
-            # Pause the current playback
-            await self._player.pause()
-            # Give the pause command time to take effect
-            await asyncio.sleep(0.5)
-        
-        # Mark announcement as in progress
-        self._announce_in_progress = True
-        
-        # Set volume if specified in extra
-        extra = kwargs.get("extra", {})
-        if "volume" in extra:
-            try:
-                volume_level = float(extra["volume"]) / 100
-                await self._player.set_volume(int(volume_level * 100))
-            except (ValueError, TypeError) as err:
-                _LOGGER.warning("Invalid volume level for announcement: %s", err)
-        
-        # Play the announcement
-        await self._player.play_url(media_id)
+
+            if self._player.state == PlayState.PLAY:
+                await self._player.pause()
+                # Give the pause command time to take effect.
+                await asyncio.sleep(0.5)
+
+            self._announce_in_progress = True
+
+            # Set volume if specified in extra. HEOS expects a percentage,
+            # while Home Assistant volume values are normalized to 0..1.
+            extra = kwargs.get("extra", {})
+            if "volume" in extra:
+                volume = float(extra["volume"])
+                if not math.isfinite(volume) or not 0 <= volume <= 100:
+                    raise ValueError("Announcement volume must be between 0 and 100")
+                volume_percent = round(volume * 100 if volume <= 1 else volume)
+                await self._player.set_volume(volume_percent)
+
+            await self._player.play_url(media_id)
+        except asyncio.CancelledError:
+            self._clear_announcement_state()
+            self._announce_lock.release()
+            raise
+        except Exception:
+            if self._announce_restore_state:
+                await self._restore_state()
+            else:
+                self._announce_lock.release()
+            raise
 
     def _snapshot_state(self) -> dict[str, Any]:
         """Snapshot the current player state for restoration after announcement."""
         return {
             "was_playing": self._player.state == PlayState.PLAY,
+            "play_state": self._player.state,
             "volume": self._player.volume,
             "is_muted": self._player.is_muted,
             "repeat": self._player.repeat,
@@ -277,7 +302,9 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             if state["tts_url"]:
                 # Small delay to ensure HEOS has processed the state change
                 await asyncio.sleep(0.2)
-                await self._remove_tts_from_queue(state["tts_url"])
+                await self._remove_tts_from_queue(
+                    state["tts_url"], state["queue_ids_before"]
+                )
             
             # Restore volume
             await self._player.set_volume(state["volume"])
@@ -289,8 +316,8 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             # Restore play mode
             await self._player.set_play_mode(state["repeat"], state["shuffle"])
             
-            # Resume playback if it was playing before
-            if state["was_playing"]:
+            # Restore the playback state from before the announcement.
+            if state["play_state"] == PlayState.PLAY:
                 # Check if we're still on the TTS track - if so, skip it
                 current_media_id = self._player.now_playing_media.media_id
                 if current_media_id == state.get("tts_url"):
@@ -301,10 +328,16 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                         _LOGGER.debug("Could not skip TTS track: %s", err)
                         # Fallback to just play
                         await self._player.play()
-                # Already moved to next track or different media, just ensure we're playing
+                # Already moved to next track or different media; ensure playback.
                 elif self._player.state != PlayState.PLAY:
                     _LOGGER.debug("Not on TTS track, ensuring playback continues")
                     await self._player.play()
+            elif state["play_state"] == PlayState.PAUSE:
+                if self._player.state != PlayState.PAUSE:
+                    await self._player.pause()
+            elif state["play_state"] == PlayState.STOP:
+                if self._player.state != PlayState.STOP:
+                    await self._player.stop()
             
             _LOGGER.debug("State restoration completed")
         except HeosError as err:
@@ -314,25 +347,35 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             self._announce_restore_state = None
             self._announce_in_progress = False
             self._announce_completed = False
+            self._announce_lock.release()
 
-    async def _remove_tts_from_queue(self, tts_url: str) -> None:
+    def _clear_announcement_state(self) -> None:
+        """Clear announcement state after a failed announcement."""
+        self._announce_restore_state = None
+        self._announce_in_progress = False
+        self._announce_completed = False
+
+    async def _remove_tts_from_queue(
+        self, tts_url: str, queue_ids_before: set[int] | None
+    ) -> None:
         """Remove TTS URL from the queue if it was added."""
+        if queue_ids_before is None:
+            _LOGGER.warning(
+                "Skipping TTS queue cleanup because the queue snapshot failed"
+            )
+            return
+
         try:
             # Get current queue after TTS
             queue_after = await self._player.get_queue()
             _LOGGER.debug("Queue after TTS: %d items", len(queue_after))
             
-            # Find all "Url Stream" items (based on the log analysis)
+            # Match only the URL created by this announcement.
             tts_queue_ids = []
             for item in queue_after:
-                # Check for the exact TTS characteristics from the logs
                 if (
-                    hasattr(item, "song")
-                    and item.song == "Url Stream"
-                    and hasattr(item, "album")
-                    and item.album == "Url Stream"
-                    and hasattr(item, "artist")
-                    and item.artist == "Url Stream"
+                    item.media_id == tts_url
+                    and item.queue_id not in queue_ids_before
                 ):
                     tts_queue_ids.append(item.queue_id)
                     _LOGGER.debug(
@@ -370,18 +413,22 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         current_media_id = self._player.now_playing_media.media_id
         tts_url = self._announce_restore_state.get("tts_url")
         
-        # Simple completion detection: if we're not playing the TTS URL anymore
-        # This handles both cases where TTS stops or moves to next track
-        if current_media_id != tts_url:
+        # Completion is signaled either by moving to another media item or by
+        # leaving the playing state while the TTS item remains current.
+        if current_media_id != tts_url or self._player.state != PlayState.PLAY:
             # Give it a moment to ensure this is a permanent state change
             await asyncio.sleep(0.3)
             
             # Double-check the state is stable
-            if self._player.now_playing_media.media_id != tts_url:
+            if (
+                self._player.now_playing_media.media_id != tts_url
+                or self._player.state != PlayState.PLAY
+            ):
                 # Mark as completed to prevent multiple triggers
                 self._announce_completed = True
                 _LOGGER.debug(
-                    "Announcement completed - was playing TTS, now playing: %s, state: %s",
+                    "Announcement completed - was playing TTS, now playing: %s, "
+                    "state: %s",
                     current_media_id,
                     self._player.state,
                 )

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -9,7 +9,7 @@ from functools import reduce, wraps
 import logging
 import math
 from operator import ior
-from typing import Any, Final, override
+from typing import Any, Final, NoReturn, override
 
 from pyheos import (
     AddCriteriaType,
@@ -150,7 +150,7 @@ def catch_action_error[**P, R](
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             try:
                 return await func(*args, **kwargs)
-            except (HeosError, TypeError, ValueError) as ex:
+            except (HeosError, ValueError) as ex:
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="action_error",
@@ -234,6 +234,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             self._announce_completed = False
             self._announce_restore_state = self._snapshot_state()
             self._announce_restore_state["tts_url"] = media_id
+            self._announce_restore_state["announcement_started"] = False
             _LOGGER.debug(
                 "Saving state for announcement: play_state=%s, volume=%s",
                 self._announce_restore_state["play_state"],
@@ -252,6 +253,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 await self._player.set_volume(volume_percent)
 
             await self._player.play_url(media_id)
+            self._announce_restore_state["announcement_started"] = True
             self._announce_in_progress = True
             self._announce_started = False
             self._announce_media_signature = None
@@ -278,13 +280,11 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 self._clear_announcement_state()
                 self._announce_lock.release()
             raise
-        except (HeosError, ValueError, TypeError) as err:
+        except (HeosError, ValueError):
             if self._announce_restore_state:
                 await self._restore_state()
             else:
                 self._announce_lock.release()
-            if isinstance(err, TypeError):
-                raise TypeError("Invalid announcement value") from err
             raise
 
     async def _capture_announcement_signature(self) -> None:
@@ -362,10 +362,18 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         if "volume" not in extra:
             return None
 
-        volume = float(extra["volume"])
+        try:
+            volume = float(extra["volume"])
+        except TypeError:
+            return HeosMediaPlayer._raise_invalid_announcement_volume()
         if not math.isfinite(volume) or not 0 <= volume <= 100:
             raise ValueError("Announcement volume must be between 0 and 100")
         return round(volume * 100 if volume <= 1 else volume)
+
+    @staticmethod
+    def _raise_invalid_announcement_volume() -> NoReturn:
+        """Raise the public error for a non-numeric announcement volume."""
+        raise ValueError("Announcement volume must be a number")
 
     def _snapshot_state(self) -> dict[str, Any]:
         """Snapshot the current player state for restoration after announcement."""
@@ -377,6 +385,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             "repeat": self._player.repeat,
             "shuffle": self._player.shuffle,
             "media_id": self._player.now_playing_media.media_id,
+            "queue_id": self._player.now_playing_media.queue_id,
             "tts_url": None,
         }
 
@@ -404,7 +413,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
 
         try:
             # Remove TTS from queue if it was added.
-            if state["tts_url"]:
+            if state["tts_url"] and state.get("announcement_started", False):
                 await asyncio.sleep(0.2)
                 await self._remove_tts_from_queue(
                     state["tts_url"], announcement_queue_id
@@ -432,15 +441,10 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 )
 
             try:
-                # Restore the playback state from before the announcement.
-                if state["play_state"] == PlayState.PLAY:
-                    current_media = self._player.now_playing_media
-                    is_announcement_media = (
-                        self._announce_media_signature is not None
-                        and self._media_signature(current_media)
-                        == self._announce_media_signature
-                    ) or current_media.media_id == state.get("tts_url")
-                    if is_announcement_media:
+                # Resume playback if it was playing before the announcement.
+                if state["was_playing"]:
+                    current_media_id = self._player.now_playing_media.media_id
+                    if current_media_id == state.get("tts_url"):
                         try:
                             _LOGGER.debug("Still on TTS track, skipping to next")
                             await self._player.play_next()
@@ -450,12 +454,6 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                     elif self._player.state != PlayState.PLAY:
                         _LOGGER.debug("Not on TTS track, ensuring playback continues")
                         await self._player.play()
-                elif state["play_state"] == PlayState.PAUSE:
-                    if self._player.state != PlayState.PAUSE:
-                        await self._player.pause()
-                elif state["play_state"] == PlayState.STOP:
-                    if self._player.state != PlayState.STOP:
-                        await self._player.stop()
             except HeosError as err:
                 _LOGGER.warning(
                     "Could not restore playback after announcement: %s", err
@@ -499,8 +497,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self._announce_start_time = None
 
     async def _remove_tts_from_queue(
-        self,
-        tts_url: str, announcement_queue_id: int | None = None
+        self, tts_url: str, announcement_queue_id: int | None = None
     ) -> None:
         """Remove TTS URL from the queue if it was added."""
         try:

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -196,6 +196,8 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self._announce_media_signature: dict[str, Any] | None = None
         self._announce_started: bool = False
         self._announce_start_time: datetime | None = None
+        self._announce_watchdog_task: asyncio.Task[None] | None = None
+        self._announce_check_lock = asyncio.Lock()
         super().__init__(coordinator, context=player.player_id)
 
     async def _player_update(self, event: str) -> None:
@@ -245,7 +247,9 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                     item.queue_id for item in queue_before
                 }
             _LOGGER.debug(
-                "Saving state for announcement: %s", self._announce_restore_state
+                "Saving state for announcement: play_state=%s, volume=%s",
+                self._announce_restore_state["play_state"],
+                self._announce_restore_state["volume"],
             )
 
             if self._player.state == PlayState.PLAY:
@@ -264,7 +268,12 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             self._announce_started = False
             self._announce_media_signature = None
             self._announce_start_time = utcnow()
-            self.hass.async_create_task(self._capture_announcement_signature())
+            self._announce_completion_task = self.hass.async_create_task(
+                self._capture_announcement_signature()
+            )
+            self._announce_watchdog_task = self.hass.async_create_task(
+                self._announcement_watchdog()
+            )
         except asyncio.CancelledError:
             if self._announce_restore_state:
                 restore_task = self.hass.async_create_task(self._restore_state())
@@ -281,11 +290,13 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 self._clear_announcement_state()
                 self._announce_lock.release()
             raise
-        except (HeosError, ValueError, TypeError):
+        except (HeosError, ValueError, TypeError) as err:
             if self._announce_restore_state:
                 await self._restore_state()
             else:
                 self._announce_lock.release()
+            if isinstance(err, TypeError):
+                raise ValueError("Invalid announcement value") from err
             raise
 
     async def _capture_announcement_signature(self) -> None:
@@ -303,10 +314,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
 
             self._announce_media_signature = self._media_signature(current_media)
             self._announce_started = True
-            _LOGGER.debug(
-                "Captured announcement media signature: %s",
-                self._announce_media_signature,
-            )
+            _LOGGER.debug("Captured announcement media signature")
             break
 
         if not self._announce_in_progress or not self._announce_start_time:
@@ -315,6 +323,15 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         if elapsed < 2.0:
             await asyncio.sleep(2.0 - elapsed)
         await self._check_announcement_completion()
+
+    async def _announcement_watchdog(self) -> None:
+        """Restore state if HEOS never sends an announcement completion event."""
+        await asyncio.sleep(30)
+        if self._announce_in_progress and not self._announce_completed:
+            _LOGGER.warning(
+                "Announcement completion event was not received; restoring state"
+            )
+            await self._check_announcement_completion(force=True)
 
     @staticmethod
     def _media_signature(media: Any) -> dict[str, Any]:
@@ -368,7 +385,11 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             return
 
         state = self._announce_restore_state
-        _LOGGER.debug("Restoring state after announcement: %s", state)
+        _LOGGER.debug(
+            "Restoring state after announcement: play_state=%s, volume=%s",
+            state["play_state"],
+            state["volume"],
+        )
 
         try:
             # Remove TTS from queue if it was added.
@@ -402,8 +423,13 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             try:
                 # Restore the playback state from before the announcement.
                 if state["play_state"] == PlayState.PLAY:
-                    current_media_id = self._player.now_playing_media.media_id
-                    if current_media_id == state.get("tts_url"):
+                    current_media = self._player.now_playing_media
+                    is_announcement_media = (
+                        self._announce_media_signature is not None
+                        and self._media_signature(current_media)
+                        == self._announce_media_signature
+                    ) or current_media.media_id == state.get("tts_url")
+                    if is_announcement_media:
                         try:
                             _LOGGER.debug("Still on TTS track, skipping to next")
                             await self._player.play_next()
@@ -433,6 +459,10 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             self._announce_media_signature = None
             self._announce_started = False
             self._announce_start_time = None
+            watchdog_task = self._announce_watchdog_task
+            self._announce_watchdog_task = None
+            if watchdog_task and watchdog_task is not asyncio.current_task():
+                watchdog_task.cancel()
             self._announce_lock.release()
 
     def _clear_announcement_state(self) -> None:
@@ -465,10 +495,9 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 if item.media_id == tts_url and item.queue_id not in queue_ids_before:
                     tts_queue_ids.append(item.queue_id)
                     _LOGGER.debug(
-                        "Found TTS Url Stream item: queue_id=%s, song=%s, media_id=%s",
+                        "Found TTS Url Stream item: queue_id=%s, song=%s",
                         item.queue_id,
                         item.song,
-                        getattr(item, "media_id", "N/A"),
                     )
             
             # Remove TTS items from queue
@@ -483,7 +512,12 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         except HeosError as err:
             _LOGGER.warning("Could not remove TTS from queue: %s", err)
 
-    async def _check_announcement_completion(self) -> None:
+    async def _check_announcement_completion(self, force: bool = False) -> None:
+        """Check announcement completion without allowing concurrent checks."""
+        async with self._announce_check_lock:
+            await self._check_announcement_completion_locked(force)
+
+    async def _check_announcement_completion_locked(self, force: bool) -> None:
         """Check if the announcement has completed and restore state."""
         if self._announce_completed:
             return
@@ -511,6 +545,11 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
 
         current_media = self._player.now_playing_media
         current_state = self._player.state
+        if force:
+            self._announce_completed = True
+            await self._restore_state()
+            return
+
         signature = self._announce_media_signature
         media_changed = False
 
@@ -547,8 +586,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         if is_stable:
             self._announce_completed = True
             _LOGGER.debug(
-                "Announcement completed - now playing: %s, state: %s",
-                current_media.media_id,
+                "Announcement completed; player state is %s",
                 current_state,
             )
             await self._restore_state()

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -56,6 +56,13 @@ from .coordinator import HeosConfigEntry, HeosCoordinator
 PARALLEL_UPDATES = 0
 
 BROWSE_ROOT: Final = "heos://media"
+EXTERNAL_SOURCE_IDS: Final = frozenset(
+    {
+        heos_const.MUSIC_SOURCE_CONNECT,
+        heos_const.MUSIC_SOURCE_SPOTIFY,
+        heos_const.MUSIC_SOURCE_AUX_INPUT,
+    }
+)
 
 BASE_SUPPORTED_FEATURES = (
     MediaPlayerEntityFeature.VOLUME_MUTE
@@ -204,7 +211,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         """Handle player attribute updated."""
         if event == heos_const.EVENT_PLAYER_NOW_PLAYING_PROGRESS:
             self._media_position_updated_at = utcnow()
-        
+
         # Check for announcement completion in the background so this event
         # callback does not delay coordinator updates.
         if (
@@ -222,11 +229,18 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             self._announce_completion_task = self.hass.async_create_task(
                 self._check_announcement_completion()
             )
-        
+
         self._handle_coordinator_update()
 
     async def _play_announcement(self, media_id: str, kwargs: dict[str, Any]) -> None:
         """Play an announcement with pause/resume functionality."""
+        if self._player.now_playing_media.source_id in EXTERNAL_SOURCE_IDS:
+            if queue := await self._player.get_queue():
+                raise HomeAssistantError(
+                    "Announcements are not supported while the HEOS queue "
+                    f"contains {len(queue)} item(s)"
+                )
+
         # Serialize announcements so a new request cannot replace the state
         # being used by an earlier announcement's completion task.
         await self._announce_lock.acquire()
@@ -386,6 +400,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             "shuffle": self._player.shuffle,
             "media_id": self._player.now_playing_media.media_id,
             "queue_id": self._player.now_playing_media.queue_id,
+            "source_id": self._player.now_playing_media.source_id,
             "tts_url": None,
         }
 
@@ -396,6 +411,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
 
         state = self._announce_restore_state
         current_media = self._player.now_playing_media
+        is_external_source = state["source_id"] in EXTERNAL_SOURCE_IDS
         announcement_queue_id = (
             self._announce_media_signature.get("queue_id")
             if self._announce_media_signature
@@ -414,6 +430,10 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         try:
             # Remove TTS from queue if it was added.
             if state["tts_url"] and state.get("announcement_started", False):
+                if is_external_source and self._player.state == PlayState.PLAY:
+                    # Stop before removing the current URL so HEOS cannot
+                    # automatically advance into its queue.
+                    await self._player.stop()
                 await asyncio.sleep(0.2)
                 await self._remove_tts_from_queue(
                     state["tts_url"], announcement_queue_id
@@ -442,7 +462,11 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
 
             try:
                 # Resume playback if it was playing before the announcement.
-                if state["was_playing"]:
+                if is_external_source:
+                    _LOGGER.warning(
+                        "Not resuming external source after announcement"
+                    )
+                elif state["was_playing"]:
                     current_media_id = self._player.now_playing_media.media_id
                     if current_media_id == state.get("tts_url"):
                         try:
@@ -539,7 +563,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                         "Found TTS item by Url Stream metadata: queue_id=%s",
                         item.queue_id,
                     )
-            
+
             # Remove TTS items from queue
             if tts_queue_ids:
                 _LOGGER.debug(
@@ -548,7 +572,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 await self._player.remove_from_queue(tts_queue_ids)
             else:
                 _LOGGER.debug("No TTS Url Stream items found to remove")
-                
+
         except HeosError as err:
             _LOGGER.warning("Could not remove TTS from queue: %s", err)
 
@@ -572,7 +596,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         # cannot be mistaken for a completed announcement.
         if self._announce_start_time:
             elapsed = (utcnow() - self._announce_start_time).total_seconds()
-            if elapsed < 2.0 and not self._announce_started:
+            if elapsed < 2.0:
                 return
 
         await asyncio.sleep(0.5)
@@ -601,10 +625,10 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             # signature for the URL stream.
             media_changed = not self._is_announcement_media(current_media, tts_url)
 
-        is_completed = media_changed or current_state in (
-            PlayState.STOP,
-            PlayState.PAUSE,
-        )
+        is_external_source = restore_state["source_id"] in EXTERNAL_SOURCE_IDS
+        is_completed = media_changed or current_state == PlayState.STOP
+        if not is_external_source:
+            is_completed = is_completed or current_state == PlayState.PAUSE
         if not is_completed:
             return
 
@@ -621,7 +645,9 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             is_stable = self._media_signature(current_media) != signature
         else:
             is_stable = not self._is_announcement_media(current_media, tts_url)
-        is_stable = is_stable or current_state in (PlayState.STOP, PlayState.PAUSE)
+        is_stable = is_stable or current_state == PlayState.STOP
+        if not is_external_source:
+            is_stable = is_stable or current_state == PlayState.PAUSE
 
         if is_stable:
             self._announce_completed = True
@@ -743,7 +769,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         """Play a piece of media."""
         # Handle announce parameter for TTS announcements
         announce = kwargs.get(ATTR_MEDIA_ANNOUNCE, False)
-        
+
         if heos_source.is_media_uri(media_id):
             media, _data = heos_source.from_media_uri(media_id)
             if not isinstance(media, MediaItem):

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -236,9 +236,10 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         """Play an announcement with pause/resume functionality."""
         if self._player.now_playing_media.source_id in EXTERNAL_SOURCE_IDS:
             if queue := await self._player.get_queue():
-                raise HomeAssistantError(
-                    "Announcements are not supported while the HEOS queue "
-                    f"contains {len(queue)} item(s)"
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="external_source_queue",
+                    translation_placeholders={"count": str(len(queue))},
                 )
 
         # Serialize announcements so a new request cannot replace the state
@@ -463,9 +464,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             try:
                 # Resume playback if it was playing before the announcement.
                 if is_external_source:
-                    _LOGGER.warning(
-                        "Not resuming external source after announcement"
-                    )
+                    _LOGGER.warning("Not resuming external source after announcement")
                 elif state["was_playing"]:
                     current_media_id = self._player.now_playing_media.media_id
                     if current_media_id == state.get("tts_url"):

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -272,7 +272,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                     await asyncio.shield(restore_task)
                 except asyncio.CancelledError:
                     pass
-                except Exception as err:
+                except (HeosError, ValueError, TypeError) as err:
                     _LOGGER.warning(
                         "Could not restore state after announcement cancellation: %s",
                         err,
@@ -281,7 +281,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 self._clear_announcement_state()
                 self._announce_lock.release()
             raise
-        except Exception:
+        except (HeosError, ValueError, TypeError):
             if self._announce_restore_state:
                 await self._restore_state()
             else:
@@ -329,10 +329,13 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
     @staticmethod
     def _is_announcement_media(media: Any, tts_url: str) -> bool:
         """Return whether HEOS reports the requested URL announcement."""
-        return media.media_id == tts_url or (
-            media.song == "Url Stream"
-            and media.album == "Url Stream"
-            and media.artist == "Url Stream"
+        return bool(
+            media.media_id == tts_url
+            or (
+                media.song == "Url Stream"
+                and media.album == "Url Stream"
+                and media.artist == "Url Stream"
+            )
         )
 
     @staticmethod
@@ -379,9 +382,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             try:
                 await self._player.set_volume(state["volume"])
             except HeosError as err:
-                _LOGGER.warning(
-                    "Could not restore volume after announcement: %s", err
-                )
+                _LOGGER.warning("Could not restore volume after announcement: %s", err)
 
             try:
                 if state["is_muted"] != self._player.is_muted:

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -228,7 +228,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         if self._player.state == PlayState.PLAY:
             self._announce_restore_state = self._snapshot_state()
             self._announce_restore_state["tts_url"] = media_id
-            LOGGER.debug(
+            _LOGGER.debug(
                 "Saving state for announcement: %s", self._announce_restore_state
             )
             

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -150,7 +150,7 @@ def catch_action_error[**P, R](
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             try:
                 return await func(*args, **kwargs)
-            except (HeosError, ValueError) as ex:
+            except (HeosError, TypeError, ValueError) as ex:
                 raise HomeAssistantError(
                     translation_domain=DOMAIN,
                     translation_key="action_error",
@@ -234,18 +234,6 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             self._announce_completed = False
             self._announce_restore_state = self._snapshot_state()
             self._announce_restore_state["tts_url"] = media_id
-            self._announce_restore_state["queue_ids_before"] = None
-            try:
-                queue_before = await self._player.get_queue()
-            except HeosError as err:
-                _LOGGER.warning(
-                    "Could not snapshot the queue before announcement: %s", err
-                )
-                self._announce_restore_state["queue_ids_before"] = None
-            else:
-                self._announce_restore_state["queue_ids_before"] = {
-                    item.queue_id for item in queue_before
-                }
             _LOGGER.debug(
                 "Saving state for announcement: play_state=%s, volume=%s",
                 self._announce_restore_state["play_state"],
@@ -296,7 +284,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             else:
                 self._announce_lock.release()
             if isinstance(err, TypeError):
-                raise ValueError("Invalid announcement value") from err
+                raise TypeError("Invalid announcement value") from err
             raise
 
     async def _capture_announcement_signature(self) -> None:
@@ -327,6 +315,17 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
     async def _announcement_watchdog(self) -> None:
         """Restore state if HEOS never sends an announcement completion event."""
         await asyncio.sleep(30)
+        while self._announce_in_progress and not self._announce_completed:
+            signature = self._announce_media_signature
+            if signature and signature.get("duration") and self._announce_start_time:
+                elapsed = (utcnow() - self._announce_start_time).total_seconds()
+                remaining = signature["duration"] / 1000 + 10 - elapsed
+                if remaining > 0:
+                    await asyncio.sleep(remaining)
+                    continue
+
+            break
+
         if self._announce_in_progress and not self._announce_completed:
             _LOGGER.warning(
                 "Announcement completion event was not received; restoring state"
@@ -338,6 +337,8 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         """Return the HEOS fields used to identify the current media."""
         return {
             "media_id": media.media_id,
+            "queue_id": media.queue_id,
+            "duration": media.duration,
             "song": getattr(media, "song", None),
             "album": getattr(media, "album", None),
             "artist": getattr(media, "artist", None),
@@ -385,6 +386,16 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             return
 
         state = self._announce_restore_state
+        current_media = self._player.now_playing_media
+        announcement_queue_id = (
+            self._announce_media_signature.get("queue_id")
+            if self._announce_media_signature
+            else (
+                current_media.queue_id
+                if self._is_announcement_media(current_media, state["tts_url"])
+                else None
+            )
+        )
         _LOGGER.debug(
             "Restoring state after announcement: play_state=%s, volume=%s",
             state["play_state"],
@@ -396,7 +407,7 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
             if state["tts_url"]:
                 await asyncio.sleep(0.2)
                 await self._remove_tts_from_queue(
-                    state["tts_url"], state["queue_ids_before"]
+                    state["tts_url"], announcement_queue_id
                 )
 
             # Restore independent settings even when an earlier command fails.
@@ -465,6 +476,19 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
                 watchdog_task.cancel()
             self._announce_lock.release()
 
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel announcement tasks when the entity is removed."""
+        for task in (
+            self._announce_completion_task,
+            self._announce_watchdog_task,
+        ):
+            if task and not task.done():
+                task.cancel()
+        self._announce_completion_task = None
+        self._announce_watchdog_task = None
+        await super().async_will_remove_from_hass()
+
     def _clear_announcement_state(self) -> None:
         """Clear announcement state after a failed announcement."""
         self._announce_restore_state = None
@@ -475,29 +499,48 @@ class HeosMediaPlayer(CoordinatorEntity[HeosCoordinator], MediaPlayerEntity):
         self._announce_start_time = None
 
     async def _remove_tts_from_queue(
-        self, tts_url: str, queue_ids_before: set[int] | None
+        self,
+        tts_url: str, announcement_queue_id: int | None = None
     ) -> None:
         """Remove TTS URL from the queue if it was added."""
-        if queue_ids_before is None:
-            _LOGGER.warning(
-                "Skipping TTS queue cleanup because the queue snapshot failed"
-            )
-            return
-
         try:
             # Get current queue after TTS
             queue_after = await self._player.get_queue()
             _LOGGER.debug("Queue after TTS: %d items", len(queue_after))
-            
-            # Match only the URL created by this announcement.
+
+            # Match by media ID when available. Some HEOS versions expose URL
+            # playback only through the generic "Url Stream" fields.
             tts_queue_ids = []
             for item in queue_after:
-                if item.media_id == tts_url and item.queue_id not in queue_ids_before:
+                if item.queue_id == announcement_queue_id:
                     tts_queue_ids.append(item.queue_id)
                     _LOGGER.debug(
-                        "Found TTS Url Stream item: queue_id=%s, song=%s",
+                        "Found announcement queue item: queue_id=%s",
                         item.queue_id,
-                        item.song,
+                    )
+                    continue
+
+                if announcement_queue_id is not None:
+                    continue
+
+                item_media_id = getattr(item, "media_id", None)
+                if item_media_id and item_media_id == tts_url:
+                    tts_queue_ids.append(item.queue_id)
+                    _LOGGER.debug(
+                        "Found TTS item by media ID: queue_id=%s",
+                        item.queue_id,
+                    )
+                elif (
+                    not item_media_id
+                    and getattr(item, "song", None) == "Url Stream"
+                    and getattr(item, "album", None) == "Url Stream"
+                    and getattr(item, "artist", None) == "Url Stream"
+                    and not tts_queue_ids
+                ):
+                    tts_queue_ids.append(item.queue_id)
+                    _LOGGER.debug(
+                        "Found TTS item by Url Stream metadata: queue_id=%s",
+                        item.queue_id,
                     )
             
             # Remove TTS items from queue

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -56,6 +56,9 @@
     "action_error": {
       "message": "Unable to {action}: {error}"
     },
+    "external_source_queue": {
+      "message": "Announcements are not supported while the HEOS queue contains {count} item(s)"
+    },
     "entity_not_found": {
       "message": "Entity {entity_id} was not found"
     },

--- a/homeassistant/components/heos/strings.json
+++ b/homeassistant/components/heos/strings.json
@@ -56,14 +56,14 @@
     "action_error": {
       "message": "Unable to {action}: {error}"
     },
-    "external_source_queue": {
-      "message": "Announcements are not supported while the HEOS queue contains {count} item(s)"
-    },
     "entity_not_found": {
       "message": "Entity {entity_id} was not found"
     },
     "entity_not_grouped": {
       "message": "Entity {entity_id} is not joined to a group"
+    },
+    "external_source_queue": {
+      "message": "Announcements are not supported while the HEOS queue contains {count} item(s)"
     },
     "integration_not_loaded": {
       "message": "The HEOS integration is not loaded"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

### Summary
This PR adds support for the `announce` parameter in the HEOS media player integration. TTS announcements pause local HEOS playback, play the announcement, clean up its temporary queue item, and restore playback when it is safe to do so.

### Features
- **Pause before announcement**: Automatically pauses music when an announcement is requested
- **Volume control**: Supports both normalized (0.0-1.0) and percentage (0-100) volume formats for announcements
- **State restoration**: Restores volume, mute state, play mode, and local HEOS playback after announcement
- **Queue cleanup**: Intelligently removes TTS items from queue by matching media signature
- **Smart resumption**: Skips TTS items and continues with the next local HEOS track without restarting the original song
- **External-source protection**: Allows announcements for Spotify/Connect/AUX only when the HEOS queue is empty; otherwise rejects the request before changing the source
- **Non-blocking**: Uses background tasks for completion detection to avoid blocking event processing
- **Robust error handling**: Restores state even if announcement fails partway through

### Implementation Details

#### Core Functionality
- Added `announce` parameter detection in `async_play_media`
- Implemented state snapshot to save player state before announcement (even when paused/stopped)
- Always captures state to ensure proper cleanup in all scenarios

#### Completion Detection
- **Media signature capture**: Records actual HEOS media info after announcement starts
- **Multiple detection signals**: Checks media signature changes and terminal state transitions
- **Grace period protection**: 2-second grace period prevents premature completion from pause events
- **Fallback detection**: Works even if signature capture fails
- **Background processing**: Completion checks run as async tasks to keep event handler responsive

#### Queue Management
- **Targeted removal**: Matches the captured announcement queue ID when available, then media ID
- **Safe cleanup**: Falls back to only the first generic `Url Stream` item when no exact match is available
- **Signature-based**: Uses captured announcement metadata for reliable identification

#### External Sources
Spotify Connect and other external sources cannot be restored through the documented HEOS CLI after `play_url()` replaces the source. The integration therefore checks the current source and HEOS queue before starting an announcement:

- If the source is Spotify, Connect, or AUX and the HEOS queue is empty, the announcement is allowed.
- If the queue contains items, the announcement is rejected before `play_url()` is called.
- This prevents HEOS from automatically resuming a local HEOS queue after the announcement.

#### Error Handling & Recovery
- **Exception safety**: Catches specific HEOS and validation exceptions
- **State restoration on failure**: If announcement fails after pausing/volume change, restores original state
- **Best-effort recovery**: Attempts restoration but doesn't fail if restoration errors occur
- **Race condition prevention**: Grace period + started flag prevents premature completion
- **Concurrent call safety**: Local state capture prevents race conditions in completion checks

#### State Machine
- `_announce_in_progress`: Tracks if announcement is active
- `_announce_started`: Set when media signature captured (prevents premature completion)
- `_announce_completed`: Prevents multiple restoration attempts
- `_announce_start_time`: Enables grace period timeout logic
- `_announce_media_signature`: Stores actual HEOS media info for reliable completion detection
- `_announce_restore_state`: Snapshot of pre-announcement state

### Technical Improvements
1. **Non-blocking event handler**: Uses `async_create_task()` for completion checks
2. **Race condition fixes**:
   - Set `_announce_in_progress` after `play_url()` to avoid pause event race
   - Grace period prevents premature completion during startup
   - Local state capture in completion check prevents concurrent call issues
3. **Timeout protection**: After 2 seconds, allows fallback detection even without signature
4. **Volume format support**: Handles both HA normalized (0.0-1.0) and percentage (0-100) formats
5. **Comprehensive cleanup**: All state variables cleared in finally blocks and exception handlers

### Limitations
Due to HEOS protocol limitations, exact position resumption within a track is not supported. For local HEOS playback, the implementation skips to the next track rather than restarting the current track from the beginning. Spotify Connect and other external sessions cannot be restored by the documented HEOS CLI; announcements are blocked when a non-empty HEOS queue could otherwise resume.

### Testing
Tested with Home Assistant TTS integrations (Google Translate, Cloud TTS, etc.) and confirmed:
- Music pauses before announcement
- Announcement plays at specified volume (both normalized and percentage formats)
- Local HEOS music resumes with the next track after announcement
- Announcements are rejected safely when Spotify/Connect/AUX is active with a non-empty HEOS queue
- TTS items are removed from queue
- Volume and play mode are restored
- State restored even if announcement fails
- No blocking of event processing
- Handles concurrent completion checks safely
- Works even if media signature capture fails
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47942
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
