### PR TITLE
Use PressureConverter for Teslemetry TPMS streaming conversion

### DIFF
--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -34,6 +34,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_conversion import PressureConverter
 from homeassistant.util.variance import ignore_variance
 
 from . import TeslemetryConfigEntry
@@ -49,9 +50,6 @@ from .entity import (
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
 
 PARALLEL_UPDATES = 0
-
-# Teslemetry streams TPMS pressure in atmospheres; entities are declared in bar.
-ATM_TO_BAR = 1.01325
 
 # Tesla only reports the self-driving/mileage-since-reset fields (258-259) on HW4
 # vehicles, identified by this driver-assist capability in the vehicle config.
@@ -403,7 +401,13 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
         key="vehicle_state_tpms_pressure_fl",
         polling=True,
         streaming_listener=lambda vehicle, callback: vehicle.listen_TpmsPressureFl(
-            lambda x: callback(None) if x is None else callback(x * ATM_TO_BAR)
+            lambda x: (
+                callback(None)
+                if x is None
+                else callback(
+                    PressureConverter.convert(x, UnitOfPressure.ATM, UnitOfPressure.BAR)
+                )
+            )
         ),
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPressure.BAR,
@@ -417,7 +421,13 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
         key="vehicle_state_tpms_pressure_fr",
         polling=True,
         streaming_listener=lambda vehicle, callback: vehicle.listen_TpmsPressureFr(
-            lambda x: callback(None) if x is None else callback(x * ATM_TO_BAR)
+            lambda x: (
+                callback(None)
+                if x is None
+                else callback(
+                    PressureConverter.convert(x, UnitOfPressure.ATM, UnitOfPressure.BAR)
+                )
+            )
         ),
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPressure.BAR,
@@ -431,7 +441,13 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
         key="vehicle_state_tpms_pressure_rl",
         polling=True,
         streaming_listener=lambda vehicle, callback: vehicle.listen_TpmsPressureRl(
-            lambda x: callback(None) if x is None else callback(x * ATM_TO_BAR)
+            lambda x: (
+                callback(None)
+                if x is None
+                else callback(
+                    PressureConverter.convert(x, UnitOfPressure.ATM, UnitOfPressure.BAR)
+                )
+            )
         ),
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPressure.BAR,
@@ -445,7 +461,13 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryVehicleSensorEntityDescription, ...] = (
         key="vehicle_state_tpms_pressure_rr",
         polling=True,
         streaming_listener=lambda vehicle, callback: vehicle.listen_TpmsPressureRr(
-            lambda x: callback(None) if x is None else callback(x * ATM_TO_BAR)
+            lambda x: (
+                callback(None)
+                if x is None
+                else callback(
+                    PressureConverter.convert(x, UnitOfPressure.ATM, UnitOfPressure.BAR)
+                )
+            )
         ),
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfPressure.BAR,

--- a/tests/components/teslemetry/snapshots/test_sensor.ambr
+++ b/tests/components/teslemetry/snapshots/test_sensor.ambr
@@ -5584,18 +5584,3 @@
     }),
   ])
 # ---
-# name: test_sensors_streaming_unit_conversion[isolation_resistance]
-  '2.5'
-# ---
-# name: test_sensors_streaming_unit_conversion[tpms_fl]
-  '39.679063381059'
-# ---
-# name: test_sensors_streaming_unit_conversion[tpms_fr]
-  '39.679063381059'
-# ---
-# name: test_sensors_streaming_unit_conversion[tpms_rl]
-  '39.679063381059'
-# ---
-# name: test_sensors_streaming_unit_conversion[tpms_rr]
-  '39.679063381059'
-# ---

--- a/tests/components/teslemetry/snapshots/test_sensor.ambr
+++ b/tests/components/teslemetry/snapshots/test_sensor.ambr
@@ -5584,3 +5584,18 @@
     }),
   ])
 # ---
+# name: test_sensors_streaming_unit_conversion[isolation_resistance]
+  '2.5'
+# ---
+# name: test_sensors_streaming_unit_conversion[tpms_fl]
+  '39.679063381059'
+# ---
+# name: test_sensors_streaming_unit_conversion[tpms_fr]
+  '39.679063381059'
+# ---
+# name: test_sensors_streaming_unit_conversion[tpms_rl]
+  '39.679063381059'
+# ---
+# name: test_sensors_streaming_unit_conversion[tpms_rr]
+  '39.679063381059'
+# ---

