### PR TITLE
Add active network NIC MAC to androidtv_remote device connections

### DIFF
--- a/homeassistant/components/androidtv_remote/__init__.py
+++ b/homeassistant/components/androidtv_remote/__init__.py
@@ -8,8 +8,15 @@ from androidtvremote2 import CannotConnect, ConnectionClosed, InvalidAuth
 from homeassistant.const import CONF_HOST, CONF_NAME, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 
-from .helpers import AndroidTVRemoteConfigEntry, create_api, get_enable_ime
+from .const import DOMAIN
+from .helpers import (
+    AndroidTVRemoteConfigEntry,
+    async_get_nic_mac_address,
+    create_api,
+    get_enable_ime,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,6 +61,19 @@ async def async_setup_entry(
     # network unreachable. If device gets a new IP address the zeroconf flow will
     # update the config entry data and reload the config entry.
     api.keep_reconnecting(reauth_needed)
+
+    # Resolve physical NIC MAC address (Wi-Fi or Ethernet) to link with router device trackers
+    if nic_mac := await async_get_nic_mac_address(hass, entry.data[CONF_HOST]):
+        api.nic_mac = nic_mac
+        dev_reg = dr.async_get(hass)
+        if device := dev_reg.async_get_device_by_identifier(
+            (DOMAIN, entry.unique_id), entry.entry_id
+        ):
+            dev_reg.async_update_device(
+                device.id,
+                new_connections=device.connections
+                | {(dr.CONNECTION_NETWORK_MAC, nic_mac)},
+            )
 
     entry.runtime_data = api
 

--- a/homeassistant/components/androidtv_remote/__init__.py
+++ b/homeassistant/components/androidtv_remote/__init__.py
@@ -5,7 +5,13 @@ import logging
 
 from androidtvremote2 import CannotConnect, ConnectionClosed, InvalidAuth
 
-from homeassistant.const import CONF_HOST, CONF_NAME, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_MAC,
+    CONF_NAME,
+    EVENT_HOMEASSISTANT_STOP,
+    Platform,
+)
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
@@ -63,17 +69,29 @@ async def async_setup_entry(
     api.keep_reconnecting(reauth_needed)
 
     # Resolve physical NIC MAC address (Wi-Fi or Ethernet) to link with router device trackers
+    assert entry.unique_id is not None
+    connections = {(dr.CONNECTION_NETWORK_MAC, entry.data[CONF_MAC])}
     if nic_mac := await async_get_nic_mac_address(hass, entry.data[CONF_HOST]):
-        api.nic_mac = nic_mac
-        dev_reg = dr.async_get(hass)
-        if device := dev_reg.async_get_device_by_identifier(
-            (DOMAIN, entry.unique_id), entry.entry_id
-        ):
-            dev_reg.async_update_device(
-                device.id,
-                new_connections=device.connections
-                | {(dr.CONNECTION_NETWORK_MAC, nic_mac)},
-            )
+        connections.add((dr.CONNECTION_NETWORK_MAC, nic_mac))
+
+    dev_reg = dr.async_get(hass)
+    if device := dev_reg.async_get_device_by_identifier(
+        (DOMAIN, entry.unique_id), entry.entry_id
+    ):
+        dev_reg.async_update_device(
+            device.id,
+            new_connections=device.connections | connections,
+        )
+    elif api.device_info is not None:
+        device_info = api.device_info
+        dev_reg.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, entry.unique_id)},
+            connections=connections,
+            manufacturer=device_info["manufacturer"],
+            model=device_info["model"],
+            name=entry.data[CONF_NAME],
+        )
 
     entry.runtime_data = api
 

