### PR TITLE
Add specific gravity velocity sensor to rapt_ble

### DIFF
--- a/homeassistant/components/rapt_ble/icons.json
+++ b/homeassistant/components/rapt_ble/icons.json
@@ -1,0 +1,9 @@
+{
+  "entity": {
+    "sensor": {
+      "specific_gravity_velocity": {
+        "default": "mdi:trending-down"
+      }
+    }
+  }
+}

--- a/homeassistant/components/rapt_ble/sensor.py
+++ b/homeassistant/components/rapt_ble/sensor.py
@@ -45,6 +45,7 @@ SENSOR_DESCRIPTIONS: dict[tuple[str | None, str | None], SensorEntityDescription
     ): SensorEntityDescription(
         key=f"{DeviceClass.SPECIFIC_GRAVITY_VELOCITY}_{Units.SPECIFIC_GRAVITY_POINTS_PER_DAY}",
         translation_key="specific_gravity_velocity",
+        native_unit_of_measurement=Units.SPECIFIC_GRAVITY_POINTS_PER_DAY,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
     ),

--- a/homeassistant/components/rapt_ble/sensor.py
+++ b/homeassistant/components/rapt_ble/sensor.py
@@ -39,6 +39,15 @@ SENSOR_DESCRIPTIONS: dict[tuple[str | None, str | None], SensorEntityDescription
         key=f"{DeviceClass.SPECIFIC_GRAVITY}_{Units.SPECIFIC_GRAVITY}",
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    (
+        DeviceClass.SPECIFIC_GRAVITY_VELOCITY,
+        Units.SPECIFIC_GRAVITY_POINTS_PER_DAY,
+    ): SensorEntityDescription(
+        key=f"{DeviceClass.SPECIFIC_GRAVITY_VELOCITY}_{Units.SPECIFIC_GRAVITY_POINTS_PER_DAY}",
+        translation_key="specific_gravity_velocity",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+    ),
     (DeviceClass.BATTERY, Units.PERCENTAGE): SensorEntityDescription(
         key=f"{DeviceClass.BATTERY}_{Units.PERCENTAGE}",
         device_class=SensorDeviceClass.BATTERY,

--- a/tests/components/rapt_ble/test_sensor.py
+++ b/tests/components/rapt_ble/test_sensor.py
@@ -112,6 +112,7 @@ async def test_specific_gravity_velocity_sensor(
         == "RAPT Pill 0666 Specific Gravity Velocity"
     )
     assert velocity_sensor.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+    assert velocity_sensor.attributes[ATTR_UNIT_OF_MEASUREMENT] == "SG points/day"
 
     entity_entry = entity_registry.async_get(VELOCITY_ENTITY_ID)
     assert entity_entry is not None

--- a/tests/components/rapt_ble/test_sensor.py
+++ b/tests/components/rapt_ble/test_sensor.py
@@ -8,9 +8,11 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
     PERCENTAGE,
+    STATE_UNKNOWN,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
 from . import (
@@ -22,6 +24,8 @@ from . import (
 
 from tests.common import MockConfigEntry
 from tests.components.bluetooth import inject_bluetooth_service_info
+
+VELOCITY_ENTITY_ID = "sensor.rapt_pill_0666_specific_gravity_velocity"
 
 
 async def test_sensors(hass: HomeAssistant) -> None:
@@ -39,6 +43,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
     inject_bluetooth_service_info(hass, COMPLETE_SERVICE_INFO)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 3
+    assert hass.states.get(VELOCITY_ENTITY_ID) is None
 
     temp_sensor = hass.states.get("sensor.rapt_pill_0666_battery")
     assert temp_sensor is not None
@@ -73,16 +78,19 @@ async def test_sensors(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "service_info",
+    ("service_info", "expected_state"),
     [
-        pytest.param(V2_SERVICE_INFO, id="valid_velocity"),
-        pytest.param(V2_NO_VELOCITY_SERVICE_INFO, id="invalid_velocity"),
+        pytest.param(V2_SERVICE_INFO, "-14.8217964172363", id="valid_velocity"),
+        pytest.param(V2_NO_VELOCITY_SERVICE_INFO, STATE_UNKNOWN, id="invalid_velocity"),
     ],
 )
-async def test_sensors_v2_payload(
-    hass: HomeAssistant, service_info: BluetoothServiceInfo
+async def test_specific_gravity_velocity_sensor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    service_info: BluetoothServiceInfo,
+    expected_state: str,
 ) -> None:
-    """Test a version 2 advertisement sets up the known sensors."""
+    """Test the specific gravity velocity sensor from a v2 payload."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id=RAPT_MAC,
@@ -94,8 +102,21 @@ async def test_sensors_v2_payload(
 
     inject_bluetooth_service_info(hass, service_info)
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 3
-    assert hass.states.get("sensor.rapt_pill_0666_specific_gravity") is not None
+    assert len(hass.states.async_all()) == 4
+
+    velocity_sensor = hass.states.get(VELOCITY_ENTITY_ID)
+    assert velocity_sensor is not None
+    assert velocity_sensor.state == expected_state
+    assert (
+        velocity_sensor.attributes[ATTR_FRIENDLY_NAME]
+        == "RAPT Pill 0666 Specific Gravity Velocity"
+    )
+    assert velocity_sensor.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+
+    entity_entry = entity_registry.async_get(VELOCITY_ENTITY_ID)
+    assert entity_entry is not None
+    assert entity_entry.translation_key == "specific_gravity_velocity"
+    assert entity_entry.options["sensor"]["suggested_display_precision"] == 1
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change

Version 2 RAPT Pill advertisements report how fast the gravity is changing, in points per day, rapt-ble 2.0.0 (#181064) allows accessing this value. Expose it as a sensor with one decimal of display precision and a trending-down icon. The value stays unknown until the Pill has collected enough data (managed by a flag in the advertisement payload).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
