### PR TITLE
Speed up orjson buffer trimming

### DIFF
--- a/homeassistant/helpers/json.py
+++ b/homeassistant/helpers/json.py
@@ -122,10 +122,11 @@ def cached_json_bytes(data: Any) -> bytes:
     orjson over-allocates the returned bytes buffer and does not shrink it: the
     logical length is set but the capacity is rounded up to a power of two (at
     least a few KiB), so bytes cached for the lifetime of a long-lived object
-    retain several KiB of unused buffer.
+    retain several KiB of unused buffer. Copy them into a right-sized buffer.
     """
-    # Drop orjson's over-allocated slack with help of a memoryview.
-    return bytes(memoryview(json_bytes(data)))
+    # The empty second join item is load-bearing: it forces a copy into a
+    # right-sized buffer; a single-item join returns the input unchanged.
+    return b"".join((json_bytes(data), b""))
 
 
 def cached_json_fragment(data: Any) -> orjson.Fragment:
@@ -134,8 +135,9 @@ def cached_json_fragment(data: Any) -> orjson.Fragment:
     Wraps the same right-sized bytes as cached_json_bytes; the body is inlined
     rather than calling it to avoid an extra function call on this hot path.
     """
-    # Drop orjson's over-allocated slack with help of a memoryview.
-    return orjson.Fragment(bytes(memoryview(json_bytes(data))))
+    # The empty second join item is load-bearing: it forces a copy into a
+    # right-sized buffer; a single-item join returns the input unchanged.
+    return orjson.Fragment(b"".join((json_bytes(data), b"")))
 
 
 def json_dumps(data: Any) -> str:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Speed up orjson buffer trimming by replacing the `memoryview` with `bytes.join`

Benchmark with orjson 3.12.0 comparing no trimming with trimming implemented with `memorview` and with `bytes.join`:
```
--- small (268 B serialized, sys.getsizeof=301 B) ---
  serialize only : 0.5638 us/op   buffer =   4102 B
  + memoryview    : 0.7524 us/op   buffer =    314 B   trim +0.2124 us (+39.3%)
  + bytes.join    : 0.6323 us/op   buffer =    314 B   trim +0.0924 us (+17.1%)
--- typical (451 B serialized, sys.getsizeof=484 B) ---
  serialize only : 0.8230 us/op   buffer =   4102 B
  + memoryview    : 1.0162 us/op   buffer =    497 B   trim +0.1901 us (+23.0%)
  + bytes.join    : 0.9031 us/op   buffer =    497 B   trim +0.0770 us (+9.3%)
--- large (1481 B serialized, sys.getsizeof=1514 B) ---
  serialize only : 2.3340 us/op   buffer =  16270 B
  + memoryview    : 2.5949 us/op   buffer =   1527 B   trim +0.2665 us (+11.4%)
  + bytes.join    : 2.4013 us/op   buffer =   1527 B   trim +0.0730 us (+3.1%)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