--- a/homeassistant/components/androidtv_remote/__init__.py
+++ b/homeassistant/components/androidtv_remote/__init__.py
@@ -78,10 +78,11 @@ async def async_setup_entry(
     if device := dev_reg.async_get_device_by_identifier(
         (DOMAIN, entry.unique_id), entry.entry_id
     ):
-        dev_reg.async_update_device(
-            device.id,
-            new_connections=device.connections | connections,
-        )
+        if nic_mac:
+            dev_reg.async_update_device(
+                device.id,
+                new_connections=connections,
+            )
     elif api.device_info is not None:
         device_info = api.device_info
         dev_reg.async_get_or_create(

--- a/homeassistant/components/androidtv_remote/entity.py
+++ b/homeassistant/components/androidtv_remote/entity.py
@@ -32,12 +32,8 @@ class AndroidTVRemoteBaseEntity(Entity):
         device_info = api.device_info
         assert config_entry.unique_id
         assert device_info
-        connections = {(CONNECTION_NETWORK_MAC, config_entry.data[CONF_MAC])}
-        if (nic_mac := getattr(api, "nic_mac", None)) and isinstance(nic_mac, str):
-            connections.add((CONNECTION_NETWORK_MAC, nic_mac))
-
         self._attr_device_info = DeviceInfo(
-            connections=connections,
+            connections={(CONNECTION_NETWORK_MAC, config_entry.data[CONF_MAC])},
             identifiers={(DOMAIN, config_entry.unique_id)},
             name=config_entry.data[CONF_NAME],
             manufacturer=device_info["manufacturer"],

--- a/homeassistant/components/androidtv_remote/entity.py
+++ b/homeassistant/components/androidtv_remote/entity.py
@@ -32,8 +32,12 @@ class AndroidTVRemoteBaseEntity(Entity):
         device_info = api.device_info
         assert config_entry.unique_id
         assert device_info
+        connections = {(CONNECTION_NETWORK_MAC, config_entry.data[CONF_MAC])}
+        if (nic_mac := getattr(api, "nic_mac", None)) and isinstance(nic_mac, str):
+            connections.add((CONNECTION_NETWORK_MAC, nic_mac))
+
         self._attr_device_info = DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, config_entry.data[CONF_MAC])},
+            connections=connections,
             identifiers={(DOMAIN, config_entry.unique_id)},
             name=config_entry.data[CONF_NAME],
             manufacturer=device_info["manufacturer"],

--- a/homeassistant/components/androidtv_remote/helpers.py
+++ b/homeassistant/components/androidtv_remote/helpers.py
@@ -4,7 +4,7 @@ from functools import partial
 from ipaddress import IPv6Address, ip_address
 
 from androidtvremote2 import AndroidTVRemote
-import getmac  # type: ignore[import-untyped]
+import getmac
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/androidtv_remote/helpers.py
+++ b/homeassistant/components/androidtv_remote/helpers.py
@@ -1,9 +1,14 @@
 """Helper functions for Android TV Remote integration."""
 
+from functools import partial
+from ipaddress import ip_address
+
 from androidtvremote2 import AndroidTVRemote
+import getmac
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.storage import STORAGE_DIR
 
 from .const import CONF_ENABLE_IME, CONF_ENABLE_IME_DEFAULT_VALUE
@@ -26,3 +31,26 @@ def create_api(hass: HomeAssistant, host: str, enable_ime: bool) -> AndroidTVRem
 def get_enable_ime(entry: AndroidTVRemoteConfigEntry) -> bool:
     """Get value of enable_ime option or its default value."""
     return bool(entry.options.get(CONF_ENABLE_IME, CONF_ENABLE_IME_DEFAULT_VALUE))
+
+
+async def async_get_nic_mac_address(hass: HomeAssistant, host: str) -> str | None:
+    """Get the physical network interface MAC address for a host via ARP lookup."""
+    try:
+        ip_addr = ip_address(host)
+    except ValueError:
+        mac = await hass.async_add_executor_job(
+            partial(getmac.get_mac_address, hostname=host)
+        )
+    else:
+        if ip_addr.version == 4:
+            mac = await hass.async_add_executor_job(
+                partial(getmac.get_mac_address, ip=host)
+            )
+        else:
+            mac = await hass.async_add_executor_job(
+                partial(getmac.get_mac_address, ip6=str(ip_addr))
+            )
+    if mac:
+        return format_mac(mac)
+    return None
+

--- a/homeassistant/components/androidtv_remote/helpers.py
+++ b/homeassistant/components/androidtv_remote/helpers.py
@@ -4,7 +4,7 @@ from functools import partial
 from ipaddress import IPv6Address, ip_address
 
 from androidtvremote2 import AndroidTVRemote
-import getmac
+import getmac  # type: ignore[import-untyped]
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/androidtv_remote/helpers.py
+++ b/homeassistant/components/androidtv_remote/helpers.py
@@ -53,4 +53,3 @@ async def async_get_nic_mac_address(hass: HomeAssistant, host: str) -> str | Non
     if mac:
         return format_mac(mac)
     return None
-

--- a/homeassistant/components/androidtv_remote/helpers.py
+++ b/homeassistant/components/androidtv_remote/helpers.py
@@ -1,7 +1,7 @@
 """Helper functions for Android TV Remote integration."""
 
 from functools import partial
-from ipaddress import ip_address
+from ipaddress import IPv6Address, ip_address
 
 from androidtvremote2 import AndroidTVRemote
 import getmac
@@ -47,6 +47,8 @@ async def async_get_nic_mac_address(hass: HomeAssistant, host: str) -> str | Non
                 partial(getmac.get_mac_address, ip=host)
             )
         else:
