### PR TITLE
Trim cached orjson fragments kept by non core containers

### DIFF
--- a/homeassistant/components/lovelace/dashboard.py
+++ b/homeassistant/components/lovelace/dashboard.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_FILENAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import collection, storage
-from homeassistant.helpers.json import json_bytes, json_fragment
+from homeassistant.helpers.json import cached_json_fragment, json_fragment
 from homeassistant.util.yaml import Secrets, load_yaml_dict
 
 from .const import (
@@ -182,7 +182,7 @@ class LovelaceStorage(LovelaceConfig):
         """Build JSON representation of the config."""
         if self._data is None or self._data["config"] is None:
             raise ConfigNotFound
-        self._json_config = json_fragment(json_bytes(self._data["config"]))
+        self._json_config = cached_json_fragment(self._data["config"])
         return self._json_config
 
 
@@ -260,7 +260,7 @@ class LovelaceYAML(LovelaceConfig):
         except FileNotFoundError:
             raise ConfigNotFound from None
 
-        json = json_fragment(json_bytes(config))
+        json = cached_json_fragment(config)
         self._cache = (config, time.time(), json)
         return is_updated, config, json
 

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -62,8 +62,8 @@ from homeassistant.helpers.event import (
 from homeassistant.helpers.json import (
     JSON_DUMP,
     ExtendedJSONEncoder,
+    cached_json_bytes,
     find_paths_unserializable_data,
-    json_bytes,
     json_fragment,
 )
 from homeassistant.helpers.service import (
@@ -541,7 +541,7 @@ async def _async_get_all_condition_descriptions_json(hass: HomeAssistant) -> byt
         # If the descriptions are the same, return the cached JSON payload
         if cached_descriptions is descriptions:
             return cast(bytes, cached_json_payload)
-    json_payload = json_bytes(
+    json_payload = cached_json_bytes(
         {
             condition: description
             for condition, description in descriptions.items()
@@ -588,7 +588,7 @@ async def _async_get_all_service_descriptions_json(hass: HomeAssistant) -> bytes
         # If the descriptions are the same, return the cached JSON payload
         if cached_descriptions is descriptions:
             return cast(bytes, cached_json_payload)
-    json_payload = json_bytes(descriptions)
+    json_payload = cached_json_bytes(descriptions)
     hass.data[ALL_SERVICE_DESCRIPTIONS_JSON_CACHE] = (descriptions, json_payload)
     return json_payload
 
@@ -613,7 +613,7 @@ async def _async_get_all_trigger_descriptions_json(hass: HomeAssistant) -> bytes
         # If the descriptions are the same, return the cached JSON payload
         if cached_descriptions is descriptions:
             return cast(bytes, cached_json_payload)
-    json_payload = json_bytes(
+    json_payload = cached_json_bytes(
         {
             trigger: description
             for trigger, description in descriptions.items()

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -66,7 +66,11 @@ from .helpers.event import (
     async_call_later,
 )
 from .helpers.frame import ReportBehavior, report_usage
-from .helpers.json import json_bytes, json_bytes_sorted, json_fragment
+from .helpers.json import (
+    cached_json_fragment,
+    cached_json_fragment_sorted,
+    json_fragment,
+)
 from .helpers.typing import (
     UNDEFINED,
     ConfigType,
@@ -682,7 +686,7 @@ class ConfigEntry[_DataT = Any]:
             ),
             "num_subentries": len(self.subentries),
         }
-        return json_fragment(json_bytes(json_repr))
+        return cached_json_fragment(json_repr)
 
     def clear_storage_cache(self) -> None:
         """Clear cached properties that are included in as_storage_fragment."""
@@ -691,7 +695,7 @@ class ConfigEntry[_DataT = Any]:
     @cached_property
     def as_storage_fragment(self) -> json_fragment:
         """Return a storage fragment for this entry."""
-        return json_fragment(json_bytes_sorted(self.as_dict()))
+        return cached_json_fragment_sorted(self.as_dict())
 
     async def async_setup(
         self,

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -145,8 +145,9 @@ def cached_json_fragment_sorted(data: Any) -> orjson.Fragment:
 
     The sorted-key variant of cached_json_fragment (see json_bytes_sorted).
     """
-    # Drop orjson's over-allocated slack with help of a memoryview.
-    return orjson.Fragment(bytes(memoryview(json_bytes_sorted(data))))
+    # The empty second join item is load-bearing: it forces a copy into a
+    # right-sized buffer; a single-item join returns the input unchanged.
+    return orjson.Fragment(b"".join((json_bytes_sorted(data), b"")))
 
 
 def json_dumps(data: Any) -> str:

--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -140,6 +140,15 @@ def cached_json_fragment(data: Any) -> orjson.Fragment:
     return orjson.Fragment(b"".join((json_bytes(data), b"")))
 
 
+def cached_json_fragment_sorted(data: Any) -> orjson.Fragment:
+    """Return a json fragment with sorted keys, right-sized for long-term caching.
+
+    The sorted-key variant of cached_json_fragment (see json_bytes_sorted).
+    """
+    # Drop orjson's over-allocated slack with help of a memoryview.
+    return orjson.Fragment(bytes(memoryview(json_bytes_sorted(data))))
+
+
 def json_dumps(data: Any) -> str:
     r"""Dump json string.
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -45,7 +45,7 @@ from .generated.mqtt import MQTT
 from .generated.ssdp import SSDP
 from .generated.usb import USB
 from .generated.zeroconf import HOMEKIT, ZEROCONF
-from .helpers.json import json_bytes, json_fragment
+from .helpers.json import cached_json_fragment, json_fragment
 from .helpers.typing import UNDEFINED, UndefinedType
 from .util.async_ import create_eager_task
 from .util.hass_dict import HassKey
@@ -798,7 +798,7 @@ class Integration:
     @cached_property
     def manifest_json_fragment(self) -> json_fragment:
         """Return manifest as a JSON fragment."""
-        return json_fragment(json_bytes(self.manifest))
+        return cached_json_fragment(self.manifest)
 
     @cached_property
     def name(self) -> str:

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.json import (
     JSONEncoder as DefaultHASSJSONEncoder,
     cached_json_bytes,
     cached_json_fragment,
+    cached_json_fragment_sorted,
     find_paths_unserializable_data,
     json_bytes,
     json_bytes_sorted,
@@ -236,10 +237,19 @@ def test_cached_json_bytes() -> None:
     )
 
 
+def test_cached_json_fragment_sorted() -> None:
+    """Test cached_json_fragment_sorted serializes with sorted keys."""
+    data = {"c": 3, "a": 1, "b": 2}
+
+    fragment = cached_json_fragment_sorted(data)
+    assert isinstance(fragment, json_fragment)
+    assert json_dumps([fragment]) == '[{"a":1,"b":2,"c":3}]'
+
+
 @pytest.mark.parametrize(
     "cached_serializer",
-    [cached_json_bytes, cached_json_fragment],
-    ids=["cached_json_bytes", "cached_json_fragment"],
+    [cached_json_bytes, cached_json_fragment, cached_json_fragment_sorted],
+    ids=["cached_json_bytes", "cached_json_fragment", "cached_json_fragment_sorted"],
 )
 def test_cached_json_helpers_trim_buffer(
     cached_serializer: Callable[[Any], object],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Trim cached `orjson` fragments kept by non core containers

Background in https://github.com/home-assistant/core/pull/181240 which trims fragments kept by the registries

This extends trimming of orjson fragments to other cached fragments

Note: Core objects (`Context`, `Event`, `State`) are performance sensitive and handled in separate PR https://github.com/home-assistant/core/pull/181513.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
