### PR TITLE
Fix stale Duco end times for continuous ventilation states

### DIFF
--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -34,6 +34,12 @@ _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
+_CONTINUOUS_VENTILATION_STATES = {
+    VentilationState.CNT1,
+    VentilationState.CNT2,
+    VentilationState.CNT3,
+}
+
 
 @dataclass(frozen=True, kw_only=True)
 class DucoSensorEntityDescription(SensorEntityDescription):
@@ -85,7 +91,9 @@ SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=lambda node: (
             dt_util.utc_from_timestamp(node.ventilation.time_state_end)
-            if node.ventilation and node.ventilation.time_state_end != 0
+            if node.ventilation
+            and node.ventilation.state not in _CONTINUOUS_VENTILATION_STATES
+            and node.ventilation.time_state_end != 0
             else None
         ),
         node_types=VENTILATION_CAPABLE_NODE_TYPES,

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -95,11 +95,20 @@ async def test_ventilation_related_sensors_created_for_supported_node_types(
     assert hass.states.get("sensor.office_co2_state_end_time") is None
 
 
+@pytest.mark.parametrize(
+    ("ventilation_state", "expected_state_end"),
+    [
+        pytest.param(VentilationState.AUTO, "2023-11-14T22:20:59+00:00", id="auto"),
+        pytest.param(VentilationState.CNT1, STATE_UNKNOWN, id="continuous"),
+    ],
+)
 async def test_ventilation_related_sensors_created_for_box_node(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
     mock_sensor_nodes: list[Node],
+    ventilation_state: VentilationState,
+    expected_state_end: str,
 ) -> None:
     """Test ventilation-related sensors are created for the box node.
 
@@ -111,6 +120,7 @@ async def test_ventilation_related_sensors_created_for_box_node(
         mock_sensor_nodes[0],
         ventilation=replace(
             mock_sensor_nodes[0].ventilation,
+            state=ventilation_state,
             flow_lvl_tgt=42,
             time_state_end=1700000459,
         ),
@@ -124,7 +134,7 @@ async def test_ventilation_related_sensors_created_for_box_node(
 
     state = hass.states.get("sensor.living_ventilation_state")
     assert state is not None
-    assert state.state == "auto"
+    assert state.state == ventilation_state.lower()
 
     state = hass.states.get("sensor.living_target_flow_level")
     assert state is not None
@@ -132,7 +142,7 @@ async def test_ventilation_related_sensors_created_for_box_node(
 
     state = hass.states.get("sensor.living_state_end_time")
     assert state is not None
-    assert state.state == "2023-11-14T22:20:59+00:00"
+    assert state.state == expected_state_end
 
     assert hass.states.get("sensor.office_co2_ventilation_state") is None
     assert hass.states.get("sensor.office_co2_target_flow_level") is None

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -98,8 +98,10 @@ async def test_ventilation_related_sensors_created_for_supported_node_types(
 @pytest.mark.parametrize(
     ("ventilation_state", "expected_state_end"),
     [
-        pytest.param(VentilationState.AUTO, "2023-11-14T22:20:59+00:00", id="auto"),
-        pytest.param(VentilationState.CNT1, STATE_UNKNOWN, id="continuous"),
+        pytest.param(VentilationState.MAN1, "2023-11-14T22:20:59+00:00", id="timed"),
+        pytest.param(VentilationState.CNT1, STATE_UNKNOWN, id="continuous-1"),
+        pytest.param(VentilationState.CNT2, STATE_UNKNOWN, id="continuous-2"),
+        pytest.param(VentilationState.CNT3, STATE_UNKNOWN, id="continuous-3"),
     ],
 )
 async def test_ventilation_related_sensors_created_for_box_node(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Continuous Duco ventilation states do not have a scheduled end, but the device can retain a stale nonzero end time after entering one of these states. Ignore the reported end time for `CNT1`, `CNT2`, and `CNT3` so the state end time sensor becomes unknown instead of showing a misleading timestamp.

Timed ventilation states continue to expose their reported end time. The sensor test covers both behaviors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr