### PR TITLE
Fix Amcrest entity duplication by storing serial numbers as unique_id

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -122,6 +122,7 @@ CLAUDE.md @home-assistant/core
 /homeassistant/components/ambient_station/ @bachya
 /tests/components/ambient_station/ @bachya
 /homeassistant/components/amcrest/ @flacjacket
+/tests/components/amcrest/ @flacjacket
 /homeassistant/components/analytics/ @home-assistant/core
 /tests/components/analytics/ @home-assistant/core
 /homeassistant/components/analytics_insights/ @joostlek

--- a/homeassistant/components/amcrest/__init__.py
+++ b/homeassistant/components/amcrest/__init__.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 import logging
 import threading
 from typing import Any, override
+import uuid
 
 import aiohttp
 from amcrest import AmcrestError, ApiWrapper, LoginError
@@ -29,9 +30,14 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv, discovery
+from homeassistant.helpers import (
+    config_validation as cv,
+    discovery,
+    entity_registry as er,
+)
 from homeassistant.helpers.dispatcher import async_dispatcher_send, dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
 
 from .binary_sensor import BINARY_SENSOR_KEYS, BINARY_SENSORS, check_binary_sensors
@@ -71,6 +77,9 @@ NOTIFICATION_TITLE = "Amcrest Camera Setup"
 SCAN_INTERVAL = timedelta(seconds=10)
 
 AUTHENTICATION_LIST = {"basic": "basic"}
