### PR TITLE
Fix small issues in Google Weather

### DIFF
--- a/homeassistant/components/google_weather/__init__.py
+++ b/homeassistant/components/google_weather/__init__.py
@@ -31,6 +31,8 @@ async def async_setup_entry(
         api_key=entry.data[CONF_API_KEY],
         referrer=entry.data.get(CONF_REFERRER),
         language_code=hass.config.language,
+        # The entities report native values in metric units.
+        units_system="METRIC",
     )
     subentries_runtime_data: dict[str, GoogleWeatherSubEntryRuntimeData] = {}
     for subentry in entry.subentries.values():
@@ -46,16 +48,24 @@ async def async_setup_entry(
             ),
         )
         subentries_runtime_data[subentry.subentry_id] = subentry_runtime_data
-    tasks = [
-        coro
-        for subentry_runtime_data in subentries_runtime_data.values()
-        for coro in (
-            subentry_runtime_data.coordinator_observation.async_config_entry_first_refresh(),
-            subentry_runtime_data.coordinator_daily_forecast.async_config_entry_first_refresh(),
-            subentry_runtime_data.coordinator_hourly_forecast.async_config_entry_first_refresh(),
-        )
-    ]
-    await asyncio.gather(*tasks)
+    # Wait for every refresh to settle before failing, so that no refresh outlives
+    # a setup that did not complete. Exceptions are re-raised as-is, so that
+    # ConfigEntryNotReady and ConfigEntryAuthFailed keep their meaning.
+    results = await asyncio.gather(
+        *(
+            coordinator.async_config_entry_first_refresh()
+            for subentry_runtime_data in subentries_runtime_data.values()
+            for coordinator in (
+                subentry_runtime_data.coordinator_observation,
+                subentry_runtime_data.coordinator_daily_forecast,
+                subentry_runtime_data.coordinator_hourly_forecast,
+            )
+        ),
+        return_exceptions=True,
+    )
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result
     entry.runtime_data = GoogleWeatherRuntimeData(
         api=api,
         subentries_runtime_data=subentries_runtime_data,

--- a/homeassistant/components/google_weather/icons.json
+++ b/homeassistant/components/google_weather/icons.json
@@ -7,9 +7,6 @@
       "precipitation_probability": {
         "default": "mdi:weather-rainy"
       },
-      "precipitation_qpf": {
-        "default": "mdi:cup-water"
-      },
       "thunderstorm_probability": {
         "default": "mdi:weather-lightning"
       },

--- a/homeassistant/components/google_weather/sensor.py
+++ b/homeassistant/components/google_weather/sensor.py
@@ -198,7 +198,6 @@ async def async_setup_entry(
             (
                 GoogleWeatherSensor(coordinator, subentry, description)
                 for description in SENSOR_TYPES
-                if description.value_fn(coordinator.data) is not None
             ),
             config_subentry_id=subentry.subentry_id,
         )


### PR DESCRIPTION
## Proposed change

Four small fixes in the Google Weather integration, none of which change behavior a user would notice.

**Wait for all first refreshes to settle before failing setup.** `asyncio.gather()` propagates the first exception but does not cancel its siblings, so when one coordinator raised `ConfigEntryNotReady` the other two kept running against an entry whose setup had already been abandoned. Now every refresh is awaited before the error is re-raised. The exception is re-raised as-is rather than using `asyncio.TaskGroup`, so `ConfigEntryNotReady` and `ConfigEntryAuthFailed` keep their meaning instead of arriving wrapped in an `ExceptionGroup`.

**Request metric units explicitly.** The entity sets `_attr_native_temperature_unit = CELSIUS` and friends, but relied on `METRIC` being the library's default. Passing it explicitly keeps the two from drifting apart silently.

**Drop the dead `precipitation_qpf` entry from `icons.json`.** Icons resolve through `component.<domain>.entity.sensor.<translation_key>`, and that sensor description has no `translation_key`, so the entry could never match. Its `PRECIPITATION_INTENSITY` device class already supplies an icon. Note that `hassfest` validates only the shape of `icons.json`, not that its keys correspond to a real `translation_key`, so this passed silently.

**Drop the sensor filter that could never exclude anything.** Every `value_fn` reads a required model field, so `description.value_fn(coordinator.data) is not None` was always true. It is also the pattern we discourage, where entities appear or disappear depending on what the first response happened to contain.

Existing tests pass unchanged, which is the point for the last two: the same sensors are still created and the snapshots are untouched.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: not needed, no user visible change
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The manifest file has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