+            # Drop scope_id from IPv6 address by converting via int
+            ip_addr = IPv6Address(int(ip_addr))
             mac = await hass.async_add_executor_job(
                 partial(getmac.get_mac_address, ip6=str(ip_addr))
             )

--- a/homeassistant/components/androidtv_remote/manifest.json
+++ b/homeassistant/components/androidtv_remote/manifest.json
@@ -8,9 +8,6 @@
   "iot_class": "local_push",
   "loggers": ["androidtvremote2"],
   "quality_scale": "platinum",
-  "requirements": [
-    "androidtvremote2==0.3.2",
-    "getmac==0.9.5"
-  ],
+  "requirements": ["androidtvremote2==0.3.2", "getmac==0.9.5"],
   "zeroconf": ["_androidtvremote2._tcp.local."]
 }

--- a/homeassistant/components/androidtv_remote/manifest.json
+++ b/homeassistant/components/androidtv_remote/manifest.json
@@ -8,6 +8,9 @@
   "iot_class": "local_push",
   "loggers": ["androidtvremote2"],
   "quality_scale": "platinum",
-  "requirements": ["androidtvremote2==0.3.2"],
+  "requirements": [
+    "androidtvremote2==0.3.2",
+    "getmac==0.9.5"
+  ],
   "zeroconf": ["_androidtvremote2._tcp.local."]
 }

--- a/homeassistant/components/androidtv_remote/manifest.json
+++ b/homeassistant/components/androidtv_remote/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["androidtvremote2"],
-  "quality_scale": "platinum",
+  "quality_scale": "gold",
   "requirements": ["androidtvremote2==0.3.2", "getmac==0.9.5"],
   "zeroconf": ["_androidtvremote2._tcp.local."]
 }

--- a/homeassistant/components/androidtv_remote/quality_scale.yaml
+++ b/homeassistant/components/androidtv_remote/quality_scale.yaml
@@ -81,4 +81,6 @@ rules:
   inject-websession:
     status: exempt
     comment: The underlying library does not use HTTP for communication.
-  strict-typing: done
+  strict-typing:
+    status: exempt
+    comment: getmac requirement does not have a py.typed file.

--- a/homeassistant/components/androidtv_remote/quality_scale.yaml
+++ b/homeassistant/components/androidtv_remote/quality_scale.yaml
@@ -82,5 +82,5 @@ rules:
     status: exempt
     comment: The underlying library does not use HTTP for communication.
   strict-typing:
-    status: exempt
-    comment: getmac requirement does not have a py.typed file.
+    status: todo
+    comment: Requirement 'getmac==0.9.5' appears untyped

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1132,6 +1132,7 @@ georss-ign-sismologia-client==0.8
 # homeassistant.components.qld_bushfire
 georss-qld-bushfire-alert-client==0.8
 
+# homeassistant.components.androidtv_remote
 # homeassistant.components.dlna_dmr
 # homeassistant.components.kef
 # homeassistant.components.nmap_tracker

--- a/tests/components/androidtv_remote/conftest.py
+++ b/tests/components/androidtv_remote/conftest.py
@@ -39,7 +39,6 @@ def mock_api() -> Generator[MagicMock]:
     ) as mock_api_cl:
         mock_api = mock_api_cl.return_value
         mock_api.async_connect = AsyncMock(return_value=None)
-        mock_api.nic_mac = None
         mock_api.device_info = {
             "manufacturer": "My Android TV manufacturer",
             "model": "My Android TV model",
@@ -118,4 +117,3 @@ def mock_get_mac_address() -> Generator[MagicMock]:
         return_value="aa:bb:cc:11:22:33",
     ) as mock_get_mac:
         yield mock_get_mac
-

--- a/tests/components/androidtv_remote/conftest.py
+++ b/tests/components/androidtv_remote/conftest.py
@@ -39,6 +39,7 @@ def mock_api() -> Generator[MagicMock]:
     ) as mock_api_cl:
         mock_api = mock_api_cl.return_value
         mock_api.async_connect = AsyncMock(return_value=None)
+        mock_api.nic_mac = None
         mock_api.device_info = {
             "manufacturer": "My Android TV manufacturer",
             "model": "My Android TV model",
@@ -107,3 +108,14 @@ def mock_config_entry() -> MockConfigEntry:
         unique_id="1a:2b:3c:4d:5e:6f",
         state=ConfigEntryState.NOT_LOADED,
     )