+
+STORAGE_KEY = "amcrest"
+STORAGE_VERSION = 1
 
 
 def _has_unique_names(devices: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -357,18 +366,98 @@ def _start_event_monitor(
     thread.start()
 
 
+def _registered_serial_number(hass: HomeAssistant, name: str) -> str | None:
+    """Return the serial number a previous run assigned to this camera, if any.
+
+    The camera entity's unique_id is "<serial>-<resolution>-<channel>", and the
+    serial itself may contain hyphens, so only the two known trailing fields are
+    split off.
+    """
+    entity_registry = er.async_get(hass)
+    for entry in entity_registry.entities.values():
+        if (
+            entry.platform == DOMAIN
+            and entry.domain == Platform.CAMERA
+            and entry.original_name == name
+        ):
+            return entry.unique_id.rsplit("-", 2)[0]
+    return None
+
+
+async def _async_resolve_serial_number(
+    hass: HomeAssistant, api: AmcrestChecker, name: str
+) -> str:
+    """Determine a stable ID for a camera that has none stored yet."""
+    try:
+        if serial_number := (await api.async_serial_number).strip():
+            return serial_number
+        _LOGGER.warning(
+            "Camera %s returned an empty serial number, generating a stable ID", name
+        )
+    except AmcrestError:
+        _LOGGER.warning(
+            "Could not reach %s camera during initial setup, generating a stable ID; "
+            "the integration will recover when the camera comes online",
+            name,
+        )
+
+    # An earlier run may already have registered entities under a serial number.
+    # Reusing it keeps those entities rather than orphaning them behind a UUID.
+    if registered := _registered_serial_number(hass, name):
+        _LOGGER.debug("Reusing previously registered ID for camera %s", name)
+        return registered
+
+    return str(uuid.uuid4())
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Amcrest IP Camera component."""
     hass.data.setdefault(DATA_AMCREST, {DEVICES: {}})
+
+    store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
+    stored_data: dict[str, Any] = await store.async_load() or {}
+    serial_numbers: dict[str, str] = stored_data.get("serial_numbers", {})
+    store_updated = False
+
+    # Names are unique per _has_unique_names, so they identify a stored camera.
+    configured_names = {device[CONF_NAME] for device in config[DOMAIN]}
+    for stale_name in serial_numbers.keys() - configured_names:
+        _LOGGER.debug(
+            "Removing stored ID for camera %s, no longer configured", stale_name
+        )
+        del serial_numbers[stale_name]
+        store_updated = True
+
+    apis = {
+        device[CONF_NAME]: AmcrestChecker(
+            hass,
+            device[CONF_NAME],
+            device[CONF_HOST],
+            device[CONF_PORT],
+            device[CONF_USERNAME],
+            device[CONF_PASSWORD],
+        )
+        for device in config[DOMAIN]
+    }
+
+    # Resolve together; an unreachable camera otherwise blocks setup for the
+    # full communication timeout before the next one is even tried.
+    if unresolved := [name for name in apis if name not in serial_numbers]:
+        resolved = await asyncio.gather(
+            *(
+                _async_resolve_serial_number(hass, apis[name], name)
+                for name in unresolved
+            )
+        )
+        serial_numbers.update(zip(unresolved, resolved, strict=True))
+        store_updated = True
 
     for device in config[DOMAIN]:
         name: str = device[CONF_NAME]
         username: str = device[CONF_USERNAME]
         password: str = device[CONF_PASSWORD]
 
-        api = AmcrestChecker(
-            hass, name, device[CONF_HOST], device[CONF_PORT], username, password
-        )
+        api = apis[name]
 
         ffmpeg_arguments = device[CONF_FFMPEG_ARGUMENTS]
         resolution = RESOLUTION_LIST[device[CONF_RESOLUTION]]
@@ -394,6 +483,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             stream_source,
             resolution,
             control_light,
+            serial_number=serial_numbers[name],
         )
 
         hass.async_create_task(
@@ -446,6 +536,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 )
             )
 
+    if store_updated:
+        await store.async_save({"serial_numbers": serial_numbers})
+
     if not hass.data[DATA_AMCREST][DEVICES]:
         return False
 
@@ -465,3 +558,4 @@ class AmcrestDevice:
     resolution: int
     control_light: bool
     channel: int = 0
+    serial_number: str | None = None

--- a/homeassistant/components/amcrest/binary_sensor.py
+++ b/homeassistant/components/amcrest/binary_sensor.py
@@ -171,6 +171,10 @@ class AmcrestBinarySensor(BinarySensorEntity):
 
         self._attr_name = f"{name} {entity_description.name}"
         self._attr_should_poll = entity_description.should_poll
+        if device.serial_number is not None:
+            self._attr_unique_id = (
+                f"{device.serial_number}-{entity_description.key}-{self._channel}"
+            )
 
     @property
     @override
@@ -198,19 +202,12 @@ class AmcrestBinarySensor(BinarySensorEntity):
             # accordingly.
             with suppress(AmcrestError):
                 await self._api.async_current_time
-                await self._async_update_unique_id()
         self._attr_is_on = self._api.available
 
     async def _async_update_others(self) -> None:
         if not self.available:
             return
         _LOGGER.debug(_UPDATE_MSG, self.name)
-
-        try:
-            await self._async_update_unique_id()
-        except AmcrestError as error:
-            log_update_error(_LOGGER, "update", self.name, "binary sensor", error)
-            return
 
         if not (event_codes := self.entity_description.event_codes):
             raise ValueError(f"Binary sensor {self.name} event codes not set")
@@ -225,15 +222,6 @@ class AmcrestBinarySensor(BinarySensorEntity):
         except AmcrestError as error:
             log_update_error(_LOGGER, "update", self.name, "binary sensor", error)
             return
-
-    async def _async_update_unique_id(self) -> None:
-        """Set the unique id."""
-        if self._attr_unique_id is None and (
-            serial_number := await self._api.async_serial_number
-        ):
-            self._attr_unique_id = (
-                f"{serial_number}-{self.entity_description.key}-{self._channel}"
-            )
 
     @callback
     def async_on_demand_update_online(self) -> None:

--- a/homeassistant/components/amcrest/camera.py
+++ b/homeassistant/components/amcrest/camera.py
@@ -98,6 +98,10 @@ class AmcrestCam(Camera):
         self._channel = device.channel
         self._token = self._auth = device.authentication
         self._control_light = device.control_light
+        if device.serial_number is not None:
+            self._attr_unique_id = (
+                f"{device.serial_number}-{self._resolution}-{self._channel}"
+            )
         self._is_recording: bool = False
         self._motion_detection_enabled: bool = False
         self._brand: str | None = None
@@ -313,13 +317,6 @@ class AmcrestCam(Camera):
                     self._model = resp
                 else:
                     self._model = "unknown"
-            if self._attr_unique_id is None:
-                serial_number = (await self._api.async_serial_number).strip()
-                if serial_number:
-                    self._attr_unique_id = (
-                        f"{serial_number}-{self._resolution}-{self._channel}"
-                    )
-                    _LOGGER.debug("Assigned unique_id=%s", self._attr_unique_id)
             if self._rtsp_url is None:
                 self._rtsp_url = await self._api.async_rtsp_url(typeno=self._resolution)
 

--- a/homeassistant/components/amcrest/sensor.py
+++ b/homeassistant/components/amcrest/sensor.py
@@ -80,6 +80,10 @@ class AmcrestSensor(SensorEntity):
 
         self._attr_name = f"{name} {description.name}"
         self._attr_extra_state_attributes = {}
+        if device.serial_number is not None:
+            self._attr_unique_id = (
+                f"{device.serial_number}-{description.key}-{self._channel}"
+            )
 
     @property
     @override
@@ -96,11 +100,6 @@ class AmcrestSensor(SensorEntity):
         sensor_type = self.entity_description.key
 
         try:
-            if self._attr_unique_id is None and (
-                serial_number := (await self._api.async_serial_number)
-            ):
-                self._attr_unique_id = f"{serial_number}-{sensor_type}-{self._channel}"
-
             if sensor_type == SENSOR_PTZ_PRESET:
                 self._attr_native_value = await self._api.async_ptz_presets_count
 

--- a/homeassistant/components/amcrest/switch.py
+++ b/homeassistant/components/amcrest/switch.py
@@ -1,6 +1,9 @@
 """Support for Amcrest Switches."""
 
+import logging
 from typing import TYPE_CHECKING, Any, override
+
+from amcrest import AmcrestError
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import CONF_NAME, CONF_SWITCHES
@@ -9,6 +12,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import DATA_AMCREST, DEVICES
+from .helpers import log_update_error
+
+_LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from . import AmcrestDevice
@@ -62,6 +68,10 @@ class AmcrestSwitch(SwitchEntity):
         self._api = device.api
         self.entity_description = entity_description
         self._attr_name = f"{name} {entity_description.name}"
+        if device.serial_number is not None:
+            self._attr_unique_id = (
+                f"{device.serial_number}-{entity_description.key}-{device.channel}"
+            )
 
     @property
     @override
@@ -88,5 +98,12 @@ class AmcrestSwitch(SwitchEntity):
 
     async def async_update(self) -> None:
         """Update switch."""
-        io_res = (await self._api.async_privacy_config()).splitlines()[0].split("=")[1]
-        self._attr_is_on = io_res == "true"
+        if not self.available:
+            return
+        try:
+            io_res = (
+                (await self._api.async_privacy_config()).splitlines()[0].split("=")[1]
+            )
+            self._attr_is_on = io_res == "true"
+        except AmcrestError as error:
+            log_update_error(_LOGGER, "update", self.name, "switch", error)

--- a/tests/components/amcrest/__init__.py
+++ b/tests/components/amcrest/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Amcrest integration."""

--- a/tests/components/amcrest/conftest.py
+++ b/tests/components/amcrest/conftest.py
@@ -1,0 +1,207 @@
+"""Fixtures for Amcrest integration tests."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.components.amcrest import AmcrestDevice
+
+CAMERA_NAME = "Test Camera"
+SERIAL_NUMBER = "SN-TEST-12345"
+STORAGE_KEY = "amcrest"
+
+
+def stored_serials(serial_numbers: dict[str, str]) -> dict[str, Any]:
+    """Build a hass_storage entry as a previous HA run would have written it."""
+    return {
+        "version": 1,
+        "minor_version": 1,
+        "key": STORAGE_KEY,
+        "data": {"serial_numbers": serial_numbers},
+    }
+
+
+# YAML config for integration-level tests; produces the default camera name
+# "Amcrest Camera" via the amcrest config schema. Every optional platform is
+# enabled so setup exercises the unique_id of all four entity platforms.
+CAMERA_CONFIG = {
+    "amcrest": [
+        {
+            "host": "192.168.1.100",
+            "username": "admin",
+            "password": "password",
+            "sensors": ["ptz_preset", "sdcard"],
+            "switches": ["privacy_mode"],
+            "binary_sensors": ["online", "motion_detected_polled"],
+        }
+    ]
+}
+
+
+class _MockAmcrestAPI:
+    """Test double for AmcrestChecker.
+
+    Async properties in the amcrest library are Python @property decorators on
+    async def methods, so accessing them returns a coroutine rather than a
+    coroutine function.  Using AsyncMock() directly for these would require
+    calling the mock *and* awaiting the result, which doesn't match how the
+    integration accesses them (``await api.some_prop`` with no parentheses).
+    The @property pattern here replicates the real library behaviour.
+    """
+
+    available = True
+
+    def __init__(self) -> None:
+        """Set configurable values that tests can override directly."""
+        # Configurable return values
+        self.serial = SERIAL_NUMBER
+        self.ptz_presets_count = 5
+        self.storage_all: dict = {
+            "total": (100.0, "GB"),
+            "used": (50.0, "GB"),
+            "used_percent": 50.0,
+        }
+        self.vendor: str | None = "Amcrest"
+        self.device_type: str | None = "IP2M-841"
+        self.record_mode = "Automatic"
+        self.day_night_color = 0  # index 0 → "color"
+        self.video_enabled = True
+        self.motion_detector = False
+        self.audio_enabled = False
+        self.motion_recording = False
+        self.privacy_mode = False
+        self.event_channels: list[int] = []
+        self.rtsp_url_value = "rtsp://192.168.1.100/live"
+        # Map attribute name → exception to raise on access
+        self._raise_on: dict[str, Exception] = {}
+
+    def set_error(self, attr: str, exc: Exception) -> None:
+        """Inject an exception to be raised when *attr* is next accessed."""
+        self._raise_on[attr] = exc
+
+    def _value_or_raise(self, attr: str, value):
+        if attr in self._raise_on:
+            raise self._raise_on[attr]
+        return value
+
+    # Each returns a fresh coroutine so multiple awaits work correctly.
+
+    @property
+    def async_serial_number(self):
+        async def _():
+            return self._value_or_raise("serial_number", self.serial)
+
+        return _()
+
+    @property
+    def async_ptz_presets_count(self):
+        async def _():
+            return self._value_or_raise("ptz_presets_count", self.ptz_presets_count)
+
+        return _()
+
+    @property
+    def async_storage_all(self):
+        async def _():
+            return self._value_or_raise("storage_all", self.storage_all)
+
+        return _()
+
+    @property
+    def async_current_time(self):
+        async def _():
+            return self._value_or_raise("current_time", "2024-01-01T00:00:00")
+
+        return _()
+
+    @property
+    def async_vendor_information(self):
+        async def _():
+            return self._value_or_raise("vendor_information", self.vendor)
+
+        return _()
+
+    @property
+    def async_device_type(self):
+        async def _():
+            return self._value_or_raise("device_type", self.device_type)
+
+        return _()
+
+    @property
+    def async_record_mode(self):
+        async def _():
+            return self._value_or_raise("record_mode", self.record_mode)
+
+        return _()
+
+    @property
+    def async_day_night_color(self):
+        async def _():
+            return self._value_or_raise("day_night_color", self.day_night_color)
+
+        return _()
+
+    async def async_privacy_config(self) -> str:
+        if "privacy_config" in self._raise_on:
+            raise self._raise_on["privacy_config"]
+        mode = "true" if self.privacy_mode else "false"
+        return f"table.LeLensMask[0].Enable={mode}\nfoo=bar"
+
+    async def async_event_channels_happened(self, eventcode: str) -> list[int]:
+        if "event_channels_happened" in self._raise_on:
+            raise self._raise_on["event_channels_happened"]
+        return self.event_channels
+
+    async def async_rtsp_url(self, *, channel: int = 1, typeno: int = 0) -> str:
+        return self.rtsp_url_value
+
+    async def async_is_video_enabled(self, channel: int, stream: str) -> bool:
+        return self.video_enabled
+
+    async def async_is_motion_detector_on(self, *, channel: int = 0) -> bool:
+        return self.motion_detector
+
+    async def async_is_audio_enabled(self, channel: int, stream: str) -> bool:
+        return self.audio_enabled
+
+    async def async_is_record_on_motion_detection(self) -> bool:
+        return self.motion_recording
+
+
+@pytest.fixture
+def mock_event_monitor() -> None:
+    """Patch _start_event_monitor to prevent daemon thread creation."""
+    with patch("homeassistant.components.amcrest._start_event_monitor"):
+        yield
+
+
+@pytest.fixture
+def mock_discovery() -> None:
+    """Patch discovery.async_load_platform to prevent platform loading."""
+    with patch(
+        "homeassistant.helpers.discovery.async_load_platform",
+        new_callable=AsyncMock,
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_api() -> _MockAmcrestAPI:
+    """Return a fresh _MockAmcrestAPI for each test."""
+    return _MockAmcrestAPI()
+
+
+@pytest.fixture
+def device(mock_api: _MockAmcrestAPI) -> AmcrestDevice:
+    """AmcrestDevice backed by the mock API with a known serial number."""
+    return AmcrestDevice(
+        api=mock_api,
+        authentication=None,
+        ffmpeg_arguments=["-pred", "1"],
+        stream_source="snapshot",
+        resolution=0,
+        control_light=True,
+        serial_number=SERIAL_NUMBER,
+    )

--- a/tests/components/amcrest/test_entity_registry.py
+++ b/tests/components/amcrest/test_entity_registry.py
@@ -1,0 +1,183 @@
+"""Integration-level tests for entity registry unique ID behaviour."""
+
+from typing import Any
+from unittest.mock import patch
+
+from amcrest import AmcrestError
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from .conftest import (
+    CAMERA_CONFIG,
+    SERIAL_NUMBER,
+    STORAGE_KEY,
+    _MockAmcrestAPI,
+    stored_serials,
+)
+
+# Default camera name produced by the amcrest config schema when no `name` key
+# is supplied in CAMERA_CONFIG.
+_DEFAULT_CAMERA_NAME = "Amcrest Camera"
+
+# The entities CAMERA_CONFIG produces: domain, object id, the unique_id suffix
+# appended to the camera's serial number, and the registered original name.
+_ENTITIES = [
+    ("camera", "amcrest_camera", "0-0", _DEFAULT_CAMERA_NAME),
+    ("binary_sensor", "amcrest_camera_online", "online-0", "Amcrest Camera Online"),
+    (
+        "binary_sensor",
+        "amcrest_camera_motion_detected",
+        "motion_detected_polled-0",
+        "Amcrest Camera Motion Detected",
+    ),
+    (
+        "sensor",
+        "amcrest_camera_ptz_preset",
+        "ptz_preset-0",
+        "Amcrest Camera PTZ Preset",
+    ),
+    ("sensor", "amcrest_camera_sd_used", "sdcard-0", "Amcrest Camera SD Used"),
+    (
+        "switch",
+        "amcrest_camera_privacy_mode",
+        "privacy_mode-0",
+        "Amcrest Camera Privacy Mode",
+    ),
+]
+
+
+def _make_unreachable(mock_api: _MockAmcrestAPI) -> None:
+    """Make every call the entities use during setup fail, as an offline camera would."""
+    mock_api.available = False
+    mock_api.set_error("serial_number", AmcrestError("offline"))
+    mock_api.set_error("current_time", AmcrestError("offline"))
+    mock_api.set_error("event_channels_happened", AmcrestError("offline"))
+    mock_api.set_error("ptz_presets_count", AmcrestError("offline"))
+    mock_api.set_error("storage_all", AmcrestError("offline"))
+    mock_api.set_error("privacy_config", AmcrestError("offline"))
+    mock_api.set_error("vendor_information", AmcrestError("offline"))
+
+
+def _seed_previous_run(entity_registry: er.EntityRegistry, serial: str) -> list[str]:
+    """Register the entities a previous run with a reachable camera would have left."""
+    return [
+        entity_registry.async_get_or_create(
+            domain,
+            "amcrest",
+            f"{serial}-{suffix}",
+            suggested_object_id=object_id,
+            original_name=original_name,
+        ).entity_id
+        for domain, object_id, suffix, original_name in _ENTITIES
+    ]
+
+
+async def _setup(hass: HomeAssistant, mock_api: _MockAmcrestAPI) -> None:
+    """Run a full setup of the amcrest integration against the mock API."""
+    with patch(
+        "homeassistant.components.amcrest.AmcrestChecker", return_value=mock_api
+    ):
+        assert await async_setup_component(hass, "amcrest", CAMERA_CONFIG)
+        await hass.async_block_till_done()
+
+
+def _amcrest_entries(entity_registry: er.EntityRegistry) -> list[er.RegistryEntry]:
+    """Return every amcrest entry currently in the registry."""
+    return [
+        entry
+        for entry in entity_registry.entities.values()
+        if entry.platform == "amcrest"
+    ]
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_entities_registered_with_serial_unique_ids(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_storage: dict[str, Any],
+    mock_api: _MockAmcrestAPI,
+) -> None:
+    """A reachable camera registers every entity against its serial number."""
+    await _setup(hass, mock_api)
+
+    entries = _amcrest_entries(entity_registry)
+    assert len(entries) == len(_ENTITIES)
+    for entry in entries:
+        assert entry.unique_id.startswith(SERIAL_NUMBER), (
+            f"{entry.entity_id!r} has unique_id {entry.unique_id!r}; "
+            f"expected prefix {SERIAL_NUMBER!r}"
+        )
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_entities_registered_when_camera_unreachable(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_storage: dict[str, Any],
+    mock_api: _MockAmcrestAPI,
+) -> None:
+    """An unreachable camera still registers every entity, against the fallback ID."""
+    _make_unreachable(mock_api)
+
+    await _setup(hass, mock_api)
+
+    # Before the fix, an unreachable camera left unique_id unset, so none of
+    # these entities reached the registry at all.
+    entries = _amcrest_entries(entity_registry)
+    assert len(entries) == len(_ENTITIES)
+    fallback_id = hass_storage[STORAGE_KEY]["data"]["serial_numbers"][
+        _DEFAULT_CAMERA_NAME
+    ]
+    for entry in entries:
+        assert entry.unique_id.startswith(fallback_id)
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_entity_ids_stable_across_restart(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_storage: dict[str, Any],
+    mock_api: _MockAmcrestAPI,
+) -> None:
+    """Entity IDs survive a restart in which the camera is unreachable."""
+    previous_entity_ids = _seed_previous_run(entity_registry, SERIAL_NUMBER)
+    hass_storage[STORAGE_KEY] = stored_serials({_DEFAULT_CAMERA_NAME: SERIAL_NUMBER})
+    _make_unreachable(mock_api)
+
+    await _setup(hass, mock_api)
+
+    # Asserted against the state machine, not the registry: entities without a
+    # unique_id never reach the registry, so that is where the duplicates land.
+    live_entity_ids = hass.states.async_entity_ids()
+    assert sorted(live_entity_ids) == sorted(previous_entity_ids)
+    assert not any("_2" in entity_id for entity_id in live_entity_ids), (
+        f"Unexpected _2 suffix: {sorted(live_entity_ids)}"
+    )
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_registered_serial_reused_when_camera_unreachable(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_storage: dict[str, Any],
+    mock_api: _MockAmcrestAPI,
+) -> None:
+    """With nothing stored, an offline camera recovers its serial from the registry.
+
+    This is the upgrade path: entities already exist under the camera's real
+    serial number, but nothing has been persisted yet. Minting a UUID here would
+    orphan them permanently, since the UUID is preferred on every later start.
+    """
+    previous_entity_ids = _seed_previous_run(entity_registry, SERIAL_NUMBER)
+    _make_unreachable(mock_api)
+
+    await _setup(hass, mock_api)
+
+    assert hass_storage[STORAGE_KEY]["data"] == {
+        "serial_numbers": {_DEFAULT_CAMERA_NAME: SERIAL_NUMBER}
+    }
+    entries = _amcrest_entries(entity_registry)
+    assert sorted(entry.entity_id for entry in entries) == sorted(previous_entity_ids)

--- a/tests/components/amcrest/test_init.py
+++ b/tests/components/amcrest/test_init.py
@@ -1,0 +1,145 @@
+"""Tests for the Amcrest integration setup."""
+
+import re
+from typing import Any
+from unittest.mock import patch
+
+from amcrest import AmcrestError
+import pytest
+
+from homeassistant.components.amcrest.const import DATA_AMCREST, DEVICES
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .conftest import CAMERA_CONFIG, STORAGE_KEY, stored_serials
+
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+class _CheckerOnline:
+    """Mock AmcrestChecker — camera online, returns serial SN-LIVE."""
+
+    available = True
+
+    @property
+    def async_serial_number(self):
+        async def _get() -> str:
+            return "SN-LIVE"
+
+        return _get()
+
+
+class _CheckerEmptySerial:
+    """Mock AmcrestChecker — camera online but reports an empty serial number."""
+
+    available = True
+
+    @property
+    def async_serial_number(self):
+        async def _get() -> str:
+            return ""
+
+        return _get()
+
+
+class _CheckerOffline:
+    """Mock AmcrestChecker — camera unreachable, raises AmcrestError on serial fetch."""
+
+    available = True
+
+    @property
+    def async_serial_number(self):
+        async def _get() -> str:
+            raise AmcrestError("Camera offline")
+
+        return _get()
+
+
+@pytest.mark.usefixtures("mock_event_monitor", "mock_discovery")
+async def test_serial_fetched_on_first_setup(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Serial number is fetched from camera and persisted on first setup."""
+    with patch(
+        "homeassistant.components.amcrest.AmcrestChecker",
+        return_value=_CheckerOnline(),
+    ):
+        assert await async_setup_component(hass, "amcrest", CAMERA_CONFIG)
+
+    device = hass.data[DATA_AMCREST][DEVICES]["Amcrest Camera"]
+    assert device.serial_number == "SN-LIVE"
+    assert hass_storage[STORAGE_KEY]["data"] == {
+        "serial_numbers": {"Amcrest Camera": "SN-LIVE"}
+    }
+
+
+@pytest.mark.usefixtures("mock_event_monitor", "mock_discovery")
+async def test_serial_loaded_from_storage_on_restart(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Stored serial number is used on restart without contacting the camera."""
+    hass_storage[STORAGE_KEY] = stored_serials({"Amcrest Camera": "SN-STORED"})
+
+    with patch(
+        "homeassistant.components.amcrest.AmcrestChecker",
+        return_value=_CheckerOnline(),
+    ):
+        assert await async_setup_component(hass, "amcrest", CAMERA_CONFIG)
+
+    device = hass.data[DATA_AMCREST][DEVICES]["Amcrest Camera"]
+    # SN-STORED (from storage) confirms the camera serial was not fetched live
+    assert device.serial_number == "SN-STORED"
+    assert hass_storage[STORAGE_KEY]["data"] == {
+        "serial_numbers": {"Amcrest Camera": "SN-STORED"}
+    }
+
+
+@pytest.mark.parametrize(
+    "checker",
+    [
+        pytest.param(_CheckerEmptySerial(), id="empty_serial"),
+        pytest.param(_CheckerOffline(), id="camera_offline"),
+    ],
+)
+@pytest.mark.usefixtures("mock_event_monitor", "mock_discovery")
+async def test_uuid_fallback_when_serial_unavailable(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    checker: _CheckerEmptySerial | _CheckerOffline,
+) -> None:
+    """A stable UUID is generated and persisted when a serial number cannot be obtained."""
+    with patch(
+        "homeassistant.components.amcrest.AmcrestChecker",
+        return_value=checker,
+    ):
+        assert await async_setup_component(hass, "amcrest", CAMERA_CONFIG)
+
+    device = hass.data[DATA_AMCREST][DEVICES]["Amcrest Camera"]
+    assert device.serial_number is not None
+    assert _UUID_RE.match(device.serial_number)
+    stored = hass_storage[STORAGE_KEY]["data"]["serial_numbers"]
+    assert stored["Amcrest Camera"] == device.serial_number
+
+
+@pytest.mark.usefixtures("mock_event_monitor", "mock_discovery")
+async def test_stale_serials_pruned_from_storage(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Serials for cameras no longer in the config are dropped from storage."""
+    hass_storage[STORAGE_KEY] = stored_serials(
+        {"Amcrest Camera": "SN-STORED", "Removed Camera": "SN-GONE"}
+    )
+
+    with patch(
+        "homeassistant.components.amcrest.AmcrestChecker",
+        return_value=_CheckerOnline(),
+    ):
+        assert await async_setup_component(hass, "amcrest", CAMERA_CONFIG)
+
+    # The configured camera is kept; the one dropped from YAML is pruned.
+    assert hass_storage[STORAGE_KEY]["data"] == {
+        "serial_numbers": {"Amcrest Camera": "SN-STORED"}
+    }

--- a/tests/components/amcrest/test_switch.py
+++ b/tests/components/amcrest/test_switch.py
@@ -1,0 +1,72 @@
+"""Tests for the Amcrest switch platform."""
+
+import logging
+
+from amcrest import AmcrestError
+import pytest
+
+from homeassistant.components.amcrest import AmcrestDevice
+from homeassistant.components.amcrest.switch import SWITCH_TYPES, AmcrestSwitch
+
+from .conftest import CAMERA_NAME, _MockAmcrestAPI
+
+_PRIVACY_MODE = SWITCH_TYPES[0]
+
+
+@pytest.mark.parametrize(
+    ("privacy_mode", "expected_is_on"),
+    [
+        pytest.param(True, True, id="privacy_on"),
+        pytest.param(False, False, id="privacy_off"),
+    ],
+)
+async def test_switch_update(
+    mock_api: _MockAmcrestAPI,
+    device: AmcrestDevice,
+    privacy_mode: bool,
+    expected_is_on: bool,
+) -> None:
+    """async_update reflects the privacy mode reported by the camera."""
+    mock_api.privacy_mode = privacy_mode
+    switch = AmcrestSwitch(CAMERA_NAME, device, _PRIVACY_MODE)
+
+    await switch.async_update()
+
+    assert switch.is_on is expected_is_on
+
+
+async def test_switch_update_skips_when_unavailable(
+    mock_api: _MockAmcrestAPI, device: AmcrestDevice
+) -> None:
+    """async_update does not query the camera while it is unavailable."""
+    mock_api.privacy_mode = True
+    mock_api.available = False
+    switch = AmcrestSwitch(CAMERA_NAME, device, _PRIVACY_MODE)
+
+    await switch.async_update()
+
+    # is_on stays None instead of picking up privacy_mode=True, which is only
+    # reachable by querying the camera.
+    assert switch.is_on is None
+
+
+async def test_switch_update_handles_error(
+    mock_api: _MockAmcrestAPI,
+    device: AmcrestDevice,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An AmcrestError during update is logged and leaves the last state intact."""
+    mock_api.privacy_mode = True
+    switch = AmcrestSwitch(CAMERA_NAME, device, _PRIVACY_MODE)
+    await switch.async_update()
+    assert switch.is_on is True
+
+    mock_api.set_error("privacy_config", AmcrestError("timeout"))
+    with caplog.at_level(logging.ERROR):
+        await switch.async_update()
+
+    assert switch.is_on is True
+    assert (
+        f"Could not update {CAMERA_NAME} Privacy Mode switch due to error: AmcrestError"
+        in caplog.text
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**This is a fix for a long-standing bug, not a feature improvement.** `amcrest` is a `legacy` quality scale integration, and nothing here adds user-facing functionality, new configuration, or new capabilities. The storage introduced below exists solely to make the existing entity identity stable; it is the smallest mechanism I could find that actually fixes the defect rather than papering over it.

Entity unique IDs were assigned lazily, during `async_update`, from the camera's serial number. That means the unique ID only existed if the camera happened to answer. When a camera was unreachable at startup — a rebooting camera, a switch coming up after Home Assistant, a PoE flap — the unique ID stayed `None`. Home Assistant then fell back to name-based entity IDs while the entity registry still held the entries from the previous run, so the entity IDs collided and came back with a `_2` suffix. Users lost history, and every automation, script, and dashboard card referencing the old entity ID silently stopped working. This has been reported since 2022 (see linked issues below); both reports were closed by the stale bot rather than fixed.

The serial number is now resolved once during `async_setup` and persisted in a `Store`, so it survives restarts and is available before any entity is constructed. Each platform builds its unique ID from the stored serial at construction time, which is what makes the ID independent of whether the camera is reachable. Serial numbers are resolved concurrently, so a camera that is down does not block setup for the full 6.05s communication timeout before the next one is even tried. Serial numbers for cameras no longer present in the YAML configuration are pruned from storage, so the store does not grow without bound.

When a camera cannot be reached and nothing has been stored yet, the serial number is recovered from an existing camera entity in the entity registry before falling back to a generated UUID. This matters for the first restart after upgrading: without it, a camera that happened to be down at that moment would get a UUID, orphaning the entities already registered under its real serial number, and — because the stored value is preferred on every later start — it would never recover. Only when there is no prior registration to recover from is a UUID generated and persisted.

`switch.py` also gained the availability guard and `AmcrestError` handling that the other platforms already had. Without it, an unreachable camera produced an unhandled `CommError` traceback from `async_update` (`ERROR [homeassistant.components.switch] amcrest: Error on device update!`); it now logs a single line through `log_update_error`, consistent with the sensor, binary sensor, and camera platforms.

That switch change is bundled here deliberately, rather than split out, even though the guidance is to keep a PR to a single subject. It sits on the same `async_update` path this PR already rewrites for the unique ID, and the crash it fixes is triggered by precisely the condition the rest of the PR is about: a camera that cannot be reached. The integration tests added here make the camera unreachable in order to reproduce the duplicate entity IDs, and that same scenario is what produced the unhandled traceback, so the coverage arrives together. Splitting it would mean shipping tests for the offline path in one PR while leaving a traceback from that path in `dev`. If reviewers would rather this PR stayed strictly to the unique ID, say so and I will move it to a follow-up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/71944, https://github.com/home-assistant/core/issues/132308 (both describe this defect and were closed as stale, not fixed)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
