### PR TITLE
Add platform tests for amcrest camera, sensor and binary sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -122,6 +122,7 @@ CLAUDE.md @home-assistant/core
 /homeassistant/components/ambient_station/ @bachya
 /tests/components/ambient_station/ @bachya
 /homeassistant/components/amcrest/ @flacjacket
+/tests/components/amcrest/ @flacjacket
 /homeassistant/components/analytics/ @home-assistant/core
 /tests/components/analytics/ @home-assistant/core
 /homeassistant/components/analytics_insights/ @joostlek

--- a/tests/components/amcrest/__init__.py
+++ b/tests/components/amcrest/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Amcrest integration."""

--- a/tests/components/amcrest/conftest.py
+++ b/tests/components/amcrest/conftest.py
@@ -1,0 +1,189 @@
+"""Fixtures for Amcrest integration tests."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+SERIAL_NUMBER = "SN-TEST-12345"
+
+# YAML config for integration-level tests; produces the default camera name
+# "Amcrest Camera" via the amcrest config schema. Every optional platform is
+# enabled so setup exercises the unique_id of all four entity platforms.
+CAMERA_CONFIG = {
+    "amcrest": [
+        {
+            "host": "192.168.1.100",
+            "username": "admin",
+            "password": "password",
+            "sensors": ["ptz_preset", "sdcard"],
+            "switches": ["privacy_mode"],
+            "binary_sensors": ["online", "motion_detected_polled"],
+        }
+    ]
+}
+
+
+class _MockAmcrestAPI:
+    """Test double for AmcrestChecker.
+
+    Async properties in the amcrest library are Python @property decorators on
+    async def methods, so accessing them returns a coroutine rather than a
+    coroutine function.  Using AsyncMock() directly for these would require
+    calling the mock *and* awaiting the result, which doesn't match how the
+    integration accesses them (``await api.some_prop`` with no parentheses).
+    The @property pattern here replicates the real library behaviour.
+    """
+
+    available = True
+
+    def __init__(self) -> None:
+        """Set configurable values that tests can override directly."""
+        # Configurable return values
+        self.serial = SERIAL_NUMBER
+        self.ptz_presets_count = 5
+        self.storage_all: dict = {
+            "total": (100.0, "GB"),
+            "used": (50.0, "GB"),
+            "used_percent": 50.0,
+        }
+        self.vendor: str | None = "Amcrest"
+        self.device_type: str | None = "IP2M-841"
+        self.record_mode = "Automatic"
+        self.day_night_color = 0  # index 0 → "color"
+        self.video_enabled = True
+        self.motion_detector = False
+        self.audio_enabled = False
+        self.motion_recording = False
+        self.privacy_mode = False
+        self.event_channels: list[int] = []
+        self.rtsp_url_value = "rtsp://192.168.1.100/live"
+        # Map attribute name → exception to raise on access
+        self._raise_on: dict[str, Exception] = {}
+
+    def set_error(self, attr: str, exc: Exception) -> None:
+        """Inject an exception to be raised when *attr* is next accessed."""
+        self._raise_on[attr] = exc
+
+    def _value_or_raise(self, attr: str, value):
+        if attr in self._raise_on:
+            raise self._raise_on[attr]
+        return value
+
+    # Each returns a fresh coroutine so multiple awaits work correctly.
+
+    @property
+    def async_serial_number(self):
+        async def _():
+            return self._value_or_raise("serial_number", self.serial)
+
+        return _()
+
+    @property
+    def async_ptz_presets_count(self):
+        async def _():
+            return self._value_or_raise("ptz_presets_count", self.ptz_presets_count)
+
+        return _()
+
+    @property
+    def async_storage_all(self):
+        async def _():
+            return self._value_or_raise("storage_all", self.storage_all)
+
+        return _()
+
+    @property
+    def async_current_time(self):
+        async def _():
+            return self._value_or_raise("current_time", "2024-01-01T00:00:00")
+
+        return _()
+
+    @property
+    def async_vendor_information(self):
+        async def _():
+            return self._value_or_raise("vendor_information", self.vendor)
+
+        return _()
+
+    @property
+    def async_device_type(self):
+        async def _():
+            return self._value_or_raise("device_type", self.device_type)
+
+        return _()
+
+    @property
+    def async_record_mode(self):
+        async def _():
+            return self._value_or_raise("record_mode", self.record_mode)
+
+        return _()
+
+    @property
+    def async_day_night_color(self):
+        async def _():
+            return self._value_or_raise("day_night_color", self.day_night_color)
+
+        return _()
+
+    async def async_privacy_config(self) -> str:
+        if "privacy_config" in self._raise_on:
+            raise self._raise_on["privacy_config"]
+        mode = "true" if self.privacy_mode else "false"
+        return f"table.LeLensMask[0].Enable={mode}\nfoo=bar"
+
+    async def async_event_channels_happened(self, eventcode: str) -> list[int]:
+        if "event_channels_happened" in self._raise_on:
+            raise self._raise_on["event_channels_happened"]
+        return self.event_channels
+
+    async def async_rtsp_url(self, *, channel: int = 1, typeno: int = 0) -> str:
+        return self.rtsp_url_value
+
+    async def async_is_video_enabled(self, channel: int, stream: str) -> bool:
+        return self.video_enabled
+
+    async def async_is_motion_detector_on(self, *, channel: int = 0) -> bool:
+        return self.motion_detector
+
+    async def async_is_audio_enabled(self, channel: int, stream: str) -> bool:
+        return self.audio_enabled
+
+    async def async_is_record_on_motion_detection(self) -> bool:
+        return self.motion_recording
+
+
+@pytest.fixture
+def mock_event_monitor() -> None:
+    """Patch _start_event_monitor to prevent daemon thread creation."""
+    with patch("homeassistant.components.amcrest._start_event_monitor"):
+        yield
+
+
+@pytest.fixture
+def mock_discovery() -> None:
+    """Patch discovery.async_load_platform to prevent platform loading."""
+    with patch(
+        "homeassistant.helpers.discovery.async_load_platform",
+        new_callable=AsyncMock,
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_api() -> _MockAmcrestAPI:
+    """Return a fresh _MockAmcrestAPI for each test."""
+    return _MockAmcrestAPI()
+
+
+async def setup_amcrest(hass: HomeAssistant, mock_api: _MockAmcrestAPI) -> None:
+    """Set up the amcrest integration against the mock API."""
+    with patch(
+        "homeassistant.components.amcrest.AmcrestChecker", return_value=mock_api
+    ):
+        assert await async_setup_component(hass, "amcrest", CAMERA_CONFIG)
+        await hass.async_block_till_done()

--- a/tests/components/amcrest/test_binary_sensor.py
+++ b/tests/components/amcrest/test_binary_sensor.py
@@ -1,0 +1,123 @@
+"""Tests for the Amcrest binary sensor platform."""
+
+from unittest.mock import patch
+
+from amcrest import AmcrestError
+import pytest
+
+from homeassistant.components.amcrest.const import SERVICE_EVENT, SERVICE_UPDATE
+from homeassistant.components.amcrest.helpers import service_signal
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.setup import async_setup_component
+
+from .conftest import _MockAmcrestAPI, setup_amcrest
+
+_ONLINE = "binary_sensor.amcrest_camera_online"
+_MOTION = "binary_sensor.amcrest_camera_motion_detected"
+_CAMERA_NAME = "Amcrest Camera"
+_MOTION_EVENT_CODE = "VideoMotion"
+
+# The event-driven motion sensor, which the shared CAMERA_CONFIG cannot use:
+# it is mutually exclusive with the polled variant.
+_EVENT_CONFIG = {
+    "amcrest": [
+        {
+            "host": "192.168.1.100",
+            "username": "admin",
+            "password": "password",
+            "binary_sensors": ["motion_detected"],
+        }
+    ]
+}
+
+
+@pytest.mark.parametrize(
+    ("event_channels", "expected_state"),
+    [
+        pytest.param([1], STATE_ON, id="motion_detected"),
+        pytest.param([], STATE_OFF, id="no_motion"),
+    ],
+)
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_polled_binary_sensor_reflects_event_channels(
+    hass: HomeAssistant,
+    mock_api: _MockAmcrestAPI,
+    event_channels: list[int],
+    expected_state: str,
+) -> None:
+    """The polled motion sensor is on only while the camera reports a fired channel."""
+    mock_api.event_channels = event_channels
+
+    await setup_amcrest(hass, mock_api)
+
+    assert hass.states.get(_MOTION).state == expected_state
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_online_sensor_stays_available_when_camera_is_not(
+    hass: HomeAssistant, mock_api: _MockAmcrestAPI
+) -> None:
+    """The online sensor keeps reporting during an outage; the others do not."""
+    mock_api.available = False
+
+    await setup_amcrest(hass, mock_api)
+
+    # The online sensor is the one entity that must survive an outage - it is
+    # what tells the user the camera is down, so it must never go unavailable.
+    assert hass.states.get(_ONLINE).state != STATE_UNAVAILABLE
+    assert hass.states.get(_MOTION).state == STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_polled_binary_sensor_update_error_is_handled(
+    hass: HomeAssistant, mock_api: _MockAmcrestAPI
+) -> None:
+    """An AmcrestError while polling for events does not propagate."""
+    mock_api.set_error("event_channels_happened", AmcrestError("timeout"))
+
+    await setup_amcrest(hass, mock_api)
+
+    assert hass.states.get(_MOTION) is not None
+    assert hass.states.get(_ONLINE).state == STATE_ON
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_event_sensor_updates_from_dispatcher(
+    hass: HomeAssistant, mock_api: _MockAmcrestAPI
+) -> None:
+    """A dispatched camera event flips the event-driven motion sensor."""
+    # The shared config uses the polled motion sensor, which never subscribes to
+    # events; the event-driven variant is mutually exclusive with it.
+    with patch(
+        "homeassistant.components.amcrest.AmcrestChecker", return_value=mock_api
+    ):
+        assert await async_setup_component(hass, "amcrest", _EVENT_CONFIG)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(_MOTION).state == STATE_OFF
+
+    async_dispatcher_send(
+        hass,
+        service_signal(SERVICE_EVENT, _CAMERA_NAME, _MOTION_EVENT_CODE),
+        True,
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(_MOTION).state == STATE_ON
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_online_sensor_follows_availability_signal(
+    hass: HomeAssistant, mock_api: _MockAmcrestAPI
+) -> None:
+    """The online sensor re-renders when the camera's availability signal fires."""
+    await setup_amcrest(hass, mock_api)
+    assert hass.states.get(_ONLINE).state == STATE_ON
+
+    mock_api.available = False
+    async_dispatcher_send(hass, service_signal(SERVICE_UPDATE, _CAMERA_NAME))
+    await hass.async_block_till_done()
+
+    assert hass.states.get(_ONLINE).state == STATE_OFF

--- a/tests/components/amcrest/test_camera.py
+++ b/tests/components/amcrest/test_camera.py
@@ -1,0 +1,365 @@
+"""Tests for the Amcrest camera platform."""
+
+from types import SimpleNamespace
+
+from amcrest import AmcrestError
+import pytest
+
+from homeassistant.components.amcrest.const import CBW, DOMAIN
+from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN, async_get_image
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from .conftest import _MockAmcrestAPI, setup_amcrest
+
+_CAMERA = "camera.amcrest_camera"
+
+
+class _CameraAPI(_MockAmcrestAPI):
+    """Adds the setter surface the camera services drive.
+
+    Kept here rather than in conftest so the shared fixtures stay identical to
+    the ones in the unique_id PR. Setters mutate the same state the getters
+    read, because _async_change_setting writes a value then reads it back and
+    retries if the two disagree.
+    """
+
+    def __init__(self) -> None:
+        """Record calls that have no readable state to assert against."""
+        super().__init__()
+        self.indicator_light = False
+        self.snapshot_bytes = b"jpeg-bytes"
+        self.mjpeg_url = "http://192.168.1.100/mjpeg"
+        self.preset_calls: list[int] = []
+        self.tour_calls: list[bool] = []
+        self.ptz_calls: list[tuple[str, str]] = []
+
+    async def async_set_video_enabled(
+        self, enable: bool, *, channel: int = 0, stream: int = 0
+    ) -> None:
+        self.video_enabled = enable
+
+    async def async_set_audio_enabled(
+        self, enable: bool, *, channel: int = 0, stream: int = 0
+    ) -> None:
+        self.audio_enabled = enable
+
+    async def async_set_record_mode(self, mode: int) -> None:
+        self.record_mode = "Manual" if mode == 1 else "Automatic"
+
+    async def async_set_motion_detection(self, enable: bool) -> None:
+        self.motion_detector = enable
+
+    async def async_set_motion_recording(self, enable: bool) -> None:
+        self.motion_recording = enable
+
+    async def async_set_day_night_color(self, value: int, *, channel: int = 0) -> None:
+        self.day_night_color = value
+
+    async def async_go_to_preset(self, *, preset_point_number: int) -> None:
+        if "go_to_preset" in self._raise_on:
+            raise self._raise_on["go_to_preset"]
+        self.preset_calls.append(preset_point_number)
+
+    async def async_tour(self, *, start: bool) -> None:
+        if "tour" in self._raise_on:
+            raise self._raise_on["tour"]
+        self.tour_calls.append(start)
+
+    async def async_ptz_control_command(
+        self, *, action: str, code: str, arg1: int, arg2: int, arg3: int
+    ) -> None:
+        if "ptz_control_command" in self._raise_on:
+            raise self._raise_on["ptz_control_command"]
+        self.ptz_calls.append((action, code))
+
+    async def async_command(self, cmd: str) -> SimpleNamespace:
+        # Only the indicator light is driven through the raw command endpoint.
+        if "setConfig" in cmd:
+            self.indicator_light = "true" in cmd
+            return SimpleNamespace(content=b"OK")
+        value = "true" if self.indicator_light else "false"
+        return SimpleNamespace(content=f"table.LightGlobal[0].Enable={value}".encode())
+
+    async def async_snapshot(self, timeout: tuple[float, float] | None = None) -> bytes:
+        if "snapshot" in self._raise_on:
+            raise self._raise_on["snapshot"]
+        return self.snapshot_bytes
+
+
+@pytest.fixture
+def camera_api() -> _CameraAPI:
+    """Return a mock API with the camera setter surface."""
+    return _CameraAPI()
+
+
+async def _call(hass: HomeAssistant, service: str, **data: object) -> None:
+    """Call one of the amcrest camera services against the test camera."""
+    await hass.services.async_call(
+        DOMAIN, service, {"entity_id": _CAMERA, **data}, blocking=True
+    )
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_camera_exposes_device_attributes(
+    hass: HomeAssistant, camera_api: _CameraAPI
+) -> None:
+    """The camera publishes brand, model and stream state after setup."""
+    await setup_amcrest(hass, camera_api)
+
+    state = hass.states.get(_CAMERA)
+    assert state.state == "streaming"
+    assert state.attributes["brand"] == "Amcrest"
+    assert state.attributes["model_name"] == "IP2M-841"
+    assert state.attributes["audio"] == "off"
+    assert state.attributes["motion_recording"] == "off"
+    assert state.attributes["color_bw"] == "color"
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_camera_unavailable_when_offline(
+    hass: HomeAssistant, camera_api: _CameraAPI
+) -> None:
+    """An unreachable camera reports unavailable and publishes no device details."""
+    camera_api.available = False
+
+    await setup_amcrest(hass, camera_api)
+
+    state = hass.states.get(_CAMERA)
+    assert state.state == STATE_UNAVAILABLE
+    # Absent rather than stale: no API contact was made.
+    assert "brand" not in state.attributes
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_camera_update_error_is_handled(
+    hass: HomeAssistant, camera_api: _CameraAPI
+) -> None:
+    """An AmcrestError while reading device details does not propagate."""
+    camera_api.set_error("vendor_information", AmcrestError("timeout"))
+
+    await setup_amcrest(hass, camera_api)
+
+    assert hass.states.get(_CAMERA) is not None
+
+
+@pytest.mark.parametrize(
+    "vendor",
+    [pytest.param("", id="empty_string"), pytest.param(None, id="none")],
+)
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_camera_unknown_brand_fallback(
+    hass: HomeAssistant, camera_api: _CameraAPI, vendor: str | None
+) -> None:
+    """A camera that reports no vendor falls back to a placeholder brand."""
+    camera_api.vendor = vendor
+
+    await setup_amcrest(hass, camera_api)
+
+    assert hass.states.get(_CAMERA).attributes["brand"] == "unknown"
+
+
+@pytest.mark.parametrize(
+    ("service", "attribute", "expected"),
+    [
+        pytest.param("enable_audio", "audio", "on", id="enable_audio"),
+        pytest.param("disable_audio", "audio", "off", id="disable_audio"),
+        pytest.param(
+            "enable_motion_recording", "motion_recording", "on", id="enable_motion_rec"
+        ),
+        pytest.param(
+            "disable_motion_recording",
+            "motion_recording",
+            "off",
+            id="disable_motion_rec",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_toggle_services_update_attributes(
+    hass: HomeAssistant,
+    camera_api: _CameraAPI,
+    service: str,
+    attribute: str,
+    expected: str,
+) -> None:
+    """The enable/disable services write to the camera and refresh the attribute."""
+    await setup_amcrest(hass, camera_api)
+
+    await _call(hass, service)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(_CAMERA).attributes[attribute] == expected
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_recording_services_change_state(
+    hass: HomeAssistant, camera_api: _CameraAPI
+) -> None:
+    """Enabling recording flips the camera state and the underlying record mode."""
+    await setup_amcrest(hass, camera_api)
+
+    await _call(hass, "enable_recording")
+    await hass.async_block_till_done()
+    assert camera_api.record_mode == "Manual"
+    assert hass.states.get(_CAMERA).state == "recording"
+
+    await _call(hass, "disable_recording")
+    await hass.async_block_till_done()
+    assert camera_api.record_mode == "Automatic"
+    assert hass.states.get(_CAMERA).state == "streaming"
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_set_color_bw_service(
+    hass: HomeAssistant, camera_api: _CameraAPI
+) -> None:
+    """The color_bw service writes the selected mode and reflects it back."""
+    await setup_amcrest(hass, camera_api)
+
+    await _call(hass, "set_color_bw", color_bw="bw")
+    await hass.async_block_till_done()
+
+    assert camera_api.day_night_color == CBW.index("bw")
+    assert hass.states.get(_CAMERA).attributes["color_bw"] == "bw"
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_goto_preset_service(hass: HomeAssistant, camera_api: _CameraAPI) -> None:
+    """The goto_preset service forwards the preset number to the camera."""
+    await setup_amcrest(hass, camera_api)
+
+    await _call(hass, "goto_preset", preset=3)
+    await hass.async_block_till_done()
+
+    assert camera_api.preset_calls == [3]
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_tour_services(hass: HomeAssistant, camera_api: _CameraAPI) -> None:
+    """The tour services start and stop a camera tour."""
+    await setup_amcrest(hass, camera_api)
+
+    await _call(hass, "start_tour")
+    await _call(hass, "stop_tour")
+    await hass.async_block_till_done()
+
+    assert camera_api.tour_calls == [True, False]
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_ptz_control_service(hass: HomeAssistant, camera_api: _CameraAPI) -> None:
+    """PTZ control issues a matched start/stop pair for the requested movement."""
+    await setup_amcrest(hass, camera_api)
+
+    await _call(hass, "ptz_control", movement="zoom_in", travel_time=0.0)
+    await hass.async_block_till_done()
+
+    assert [action for action, _ in camera_api.ptz_calls] == ["start", "stop"]
+    codes = {code for _, code in camera_api.ptz_calls}
+    assert len(codes) == 1
+
+
+@pytest.mark.parametrize(
+    ("service", "error_key", "data"),
+    [
+        pytest.param("goto_preset", "go_to_preset", {"preset": 1}, id="goto_preset"),
+        pytest.param("start_tour", "tour", {}, id="start_tour"),
+        pytest.param(
+            "ptz_control",
+            "ptz_control_command",
+            {"movement": "left", "travel_time": 0.0},
+            id="ptz_control",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_service_errors_are_logged_not_raised(
+    hass: HomeAssistant,
+    camera_api: _CameraAPI,
+    service: str,
+    error_key: str,
+    data: dict[str, object],
+) -> None:
+    """A camera that fails mid-service logs the error rather than raising."""
+    await setup_amcrest(hass, camera_api)
+    camera_api.set_error(error_key, AmcrestError("timeout"))
+
+    await _call(hass, service, **data)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(_CAMERA) is not None
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_camera_image_returns_snapshot(
+    hass: HomeAssistant, camera_api: _CameraAPI
+) -> None:
+    """A still image request returns the camera's snapshot bytes."""
+    await setup_amcrest(hass, camera_api)
+
+    image = await async_get_image(hass, _CAMERA)
+
+    assert image.content == b"jpeg-bytes"
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_turn_off_stops_streaming(
+    hass: HomeAssistant, camera_api: _CameraAPI
+) -> None:
+    """Turning the camera off disables the video stream."""
+    await setup_amcrest(hass, camera_api)
+    assert hass.states.get(_CAMERA).state == "streaming"
+
+    await hass.services.async_call(
+        CAMERA_DOMAIN, "turn_off", {"entity_id": _CAMERA}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert camera_api.video_enabled is False
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_snapshot_refused_when_camera_offline(
+    hass: HomeAssistant, camera_api: _CameraAPI
+) -> None:
+    """A snapshot is refused rather than attempted while the camera is unreachable."""
+    camera_api.available = False
+    await setup_amcrest(hass, camera_api)
+
+    with pytest.raises(HomeAssistantError):
+        await async_get_image(hass, _CAMERA)
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_snapshot_error_is_handled(
+    hass: HomeAssistant, camera_api: _CameraAPI
+) -> None:
+    """An AmcrestError while snapshotting surfaces as no image, not a traceback."""
+    await setup_amcrest(hass, camera_api)
+    camera_api.set_error("snapshot", AmcrestError("timeout"))
+
+    with pytest.raises(HomeAssistantError):
+        await async_get_image(hass, _CAMERA)
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_setting_that_never_takes_is_abandoned(
+    hass: HomeAssistant, camera_api: _CameraAPI
+) -> None:
+    """A write the camera silently ignores is retried, then given up on."""
+
+    # Accept the write but never actually change: _async_change_setting reads the
+    # value back, sees the mismatch, and retries before logging and moving on.
+    async def _ignore(enable: bool, *, channel: int = 0, stream: int = 0) -> None:
+        return
+
+    await setup_amcrest(hass, camera_api)
+    camera_api.async_set_audio_enabled = _ignore
+
+    await _call(hass, "enable_audio")
+    await hass.async_block_till_done()
+
+    assert camera_api.audio_enabled is False
+    assert hass.states.get(_CAMERA).attributes["audio"] == "off"

--- a/tests/components/amcrest/test_sensor.py
+++ b/tests/components/amcrest/test_sensor.py
@@ -1,0 +1,87 @@
+"""Tests for the Amcrest sensor platform."""
+
+from amcrest import AmcrestError
+import pytest
+
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+
+from .conftest import _MockAmcrestAPI, setup_amcrest
+
+_PTZ_PRESET = "sensor.amcrest_camera_ptz_preset"
+_SD_USED = "sensor.amcrest_camera_sd_used"
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_sensors_report_camera_values(
+    hass: HomeAssistant, mock_api: _MockAmcrestAPI
+) -> None:
+    """Both sensors expose the values reported by the camera."""
+    mock_api.ptz_presets_count = 7
+    mock_api.storage_all = {
+        "total": (128.0, "GB"),
+        "used": (64.0, "GB"),
+        "used_percent": 50.0,
+    }
+
+    await setup_amcrest(hass, mock_api)
+
+    assert hass.states.get(_PTZ_PRESET).state == "7"
+    sd_used = hass.states.get(_SD_USED)
+    assert sd_used.state == "50.00"
+    assert sd_used.attributes["Total"] == "128.00 GB"
+    assert sd_used.attributes["Used"] == "64.00 GB"
+
+
+@pytest.mark.parametrize(
+    ("used_percent", "expected_state"),
+    [
+        pytest.param(33.3333, "33.33", id="rounds_to_two_places"),
+        pytest.param(0, "0.00", id="zero"),
+        pytest.param(100, "100.00", id="full"),
+    ],
+)
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_sdcard_used_percent_formatting(
+    hass: HomeAssistant,
+    mock_api: _MockAmcrestAPI,
+    used_percent: float,
+    expected_state: str,
+) -> None:
+    """The SD card sensor formats usage to two decimal places."""
+    mock_api.storage_all = {
+        "total": (100.0, "GB"),
+        "used": (50.0, "GB"),
+        "used_percent": used_percent,
+    }
+
+    await setup_amcrest(hass, mock_api)
+
+    assert hass.states.get(_SD_USED).state == expected_state
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_sensors_unavailable_when_camera_is(
+    hass: HomeAssistant, mock_api: _MockAmcrestAPI
+) -> None:
+    """Sensors report unavailable rather than a stale value when the camera is down."""
+    mock_api.available = False
+
+    await setup_amcrest(hass, mock_api)
+
+    assert hass.states.get(_PTZ_PRESET).state == STATE_UNAVAILABLE
+    assert hass.states.get(_SD_USED).state == STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("mock_event_monitor")
+async def test_sensor_update_error_is_handled(
+    hass: HomeAssistant, mock_api: _MockAmcrestAPI
+) -> None:
+    """An AmcrestError while polling leaves the sensor unknown instead of raising."""
+    mock_api.set_error("ptz_presets_count", AmcrestError("timeout"))
+
+    await setup_amcrest(hass, mock_api)
+
+    assert hass.states.get(_PTZ_PRESET).state == STATE_UNKNOWN
+    # The other sensor is unaffected by its neighbour's failure.
+    assert hass.states.get(_SD_USED).state == "50.00"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`amcrest` has no automated tests at all. This adds integration-level coverage for the camera, sensor and binary sensor platforms, driven through `async_setup_component` and asserted against the state machine rather than by constructing entity objects directly, per the [testing guidance](https://developers.home-assistant.io/docs/development_testing/).

The camera platform gets the bulk of it, since its entity services were entirely untested: audio, recording and motion-recording toggles, colour mode, presets, tours, PTZ control and still capture, together with their error paths. The sensors cover SD card usage formatting and PTZ preset count; the binary sensors cover both the polled and the event-driven motion variants plus the availability signal. Coverage for the three platforms moves from nothing to 88% (`camera.py`), 95% (`binary_sensor.py`) and 89% (`sensor.py`). The main remaining gap is `handle_async_mjpeg_stream`, which needs a live HTTP client to exercise meaningfully.

`amcrest` has no automated tests on `dev` today — `tests/components/amcrest/` does not exist. This PR and #181496 together establish that baseline. The two are independent and can merge in either order; they overlap only in `tests/components/amcrest/conftest.py`, the one-line `tests/components/amcrest/__init__.py`, and the `CODEOWNERS` entry that hassfest generates once a test directory exists. The shared parts of `conftest.py` are byte-identical between the two branches, so whichever lands second is a mechanical reconciliation.

This PR deliberately does not cover `AmcrestChecker` and the rest of `__init__.py`, which is the least-tested code in the integration. Those tests belong in `tests/components/amcrest/test_init.py`, and #181496 already adds a file of that name. Writing one here would collide head-on and force both PRs to be reconciled twice rather than once, for no review benefit. It is deferred rather than overlooked.

Once #181496 lands, the planned follow-ups are: `test_init.py` coverage for the `AmcrestChecker` availability and recovery state machine (currently ~53%, and the offline→online transition that drives entity availability is untested); converting `test_switch.py` to the same integration-level style used here; and then a series of small Bronze quality-scale fixes, starting with the missing dispatcher subscription on the privacy-mode switch, which leaves it stale when a camera comes back online while every other platform refreshes.

One note for the code owner: writing these tests surfaced a latent bug that unit-level tests had hidden. `AmcrestSensor.async_update` catches `ValueError` when formatting `used_percent` and falls back to assigning the raw value, but the SD Used sensor declares `native_unit_of_measurement=PERCENTAGE`, so a non-numeric reading makes Home Assistant reject the state and the entity fails to be added entirely rather than degrading gracefully. I have left that behaviour untested rather than encode it, and am happy to fix it in a follow-up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/181496
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
