### PR TITLE
Make EnergyZero electricity sensor semantics interval-neutral

### DIFF
--- a/homeassistant/components/energyzero/sensor.py
+++ b/homeassistant/components/energyzero/sensor.py
@@ -12,13 +12,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import (
-    CURRENCY_EURO,
-    PERCENTAGE,
-    UnitOfEnergy,
-    UnitOfTime,
-    UnitOfVolume,
-)
+from homeassistant.const import CURRENCY_EURO, PERCENTAGE, UnitOfEnergy, UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -60,7 +54,7 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
     ),
     EnergyZeroSensorEntityDescription(
         key="current_hour_price",
-        translation_key="current_hour_price",
+        translation_key="current_price",
         service_type="today_energy",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
@@ -69,7 +63,7 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
     ),
     EnergyZeroSensorEntityDescription(
         key="next_hour_price",
-        translation_key="next_hour_price",
+        translation_key="next_price",
         service_type="today_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         suggested_display_precision=3,
@@ -128,7 +122,6 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         key="hours_priced_equal_or_lower",
         translation_key="hours_priced_equal_or_lower",
         service_type="today_energy",
-        native_unit_of_measurement=UnitOfTime.HOURS,
         value_fn=lambda data: data.energy_today.time_ranges_priced_equal_or_lower,
     ),
 )

--- a/homeassistant/components/energyzero/strings.json
+++ b/homeassistant/components/energyzero/strings.json
@@ -17,11 +17,14 @@
       "current_hour_price": {
         "name": "Current hour"
       },
+      "current_price": {
+        "name": "Current price"
+      },
       "highest_price_time": {
         "name": "Time of highest price - today"
       },
       "hours_priced_equal_or_lower": {
-        "name": "Hours priced equal or lower than current - today"
+        "name": "Periods priced equal or lower"
       },
       "lowest_price_time": {
         "name": "Time of lowest price - today"
@@ -34,6 +37,9 @@
       },
       "next_hour_price": {
         "name": "Next hour"
+      },
+      "next_price": {
+        "name": "Next price"
       },
       "percentage_of_max": {
         "name": "Current percentage of highest price - today"

--- a/tests/components/energyzero/snapshots/test_sensor.ambr
+++ b/tests/components/energyzero/snapshots/test_sensor.ambr
@@ -86,12 +86,12 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Current hour',
+    'original_name': 'Current price',
     'platform': 'energyzero',
     'previous_unique_id': None,
     'suggested_object_id': 'energyzero_today_energy_current_hour_price',
     'supported_features': 0,
-    'translation_key': 'current_hour_price',
+    'translation_key': 'current_price',
     'unique_id': '12345_today_energy_current_hour_price',
     'unit_of_measurement': '€/kWh',
   })
@@ -100,7 +100,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by EnergyZero',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Energy market price Current hour',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Energy market price Current price',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '€/kWh',
     }),
@@ -191,22 +191,21 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Hours priced equal or lower than current - today',
+    'original_name': 'Periods priced equal or lower',
     'platform': 'energyzero',
     'previous_unique_id': None,
     'suggested_object_id': 'energyzero_today_energy_hours_priced_equal_or_lower',
     'supported_features': 0,
     'translation_key': 'hours_priced_equal_or_lower',
     'unique_id': '12345_today_energy_hours_priced_equal_or_lower',
-    'unit_of_measurement': <UnitOfTime.HOURS: 'h'>,
+    'unit_of_measurement': None,
   })
 # ---
 # name: test_sensor[sensor.energyzero_today_energy_hours_priced_equal_or_lower-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by EnergyZero',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Energy market price Hours priced equal or lower than current - today',
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.HOURS: 'h'>,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Energy market price Periods priced equal or lower',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.energyzero_today_energy_hours_priced_equal_or_lower',
@@ -408,12 +407,12 @@
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Next hour',
+    'original_name': 'Next price',
     'platform': 'energyzero',
     'previous_unique_id': None,
     'suggested_object_id': 'energyzero_today_energy_next_hour_price',
     'supported_features': 0,