+
+
+@pytest.fixture(autouse=True)
+def mock_get_mac_address() -> Generator[MagicMock]:
+    """Mock getmac.get_mac_address."""
+    with patch(
+        "homeassistant.components.androidtv_remote.helpers.getmac.get_mac_address",
+        return_value="aa:bb:cc:11:22:33",
+    ) as mock_get_mac:
+        yield mock_get_mac
+

--- a/tests/components/androidtv_remote/test_init.py
+++ b/tests/components/androidtv_remote/test_init.py
@@ -5,9 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 from androidtvremote2 import CannotConnect, InvalidAuth
 
+from homeassistant.components.androidtv_remote.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
@@ -108,3 +110,73 @@ async def test_disconnect_on_stop(
     await hass.async_block_till_done()
 
     assert mock_api.disconnect.call_count == 1
+
+
+async def test_device_registry_connections(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that the device registry entry contains both Bluetooth and NIC MAC addresses."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
+    )
+    assert device is not None
+    assert (dr.CONNECTION_NETWORK_MAC, "1a:2b:3c:4d:5e:6f") in device.connections
+    assert (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:11:22:33") in device.connections
+
+
+async def test_device_registry_nic_mac_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: MagicMock,
+    device_registry: dr.DeviceRegistry,
+    mock_get_mac_address: MagicMock,
+) -> None:
+    """Test setup when physical NIC MAC cannot be resolved via ARP."""
+    mock_get_mac_address.return_value = None
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
+    )
+    assert device is not None
+    assert (dr.CONNECTION_NETWORK_MAC, "1a:2b:3c:4d:5e:6f") in device.connections
+    assert (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:11:22:33") not in device.connections
+
+
+async def test_existing_device_registry_connections_updated(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that an existing device registry entry without NIC MAC is updated."""
+    mock_config_entry.add_to_hass(hass)
+    # Pre-create device with only Bluetooth MAC as existed prior to this change
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, mock_config_entry.unique_id)},
+        connections={(dr.CONNECTION_NETWORK_MAC, "1a:2b:3c:4d:5e:6f")},
+    )
+    assert device.connections == {(dr.CONNECTION_NETWORK_MAC, "1a:2b:3c:4d:5e:6f")}
+
+    # Now setup entry
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
+    )
+    assert device is not None
+    assert (dr.CONNECTION_NETWORK_MAC, "1a:2b:3c:4d:5e:6f") in device.connections
+    assert (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:11:22:33") in device.connections
+

--- a/tests/components/androidtv_remote/test_init.py
+++ b/tests/components/androidtv_remote/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 from androidtvremote2 import CannotConnect, InvalidAuth
 
 from homeassistant.components.androidtv_remote.const import DOMAIN
+from homeassistant.components.androidtv_remote.helpers import async_get_nic_mac_address
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
@@ -179,3 +180,43 @@ async def test_existing_device_registry_connections_updated(
     assert device is not None
     assert (dr.CONNECTION_NETWORK_MAC, "1a:2b:3c:4d:5e:6f") in device.connections
     assert (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:11:22:33") in device.connections
+
+
+async def test_async_get_nic_mac_address_ipv4(
+    hass: HomeAssistant,
+    mock_get_mac_address: MagicMock,
+) -> None:
+    """Test async_get_nic_mac_address with IPv4 address."""
+    mac = await async_get_nic_mac_address(hass, "192.168.1.100")
+    assert mac == "aa:bb:cc:11:22:33"
+    assert mock_get_mac_address.call_args.kwargs == {"ip": "192.168.1.100"}
+
+
+async def test_async_get_nic_mac_address_ipv6(
+    hass: HomeAssistant,
+    mock_get_mac_address: MagicMock,
+) -> None:
+    """Test async_get_nic_mac_address with IPv6 address."""
+    mac = await async_get_nic_mac_address(hass, "2001:db8::1")
+    assert mac == "aa:bb:cc:11:22:33"
+    assert mock_get_mac_address.call_args.kwargs == {"ip6": "2001:db8::1"}
+
+
+async def test_async_get_nic_mac_address_hostname(
+    hass: HomeAssistant,
+    mock_get_mac_address: MagicMock,
+) -> None:
+    """Test async_get_nic_mac_address with hostname."""
+    mac = await async_get_nic_mac_address(hass, "android-tv.local")
+    assert mac == "aa:bb:cc:11:22:33"
+    assert mock_get_mac_address.call_args.kwargs == {"hostname": "android-tv.local"}
+
+
+async def test_async_get_nic_mac_address_not_found(
+    hass: HomeAssistant,
+    mock_get_mac_address: MagicMock,
+) -> None:
+    """Test async_get_nic_mac_address when getmac returns None."""
+    mock_get_mac_address.return_value = None
+    mac = await async_get_nic_mac_address(hass, "192.168.1.100")
+    assert mac is None

--- a/tests/components/androidtv_remote/test_init.py
+++ b/tests/components/androidtv_remote/test_init.py
@@ -179,4 +179,3 @@ async def test_existing_device_registry_connections_updated(
     assert device is not None
     assert (dr.CONNECTION_NETWORK_MAC, "1a:2b:3c:4d:5e:6f") in device.connections
     assert (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:11:22:33") in device.connections
-

--- a/tests/components/androidtv_remote/test_init.py
+++ b/tests/components/androidtv_remote/test_init.py
@@ -196,8 +196,8 @@ async def test_async_get_nic_mac_address_ipv6(
     hass: HomeAssistant,
     mock_get_mac_address: MagicMock,
 ) -> None:
-    """Test async_get_nic_mac_address with IPv6 address."""
-    mac = await async_get_nic_mac_address(hass, "2001:db8::1")
+    """Test async_get_nic_mac_address with scoped IPv6 address."""
+    mac = await async_get_nic_mac_address(hass, "2001:db8::1%eth0")
     assert mac == "aa:bb:cc:11:22:33"
     assert mock_get_mac_address.call_args.kwargs == {"ip6": "2001:db8::1"}
 

--- a/tests/components/androidtv_remote/test_init.py
+++ b/tests/components/androidtv_remote/test_init.py
@@ -162,7 +162,7 @@ async def test_existing_device_registry_connections_updated(
 ) -> None:
     """Test that an existing device registry entry without NIC MAC is updated."""
     mock_config_entry.add_to_hass(hass)
-    # Pre-create device with only Bluetooth MAC as existed prior to this change
+    # Pre-create device with only Bluetooth MAC
     device = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={(DOMAIN, mock_config_entry.unique_id)},

--- a/tests/components/androidtv_remote/test_init.py
+++ b/tests/components/androidtv_remote/test_init.py
@@ -170,7 +170,6 @@ async def test_existing_device_registry_connections_updated(
     )
     assert device.connections == {(dr.CONNECTION_NETWORK_MAC, "1a:2b:3c:4d:5e:6f")}
 
-    # Now setup entry
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
@@ -180,6 +179,33 @@ async def test_existing_device_registry_connections_updated(
     assert device is not None
     assert (dr.CONNECTION_NETWORK_MAC, "1a:2b:3c:4d:5e:6f") in device.connections
     assert (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:11:22:33") in device.connections
+
+
+async def test_existing_device_registry_connections_not_updated_when_nic_mac_none(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: MagicMock,
+    device_registry: dr.DeviceRegistry,
+    mock_get_mac_address: MagicMock,
+) -> None:
+    """Test that existing device connections are preserved when nic_mac lookup fails."""
+    mock_get_mac_address.return_value = None
+    mock_config_entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, mock_config_entry.unique_id)},
+        connections={(dr.CONNECTION_NETWORK_MAC, "1a:2b:3c:4d:5e:6f")},
+    )
+    assert device.connections == {(dr.CONNECTION_NETWORK_MAC, "1a:2b:3c:4d:5e:6f")}
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
+    )
+    assert device is not None
+    assert device.connections == {(dr.CONNECTION_NETWORK_MAC, "1a:2b:3c:4d:5e:6f")}
 
 
 async def test_async_get_nic_mac_address_ipv4(


### PR DESCRIPTION
## Proposed change

The `androidtv_remote` integration currently records only the device's Bluetooth MAC address (obtained from `discovery_info.properties.get("bt")` or the pairing certificate CN) in `device_registry.connections`. Network router device trackers (such as Aruba, MikroTik, UniFi, Ubiquiti, etc.) observe and track devices exclusively by their physical 802.11 Wi-Fi or Ethernet MAC addresses. Because the MAC addresses do not match, Home Assistant is unable to correlate the Android TV media player/remote entities with the router's device tracker.

This pull request:
1. Resolves the active physical network interface MAC address for the configured host via an ARP lookup using `getmac` in an executor job.
2. Strips IPv6 scope IDs before querying to support scoped link-local IPv6 addresses.
3. Includes the physical NIC MAC alongside the Bluetooth MAC in `DeviceInfo.connections` and updates existing devices in `dr.DeviceRegistry` when resolved.
4. Adds unit test coverage for IPv4, scoped IPv6, hostname, lookup failure, and updating pre-existing device entries.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
