### PR TITLE
Avoid blocking startup on the initial NIBE refresh

### DIFF
--- a/homeassistant/components/nibe_heatpump/__init__.py
+++ b/homeassistant/components/nibe_heatpump/__init__.py
@@ -107,7 +107,9 @@ async def async_setup_entry(
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Trigger a refresh again now that all platforms have registered
-    hass.async_create_task(coordinator.async_refresh())
+    entry.async_create_background_task(
+        hass, coordinator.async_refresh(), "NIBE initial refresh"
+    )
     return True
 
 

--- a/tests/components/nibe_heatpump/test_coordinator.py
+++ b/tests/components/nibe_heatpump/test_coordinator.py
@@ -1,6 +1,7 @@
 """Test the Nibe Heat Pump config flow."""
 
 import asyncio
+from collections.abc import AsyncGenerator
 from typing import Any
 from unittest.mock import patch
 
@@ -9,10 +10,12 @@ from nibe.heatpump import Model
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.core import CoreState, HomeAssistant
 
 from . import MockConnection, async_add_model
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
@@ -129,3 +132,76 @@ async def test_shutdown(
 
     assert done.is_set()
     mock_connection.stop.assert_called_once()
+
+
+@pytest.fixture
+async def pending_initial_refresh(
+    hass: HomeAssistant,
+    coils: dict[int, Any],
+    mock_connection: MockConnection,
+) -> AsyncGenerator[tuple[MockConfigEntry, asyncio.Event]]:
+    """Start HA while the initial register read remains pending."""
+    coils[40031] = 10
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def read_coil(coil: Coil, timeout: float = 0) -> CoilData:
+        started.set()
+        await release.wait()
+        return CoilData(coil, 10)
+
+    with patch.object(mock_connection, "read_coil", side_effect=read_coil):
+        try:
+            # Bound the wait so a startup-blocking refresh fails instead of hanging.
+            async with asyncio.timeout(5):
+                entry = await async_add_model(hass, Model.S320)
+                await started.wait()
+                await hass.async_start()
+                await hass.async_block_till_done()
+
+            assert hass.state is CoreState.running
+            assert not release.is_set()
+            assert entry.runtime_data.task is not None
+            assert not entry.runtime_data.task.done()
+            assert (
+                hass.states.get("number.heating_offset_climate_system_1_40031").state
+                == STATE_UNAVAILABLE
+            )
+            yield entry, release
+        finally:
+            release.set()
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_initial_refresh_completes_after_startup(
+    hass: HomeAssistant,
+    pending_initial_refresh: tuple[MockConfigEntry, asyncio.Event],
+) -> None:
+    """Initial readings update entities after HA has finished starting."""
+    entry, release = pending_initial_refresh
+    task = entry.runtime_data.task
+    release.set()
+    await task
+    await hass.async_block_till_done()
+
+    assert entry.runtime_data.task is None
+    assert (
+        hass.states.get("number.heating_offset_climate_system_1_40031").state == "10.0"
+    )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_unload_cancels_initial_refresh(
+    hass: HomeAssistant,
+    pending_initial_refresh: tuple[MockConfigEntry, asyncio.Event],
+    mock_connection: MockConnection,
+) -> None:
+    """Unloading cancels the pending initial read and closes its connection."""
+    entry, release = pending_initial_refresh
+    task = entry.runtime_data.task
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+
+    assert not release.is_set()
+    assert task.cancelled()
+    mock_connection.stop.assert_awaited_once()

--- a/tests/components/nibe_heatpump/test_coordinator.py
+++ b/tests/components/nibe_heatpump/test_coordinator.py
@@ -160,8 +160,6 @@ async def pending_initial_refresh(
                 await hass.async_block_till_done()
 
             assert hass.state is CoreState.running
-            assert not release.is_set()
-            assert entry.runtime_data.task is not None
             assert not entry.runtime_data.task.done()
             assert (
                 hass.states.get("number.heating_offset_climate_system_1_40031").state
@@ -197,11 +195,10 @@ async def test_unload_cancels_initial_refresh(
     mock_connection: MockConnection,
 ) -> None:
     """Unloading cancels the pending initial read and closes its connection."""
-    entry, release = pending_initial_refresh
+    entry, _ = pending_initial_refresh
     task = entry.runtime_data.task
 
     assert await hass.config_entries.async_unload(entry.entry_id)
 
-    assert not release.is_set()
     assert task.cancelled()
     mock_connection.stop.assert_awaited_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The initial NIBE refresh can block Home Assistant startup while it reads the enabled heatpump registers. On my NibeGW installation, this refresh took ~115s, leaving some other controls unavailable in the meantime.

This change runs the initial refresh as a background task, allowing Home Assistant to finish starting while readings arrive. The refresh still starts after all platforms have registered, and the task is cancelled when the integration unloads.

With the change applied locally on HA 2026.9.1, startup time measured through Supervisor dropped from ~115s to 20s.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