-    'translation_key': 'next_hour_price',
+    'translation_key': 'next_price',
     'unique_id': '12345_today_energy_next_hour_price',
     'unit_of_measurement': '€/kWh',
   })
@@ -422,7 +421,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.ATTRIBUTION: 'attribution'>: 'Data provided by EnergyZero',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Energy market price Next hour',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Energy market price Next price',
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '€/kWh',
     }),
     'context': <ANY>,

--- a/tests/components/energyzero/test_sensor.py
+++ b/tests/components/energyzero/test_sensor.py
@@ -44,6 +44,44 @@ async def test_sensor(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
+@pytest.mark.usefixtures("mock_energyzero")
+@pytest.mark.parametrize(
+    "key",
+    ["current_hour_price", "next_hour_price", "hours_priced_equal_or_lower"],
+)
+async def test_existing_sensor(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    key: str,
+) -> None:
+    """Test existing sensors retain their registry entries and customized entity IDs."""
+    mock_config_entry.add_to_hass(hass)
+    entry = entity_registry.async_get_or_create(
+        "sensor",
+        "energyzero",
+        f"{mock_config_entry.entry_id}_today_energy_{key}",
+        suggested_object_id=f"custom_{key}",
+        config_entry=mock_config_entry,
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entry.entity_id) is not None
+    assert (updated_entry := entity_registry.async_get(entry.entity_id))
+    assert updated_entry.id == entry.id
+    assert updated_entry.unique_id == entry.unique_id
+    assert (
+        len(
+            er.async_entries_for_config_entry(
+                entity_registry, mock_config_entry.entry_id
+            )
+        )
+        == 11
+    )
+
+
 async def test_sensor_ignores_missing_tomorrow_prices(
     hass: HomeAssistant,
     mock_energyzero: MagicMock,

--- a/tests/components/energyzero/test_sensor.py
+++ b/tests/components/energyzero/test_sensor.py
@@ -44,44 +44,6 @@ async def test_sensor(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.usefixtures("mock_energyzero")
-@pytest.mark.parametrize(
-    "key",
-    ["current_hour_price", "next_hour_price", "hours_priced_equal_or_lower"],
-)
-async def test_existing_sensor(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    entity_registry: er.EntityRegistry,
-    key: str,
-) -> None:
-    """Test existing sensors retain their registry entries and customized entity IDs."""
-    mock_config_entry.add_to_hass(hass)
-    entry = entity_registry.async_get_or_create(
-        "sensor",
-        "energyzero",
-        f"{mock_config_entry.entry_id}_today_energy_{key}",
-        suggested_object_id=f"custom_{key}",
-        config_entry=mock_config_entry,
-    )
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert hass.states.get(entry.entity_id) is not None
-    assert (updated_entry := entity_registry.async_get(entry.entity_id))
-    assert updated_entry.id == entry.id
-    assert updated_entry.unique_id == entry.unique_id
-    assert (
-        len(
-            er.async_entries_for_config_entry(
-                entity_registry, mock_config_entry.entry_id
-            )
-        )
-        == 11
-    )
-
-
 async def test_sensor_ignores_missing_tomorrow_prices(
     hass: HomeAssistant,
     mock_energyzero: MagicMock,


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The EnergyZero electricity sensor `hours_priced_equal_or_lower`, now named "Periods priced equal or lower", no longer exposes the `h` unit of measurement. Its value counts price periods, not a duration in hours.

Update any templates or dashboard cards that depend on this sensor's `unit_of_measurement` attribute to handle a unitless count. The numeric value, entity ID, and unique ID remain unchanged. Automations that compare only the numeric sensor value require no changes.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Rename the electricity sensors to "Current price" and "Next price", and correct `hours_priced_equal_or_lower` to a unitless count named "Periods priced equal or lower". Its existing value counts price ranges, so reporting it in hours is misleading.

This is a preparatory semantic cleanup for interval-independent price periods. It is independently useful with hourly prices and does not implement quarter-hour support. Entity-description keys, generated entity IDs, and unique IDs are preserved, with no registry migration. Gas sensor names, fetching, coordinator timing, configuration, and service actions are unchanged.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47949
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

