### PR TITLE
Back off SNMP polling when a host stays unreachable

### DIFF
--- a/homeassistant/components/snmp/sensor.py
+++ b/homeassistant/components/snmp/sensor.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 import logging
 from struct import unpack
+from time import monotonic
 from typing import override
 
 from pyasn1.codec.ber import decoder
@@ -75,6 +76,14 @@ from .util import async_create_request_cmd_args
 _LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(seconds=10)
+
+# A host that stays unreachable is polled with an exponentially increasing
+# delay instead of once per scan interval forever. The first few failures are
+# still retried at the normal interval so that a transient timeout recovers
+# immediately.
+FAILURES_BEFORE_BACKOFF = 3
+MIN_BACKOFF = 60
+MAX_BACKOFF = 600
 
 TRIGGER_ENTITY_OPTIONS = (
     CONF_AVAILABILITY,
@@ -222,12 +231,30 @@ class SnmpData:
         self._accept_errors = accept_errors
         self._default_value = default_value
         self.value = None
+        self._failures = 0
+        self._skip_until = 0.0
 
     async def async_update(self):
         """Get the latest data from the remote SNMP capable host."""
 
+        now = monotonic()
+        if now < self._skip_until:
+            # Backing off after repeated failures; keep the previous value.
+            return
+
         get_result = await get_cmd(*self._request_args)
         errindication, errstatus, errindex, restable = get_result
+
+        if errindication or errstatus:
+            self._failures += 1
+            if self._failures > FAILURES_BEFORE_BACKOFF:
+                self._skip_until = now + min(
+                    MAX_BACKOFF,
+                    MIN_BACKOFF * 2 ** (self._failures - FAILURES_BEFORE_BACKOFF - 1),
+                )
+        else:
+            self._failures = 0
+            self._skip_until = 0.0
 
         if errindication and not self._accept_errors:
             _LOGGER.error("SNMP error: %s", errindication)

--- a/tests/components/snmp/test_sensor.py
+++ b/tests/components/snmp/test_sensor.py
@@ -71,7 +71,6 @@ async def test_backoff_when_device_stays_unreachable(hass: HomeAssistant) -> Non
     clock = 0.0
     now = dt_util.utcnow()
     interval = SCAN_INTERVAL.total_seconds()
-    skipped_polls = int(MIN_BACKOFF // interval)
 
     def _monotonic() -> float:
         return clock
@@ -92,24 +91,28 @@ async def test_backoff_when_device_stays_unreachable(hass: HomeAssistant) -> Non
         await hass.async_block_till_done()
         assert get_cmd.call_count == 1
 
-        # Early failures are still retried on every scan interval.
+        # Failures below the threshold are retried on every scan interval.
         for expected in range(2, FAILURES_BEFORE_BACKOFF + 1):
             await _poll()
             assert get_cmd.call_count == expected
 
-        # Threshold passed: the next MIN_BACKOFF seconds of polls are skipped.
+        # The failure that exceeds the threshold still polls, and arms the backoff.
+        await _poll()
         calls = get_cmd.call_count
-        for _ in range(skipped_polls):
+        assert calls == FAILURES_BEFORE_BACKOFF + 1
+
+        # Polls inside the backoff window are skipped.
+        for _ in range(int(MIN_BACKOFF // interval) - 1):
             await _poll()
         assert get_cmd.call_count == calls
 
-        # Once the delay expires, polling resumes.
+        # The poll at the end of the window runs, and doubles the delay.
         await _poll()
         assert get_cmd.call_count == calls + 1
-
-        # That failure doubled the delay, so MIN_BACKOFF is no longer enough.
         calls = get_cmd.call_count
-        for _ in range(skipped_polls):
+
+        # MIN_BACKOFF is no longer long enough to reach the next poll.
+        for _ in range(int(MIN_BACKOFF // interval)):
             await _poll()
         assert get_cmd.call_count == calls
 

--- a/tests/components/snmp/test_sensor.py
+++ b/tests/components/snmp/test_sensor.py
@@ -1,11 +1,16 @@
 """Tests for SNMP sensor platform setup behaviour."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
 from pysnmp.proto.rfc1902 import Integer32
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.components.snmp.sensor import FAILURES_BEFORE_BACKOFF, SCAN_INTERVAL
+from homeassistant.components.snmp.sensor import (
+    FAILURES_BEFORE_BACKOFF,
+    MIN_BACKOFF,
+    SCAN_INTERVAL,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -56,36 +61,67 @@ async def test_entity_recovers_when_device_unreachable(hass: HomeAssistant) -> N
     assert hass.states.get("sensor.snmp").state == "13"
 
 
+TIMEOUT_RESULT = ("No SNMP response received before timeout", None, None, None)
+OK_RESULT = (None, None, None, [[Integer32(13)]])
+
+
 async def test_backoff_when_device_stays_unreachable(hass: HomeAssistant) -> None:
-    """Test polling backs off once a device has failed repeatedly."""
-    get_cmd = AsyncMock(
-        return_value=("No SNMP response received before timeout", None, None, None)
-    )
+    """Test polling backs off, recovers and resets for an unreachable device."""
+    get_cmd = AsyncMock(return_value=TIMEOUT_RESULT)
+    clock = 0.0
+    now = dt_util.utcnow()
+    interval = SCAN_INTERVAL.total_seconds()
+    skipped_polls = int(MIN_BACKOFF // interval)
 
-    with patch("homeassistant.components.snmp.sensor.get_cmd", get_cmd):
-        assert await async_setup_component(hass, SENSOR_DOMAIN, CONFIG)
-        await hass.async_block_till_done()
+    def _monotonic() -> float:
+        return clock
 
-        # The first failures are still retried at the normal scan interval.
-        now = dt_util.utcnow()
-        for _ in range(FAILURES_BEFORE_BACKOFF - 1):
-            now += SCAN_INTERVAL
-            async_fire_time_changed(hass, now)
-            await hass.async_block_till_done()
-
-        assert get_cmd.call_count == FAILURES_BEFORE_BACKOFF
-
-        # Once the threshold is passed, further scan intervals are skipped.
+    async def _poll() -> None:
+        """Advance the scan timer and the backoff clock by one interval."""
+        nonlocal clock, now
+        clock += interval
         now += SCAN_INTERVAL
         async_fire_time_changed(hass, now)
         await hass.async_block_till_done()
-        calls_at_backoff = get_cmd.call_count
 
-        for _ in range(3):
-            now += SCAN_INTERVAL
-            async_fire_time_changed(hass, now)
-            await hass.async_block_till_done()
+    with (
+        patch("homeassistant.components.snmp.sensor.get_cmd", get_cmd),
+        patch("homeassistant.components.snmp.sensor.monotonic", _monotonic),
+    ):
+        assert await async_setup_component(hass, SENSOR_DOMAIN, CONFIG)
+        await hass.async_block_till_done()
+        assert get_cmd.call_count == 1
 
-        assert get_cmd.call_count == calls_at_backoff
+        # Early failures are still retried on every scan interval.
+        for expected in range(2, FAILURES_BEFORE_BACKOFF + 1):
+            await _poll()
+            assert get_cmd.call_count == expected
 
-    assert hass.states.get("sensor.snmp").state == "unknown"
+        # Threshold passed: the next MIN_BACKOFF seconds of polls are skipped.
+        calls = get_cmd.call_count
+        for _ in range(skipped_polls):
+            await _poll()
+        assert get_cmd.call_count == calls
+
+        # Once the delay expires, polling resumes.
+        await _poll()
+        assert get_cmd.call_count == calls + 1
+
+        # That failure doubled the delay, so MIN_BACKOFF is no longer enough.
+        calls = get_cmd.call_count
+        for _ in range(skipped_polls):
+            await _poll()
+        assert get_cmd.call_count == calls
+
+        # A success clears the backoff entirely.
+        clock += 2 * MIN_BACKOFF
+        now += timedelta(seconds=2 * MIN_BACKOFF)
+        get_cmd.return_value = OK_RESULT
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+        assert hass.states.get("sensor.snmp").state == "13"
+
+        # Normal polling resumes immediately after recovery.
+        calls = get_cmd.call_count
+        await _poll()
+        assert get_cmd.call_count == calls + 1

--- a/tests/components/snmp/test_sensor.py
+++ b/tests/components/snmp/test_sensor.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 from pysnmp.proto.rfc1902 import Integer32
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.components.snmp.sensor import SCAN_INTERVAL
+from homeassistant.components.snmp.sensor import FAILURES_BEFORE_BACKOFF, SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -54,3 +54,38 @@ async def test_entity_recovers_when_device_unreachable(hass: HomeAssistant) -> N
         await hass.async_block_till_done()
 
     assert hass.states.get("sensor.snmp").state == "13"
+
+
+async def test_backoff_when_device_stays_unreachable(hass: HomeAssistant) -> None:
+    """Test polling backs off once a device has failed repeatedly."""
+    get_cmd = AsyncMock(
+        return_value=("No SNMP response received before timeout", None, None, None)
+    )
+
+    with patch("homeassistant.components.snmp.sensor.get_cmd", get_cmd):
+        assert await async_setup_component(hass, SENSOR_DOMAIN, CONFIG)
+        await hass.async_block_till_done()
+
+        # The first failures are still retried at the normal scan interval.
+        now = dt_util.utcnow()
+        for _ in range(FAILURES_BEFORE_BACKOFF - 1):
+            now += SCAN_INTERVAL
+            async_fire_time_changed(hass, now)
+            await hass.async_block_till_done()
+
+        assert get_cmd.call_count == FAILURES_BEFORE_BACKOFF
+
+        # Once the threshold is passed, further scan intervals are skipped.
+        now += SCAN_INTERVAL
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+        calls_at_backoff = get_cmd.call_count
+
+        for _ in range(3):
+            now += SCAN_INTERVAL
+            async_fire_time_changed(hass, now)
+            await hass.async_block_till_done()
+
+        assert get_cmd.call_count == calls_at_backoff
+
+    assert hass.states.get("sensor.snmp").state == "unknown"


### PR DESCRIPTION
## Proposed change

The SNMP sensor polls every `SCAN_INTERVAL` (10 seconds) regardless of whether the previous request succeeded. When a device is switched off or otherwise unreachable, each poll waits for the full request timeout — longer than the scan interval — so requests are issued faster than they complete and pending updates accumulate.

The visible result is a continuous stream of:

```
Updating snmp sensor took longer than the scheduled update interval 0:00:10
Update of sensor.<name> is taking over 10 seconds
```

plus an SNMP request every 10 seconds for as long as the device stays down. This is a recurring report for devices that are only intermittently powered — printers that sleep, UPS units that are unplugged.

This change tracks consecutive failures and skips polls with an exponentially increasing delay once a host has failed repeatedly, resetting immediately on the first success.

The first `FAILURES_BEFORE_BACKOFF` (3) failures are still retried at the normal scan interval, so a transient timeout recovers on the next poll exactly as before and the existing `test_entity_recovers_when_device_unreachable` behaviour is unchanged.

For a host that stays down this reduces polling from 360 requests per hour to 12. The reachable path is untouched: on success `_failures` resets to 0 and `_skip_until` to 0.0, so a healthy sensor never takes the early return.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #152470
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Related reports of the same behaviour: #75153, #116156, #31179.

Note on testing: the test suite could not be executed locally because the
development machine is Windows and `homeassistant/runner.py` imports `fcntl`.
The backoff arithmetic was verified in isolation and Ruff lint/format are clean,
but CI is the first full execution of these tests.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io