### PR TITLE
Fix delayed Duco node updates after ventilation changes

### DIFF
--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, replace
 import logging
 from typing import cast, override
 
-from duco_connectivity import DucoClient
+from duco_connectivity import DucoClient, VentilationState
 from duco_connectivity.exceptions import (
     DucoConnectionError,
     DucoError,
@@ -53,6 +53,7 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
     config_entry: DucoConfigEntry
     board_info: BoardInfo
     _configured_node_names: dict[int, str]
+    _full_update_failed: bool
     _node_update_errors: dict[int, DucoError]
     _request_lock: asyncio.Lock
 
@@ -72,37 +73,46 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         )
         self.client = client
         self._configured_node_names = {}
+        self._full_update_failed = False
         self._node_update_errors = {}
         self._request_lock = asyncio.Lock()
 
-    async def async_refresh_node(self, node_id: int) -> None:
-        """Refresh one node and publish its latest reported state."""
+    async def async_set_ventilation_state(
+        self, node_id: int, state: str | VentilationState
+    ) -> None:
+        """Set and refresh a node's ventilation state."""
+        # Keep an older read from publishing after this write completes.
         async with self._request_lock:
-            try:
-                node = await self.client.async_get_node_info(node_id)
-            except DucoError as err:
-                self._node_update_errors[node_id] = err
-                self.async_set_update_error(err)
-                return
+            await self.client.async_set_ventilation_state(node_id, state)
+            await self._async_refresh_node(node_id)
 
-            if current_node := self.data.nodes.get(node_id):
-                node = replace(
-                    node,
-                    general=replace(
-                        node.general,
-                        name=current_node.general.name,
-                    ),
-                )
+    async def _async_refresh_node(self, node_id: int) -> None:
+        """Refresh one node while holding the request lock."""
+        try:
+            node = await self.client.async_get_node_info(node_id)
+        except DucoError as err:
+            self._node_update_errors[node_id] = err
+            self.async_set_update_error(err)
+            return
 
-            self._node_update_errors.pop(node_id, None)
-            data = replace(
-                self.data,
-                nodes={**self.data.nodes, node_id: node},
+        if current_node := self.data.nodes.get(node_id):
+            node = replace(
+                node,
+                general=replace(
+                    node.general,
+                    name=current_node.general.name,
+                ),
             )
-            if self._node_update_errors:
-                self.data = data
-            else:
-                self.async_set_updated_data(data)
+
+        self._node_update_errors.pop(node_id, None)
+        self.data = replace(
+            self.data,
+            nodes={**self.data.nodes, node_id: node},
+        )
+        if not self._full_update_failed and not self._node_update_errors:
+            self.last_update_success = True
+        # A targeted readback must not postpone the periodic full refresh.
+        self.async_update_listeners()
 
     async def _async_load_node_names(self) -> None:
         """Load configured Duco node names during setup."""
@@ -152,7 +162,11 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
     async def _async_update_data(self) -> DucoData:
         """Fetch node data from the Duco box."""
         async with self._request_lock:
-            return await self._async_fetch_data()
+            self._full_update_failed = True
+            data = await self._async_fetch_data()
+            self._full_update_failed = False
+            self._node_update_errors.clear()
+            return data
 
     async def _async_fetch_data(self) -> DucoData:
         """Fetch node data while holding the request lock."""
@@ -247,7 +261,6 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
                 translation_key="api_error",
             ) from err
 
