### PR TITLE
Bump python-google-drive-api to 0.2.0

### DIFF
--- a/homeassistant/components/google_drive/manifest.json
+++ b/homeassistant/components/google_drive/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["google_drive_api"],
   "quality_scale": "platinum",
-  "requirements": ["python-google-drive-api==0.1.0"]
+  "requirements": ["python-google-drive-api==0.2.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2726,7 +2726,7 @@ python-gc100==1.0.3a0
 python-gitlab==1.6.0
 
 # homeassistant.components.google_drive
-python-google-drive-api==0.1.0
+python-google-drive-api==0.2.0
 
 # homeassistant.components.google_weather
 python-google-weather-api==0.0.6


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `python-google-drive-api` from 0.1.0 to 0.2.0.

The release fixes the resumable upload protocol, which never actually resumed. aiohttp classifies `308 Resume Incomplete` as a redirect and the streamed request body cannot be replayed, so a 308 either failed the upload with `Cannot follow redirect with a consumed request body` (aiohttp 3.14 and later, which is what Home Assistant ships) or, on earlier versions, was returned to the caller as a success, reporting a partial upload as complete. The session URI is now requested with `allow_redirects=False`, and a non 2xx response is never returned as success.

It also brings error handling in line with the [Google Drive API contract](https://developers.google.com/drive/api/guides/manage-uploads#resumable): the upload session is restarted on `410 Gone` as well as `404 Not Found`, `429` and the `403` rate limit reasons are retried with backoff instead of immediately, permanent errors such as `storageQuotaExceeded` now fail fast instead of using up every retry, and the exponential backoff has jitter and honors `Retry-After`.

No changes are needed in this integration. The breaking changes in the release are to parts of the library Home Assistant does not use, and the integration's calls are unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

Release notes: https://github.com/tronikos/python-google-drive-api/releases/tag/v0.2.0
Diff: https://github.com/tronikos/python-google-drive-api/compare/v0.1.0...v0.2.0

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: not needed, dependency upgrade only
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