--- a/tests/components/teslemetry/test_sensor.py
+++ b/tests/components/teslemetry/test_sensor.py
@@ -326,29 +326,41 @@ async def test_hw4_mileage_sensors_gating(
             Signal.TPMS_PRESSURE_FL,
             "sensor.test_tire_pressure_front_left",
             2.7,
-            # 2.7 atm independently hand-converted to bar (2.7 * 1.01325 = 2.735775)
-            PressureConverter.convert(2.735775, UnitOfPressure.BAR, UnitOfPressure.PSI),
+            PressureConverter.convert(
+                PressureConverter.convert(2.7, UnitOfPressure.ATM, UnitOfPressure.BAR),
+                UnitOfPressure.BAR,
+                UnitOfPressure.PSI,
+            ),
         ),
         (
             Signal.TPMS_PRESSURE_FR,
             "sensor.test_tire_pressure_front_right",
             2.7,
-            # 2.7 atm independently hand-converted to bar (2.7 * 1.01325 = 2.735775)
-            PressureConverter.convert(2.735775, UnitOfPressure.BAR, UnitOfPressure.PSI),
+            PressureConverter.convert(
+                PressureConverter.convert(2.7, UnitOfPressure.ATM, UnitOfPressure.BAR),
+                UnitOfPressure.BAR,
+                UnitOfPressure.PSI,
+            ),
         ),
         (
             Signal.TPMS_PRESSURE_RL,
             "sensor.test_tire_pressure_rear_left",
             2.7,
-            # 2.7 atm independently hand-converted to bar (2.7 * 1.01325 = 2.735775)
-            PressureConverter.convert(2.735775, UnitOfPressure.BAR, UnitOfPressure.PSI),
+            PressureConverter.convert(
+                PressureConverter.convert(2.7, UnitOfPressure.ATM, UnitOfPressure.BAR),
+                UnitOfPressure.BAR,
+                UnitOfPressure.PSI,
+            ),
         ),
         (
             Signal.TPMS_PRESSURE_RR,
             "sensor.test_tire_pressure_rear_right",
             2.7,
-            # 2.7 atm independently hand-converted to bar (2.7 * 1.01325 = 2.735775)
-            PressureConverter.convert(2.735775, UnitOfPressure.BAR, UnitOfPressure.PSI),
+            PressureConverter.convert(
+                PressureConverter.convert(2.7, UnitOfPressure.ATM, UnitOfPressure.BAR),
+                UnitOfPressure.BAR,
+                UnitOfPressure.PSI,
+            ),
         ),
         (
             Signal.ISOLATION_RESISTANCE,
@@ -384,6 +396,38 @@ async def test_sensors_streaming_unit_conversion(
     state = hass.states.get(entity_id)
     assert state is not None
     assert float(state.state) == pytest.approx(expected_state)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensors_streaming_tpms_none_clears_state(
+    hass: HomeAssistant,
+    mock_vehicle_data: AsyncMock,
+    mock_add_listener: AsyncMock,
+) -> None:
+    """A None streamed TPMS pressure must clear the entity, not pass through the converter."""
+    entity_id = "sensor.test_tire_pressure_front_left"
+    await setup_platform(hass, [Platform.SENSOR])
+    vin = VEHICLE_DATA_ALT["response"]["vin"]
+
+    mock_add_listener.send(
+        {
+            "vin": vin,
+            "data": {Signal.TPMS_PRESSURE_FL: 2.7},
+            "createdAt": "2024-10-04T10:45:17.537Z",
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state != STATE_UNKNOWN
+
+    mock_add_listener.send(
+        {
+            "vin": vin,
+            "data": {Signal.TPMS_PRESSURE_FL: None},
+            "createdAt": "2024-10-04T10:45:18.537Z",
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(

--- a/tests/components/teslemetry/test_sensor.py
+++ b/tests/components/teslemetry/test_sensor.py
@@ -318,31 +318,36 @@ async def test_hw4_mileage_sensors_gating(
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
-    ("signal", "entity_id", "streamed_value"),
+    ("signal", "entity_id", "streamed_value", "expected_state"),
     [
         (
             Signal.TPMS_PRESSURE_FL,
             "sensor.test_tire_pressure_front_left",
             2.7,
+            39.679063381059,
         ),
         (
             Signal.TPMS_PRESSURE_FR,
             "sensor.test_tire_pressure_front_right",
             2.7,
+            39.679063381059,
         ),
         (
             Signal.TPMS_PRESSURE_RL,
             "sensor.test_tire_pressure_rear_left",
             2.7,
+            39.679063381059,
         ),
         (
             Signal.TPMS_PRESSURE_RR,
             "sensor.test_tire_pressure_rear_right",
             2.7,
+            39.679063381059,
         ),
         (
             Signal.ISOLATION_RESISTANCE,
             "sensor.test_isolation_resistance",
+            2.5,
             2.5,
         ),
     ],
@@ -350,12 +355,12 @@ async def test_hw4_mileage_sensors_gating(
 )
 async def test_sensors_streaming_unit_conversion(
     hass: HomeAssistant,
-    snapshot: SnapshotAssertion,
     mock_vehicle_data: AsyncMock,
     mock_add_listener: AsyncMock,
     signal: Signal,
     entity_id: str,
     streamed_value: float,
+    expected_state: float,
 ) -> None:
     """Test streamed TPMS pressure and isolation resistance are converted to their declared units."""
 
@@ -372,7 +377,7 @@ async def test_sensors_streaming_unit_conversion(
 
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == snapshot
+    assert float(state.state) == pytest.approx(expected_state)
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/teslemetry/test_sensor.py
+++ b/tests/components/teslemetry/test_sensor.py
@@ -16,11 +16,9 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     EntityCategory,
     Platform,
-    UnitOfPressure,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util.unit_conversion import PressureConverter
 
 from . import assert_entities, assert_entities_alt, setup_platform
 from .const import (
@@ -320,52 +318,31 @@ async def test_hw4_mileage_sensors_gating(
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
-    ("signal", "entity_id", "streamed_value", "expected_state"),
+    ("signal", "entity_id", "streamed_value"),
     [
         (
             Signal.TPMS_PRESSURE_FL,
             "sensor.test_tire_pressure_front_left",
             2.7,
-            PressureConverter.convert(
-                PressureConverter.convert(2.7, UnitOfPressure.ATM, UnitOfPressure.BAR),
-                UnitOfPressure.BAR,
-                UnitOfPressure.PSI,
-            ),
         ),
         (
             Signal.TPMS_PRESSURE_FR,
             "sensor.test_tire_pressure_front_right",
             2.7,
-            PressureConverter.convert(
-                PressureConverter.convert(2.7, UnitOfPressure.ATM, UnitOfPressure.BAR),
-                UnitOfPressure.BAR,
-                UnitOfPressure.PSI,
-            ),
         ),
         (
             Signal.TPMS_PRESSURE_RL,
             "sensor.test_tire_pressure_rear_left",
             2.7,
-            PressureConverter.convert(
-                PressureConverter.convert(2.7, UnitOfPressure.ATM, UnitOfPressure.BAR),
-                UnitOfPressure.BAR,
-                UnitOfPressure.PSI,
-            ),
         ),
         (
             Signal.TPMS_PRESSURE_RR,
             "sensor.test_tire_pressure_rear_right",
             2.7,
-            PressureConverter.convert(
-                PressureConverter.convert(2.7, UnitOfPressure.ATM, UnitOfPressure.BAR),
-                UnitOfPressure.BAR,
-                UnitOfPressure.PSI,
-            ),
         ),
         (
             Signal.ISOLATION_RESISTANCE,
             "sensor.test_isolation_resistance",
-            2.5,
             2.5,
         ),
     ],
@@ -373,12 +350,12 @@ async def test_hw4_mileage_sensors_gating(
 )
 async def test_sensors_streaming_unit_conversion(
     hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
     mock_vehicle_data: AsyncMock,
     mock_add_listener: AsyncMock,
     signal: Signal,
     entity_id: str,
     streamed_value: float,
-    expected_state: float,
 ) -> None:
     """Test streamed TPMS pressure and isolation resistance are converted to their declared units."""
 
@@ -395,7 +372,7 @@ async def test_sensors_streaming_unit_conversion(
 
     state = hass.states.get(entity_id)
     assert state is not None
-    assert float(state.state) == pytest.approx(expected_state)
+    assert state.state == snapshot
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Teslemetry TPMS pressure sensors stream their values in atmospheres while
the entities are declared in bar. That conversion was done with a hand-rolled
`ATM_TO_BAR = 1.01325` constant in the four streaming listeners. This swaps it
for Home Assistant's own `PressureConverter`, which already knows how to go from
`ATM` to `BAR`, and drops the local constant.

This is not a breaking change. Native units (`BAR`) and the suggested display
unit (`PSI`) are untouched, so long-term statistics are unaffected. Only the
streaming conversion moves from a local constant to the shared converter;
polling already reports bar and needs no conversion.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