-        self._node_update_errors.clear()
         return DucoData(
             nodes={node.node_id: node for node in nodes},
             node_actions=node_actions,

--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -52,6 +52,7 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
     config_entry: DucoConfigEntry
     board_info: BoardInfo
     _configured_node_names: dict[int, str]
+    _node_refresh_versions: dict[int, int]
     _node_update_versions: dict[int, int]
 
     def __init__(
@@ -70,18 +71,26 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         )
         self.client = client
         self._configured_node_names = {}
+        self._node_refresh_versions = {}
         self._node_update_versions = {}
 
     async def async_refresh_node(self, node_id: int) -> None:
-        """Refresh one node and publish its authoritative state."""
+        """Refresh one node and publish its latest reported state."""
+        refresh_version = self._node_refresh_versions.get(node_id, 0) + 1
+        self._node_refresh_versions[node_id] = refresh_version
+
         try:
             node = await self.client.async_get_node_info(node_id)
         except DucoError as err:
-            self.async_set_update_error(err)
+            if self._node_refresh_versions[node_id] == refresh_version:
+                self.async_set_update_error(err)
             return
 
-        # Do not let a node readback mask a concurrent coordinator refresh failure.
-        if not self.last_update_success:
+        # Do not publish stale readbacks or mask a concurrent coordinator failure.
+        if (
+            self._node_refresh_versions[node_id] != refresh_version
+            or not self.last_update_success
+        ):
             return
 
         node = replace(

--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -52,6 +52,7 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
     config_entry: DucoConfigEntry
     board_info: BoardInfo
     _configured_node_names: dict[int, str]
+    _coordinator_update_version: int
     _node_refresh_versions: dict[int, int]
     _node_update_errors: dict[int, DucoError]
     _node_update_versions: dict[int, int]
@@ -72,19 +73,24 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         )
         self.client = client
         self._configured_node_names = {}
+        self._coordinator_update_version = 0
         self._node_refresh_versions = {}
         self._node_update_errors = {}
         self._node_update_versions = {}
 
     async def async_refresh_node(self, node_id: int) -> None:
         """Refresh one node and publish its latest reported state."""
+        coordinator_update_version = self._coordinator_update_version
         refresh_version = self._node_refresh_versions.get(node_id, 0) + 1
         self._node_refresh_versions[node_id] = refresh_version
 
         try:
             node = await self.client.async_get_node_info(node_id)
         except DucoError as err:
-            if self._node_refresh_versions[node_id] == refresh_version:
+            if (
+                self._coordinator_update_version == coordinator_update_version
+                and self._node_refresh_versions[node_id] == refresh_version
+            ):
                 self._node_update_errors[node_id] = err
                 self._node_update_versions[node_id] = (
                     self._node_update_versions.get(node_id, 0) + 1
@@ -94,7 +100,8 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
 
         # Do not publish stale readbacks or mask a concurrent coordinator failure.
         if (
-            self._node_refresh_versions[node_id] != refresh_version
+            self._coordinator_update_version != coordinator_update_version
+            or self._node_refresh_versions[node_id] != refresh_version
             or not self.last_update_success
         ):
             return
@@ -278,6 +285,7 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
                 if node_id in nodes_by_id and node_id in self.data.nodes:
                     nodes_by_id[node_id] = self.data.nodes[node_id]
 
+            self._coordinator_update_version += 1
         return DucoData(
             nodes=nodes_by_id,
             node_actions=node_actions,

--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -1,5 +1,6 @@
 """Data update coordinator for the Duco integration."""
 
+import asyncio
 from contextlib import suppress
 from dataclasses import dataclass, replace
 import logging
@@ -52,10 +53,8 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
     config_entry: DucoConfigEntry
     board_info: BoardInfo
     _configured_node_names: dict[int, str]
-    _update_version: int
-    _poll_version: int
-    _node_update_errors: dict[int, tuple[int, DucoError]]
-    _node_update_versions: dict[int, int]
+    _node_update_errors: dict[int, DucoError]
+    _request_lock: asyncio.Lock
 
     def __init__(
         self,
@@ -73,52 +72,37 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         )
         self.client = client
         self._configured_node_names = {}
-        self._update_version = 0
-        self._poll_version = 0
         self._node_update_errors = {}
-        self._node_update_versions = {}
+        self._request_lock = asyncio.Lock()
 
     async def async_refresh_node(self, node_id: int) -> None:
         """Refresh one node and publish its latest reported state."""
-        self._update_version += 1
-        refresh_version = self._update_version
-        self._node_update_versions[node_id] = refresh_version
-
-        try:
-            node = await self.client.async_get_node_info(node_id)
-        except DucoError as err:
-            if (
-                self._poll_version <= refresh_version
-                and self._node_update_versions[node_id] == refresh_version
-            ):
-                self._node_update_errors[node_id] = (refresh_version, err)
+        async with self._request_lock:
+            try:
+                node = await self.client.async_get_node_info(node_id)
+            except DucoError as err:
+                self._node_update_errors[node_id] = err
                 self.async_set_update_error(err)
-            return
+                return
 
-        # Do not publish a readback superseded by a later operation.
-        if (
-            self._poll_version > refresh_version
-            or self._node_update_versions[node_id] != refresh_version
-        ):
-            return
+            if current_node := self.data.nodes.get(node_id):
+                node = replace(
+                    node,
+                    general=replace(
+                        node.general,
+                        name=current_node.general.name,
+                    ),
+                )
 
-        if (current_node := self.data.nodes.get(node_id)) is None:
-            return
-
-        node = replace(
-            node,
-            general=replace(
-                node.general,
-                name=current_node.general.name,
-            ),
-        )
-        self._node_update_errors.pop(node_id, None)
-        self.async_set_updated_data(
-            replace(
+            self._node_update_errors.pop(node_id, None)
+            data = replace(
                 self.data,
                 nodes={**self.data.nodes, node_id: node},
             )
-        )
+            if self._node_update_errors:
+                self.data = data
+            else:
+                self.async_set_updated_data(data)
 
     async def _async_load_node_names(self) -> None:
         """Load configured Duco node names during setup."""
@@ -167,9 +151,11 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
     @override
     async def _async_update_data(self) -> DucoData:
         """Fetch node data from the Duco box."""
-        self._update_version += 1
-        update_version = self._update_version
-        self._poll_version = update_version
+        async with self._request_lock:
+            return await self._async_fetch_data()
+
+    async def _async_fetch_data(self) -> DucoData:
+        """Fetch node data while holding the request lock."""
         try:
             nodes = await self.client.async_get_nodes()
         except DucoConnectionError as err:
@@ -198,8 +184,6 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
                 )
                 for node in nodes
             ]
-
-        nodes_by_id = {node.node_id: node for node in nodes}
 
         try:
             node_actions = await self.client.async_get_node_actions()
@@ -263,28 +247,9 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
                 translation_key="api_error",
             ) from err
 
-        # The bulk node response may predate a write completed during this poll.
-        if self.data is not None:
-            for node_id, version in self._node_update_versions.items():
-                if version <= update_version:
-                    continue
-                if (
-                    node_update_error := self._node_update_errors.get(node_id)
-                ) and node_update_error[0] > update_version:
-                    error = node_update_error[1]
-                    raise UpdateFailed(
-                        translation_domain=DOMAIN,
-                        translation_key=(
-                            "cannot_connect"
-                            if isinstance(error, DucoConnectionError)
-                            else "api_error"
-                        ),
-                    ) from error
-                if node_id in nodes_by_id and node_id in self.data.nodes:
-                    nodes_by_id[node_id] = self.data.nodes[node_id]
-
+        self._node_update_errors.clear()
         return DucoData(
-            nodes=nodes_by_id,
+            nodes={node.node_id: node for node in nodes},
             node_actions=node_actions,
             rssi_wifi=rssi_wifi,
             time_filter_remain=time_filter_remain,

--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -53,6 +53,7 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
     board_info: BoardInfo
     _configured_node_names: dict[int, str]
     _node_refresh_versions: dict[int, int]
+    _node_update_errors: dict[int, DucoError]
     _node_update_versions: dict[int, int]
 
     def __init__(
@@ -72,6 +73,7 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         self.client = client
         self._configured_node_names = {}
         self._node_refresh_versions = {}
+        self._node_update_errors = {}
         self._node_update_versions = {}
 
     async def async_refresh_node(self, node_id: int) -> None:
@@ -83,6 +85,10 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
             node = await self.client.async_get_node_info(node_id)
         except DucoError as err:
             if self._node_refresh_versions[node_id] == refresh_version:
+                self._node_update_errors[node_id] = err
+                self._node_update_versions[node_id] = (
+                    self._node_update_versions.get(node_id, 0) + 1
+                )
                 self.async_set_update_error(err)
             return
 
@@ -93,16 +99,20 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         ):
             return
 
+        if (current_node := self.data.nodes.get(node_id)) is None:
+            return
+
         node = replace(
             node,
             general=replace(
                 node.general,
-                name=self.data.nodes[node_id].general.name,
+                name=current_node.general.name,
             ),
         )
         self._node_update_versions[node_id] = (
             self._node_update_versions.get(node_id, 0) + 1
         )
+        self._node_update_errors.pop(node_id, None)
         self.async_set_updated_data(
             replace(
                 self.data,
@@ -254,11 +264,18 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         # The bulk node response may predate a write completed during this poll.
         if self.data is not None:
             for node_id, version in self._node_update_versions.items():
-                if (
-                    node_update_versions.get(node_id) != version
-                    and node_id in nodes_by_id
-                    and node_id in self.data.nodes
-                ):
+                if node_update_versions.get(node_id) == version:
+                    continue
+                if node_update_error := self._node_update_errors.get(node_id):
+                    raise UpdateFailed(
+                        translation_domain=DOMAIN,
+                        translation_key=(
+                            "cannot_connect"
+                            if isinstance(node_update_error, DucoConnectionError)
+                            else "api_error"
+                        ),
+                    ) from node_update_error
+                if node_id in nodes_by_id and node_id in self.data.nodes:
                     nodes_by_id[node_id] = self.data.nodes[node_id]
 
         return DucoData(

--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -285,8 +285,7 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
                 if node_id in nodes_by_id and node_id in self.data.nodes:
                     nodes_by_id[node_id] = self.data.nodes[node_id]
 
-            self._coordinator_update_version += 1
-        return DucoData(
+        data = DucoData(
             nodes=nodes_by_id,
             node_actions=node_actions,
             rssi_wifi=rssi_wifi,
@@ -294,3 +293,5 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
             ventilation_temperatures=ventilation_temperatures,
             bypass_supply_temperature_targets=bypass_supply_temperature_targets,
         )
+        self._coordinator_update_version += 1
+        return data

--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -52,9 +52,9 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
     config_entry: DucoConfigEntry
     board_info: BoardInfo
     _configured_node_names: dict[int, str]
-    _coordinator_update_version: int
-    _node_refresh_versions: dict[int, int]
-    _node_update_errors: dict[int, DucoError]
+    _update_version: int
+    _poll_version: int
+    _node_update_errors: dict[int, tuple[int, DucoError]]
     _node_update_versions: dict[int, int]
 
     def __init__(
@@ -73,36 +73,32 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         )
         self.client = client
         self._configured_node_names = {}
-        self._coordinator_update_version = 0
-        self._node_refresh_versions = {}
+        self._update_version = 0
+        self._poll_version = 0
         self._node_update_errors = {}
         self._node_update_versions = {}
 
     async def async_refresh_node(self, node_id: int) -> None:
         """Refresh one node and publish its latest reported state."""
-        coordinator_update_version = self._coordinator_update_version
-        refresh_version = self._node_refresh_versions.get(node_id, 0) + 1
-        self._node_refresh_versions[node_id] = refresh_version
+        self._update_version += 1
+        refresh_version = self._update_version
+        self._node_update_versions[node_id] = refresh_version
 
         try:
             node = await self.client.async_get_node_info(node_id)
         except DucoError as err:
             if (
-                self._coordinator_update_version == coordinator_update_version
-                and self._node_refresh_versions[node_id] == refresh_version
+                self._poll_version <= refresh_version
+                and self._node_update_versions[node_id] == refresh_version
             ):
-                self._node_update_errors[node_id] = err
-                self._node_update_versions[node_id] = (
-                    self._node_update_versions.get(node_id, 0) + 1
-                )
+                self._node_update_errors[node_id] = (refresh_version, err)
                 self.async_set_update_error(err)
             return
 
-        # Do not publish stale readbacks or mask a concurrent coordinator failure.
+        # Do not publish a readback superseded by a later operation.
         if (
-            self._coordinator_update_version != coordinator_update_version
-            or self._node_refresh_versions[node_id] != refresh_version
-            or not self.last_update_success
+            self._poll_version > refresh_version
+            or self._node_update_versions[node_id] != refresh_version
         ):
             return
 
@@ -115,9 +111,6 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
                 node.general,
                 name=current_node.general.name,
             ),
-        )
-        self._node_update_versions[node_id] = (
-            self._node_update_versions.get(node_id, 0) + 1
         )
         self._node_update_errors.pop(node_id, None)
         self.async_set_updated_data(
@@ -174,7 +167,9 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
     @override
     async def _async_update_data(self) -> DucoData:
         """Fetch node data from the Duco box."""
-        node_update_versions = self._node_update_versions.copy()
+        self._update_version += 1
+        update_version = self._update_version
+        self._poll_version = update_version
         try:
             nodes = await self.client.async_get_nodes()
         except DucoConnectionError as err:
@@ -271,21 +266,24 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         # The bulk node response may predate a write completed during this poll.
         if self.data is not None:
             for node_id, version in self._node_update_versions.items():
-                if node_update_versions.get(node_id) == version:
+                if version <= update_version:
                     continue
-                if node_update_error := self._node_update_errors.get(node_id):
+                if (
+                    node_update_error := self._node_update_errors.get(node_id)
+                ) and node_update_error[0] > update_version:
+                    error = node_update_error[1]
                     raise UpdateFailed(
                         translation_domain=DOMAIN,
                         translation_key=(
                             "cannot_connect"
-                            if isinstance(node_update_error, DucoConnectionError)
+                            if isinstance(error, DucoConnectionError)
                             else "api_error"
                         ),
-                    ) from node_update_error
+                    ) from error
                 if node_id in nodes_by_id and node_id in self.data.nodes:
                     nodes_by_id[node_id] = self.data.nodes[node_id]
 
-        data = DucoData(
+        return DucoData(
             nodes=nodes_by_id,
             node_actions=node_actions,
             rssi_wifi=rssi_wifi,
@@ -293,5 +291,3 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
             ventilation_temperatures=ventilation_temperatures,
             bypass_supply_temperature_targets=bypass_supply_temperature_targets,
         )
-        self._coordinator_update_version += 1
-        return data

--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -52,6 +52,7 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
     config_entry: DucoConfigEntry
     board_info: BoardInfo
     _configured_node_names: dict[int, str]
+    _node_update_versions: dict[int, int]
 
     def __init__(
         self,
@@ -69,6 +70,36 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         )
         self.client = client
         self._configured_node_names = {}
+        self._node_update_versions = {}
+
+    async def async_refresh_node(self, node_id: int) -> None:
+        """Refresh one node and publish its authoritative state."""
+        try:
+            node = await self.client.async_get_node_info(node_id)
+        except DucoError as err:
+            self.async_set_update_error(err)
+            return
+
+        # Do not let a node readback mask a concurrent coordinator refresh failure.
+        if not self.last_update_success:
+            return
+
+        node = replace(
+            node,
+            general=replace(
+                node.general,
+                name=self.data.nodes[node_id].general.name,
+            ),
+        )
+        self._node_update_versions[node_id] = (
+            self._node_update_versions.get(node_id, 0) + 1
+        )
+        self.async_set_updated_data(
+            replace(
+                self.data,
+                nodes={**self.data.nodes, node_id: node},
+            )
+        )
 
     async def _async_load_node_names(self) -> None:
         """Load configured Duco node names during setup."""
@@ -117,6 +148,7 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
     @override
     async def _async_update_data(self) -> DucoData:
         """Fetch node data from the Duco box."""
+        node_update_versions = self._node_update_versions.copy()
         try:
             nodes = await self.client.async_get_nodes()
         except DucoConnectionError as err:
@@ -145,6 +177,8 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
                 )
                 for node in nodes
             ]
+
+        nodes_by_id = {node.node_id: node for node in nodes}
 
         try:
             node_actions = await self.client.async_get_node_actions()
@@ -208,8 +242,18 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
                 translation_key="api_error",
             ) from err
 
+        # The bulk node response may predate a write completed during this poll.
+        if self.data is not None:
+            for node_id, version in self._node_update_versions.items():
+                if (
+                    node_update_versions.get(node_id) != version
+                    and node_id in nodes_by_id
+                    and node_id in self.data.nodes
+                ):
+                    nodes_by_id[node_id] = self.data.nodes[node_id]
+
         return DucoData(
-            nodes={node.node_id: node for node in nodes},
+            nodes=nodes_by_id,
             node_actions=node_actions,
             rssi_wifi=rssi_wifi,
             time_filter_remain=time_filter_remain,

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -122,7 +122,7 @@ class DucoVentilationFanEntity(DucoEntity, FanEntity):
         await self._async_set_state(state)
 
     async def _async_set_state(self, state: VentilationState) -> None:
-        """Send the ventilation state to the device and refresh coordinator."""
+        """Set the ventilation state."""
         try:
             await self.coordinator.client.async_set_ventilation_state(
                 self._node_id, state
@@ -138,4 +138,5 @@ class DucoVentilationFanEntity(DucoEntity, FanEntity):
                 translation_domain=DOMAIN,
                 translation_key="failed_to_set_state",
             ) from err
-        await self.coordinator.async_refresh()
+
+        await self.coordinator.async_refresh_node(self._node_id)

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -124,9 +124,7 @@ class DucoVentilationFanEntity(DucoEntity, FanEntity):
     async def _async_set_state(self, state: VentilationState) -> None:
         """Set the ventilation state."""
         try:
-            await self.coordinator.client.async_set_ventilation_state(
-                self._node_id, state
-            )
+            await self.coordinator.async_set_ventilation_state(self._node_id, state)
         except DucoRateLimitError as err:
             _LOGGER.warning("Duco write rate limit exceeded for node %s", self._node_id)
             raise HomeAssistantError(
@@ -138,5 +136,3 @@ class DucoVentilationFanEntity(DucoEntity, FanEntity):
                 translation_domain=DOMAIN,
                 translation_key="failed_to_set_state",
             ) from err
-
-        await self.coordinator.async_refresh_node(self._node_id)

--- a/homeassistant/components/duco/select.py
+++ b/homeassistant/components/duco/select.py
@@ -129,9 +129,7 @@ class DucoVentilationStateSelect(DucoEntity, SelectEntity):
         try:
             # SelectEntity exposes string options, and passing the raw API value
             # through keeps newly added Duco states forward-compatible.
-            await self.coordinator.client.async_set_ventilation_state(
-                self._node_id, option
-            )
+            await self.coordinator.async_set_ventilation_state(self._node_id, option)
         except DucoRateLimitError as err:
             _LOGGER.warning("Duco write rate limit exceeded for node %s", self._node_id)
             raise HomeAssistantError(
@@ -143,7 +141,3 @@ class DucoVentilationStateSelect(DucoEntity, SelectEntity):
                 translation_domain=DOMAIN,
                 translation_key="failed_to_set_state",
             ) from err
-
-        # Duco may normalize the requested action on readback, such as
-        # MAN1x2 -> MAN1 or AUTO -> CNT1, so refresh the latest reported state.
-        await self.coordinator.async_refresh_node(self._node_id)

--- a/homeassistant/components/duco/select.py
+++ b/homeassistant/components/duco/select.py
@@ -145,5 +145,5 @@ class DucoVentilationStateSelect(DucoEntity, SelectEntity):
             ) from err
 
         # Duco may normalize the requested action on readback, such as
-        # MAN1x2 -> MAN1 or AUTO -> CNT1, so refresh the authoritative state.
+        # MAN1x2 -> MAN1 or AUTO -> CNT1, so refresh the latest reported state.
         await self.coordinator.async_refresh_node(self._node_id)

--- a/homeassistant/components/duco/select.py
+++ b/homeassistant/components/duco/select.py
@@ -146,4 +146,4 @@ class DucoVentilationStateSelect(DucoEntity, SelectEntity):
 
         # Duco may normalize the requested action on readback, such as
         # MAN1x2 -> MAN1 or AUTO -> CNT1, so refresh the authoritative state.
-        await self.coordinator.async_refresh()
+        await self.coordinator.async_refresh_node(self._node_id)

--- a/tests/components/duco/conftest.py
+++ b/tests/components/duco/conftest.py
@@ -299,10 +299,19 @@ def mock_duco_client(
         ),
     ):
         client = mock_class.return_value
+
+        def get_node_info(node_id: int) -> Node:
+            return next(
+                node
+                for node in client.async_get_nodes.return_value
+                if node.node_id == node_id
+            )
+
         client.async_get_api_info.return_value = mock_api_info
         client.async_get_board_info.return_value = mock_board_info
         client.async_get_lan_info.return_value = mock_lan_info
         client.async_get_nodes.return_value = mock_nodes
+        client.async_get_node_info.side_effect = get_node_info
         client.async_get_node_configs.return_value = node_configs_from_nodes(mock_nodes)
         client.async_get_node_actions.return_value = mock_node_actions
         client.async_get_time_filter_remaining.return_value = 180

--- a/tests/components/duco/test_fan.py
+++ b/tests/components/duco/test_fan.py
@@ -68,8 +68,6 @@ async def test_fan_set_state(
     expected_duco_state: str,
 ) -> None:
     """Test that fan service calls map to the correct Duco ventilation state."""
-    mock_duco_client.async_set_ventilation_state = AsyncMock()
-
     await hass.services.async_call(
         FAN_DOMAIN,
         service,
@@ -77,9 +75,11 @@ async def test_fan_set_state(
         blocking=True,
     )
 
-    mock_duco_client.async_set_ventilation_state.assert_called_once_with(
+    mock_duco_client.async_set_ventilation_state.assert_awaited_once_with(
         1, expected_duco_state
     )
+    mock_duco_client.async_get_node_info.assert_awaited_once_with(1)
+    assert mock_duco_client.async_get_nodes.await_count == 1
 
 
 @pytest.mark.usefixtures("init_integration")

--- a/tests/components/duco/test_select.py
+++ b/tests/components/duco/test_select.py
@@ -237,6 +237,23 @@ async def test_select_option_calls_ventilation_state_library_method(
 
 
 @pytest.mark.usefixtures("init_integration")
+async def test_targeted_readback_keeps_coordinator_poll_schedule(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a targeted readback does not postpone the full coordinator poll."""
+    freezer.tick(SCAN_INTERVAL / 2)
+    await _async_select_option(hass, "CNT2")
+
+    freezer.tick(SCAN_INTERVAL / 2)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert mock_duco_client.async_get_nodes.await_count == 2
+
+
+@pytest.mark.usefixtures("init_integration")
 @pytest.mark.parametrize(
     ("exception", "match"),
     [
@@ -336,30 +353,28 @@ async def test_targeted_readback_failure_and_recovery(
     await setup_platform_integration(
         hass, mock_config_entry, [Platform.FAN, Platform.SELECT]
     )
-    fan_write_started = asyncio.Event()
-    release_fan_write = asyncio.Event()
+    readback_started = asyncio.Event()
+    release_readback = asyncio.Event()
+    readback_count = 0
 
-    async def set_ventilation_state(
-        node_id: int, state: str | VentilationState
-    ) -> None:
-        if state == "CNT1":
-            fan_write_started.set()
-            await release_fan_write.wait()
+    async def get_node_info(node_id: int) -> Node:
+        nonlocal readback_count
+        readback_count += 1
+        if readback_count == 1:
+            readback_started.set()
+            await release_readback.wait()
+            raise DucoError("Readback failed")
+        return _replace_node_state(mock_sensor_nodes[0], "CNT1")
 
-    mock_duco_client.async_set_ventilation_state.side_effect = set_ventilation_state
-    mock_duco_client.async_get_node_info.side_effect = [
-        DucoError("Readback failed"),
-        _replace_node_state(mock_sensor_nodes[0], "CNT1"),
-    ]
+    mock_duco_client.async_get_node_info.side_effect = get_node_info
+    failed_task = asyncio.create_task(
+        _async_select_option(hass, "MAN3", failed_entity_id)
+    )
+    await readback_started.wait()
 
     fan_task = asyncio.create_task(_async_set_fan_percentage(hass))
-    await fan_write_started.wait()
-
-    await _async_select_option(hass, "MAN3", failed_entity_id)
-    _assert_select_state(hass, STATE_UNAVAILABLE)
-
-    release_fan_write.set()
-    await fan_task
+    release_readback.set()
+    await asyncio.gather(failed_task, fan_task)
 
     _assert_select_state(hass, expected_state)
 
@@ -397,12 +412,51 @@ async def test_targeted_readback_restores_node_omitted_by_older_poll(
     await poll_started.wait()
 
     write_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
-    await write_started.wait()
+    await asyncio.sleep(0)
+    assert not write_started.is_set()
 
     release_poll.set()
     await write_task
 
     _assert_select_state(hass, "MAN3")
+
+
+async def test_targeted_readback_does_not_recover_failed_coordinator_poll(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a node readback does not recover a failed full coordinator poll."""
+    await setup_platform_integration(hass, mock_config_entry, [Platform.SELECT])
+    poll_started = asyncio.Event()
+    release_poll = asyncio.Event()
+
+    async def get_nodes() -> list[Node]:
+        poll_started.set()
+        await release_poll.wait()
+        raise DucoConnectionError("Connection failed")
+
+    mock_duco_client.async_get_nodes.side_effect = get_nodes
+    mock_duco_client.async_get_node_info.return_value = _replace_node_state(
+        mock_nodes[0], "MAN3"
+    )
+    mock_duco_client.async_get_node_info.side_effect = None
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await poll_started.wait()
+
+    write_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
+    await asyncio.sleep(0)
+    release_poll.set()
+    await write_task
+    await hass.async_block_till_done()
+
+    mock_duco_client.async_set_ventilation_state.assert_awaited_once_with(1, "MAN3")
+    mock_duco_client.async_get_node_info.assert_awaited_once_with(1)
+    _assert_select_state(hass, STATE_UNAVAILABLE)
 
 
 async def test_latest_targeted_readback_wins_when_fan_and_select_overlap(
@@ -439,7 +493,8 @@ async def test_latest_targeted_readback_wins_when_fan_and_select_overlap(
     await first_readback_started.wait()
 
     select_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
-    await select_write_started.wait()
+    await asyncio.sleep(0)
+    assert not select_write_started.is_set()
 
     release_first_readback.set()
     await asyncio.gather(fan_task, select_task)

--- a/tests/components/duco/test_select.py
+++ b/tests/components/duco/test_select.py
@@ -1,5 +1,6 @@
 """Tests for the Duco select platform."""
 
+import asyncio
 from dataclasses import replace
 from unittest.mock import AsyncMock
 
@@ -24,7 +25,12 @@ from homeassistant.components.select import (
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
@@ -91,6 +97,23 @@ def _replace_node_state(node: Node, state: str | VentilationState | None) -> Nod
 
     assert node.ventilation is not None
     return replace(node, ventilation=replace(node.ventilation, state=state))
+
+
+def _assert_select_state(hass: HomeAssistant, expected_state: str) -> None:
+    """Assert the ventilation select state."""
+    state = hass.states.get(_SELECT_ENTITY)
+    assert state is not None
+    assert state.state == expected_state
+
+
+async def _async_select_option(hass: HomeAssistant, option: str) -> None:
+    """Select a ventilation option."""
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: _SELECT_ENTITY, ATTR_OPTION: option},
+        blocking=True,
+    )
 
 
 @pytest.fixture
@@ -194,7 +217,9 @@ async def test_select_option_calls_ventilation_state_library_method(
         blocking=True,
     )
 
-    mock_duco_client.async_set_ventilation_state.assert_called_once_with(1, "CNT2")
+    mock_duco_client.async_set_ventilation_state.assert_awaited_once_with(1, "CNT2")
+    mock_duco_client.async_get_node_info.assert_awaited_once_with(1)
+    assert mock_duco_client.async_get_nodes.await_count == 1
 
 
 @pytest.mark.usefixtures("init_integration")
@@ -238,7 +263,6 @@ async def test_select_extended_manual_options_allow_normalized_readback(
     state = hass.states.get(_SELECT_ENTITY)
     assert state is not None
     assert state.attributes[ATTR_OPTIONS] == ["AUTO", "MAN1", "MAN1x2", "MAN1x3"]
-
     box_node = mock_nodes[0]
     mock_duco_client.async_set_ventilation_state = AsyncMock()
     mock_duco_client.async_get_nodes.return_value = [
@@ -270,7 +294,6 @@ async def test_select_auto_option_allows_cnt1_readback(
         options=["AUTO", "CNT1", "CNT2"]
     )
     await setup_platform_integration(hass, mock_config_entry, [Platform.SELECT])
-
     box_node = mock_nodes[0]
     mock_duco_client.async_set_ventilation_state = AsyncMock()
     mock_duco_client.async_get_nodes.return_value = [
@@ -289,6 +312,81 @@ async def test_select_auto_option_allows_cnt1_readback(
     state = hass.states.get(_SELECT_ENTITY)
     assert state is not None
     assert state.state == "CNT1"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_targeted_readback_failure_marks_coordinator_unavailable(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test a failed targeted readback marks entities unavailable."""
+    mock_duco_client.async_get_node_info.side_effect = DucoError("Readback failed")
+    await _async_select_option(hass, "MAN3")
+
+    mock_duco_client.async_set_ventilation_state.assert_awaited_once_with(1, "MAN3")
+    _assert_select_state(hass, STATE_UNAVAILABLE)
+
+
+async def test_targeted_readback_survives_older_coordinator_poll(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
+) -> None:
+    """Test an older in-flight poll cannot overwrite a targeted node readback."""
+    poll_started = asyncio.Event()
+    release_poll = asyncio.Event()
+
+    async def get_nodes() -> list[Node]:
+        poll_started.set()
+        await release_poll.wait()
+        return mock_nodes
+
+    mock_duco_client.async_get_nodes.side_effect = get_nodes
+    mock_duco_client.async_get_node_info.side_effect = None
+    mock_duco_client.async_get_node_info.return_value = _replace_node_state(
+        mock_nodes[0], "MAN3"
+    )
+
+    poll_task = asyncio.create_task(init_integration.runtime_data.async_refresh())
+    await poll_started.wait()
+
+    await _async_select_option(hass, "MAN3")
+
+    release_poll.set()
+    await poll_task
+
+    _assert_select_state(hass, "MAN3")
+
+
+async def test_targeted_readback_does_not_recover_failed_coordinator(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
+) -> None:
+    """Test a node readback does not recover a failed coordinator."""
+    readback_started = asyncio.Event()
+    release_readback = asyncio.Event()
+
+    async def get_node_info(node_id: int) -> Node:
+        readback_started.set()
+        await release_readback.wait()
+        return _replace_node_state(mock_nodes[0], "MAN3")
+
+    mock_duco_client.async_get_node_info.side_effect = get_node_info
+    write_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
+    await readback_started.wait()
+
+    mock_duco_client.async_get_nodes.side_effect = DucoError("Temporary update failure")
+    await init_integration.runtime_data.async_refresh()
+
+    _assert_select_state(hass, STATE_UNAVAILABLE)
+
+    release_readback.set()
+    await write_task
+
+    _assert_select_state(hass, STATE_UNAVAILABLE)
 
 
 async def test_select_entity_is_added_when_action_discovery_succeeds_later(

--- a/tests/components/duco/test_select.py
+++ b/tests/components/duco/test_select.py
@@ -17,8 +17,10 @@ from duco_connectivity import (
     NodeType,
     VentilationState,
 )
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.duco.const import SCAN_INTERVAL
 from homeassistant.components.fan import (
     ATTR_PERCENTAGE,
     DOMAIN as FAN_DOMAIN,
@@ -41,7 +43,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 from . import setup_platform_integration
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 _SELECT_ENTITY = "select.living_ventilation_state"
 _VALVE_SELECT_ENTITY = "select.bedroom_valve_ventilation_state"
@@ -109,6 +111,17 @@ def _assert_select_state(hass: HomeAssistant, expected_state: str) -> None:
     state = hass.states.get(_SELECT_ENTITY)
     assert state is not None
     assert state.state == expected_state
+
+
+async def _async_wait_for_select_state(
+    hass: HomeAssistant, expected_state: str
+) -> None:
+    """Wait for the ventilation select state."""
+    async with asyncio.timeout(1):
+        while (
+            state := hass.states.get(_SELECT_ENTITY)
+        ) is None or state.state != expected_state:
+            await asyncio.sleep(0)
 
 
 async def _async_select_option(hass: HomeAssistant, option: str) -> None:
@@ -332,13 +345,23 @@ async def test_targeted_readback_failure_marks_coordinator_unavailable(
     _assert_select_state(hass, STATE_UNAVAILABLE)
 
 
-async def test_targeted_readback_survives_older_coordinator_poll(
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    ("readback_error", "expected_state"),
+    [
+        pytest.param(None, "MAN3", id="success"),
+        pytest.param(DucoError("Readback failed"), STATE_UNAVAILABLE, id="failure"),
+    ],
+)
+async def test_targeted_outcome_survives_older_coordinator_poll(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_duco_client: AsyncMock,
     mock_nodes: list[Node],
+    freezer: FrozenDateTimeFactory,
+    readback_error: DucoError | None,
+    expected_state: str,
 ) -> None:
-    """Test an older in-flight poll cannot overwrite a targeted node readback."""
+    """Test an older in-flight poll cannot overwrite a targeted outcome."""
     poll_started = asyncio.Event()
     release_poll = asyncio.Event()
 
@@ -348,49 +371,22 @@ async def test_targeted_readback_survives_older_coordinator_poll(
         return mock_nodes
 
     mock_duco_client.async_get_nodes.side_effect = get_nodes
-    mock_duco_client.async_get_node_info.side_effect = None
     mock_duco_client.async_get_node_info.return_value = _replace_node_state(
         mock_nodes[0], "MAN3"
     )
+    mock_duco_client.async_get_node_info.side_effect = readback_error
 
-    poll_task = asyncio.create_task(init_integration.runtime_data.async_refresh())
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
     await poll_started.wait()
 
     await _async_select_option(hass, "MAN3")
+    _assert_select_state(hass, expected_state)
 
     release_poll.set()
-    await poll_task
+    await hass.async_block_till_done()
 
-    _assert_select_state(hass, "MAN3")
-
-
-async def test_older_coordinator_poll_does_not_recover_failed_targeted_readback(
-    hass: HomeAssistant,
-    init_integration: MockConfigEntry,
-    mock_duco_client: AsyncMock,
-    mock_nodes: list[Node],
-) -> None:
-    """Test an older poll cannot recover a failed targeted readback."""
-    poll_started = asyncio.Event()
-    release_poll = asyncio.Event()
-
-    async def get_nodes() -> list[Node]:
-        poll_started.set()
-        await release_poll.wait()
-        return mock_nodes
-
-    mock_duco_client.async_get_nodes.side_effect = get_nodes
-    poll_task = asyncio.create_task(init_integration.runtime_data.async_refresh())
-    await poll_started.wait()
-
-    mock_duco_client.async_get_node_info.side_effect = DucoError("Readback failed")
-    await _async_select_option(hass, "MAN3")
-    _assert_select_state(hass, STATE_UNAVAILABLE)
-
-    release_poll.set()
-    await poll_task
-
-    _assert_select_state(hass, STATE_UNAVAILABLE)
+    _assert_select_state(hass, expected_state)
 
 
 async def test_latest_targeted_readback_wins_when_fan_and_select_overlap(
@@ -436,11 +432,58 @@ async def test_latest_targeted_readback_wins_when_fan_and_select_overlap(
     _assert_select_state(hass, "MAN3")
 
 
-async def test_targeted_readback_ignored_when_node_disappears(
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    "readback_error",
+    [
+        pytest.param(None, id="success"),
+        pytest.param(DucoError("Readback failed"), id="failure"),
+    ],
+)
+async def test_newer_coordinator_poll_supersedes_targeted_outcome(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_duco_client: AsyncMock,
     mock_nodes: list[Node],
+    freezer: FrozenDateTimeFactory,
+    readback_error: DucoError | None,
+) -> None:
+    """Test a newer coordinator poll supersedes an older targeted outcome."""
+    readback_started = asyncio.Event()
+    release_readback = asyncio.Event()
+    readback = AsyncMock(
+        return_value=_replace_node_state(mock_nodes[0], "MAN3"),
+        side_effect=readback_error,
+    )
+
+    async def get_node_info(node_id: int) -> Node:
+        readback_started.set()
+        await release_readback.wait()
+        return await readback(node_id)
+
+    mock_duco_client.async_get_node_info.side_effect = get_node_info
+    write_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
+    await readback_started.wait()
+
+    mock_duco_client.async_get_nodes.return_value = [
+        _replace_node_state(mock_nodes[0], "CNT2"),
+        *mock_nodes[1:],
+    ]
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await _async_wait_for_select_state(hass, "CNT2")
+
+    release_readback.set()
+    await write_task
+
+    _assert_select_state(hass, "CNT2")
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_targeted_readback_ignored_when_node_disappears(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test a readback is ignored when its node disappears during the request."""
     readback_started = asyncio.Event()
@@ -458,8 +501,9 @@ async def test_targeted_readback_ignored_when_node_disappears(
     mock_duco_client.async_get_nodes.return_value = [
         node for node in mock_nodes if node.node_id != 1
     ]
-    await init_integration.runtime_data.async_refresh()
-    _assert_select_state(hass, STATE_UNAVAILABLE)
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await _async_wait_for_select_state(hass, STATE_UNAVAILABLE)
 
     release_readback.set()
     await write_task
@@ -467,11 +511,12 @@ async def test_targeted_readback_ignored_when_node_disappears(
     _assert_select_state(hass, STATE_UNAVAILABLE)
 
 
+@pytest.mark.usefixtures("init_integration")
 async def test_targeted_readback_does_not_recover_failed_coordinator(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
     mock_duco_client: AsyncMock,
     mock_nodes: list[Node],
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test a node readback does not recover a failed coordinator."""
     readback_started = asyncio.Event()
@@ -487,9 +532,9 @@ async def test_targeted_readback_does_not_recover_failed_coordinator(
     await readback_started.wait()
 
     mock_duco_client.async_get_nodes.side_effect = DucoError("Temporary update failure")
-    await init_integration.runtime_data.async_refresh()
-
-    _assert_select_state(hass, STATE_UNAVAILABLE)
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await _async_wait_for_select_state(hass, STATE_UNAVAILABLE)
 
     release_readback.set()
     await write_task
@@ -501,6 +546,7 @@ async def test_select_entity_is_added_when_action_discovery_succeeds_later(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test select entities are added when action discovery becomes available later."""
     mock_duco_client.async_get_node_actions.side_effect = [
@@ -510,13 +556,12 @@ async def test_select_entity_is_added_when_action_discovery_succeeds_later(
         ),
     ]
 
-    config_entry = await setup_platform_integration(
-        hass, mock_config_entry, [Platform.SELECT]
-    )
+    await setup_platform_integration(hass, mock_config_entry, [Platform.SELECT])
 
     assert hass.states.get(_SELECT_ENTITY) is None
 
-    await config_entry.runtime_data.async_refresh()
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     state = hass.states.get(_SELECT_ENTITY)

--- a/tests/components/duco/test_select.py
+++ b/tests/components/duco/test_select.py
@@ -1,6 +1,7 @@
 """Tests for the Duco select platform."""
 
 import asyncio
+from collections.abc import Callable
 from dataclasses import replace
 from unittest.mock import AsyncMock
 
@@ -113,14 +114,14 @@ def _assert_select_state(hass: HomeAssistant, expected_state: str) -> None:
     assert state.state == expected_state
 
 
-async def _async_wait_for_select_state(
-    hass: HomeAssistant, expected_state: str
+async def _async_wait_for_state(
+    hass: HomeAssistant, entity_id: str, expected_state: str
 ) -> None:
-    """Wait for the ventilation select state."""
+    """Wait for an entity state."""
     async with asyncio.timeout(1):
-        while (
-            state := hass.states.get(_SELECT_ENTITY)
-        ) is None or state.state != expected_state:
+        while (state := hass.states.get(entity_id)) is None or (
+            state.state != expected_state
+        ):
             await asyncio.sleep(0)
 
 
@@ -132,6 +133,53 @@ async def _async_select_option(hass: HomeAssistant, option: str) -> None:
         {ATTR_ENTITY_ID: _SELECT_ENTITY, ATTR_OPTION: option},
         blocking=True,
     )
+
+
+async def _async_set_fan_percentage(hass: HomeAssistant) -> None:
+    """Set the ventilation fan percentage."""
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PERCENTAGE,
+        {ATTR_ENTITY_ID: "fan.living", ATTR_PERCENTAGE: 33},
+        blocking=True,
+    )
+
+
+async def _async_start_blocked_readback(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    outcome: Node | DucoError,
+) -> tuple[asyncio.Task[None], asyncio.Event]:
+    """Start a select action with a blocked node readback."""
+    readback_started = asyncio.Event()
+    release_readback = asyncio.Event()
+
+    async def get_node_info(node_id: int) -> Node:
+        readback_started.set()
+        await release_readback.wait()
+        if isinstance(outcome, DucoError):
+            raise outcome
+        return outcome
+
+    mock_duco_client.async_get_node_info.side_effect = get_node_info
+    write_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
+    await readback_started.wait()
+    return write_task, release_readback
+
+
+def _nodes_with_updated_box(nodes: list[Node]) -> list[Node]:
+    """Return poll data with an updated box state."""
+    return [_replace_node_state(nodes[0], "CNT2"), *nodes[1:]]
+
+
+def _nodes_without_box(nodes: list[Node]) -> list[Node]:
+    """Return poll data without the box node."""
+    return [node for node in nodes if node.node_id != 1]
+
+
+def _failed_poll(nodes: list[Node]) -> DucoError:
+    """Return a failed poll outcome."""
+    return DucoError("Temporary update failure")
 
 
 @pytest.fixture
@@ -228,12 +276,7 @@ async def test_select_option_calls_ventilation_state_library_method(
     """Test that selecting an option uses the typed ventilation state helper."""
     mock_duco_client.async_set_ventilation_state = AsyncMock()
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: _SELECT_ENTITY, ATTR_OPTION: "CNT2"},
-        blocking=True,
-    )
+    await _async_select_option(hass, "CNT2")
 
     mock_duco_client.async_set_ventilation_state.assert_awaited_once_with(1, "CNT2")
     mock_duco_client.async_get_node_info.assert_awaited_once_with(1)
@@ -258,12 +301,7 @@ async def test_select_option_error(
     mock_duco_client.async_set_ventilation_state = AsyncMock(side_effect=exception)
 
     with pytest.raises(HomeAssistantError, match=match):
-        await hass.services.async_call(
-            SELECT_DOMAIN,
-            SERVICE_SELECT_OPTION,
-            {ATTR_ENTITY_ID: _SELECT_ENTITY, ATTR_OPTION: "CNT2"},
-            blocking=True,
-        )
+        await _async_select_option(hass, "CNT2")
 
 
 async def test_select_extended_manual_options_allow_normalized_readback(
@@ -288,12 +326,7 @@ async def test_select_extended_manual_options_allow_normalized_readback(
         *mock_nodes[1:],
     ]
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: _SELECT_ENTITY, ATTR_OPTION: "MAN1x2"},
-        blocking=True,
-    )
+    await _async_select_option(hass, "MAN1x2")
 
     mock_duco_client.async_set_ventilation_state.assert_called_once_with(1, "MAN1x2")
     state = hass.states.get(_SELECT_ENTITY)
@@ -319,12 +352,7 @@ async def test_select_auto_option_allows_cnt1_readback(
         *mock_nodes[1:],
     ]
 
-    await hass.services.async_call(
-        SELECT_DOMAIN,
-        SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: _SELECT_ENTITY, ATTR_OPTION: "AUTO"},
-        blocking=True,
-    )
+    await _async_select_option(hass, "AUTO")
 
     mock_duco_client.async_set_ventilation_state.assert_called_once_with(1, "AUTO")
     state = hass.states.get(_SELECT_ENTITY)
@@ -332,20 +360,44 @@ async def test_select_auto_option_allows_cnt1_readback(
     assert state.state == "CNT1"
 
 
-@pytest.mark.usefixtures("init_integration")
-async def test_targeted_readback_failure_marks_coordinator_unavailable(
+async def test_targeted_readback_failure_and_recovery(
     hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
 ) -> None:
-    """Test a failed targeted readback marks entities unavailable."""
-    mock_duco_client.async_get_node_info.side_effect = DucoError("Readback failed")
-    await _async_select_option(hass, "MAN3")
+    """Test a later targeted readback recovers an earlier failure."""
+    await setup_platform_integration(
+        hass, mock_config_entry, [Platform.FAN, Platform.SELECT]
+    )
+    fan_write_started = asyncio.Event()
+    release_fan_write = asyncio.Event()
 
-    mock_duco_client.async_set_ventilation_state.assert_awaited_once_with(1, "MAN3")
+    async def set_ventilation_state(
+        node_id: int, state: str | VentilationState
+    ) -> None:
+        if state == "CNT1":
+            fan_write_started.set()
+            await release_fan_write.wait()
+
+    mock_duco_client.async_set_ventilation_state.side_effect = set_ventilation_state
+    mock_duco_client.async_get_node_info.side_effect = [
+        DucoError("Readback failed"),
+        _replace_node_state(mock_nodes[0], "CNT1"),
+    ]
+
+    fan_task = asyncio.create_task(_async_set_fan_percentage(hass))
+    await fan_write_started.wait()
+
+    await _async_select_option(hass, "MAN3")
     _assert_select_state(hass, STATE_UNAVAILABLE)
 
+    release_fan_write.set()
+    await fan_task
 
-@pytest.mark.usefixtures("init_integration")
+    _assert_select_state(hass, "CNT1")
+
+
 @pytest.mark.parametrize(
     ("readback_error", "expected_state"),
     [
@@ -355,6 +407,7 @@ async def test_targeted_readback_failure_marks_coordinator_unavailable(
 )
 async def test_targeted_outcome_survives_older_coordinator_poll(
     hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
     mock_nodes: list[Node],
     freezer: FrozenDateTimeFactory,
@@ -362,29 +415,43 @@ async def test_targeted_outcome_survives_older_coordinator_poll(
     expected_state: str,
 ) -> None:
     """Test an older in-flight poll cannot overwrite a targeted outcome."""
+    await setup_platform_integration(
+        hass, mock_config_entry, [Platform.SELECT, Platform.SENSOR]
+    )
     poll_started = asyncio.Event()
     release_poll = asyncio.Event()
 
     async def get_nodes() -> list[Node]:
         poll_started.set()
         await release_poll.wait()
-        return mock_nodes
+        assert mock_nodes[3].sensor is not None
+        return [
+            _replace_node_state(mock_nodes[0], "CNT2"),
+            *mock_nodes[1:3],
+            replace(
+                mock_nodes[3],
+                sensor=replace(mock_nodes[3].sensor, rh=62.0),
+            ),
+        ]
 
     mock_duco_client.async_get_nodes.side_effect = get_nodes
-    mock_duco_client.async_get_node_info.return_value = _replace_node_state(
-        mock_nodes[0], "MAN3"
-    )
-    mock_duco_client.async_get_node_info.side_effect = readback_error
 
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await poll_started.wait()
 
-    await _async_select_option(hass, "MAN3")
-    _assert_select_state(hass, expected_state)
+    write_task, release_readback = await _async_start_blocked_readback(
+        hass,
+        mock_duco_client,
+        readback_error or _replace_node_state(mock_nodes[0], "MAN3"),
+    )
 
     release_poll.set()
-    await hass.async_block_till_done()
+    await _async_wait_for_state(hass, "sensor.kitchen_rh_humidity", "62.0")
+    _assert_select_state(hass, "AUTO")
+
+    release_readback.set()
+    await write_task
 
     _assert_select_state(hass, expected_state)
 
@@ -413,14 +480,7 @@ async def test_latest_targeted_readback_wins_when_fan_and_select_overlap(
         return _replace_node_state(mock_nodes[0], "MAN3")
 
     mock_duco_client.async_get_node_info.side_effect = get_node_info
-    fan_task = asyncio.create_task(
-        hass.services.async_call(
-            FAN_DOMAIN,
-            SERVICE_SET_PERCENTAGE,
-            {ATTR_ENTITY_ID: "fan.living", ATTR_PERCENTAGE: 33},
-            blocking=True,
-        )
-    )
+    fan_task = asyncio.create_task(_async_set_fan_percentage(hass))
     await first_readback_started.wait()
 
     await _async_select_option(hass, "MAN3")
@@ -434,10 +494,26 @@ async def test_latest_targeted_readback_wins_when_fan_and_select_overlap(
 
 @pytest.mark.usefixtures("init_integration")
 @pytest.mark.parametrize(
-    "readback_error",
+    ("poll_result_factory", "readback_outcome", "expected_state"),
     [
-        pytest.param(None, id="success"),
-        pytest.param(DucoError("Readback failed"), id="failure"),
+        pytest.param(
+            _nodes_with_updated_box,
+            DucoError("Readback failed"),
+            "CNT2",
+            id="success",
+        ),
+        pytest.param(
+            _nodes_without_box,
+            None,
+            STATE_UNAVAILABLE,
+            id="node-removed",
+        ),
+        pytest.param(
+            _failed_poll,
+            None,
+            STATE_UNAVAILABLE,
+            id="failure",
+        ),
     ],
 )
 async def test_newer_coordinator_poll_supersedes_targeted_outcome(
@@ -445,101 +521,26 @@ async def test_newer_coordinator_poll_supersedes_targeted_outcome(
     mock_duco_client: AsyncMock,
     mock_nodes: list[Node],
     freezer: FrozenDateTimeFactory,
-    readback_error: DucoError | None,
+    poll_result_factory: Callable[[list[Node]], list[Node] | DucoError],
+    readback_outcome: DucoError | None,
+    expected_state: str,
 ) -> None:
     """Test a newer coordinator poll supersedes an older targeted outcome."""
-    readback_started = asyncio.Event()
-    release_readback = asyncio.Event()
-    readback = AsyncMock(
-        return_value=_replace_node_state(mock_nodes[0], "MAN3"),
-        side_effect=readback_error,
+    write_task, release_readback = await _async_start_blocked_readback(
+        hass,
+        mock_duco_client,
+        readback_outcome or _replace_node_state(mock_nodes[0], "MAN3"),
     )
 
-    async def get_node_info(node_id: int) -> Node:
-        readback_started.set()
-        await release_readback.wait()
-        return await readback(node_id)
-
-    mock_duco_client.async_get_node_info.side_effect = get_node_info
-    write_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
-    await readback_started.wait()
-
-    mock_duco_client.async_get_nodes.return_value = [
-        _replace_node_state(mock_nodes[0], "CNT2"),
-        *mock_nodes[1:],
-    ]
+    mock_duco_client.async_get_nodes.side_effect = [poll_result_factory(mock_nodes)]
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
-    await _async_wait_for_select_state(hass, "CNT2")
+    await _async_wait_for_state(hass, _SELECT_ENTITY, expected_state)
 
     release_readback.set()
     await write_task
 
-    _assert_select_state(hass, "CNT2")
-
-
-@pytest.mark.usefixtures("init_integration")
-async def test_targeted_readback_ignored_when_node_disappears(
-    hass: HomeAssistant,
-    mock_duco_client: AsyncMock,
-    mock_nodes: list[Node],
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test a readback is ignored when its node disappears during the request."""
-    readback_started = asyncio.Event()
-    release_readback = asyncio.Event()
-
-    async def get_node_info(node_id: int) -> Node:
-        readback_started.set()
-        await release_readback.wait()
-        return _replace_node_state(mock_nodes[0], "MAN3")
-
-    mock_duco_client.async_get_node_info.side_effect = get_node_info
-    write_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
-    await readback_started.wait()
-
-    mock_duco_client.async_get_nodes.return_value = [
-        node for node in mock_nodes if node.node_id != 1
-    ]
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await _async_wait_for_select_state(hass, STATE_UNAVAILABLE)
-
-    release_readback.set()
-    await write_task
-
-    _assert_select_state(hass, STATE_UNAVAILABLE)
-
-
-@pytest.mark.usefixtures("init_integration")
-async def test_targeted_readback_does_not_recover_failed_coordinator(
-    hass: HomeAssistant,
-    mock_duco_client: AsyncMock,
-    mock_nodes: list[Node],
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test a node readback does not recover a failed coordinator."""
-    readback_started = asyncio.Event()
-    release_readback = asyncio.Event()
-
-    async def get_node_info(node_id: int) -> Node:
-        readback_started.set()
-        await release_readback.wait()
-        return _replace_node_state(mock_nodes[0], "MAN3")
-
-    mock_duco_client.async_get_node_info.side_effect = get_node_info
-    write_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
-    await readback_started.wait()
-
-    mock_duco_client.async_get_nodes.side_effect = DucoError("Temporary update failure")
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await _async_wait_for_select_state(hass, STATE_UNAVAILABLE)
-
-    release_readback.set()
-    await write_task
-
-    _assert_select_state(hass, STATE_UNAVAILABLE)
+    _assert_select_state(hass, expected_state)
 
 
 async def test_select_entity_is_added_when_action_discovery_succeeds_later(

--- a/tests/components/duco/test_select.py
+++ b/tests/components/duco/test_select.py
@@ -19,6 +19,11 @@ from duco_connectivity import (
 )
 import pytest
 
+from homeassistant.components.fan import (
+    ATTR_PERCENTAGE,
+    DOMAIN as FAN_DOMAIN,
+    SERVICE_SET_PERCENTAGE,
+)
 from homeassistant.components.select import (
     ATTR_OPTION,
     ATTR_OPTIONS,
@@ -355,6 +360,49 @@ async def test_targeted_readback_survives_older_coordinator_poll(
 
     release_poll.set()
     await poll_task
+
+    _assert_select_state(hass, "MAN3")
+
+
+async def test_latest_targeted_readback_wins_when_fan_and_select_overlap(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
+) -> None:
+    """Test an older fan readback cannot overwrite a newer select readback."""
+    await setup_platform_integration(
+        hass, mock_config_entry, [Platform.FAN, Platform.SELECT]
+    )
+    first_readback_started = asyncio.Event()
+    release_first_readback = asyncio.Event()
+    readback_count = 0
+
+    async def get_node_info(node_id: int) -> Node:
+        nonlocal readback_count
+        readback_count += 1
+        if readback_count == 1:
+            first_readback_started.set()
+            await release_first_readback.wait()
+            return _replace_node_state(mock_nodes[0], "CNT1")
+        return _replace_node_state(mock_nodes[0], "MAN3")
+
+    mock_duco_client.async_get_node_info.side_effect = get_node_info
+    fan_task = asyncio.create_task(
+        hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_SET_PERCENTAGE,
+            {ATTR_ENTITY_ID: "fan.living", ATTR_PERCENTAGE: 33},
+            blocking=True,
+        )
+    )
+    await first_readback_started.wait()
+
+    await _async_select_option(hass, "MAN3")
+    _assert_select_state(hass, "MAN3")
+
+    release_first_readback.set()
+    await fan_task
 
     _assert_select_state(hass, "MAN3")
 

--- a/tests/components/duco/test_select.py
+++ b/tests/components/duco/test_select.py
@@ -1,7 +1,6 @@
 """Tests for the Duco select platform."""
 
 import asyncio
-from collections.abc import Callable
 from dataclasses import replace
 from unittest.mock import AsyncMock
 
@@ -114,23 +113,14 @@ def _assert_select_state(hass: HomeAssistant, expected_state: str) -> None:
     assert state.state == expected_state
 
 
-async def _async_wait_for_state(
-    hass: HomeAssistant, entity_id: str, expected_state: str
+async def _async_select_option(
+    hass: HomeAssistant, option: str, entity_id: str = _SELECT_ENTITY
 ) -> None:
-    """Wait for an entity state."""
-    async with asyncio.timeout(1):
-        while (state := hass.states.get(entity_id)) is None or (
-            state.state != expected_state
-        ):
-            await asyncio.sleep(0)
-
-
-async def _async_select_option(hass: HomeAssistant, option: str) -> None:
     """Select a ventilation option."""
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: _SELECT_ENTITY, ATTR_OPTION: option},
+        {ATTR_ENTITY_ID: entity_id, ATTR_OPTION: option},
         blocking=True,
     )
 
@@ -143,43 +133,6 @@ async def _async_set_fan_percentage(hass: HomeAssistant) -> None:
         {ATTR_ENTITY_ID: "fan.living", ATTR_PERCENTAGE: 33},
         blocking=True,
     )
-
-
-async def _async_start_blocked_readback(
-    hass: HomeAssistant,
-    mock_duco_client: AsyncMock,
-    outcome: Node | DucoError,
-) -> tuple[asyncio.Task[None], asyncio.Event]:
-    """Start a select action with a blocked node readback."""
-    readback_started = asyncio.Event()
-    release_readback = asyncio.Event()
-
-    async def get_node_info(node_id: int) -> Node:
-        readback_started.set()
-        await release_readback.wait()
-        if isinstance(outcome, DucoError):
-            raise outcome
-        return outcome
-
-    mock_duco_client.async_get_node_info.side_effect = get_node_info
-    write_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
-    await readback_started.wait()
-    return write_task, release_readback
-
-
-def _nodes_with_updated_box(nodes: list[Node]) -> list[Node]:
-    """Return poll data with an updated box state."""
-    return [_replace_node_state(nodes[0], "CNT2"), *nodes[1:]]
-
-
-def _nodes_without_box(nodes: list[Node]) -> list[Node]:
-    """Return poll data without the box node."""
-    return [node for node in nodes if node.node_id != 1]
-
-
-def _failed_poll(nodes: list[Node]) -> DucoError:
-    """Return a failed poll outcome."""
-    return DucoError("Temporary update failure")
 
 
 @pytest.fixture
@@ -360,13 +313,26 @@ async def test_select_auto_option_allows_cnt1_readback(
     assert state.state == "CNT1"
 
 
+@pytest.mark.parametrize(
+    ("failed_entity_id", "expected_state"),
+    [
+        pytest.param(_SELECT_ENTITY, "CNT1", id="same-node"),
+        pytest.param(_VALVE_SELECT_ENTITY, STATE_UNAVAILABLE, id="other-node"),
+    ],
+)
 async def test_targeted_readback_failure_and_recovery(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
-    mock_nodes: list[Node],
+    mock_sensor_nodes: list[Node],
+    failed_entity_id: str,
+    expected_state: str,
 ) -> None:
-    """Test a later targeted readback recovers an earlier failure."""
+    """Test a targeted success only clears its own node's failure."""
+    mock_duco_client.async_get_nodes.return_value = mock_sensor_nodes
+    mock_duco_client.async_get_node_actions.return_value = _build_multi_node_actions(
+        [1, 60], options=["AUTO", "CNT1", "MAN3"]
+    )
     await setup_platform_integration(
         hass, mock_config_entry, [Platform.FAN, Platform.SELECT]
     )
@@ -383,77 +349,60 @@ async def test_targeted_readback_failure_and_recovery(
     mock_duco_client.async_set_ventilation_state.side_effect = set_ventilation_state
     mock_duco_client.async_get_node_info.side_effect = [
         DucoError("Readback failed"),
-        _replace_node_state(mock_nodes[0], "CNT1"),
+        _replace_node_state(mock_sensor_nodes[0], "CNT1"),
     ]
 
     fan_task = asyncio.create_task(_async_set_fan_percentage(hass))
     await fan_write_started.wait()
 
-    await _async_select_option(hass, "MAN3")
+    await _async_select_option(hass, "MAN3", failed_entity_id)
     _assert_select_state(hass, STATE_UNAVAILABLE)
 
     release_fan_write.set()
     await fan_task
 
-    _assert_select_state(hass, "CNT1")
+    _assert_select_state(hass, expected_state)
 
 
-@pytest.mark.parametrize(
-    ("readback_error", "expected_state"),
-    [
-        pytest.param(None, "MAN3", id="success"),
-        pytest.param(DucoError("Readback failed"), STATE_UNAVAILABLE, id="failure"),
-    ],
-)
-async def test_targeted_outcome_survives_older_coordinator_poll(
+async def test_targeted_readback_restores_node_omitted_by_older_poll(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
     mock_nodes: list[Node],
     freezer: FrozenDateTimeFactory,
-    readback_error: DucoError | None,
-    expected_state: str,
 ) -> None:
-    """Test an older in-flight poll cannot overwrite a targeted outcome."""
-    await setup_platform_integration(
-        hass, mock_config_entry, [Platform.SELECT, Platform.SENSOR]
-    )
+    """Test a targeted readback restores a node omitted by an older poll."""
+    await setup_platform_integration(hass, mock_config_entry, [Platform.SELECT])
     poll_started = asyncio.Event()
     release_poll = asyncio.Event()
+    write_started = asyncio.Event()
 
     async def get_nodes() -> list[Node]:
         poll_started.set()
         await release_poll.wait()
-        assert mock_nodes[3].sensor is not None
-        return [
-            _replace_node_state(mock_nodes[0], "CNT2"),
-            *mock_nodes[1:3],
-            replace(
-                mock_nodes[3],
-                sensor=replace(mock_nodes[3].sensor, rh=62.0),
-            ),
-        ]
+        return mock_nodes[1:]
+
+    def set_ventilation_state(node_id: int, state: str | VentilationState) -> None:
+        write_started.set()
 
     mock_duco_client.async_get_nodes.side_effect = get_nodes
+    mock_duco_client.async_set_ventilation_state.side_effect = set_ventilation_state
+    mock_duco_client.async_get_node_info.return_value = _replace_node_state(
+        mock_nodes[0], "MAN3"
+    )
+    mock_duco_client.async_get_node_info.side_effect = None
 
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await poll_started.wait()
 
-    write_task, release_readback = await _async_start_blocked_readback(
-        hass,
-        mock_duco_client,
-        readback_error or _replace_node_state(mock_nodes[0], "MAN3"),
-    )
+    write_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
+    await write_started.wait()
 
     release_poll.set()
-    await _async_wait_for_state(hass, "sensor.kitchen_rh_humidity", "62.0")
-    _assert_select_state(hass, "AUTO")
-
-    release_readback.set()
     await write_task
 
-    _assert_select_state(hass, expected_state)
+    _assert_select_state(hass, "MAN3")
 
 
 async def test_latest_targeted_readback_wins_when_fan_and_select_overlap(
@@ -468,7 +417,12 @@ async def test_latest_targeted_readback_wins_when_fan_and_select_overlap(
     )
     first_readback_started = asyncio.Event()
     release_first_readback = asyncio.Event()
+    select_write_started = asyncio.Event()
     readback_count = 0
+
+    def set_ventilation_state(node_id: int, state: str | VentilationState) -> None:
+        if state == "MAN3":
+            select_write_started.set()
 
     async def get_node_info(node_id: int) -> Node:
         nonlocal readback_count
@@ -479,39 +433,27 @@ async def test_latest_targeted_readback_wins_when_fan_and_select_overlap(
             return _replace_node_state(mock_nodes[0], "CNT1")
         return _replace_node_state(mock_nodes[0], "MAN3")
 
+    mock_duco_client.async_set_ventilation_state.side_effect = set_ventilation_state
     mock_duco_client.async_get_node_info.side_effect = get_node_info
     fan_task = asyncio.create_task(_async_set_fan_percentage(hass))
     await first_readback_started.wait()
 
-    await _async_select_option(hass, "MAN3")
-    _assert_select_state(hass, "MAN3")
+    select_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
+    await select_write_started.wait()
 
     release_first_readback.set()
-    await fan_task
+    await asyncio.gather(fan_task, select_task)
 
     _assert_select_state(hass, "MAN3")
 
 
 @pytest.mark.usefixtures("init_integration")
 @pytest.mark.parametrize(
-    ("poll_result_factory", "readback_outcome", "expected_state"),
+    "readback_error",
     [
+        pytest.param(None, id="success"),
         pytest.param(
-            _nodes_with_updated_box,
             DucoError("Readback failed"),
-            "CNT2",
-            id="success",
-        ),
-        pytest.param(
-            _nodes_without_box,
-            None,
-            STATE_UNAVAILABLE,
-            id="node-removed",
-        ),
-        pytest.param(
-            _failed_poll,
-            None,
-            STATE_UNAVAILABLE,
             id="failure",
         ),
     ],
@@ -521,26 +463,35 @@ async def test_newer_coordinator_poll_supersedes_targeted_outcome(
     mock_duco_client: AsyncMock,
     mock_nodes: list[Node],
     freezer: FrozenDateTimeFactory,
-    poll_result_factory: Callable[[list[Node]], list[Node] | DucoError],
-    readback_outcome: DucoError | None,
-    expected_state: str,
+    readback_error: DucoError | None,
 ) -> None:
     """Test a newer coordinator poll supersedes an older targeted outcome."""
-    write_task, release_readback = await _async_start_blocked_readback(
-        hass,
-        mock_duco_client,
-        readback_outcome or _replace_node_state(mock_nodes[0], "MAN3"),
-    )
+    readback_started = asyncio.Event()
+    release_readback = asyncio.Event()
 
-    mock_duco_client.async_get_nodes.side_effect = [poll_result_factory(mock_nodes)]
+    async def get_node_info(node_id: int) -> Node:
+        readback_started.set()
+        await release_readback.wait()
+        if readback_error:
+            raise readback_error
+        return _replace_node_state(mock_nodes[0], "MAN3")
+
+    mock_duco_client.async_get_node_info.side_effect = get_node_info
+    write_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
+    await readback_started.wait()
+
+    mock_duco_client.async_get_nodes.return_value = [
+        _replace_node_state(mock_nodes[0], "CNT2"),
+        *mock_nodes[1:],
+    ]
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
-    await _async_wait_for_state(hass, _SELECT_ENTITY, expected_state)
 
     release_readback.set()
     await write_task
+    await hass.async_block_till_done()
 
-    _assert_select_state(hass, expected_state)
+    _assert_select_state(hass, "CNT2")
 
 
 async def test_select_entity_is_added_when_action_discovery_succeeds_later(

--- a/tests/components/duco/test_select.py
+++ b/tests/components/duco/test_select.py
@@ -364,6 +364,35 @@ async def test_targeted_readback_survives_older_coordinator_poll(
     _assert_select_state(hass, "MAN3")
 
 
+async def test_older_coordinator_poll_does_not_recover_failed_targeted_readback(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
+) -> None:
+    """Test an older poll cannot recover a failed targeted readback."""
+    poll_started = asyncio.Event()
+    release_poll = asyncio.Event()
+
+    async def get_nodes() -> list[Node]:
+        poll_started.set()
+        await release_poll.wait()
+        return mock_nodes
+
+    mock_duco_client.async_get_nodes.side_effect = get_nodes
+    poll_task = asyncio.create_task(init_integration.runtime_data.async_refresh())
+    await poll_started.wait()
+
+    mock_duco_client.async_get_node_info.side_effect = DucoError("Readback failed")
+    await _async_select_option(hass, "MAN3")
+    _assert_select_state(hass, STATE_UNAVAILABLE)
+
+    release_poll.set()
+    await poll_task
+
+    _assert_select_state(hass, STATE_UNAVAILABLE)
+
+
 async def test_latest_targeted_readback_wins_when_fan_and_select_overlap(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -405,6 +434,37 @@ async def test_latest_targeted_readback_wins_when_fan_and_select_overlap(
     await fan_task
 
     _assert_select_state(hass, "MAN3")
+
+
+async def test_targeted_readback_ignored_when_node_disappears(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
+) -> None:
+    """Test a readback is ignored when its node disappears during the request."""
+    readback_started = asyncio.Event()
+    release_readback = asyncio.Event()
+
+    async def get_node_info(node_id: int) -> Node:
+        readback_started.set()
+        await release_readback.wait()
+        return _replace_node_state(mock_nodes[0], "MAN3")
+
+    mock_duco_client.async_get_node_info.side_effect = get_node_info
+    write_task = asyncio.create_task(_async_select_option(hass, "MAN3"))
+    await readback_started.wait()
+
+    mock_duco_client.async_get_nodes.return_value = [
+        node for node in mock_nodes if node.node_id != 1
+    ]
+    await init_integration.runtime_data.async_refresh()
+    _assert_select_state(hass, STATE_UNAVAILABLE)
+
+    release_readback.set()
+    await write_task
+
+    _assert_select_state(hass, STATE_UNAVAILABLE)
 
 
 async def test_targeted_readback_does_not_recover_failed_coordinator(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

After a fan or select changes a ventilation state, refresh only the affected Duco node instead of performing a complete coordinator refresh. This publishes the latest reported, potentially normalized state sooner while avoiding an additional full API request sequence.

A coordinator-owned request lock serializes full polls, ventilation writes, and targeted readbacks so an older request cannot publish stale state after a completed write. Targeted readbacks notify listeners without postponing the regular full-refresh schedule. Per-node readback errors keep the coordinator unavailable until the affected nodes recover or a successful full poll supersedes them. Tests cover normalized states, readback failures and recovery, overlapping fan and select commands, and periodic poll scheduling.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr