### PR TITLE
Add configurable EnergyZero electricity price interval

### DIFF
--- a/homeassistant/components/energyzero/config_flow.py
+++ b/homeassistant/components/energyzero/config_flow.py
@@ -2,15 +2,36 @@
 
 from typing import Any, override
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+import voluptuous as vol
 
-from .const import DOMAIN
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
+from homeassistant.core import callback
+from homeassistant.helpers.selector import SelectSelector, SelectSelectorConfig
+
+from .const import (
+    CONF_ELECTRICITY_PRICE_INTERVAL,
+    DEFAULT_ELECTRICITY_PRICE_INTERVAL,
+    DOMAIN,
+    ELECTRICITY_INTERVALS,
+)
 
 
 class EnergyZeroFlowHandler(ConfigFlow, domain=DOMAIN):
     """Config flow for EnergyZero integration."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    @override
+    def async_get_options_flow(config_entry: ConfigEntry) -> EnergyZeroOptionsFlow:
+        """Return the options flow."""
+        return EnergyZeroOptionsFlow()
 
     @override
     async def async_step_user(
@@ -27,4 +48,35 @@ class EnergyZeroFlowHandler(ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title="EnergyZero",
             data={},
+        )
+
+
+class EnergyZeroOptionsFlow(OptionsFlowWithReload):
+    """Manage EnergyZero options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the electricity price interval."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_ELECTRICITY_PRICE_INTERVAL,
+                            default=DEFAULT_ELECTRICITY_PRICE_INTERVAL,
+                        ): SelectSelector(
+                            SelectSelectorConfig(
+                                options=list(ELECTRICITY_INTERVALS),
+                                translation_key=CONF_ELECTRICITY_PRICE_INTERVAL,
+                            )
+                        ),
+                    }
+                ),
+                self.config_entry.options,
+            ),
         )

--- a/homeassistant/components/energyzero/const.py
+++ b/homeassistant/components/energyzero/const.py
@@ -4,6 +4,12 @@ from datetime import timedelta
 import logging
 from typing import Final
 
+from energyzero import Interval
+
+CONF_ELECTRICITY_PRICE_INTERVAL = "electricity_price_interval"
+ELECTRICITY_INTERVALS = {"hourly": Interval.HOUR, "quarter_hourly": Interval.QUARTER}
+DEFAULT_ELECTRICITY_PRICE_INTERVAL = "hourly"
+
 DOMAIN: Final = "energyzero"
 LOGGER = logging.getLogger(__package__)
 SCAN_INTERVAL = timedelta(minutes=10)

--- a/homeassistant/components/energyzero/coordinator.py
+++ b/homeassistant/components/energyzero/coordinator.py
@@ -9,7 +9,6 @@ from energyzero import (
     EnergyZero,
     EnergyZeroConnectionError,
     EnergyZeroNoDataError,
-    Interval,
     PriceType,
 )
 
@@ -19,7 +18,15 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, LOGGER, SCAN_INTERVAL, THRESHOLD_HOUR
+from .const import (
+    CONF_ELECTRICITY_PRICE_INTERVAL,
+    DEFAULT_ELECTRICITY_PRICE_INTERVAL,
+    DOMAIN,
+    ELECTRICITY_INTERVALS,
+    LOGGER,
+    SCAN_INTERVAL,
+    THRESHOLD_HOUR,
+)
 
 type EnergyZeroConfigEntry = ConfigEntry[EnergyZeroDataUpdateCoordinator]
 
@@ -30,6 +37,14 @@ class EnergyZeroData(NamedTuple):
     energy_today: EnergyPrices
     energy_tomorrow: EnergyPrices | None
     gas_today: EnergyPrices | None
+    electricity_price_step: timedelta
+
+    @property
+    def next_energy_price(self) -> float | None:
+        """Return the electricity price one market period from now."""
+        return self.energy_today.price_at_time(
+            self.energy_today.utcnow() + self.electricity_price_step
+        )
 
 
 class EnergyZeroDataUpdateCoordinator(DataUpdateCoordinator[EnergyZeroData]):
@@ -47,6 +62,13 @@ class EnergyZeroDataUpdateCoordinator(DataUpdateCoordinator[EnergyZeroData]):
             config_entry=entry,
         )
 
+        interval = entry.options.get(
+            CONF_ELECTRICITY_PRICE_INTERVAL, DEFAULT_ELECTRICITY_PRICE_INTERVAL
+        )
+        self.electricity_interval = ELECTRICITY_INTERVALS[interval]
+        self.electricity_price_step = timedelta(
+            minutes=15 if interval == "quarter_hourly" else 60
+        )
         self.energyzero = EnergyZero(session=async_get_clientsession(hass))
 
     @override
@@ -61,7 +83,7 @@ class EnergyZeroDataUpdateCoordinator(DataUpdateCoordinator[EnergyZeroData]):
             energy_today = await self.energyzero.get_electricity_prices(
                 start_date=today,
                 end_date=today,
-                interval=Interval.HOUR,
+                interval=self.electricity_interval,
                 price_type=PriceType.MARKET_WITH_VAT,
                 local_tz=local_tz,
             )
@@ -81,7 +103,7 @@ class EnergyZeroDataUpdateCoordinator(DataUpdateCoordinator[EnergyZeroData]):
                     energy_tomorrow = await self.energyzero.get_electricity_prices(
                         start_date=tomorrow,
                         end_date=tomorrow,
-                        interval=Interval.HOUR,
+                        interval=self.electricity_interval,
                         price_type=PriceType.MARKET_WITH_VAT,
                         local_tz=local_tz,
                     )
@@ -95,4 +117,5 @@ class EnergyZeroDataUpdateCoordinator(DataUpdateCoordinator[EnergyZeroData]):
             energy_today=energy_today,
             energy_tomorrow=energy_tomorrow,
             gas_today=gas_today,
+            electricity_price_step=self.electricity_price_step,
         )

--- a/homeassistant/components/energyzero/diagnostics.py
+++ b/homeassistant/components/energyzero/diagnostics.py
@@ -39,9 +39,7 @@ async def async_get_config_entry_diagnostics(
         },
         "energy": {
             "current_hour_price": energy_today.current_price,
-            "next_hour_price": energy_today.price_at_time(
-                energy_today.utcnow() + timedelta(hours=1)
-            ),
+            "next_hour_price": coordinator_data.next_energy_price,
             "average_price": energy_today.average_price,
             "max_price": energy_today.extreme_prices[1],
             "min_price": energy_today.extreme_prices[0],

--- a/homeassistant/components/energyzero/diagnostics.py
+++ b/homeassistant/components/energyzero/diagnostics.py
@@ -34,9 +34,6 @@ async def async_get_config_entry_diagnostics(
     energy_today = coordinator_data.energy_today
 
     return {
-        "entry": {
-            "title": entry.title,
-        },
         "energy": {
             "current_price": energy_today.current_price,
             "next_price": coordinator_data.next_energy_price,

--- a/homeassistant/components/energyzero/diagnostics.py
+++ b/homeassistant/components/energyzero/diagnostics.py
@@ -38,8 +38,8 @@ async def async_get_config_entry_diagnostics(
             "title": entry.title,
         },
         "energy": {
-            "current_hour_price": energy_today.current_price,
-            "next_hour_price": coordinator_data.next_energy_price,
+            "current_price": energy_today.current_price,
+            "next_price": coordinator_data.next_energy_price,
             "average_price": energy_today.average_price,
             "max_price": energy_today.extreme_prices[1],
             "min_price": energy_today.extreme_prices[0],

--- a/homeassistant/components/energyzero/sensor.py
+++ b/homeassistant/components/energyzero/sensor.py
@@ -67,9 +67,7 @@ SENSORS: tuple[EnergyZeroSensorEntityDescription, ...] = (
         service_type="today_energy",
         native_unit_of_measurement=f"{CURRENCY_EURO}/{UnitOfEnergy.KILO_WATT_HOUR}",
         suggested_display_precision=3,
-        value_fn=lambda data: data.energy_today.price_at_time(
-            data.energy_today.utcnow() + timedelta(hours=1)
-        ),
+        value_fn=lambda data: data.next_energy_price,
     ),
     EnergyZeroSensorEntityDescription(
         key="average_price",

--- a/homeassistant/components/energyzero/strings.json
+++ b/homeassistant/components/energyzero/strings.json
@@ -57,6 +57,23 @@
       "message": "No price data available for {date}."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "electricity_price_interval": "Electricity price interval"
+        }
+      }
+    }
+  },
+  "selector": {
+    "electricity_price_interval": {
+      "options": {
+        "hourly": "Hourly",
+        "quarter_hourly": "Quarter-hourly"
+      }
+    }
+  },
   "services": {
     "get_energy_prices": {
       "description": "Requests energy prices from EnergyZero.",

--- a/tests/components/energyzero/snapshots/test_diagnostics.ambr
+++ b/tests/components/energyzero/snapshots/test_diagnostics.ambr
@@ -3,13 +3,13 @@
   dict({
     'energy': dict({
       'average_price': 0.14609224895833334,
-      'current_hour_price': 0.17191075,
+      'current_price': 0.17191075,
       'highest_price_time': '2026-04-10T18:00:00+00:00',
       'hours_priced_equal_or_lower': 20,
       'lowest_price_time': '2026-04-11T06:00:00+00:00',
       'max_price': 0.288152425,
       'min_price': 0.077503525,
-      'next_hour_price': 0.1521212,
+      'next_price': 0.1521212,
       'percentage_of_max': 59.66,
     }),
     'entry': dict({
@@ -25,13 +25,13 @@
   dict({
     'energy': dict({
       'average_price': 0.14609224895833334,
-      'current_hour_price': 0.17191075,
+      'current_price': 0.17191075,
       'highest_price_time': '2026-04-10T18:00:00+00:00',
       'hours_priced_equal_or_lower': 20,
       'lowest_price_time': '2026-04-11T06:00:00+00:00',
       'max_price': 0.288152425,
       'min_price': 0.077503525,
-      'next_hour_price': 0.1521212,
+      'next_price': 0.1521212,
       'percentage_of_max': 59.66,
     }),
     'entry': dict({

--- a/tests/components/energyzero/snapshots/test_diagnostics.ambr
+++ b/tests/components/energyzero/snapshots/test_diagnostics.ambr
@@ -12,9 +12,6 @@
       'next_price': 0.1521212,
       'percentage_of_max': 59.66,
     }),
-    'entry': dict({
-      'title': 'energy',
-    }),
     'gas': dict({
       'current_hour_price': None,
       'next_hour_price': None,
@@ -33,9 +30,6 @@
       'min_price': 0.077503525,
       'next_price': 0.1521212,
       'percentage_of_max': 59.66,
-    }),
-    'entry': dict({
-      'title': 'energy',
     }),
     'gas': dict({
       'current_hour_price': None,

--- a/tests/components/energyzero/test_config_flow.py
+++ b/tests/components/energyzero/test_config_flow.py
@@ -1,8 +1,14 @@
 """Test the EnergyZero config flow."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from homeassistant.components.energyzero.const import DOMAIN
+import pytest
+
+from homeassistant.components.energyzero.const import (
+    CONF_ELECTRICITY_PRICE_INTERVAL,
+    DOMAIN,
+    ELECTRICITY_INTERVALS,
+)
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -48,3 +54,67 @@ async def test_single_instance(
 
     assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "single_instance_allowed"
+
+
+@pytest.mark.freeze_time("2026-04-10 20:32:59")
+@pytest.mark.parametrize("initial", [None, "hourly", "quarter_hourly"])
+@pytest.mark.parametrize("selected", ["hourly", "quarter_hourly"])
+@pytest.mark.usefixtures("mock_energyzero")
+async def test_options_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    initial: str | None,
+    selected: str,
+) -> None:
+    """Test defaults, saved options and automatic reload on changes."""
+    options = {} if initial is None else {CONF_ELECTRICITY_PRICE_INTERVAL: initial}
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(mock_config_entry, options=options)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    schema = result["data_schema"]
+    assert schema({}) == {CONF_ELECTRICITY_PRICE_INTERVAL: "hourly"}
+    key = next(iter(schema.schema))
+    assert (key.description or {}).get("suggested_value", "hourly") == (
+        initial or "hourly"
+    )
+
+    with patch.object(hass.config_entries, "async_reload", return_value=True) as reload:
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={CONF_ELECTRICITY_PRICE_INTERVAL: selected},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert mock_config_entry.options == {CONF_ELECTRICITY_PRICE_INTERVAL: selected}
+    assert reload.call_count == (initial != selected)
+
+
+@pytest.mark.freeze_time("2026-04-10 20:32:59")
+@pytest.mark.parametrize("selected", ["hourly", "quarter_hourly"])
+async def test_options_reload(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_energyzero: MagicMock,
+    selected: str,
+) -> None:
+    """Apply changed options to both requests without recreating entities."""
+    original_coordinator = init_integration.runtime_data
+    original_entities = set(hass.states.async_entity_ids("sensor"))
+    mock_energyzero.get_electricity_prices.reset_mock()
+    result = await hass.config_entries.options.async_init(init_integration.entry_id)
+    await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_ELECTRICITY_PRICE_INTERVAL: selected}
+    )
+    await hass.async_block_till_done()
+    assert init_integration.runtime_data is not original_coordinator
+    assert set(hass.states.async_entity_ids("sensor")) == original_entities
+    assert mock_energyzero.get_electricity_prices.await_count == 2
+    assert all(
+        request.kwargs["interval"] == ELECTRICITY_INTERVALS[selected]
+        for request in mock_energyzero.get_electricity_prices.await_args_list
+    )

--- a/tests/components/energyzero/test_init.py
+++ b/tests/components/energyzero/test_init.py
@@ -7,20 +7,38 @@ from zoneinfo import ZoneInfo
 from energyzero import EnergyZeroConnectionError, Interval, PriceType
 import pytest
 
+from homeassistant.components.energyzero.const import CONF_ELECTRICITY_PRICE_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.parametrize(
+    ("options", "interval"),
+    [
+        pytest.param({}, Interval.HOUR, id="existing"),
+        pytest.param(
+            {CONF_ELECTRICITY_PRICE_INTERVAL: "hourly"}, Interval.HOUR, id="hourly"
+        ),
+        pytest.param(
+            {CONF_ELECTRICITY_PRICE_INTERVAL: "quarter_hourly"},
+            Interval.QUARTER,
+            id="quarter_hourly",
+        ),
+    ],
+)
 @pytest.mark.freeze_time("2026-04-10 20:32:59")
 async def test_coordinator_requests_market_prices_with_vat(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_energyzero: MagicMock,
+    options: dict[str, str],
+    interval: Interval,
 ) -> None:
     """Test the coordinator requests the backwards-compatible price stream."""
     mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(mock_config_entry, options=options)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
@@ -32,14 +50,14 @@ async def test_coordinator_requests_market_prices_with_vat(
             call(
                 start_date=today,
                 end_date=today,
-                interval=Interval.HOUR,
+                interval=interval,
                 price_type=PriceType.MARKET_WITH_VAT,
                 local_tz=local_tz,
             ),
             call(
                 start_date=tomorrow,
                 end_date=tomorrow,
-                interval=Interval.HOUR,
+                interval=interval,
                 price_type=PriceType.MARKET_WITH_VAT,
                 local_tz=local_tz,
             ),

--- a/tests/components/energyzero/test_interval.py
+++ b/tests/components/energyzero/test_interval.py
@@ -1,0 +1,105 @@
+"""Test electricity resolution with timezone-aware price data."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+from zoneinfo import ZoneInfo
+
+from energyzero import EnergyPrices, EnergyZeroNoDataError, Interval
+from energyzero.models import TimeRange
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+
+from homeassistant.components.energyzero.const import CONF_ELECTRICITY_PRICE_INTERVAL
+from homeassistant.components.energyzero.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize(
+    ("selected", "minutes", "interval"),
+    [("hourly", 60, Interval.HOUR), ("quarter_hourly", 15, Interval.QUARTER)],
+)
+@pytest.mark.parametrize("missing_tomorrow", [False, True])
+@pytest.mark.parametrize(
+    ("moment", "hours", "requests_tomorrow"),
+    [
+        pytest.param("2026-04-10 20:32:59", 24, True, id="normal"),
+        pytest.param("2026-03-29 00:55:00", 23, False, id="spring"),
+        pytest.param("2026-10-25 00:55:00", 25, False, id="autumn"),
+    ],
+)
+async def test_electricity_interval(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_energyzero: MagicMock,
+    entity_registry: er.EntityRegistry,
+    freezer: FrozenDateTimeFactory,
+    selected: str,
+    minutes: int,
+    interval: Interval,
+    missing_tomorrow: bool,
+    moment: str,
+    hours: int,
+    requests_tomorrow: bool,
+) -> None:
+    """Keep all periods on DST days and use the selected next-price step."""
+    freezer.move_to(moment)
+    await hass.config.async_set_time_zone("Europe/Amsterdam")
+    today = dt_util.now().date()
+    start = datetime.combine(
+        today, datetime.min.time(), ZoneInfo("Europe/Amsterdam")
+    ).astimezone(UTC)
+    step = timedelta(minutes=minutes)
+    prices = EnergyPrices(
+        prices={
+            TimeRange(start + index * step, start + (index + 1) * step): float(
+                index + 1
+            )
+            for index in range(hours * 60 // minutes)
+        },
+        average_price=(hours * 60 // minutes + 1) / 2,
+    )
+    mock_energyzero.get_electricity_prices.side_effect = [
+        prices,
+        EnergyZeroNoDataError() if missing_tomorrow else prices,
+    ]
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry, options={CONF_ELECTRICITY_PRICE_INTERVAL: selected}
+    )
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    expected = prices.price_at_time(dt_util.utcnow() + step)
+    assert expected != prices.current_price
+    assert (state := hass.states.get("sensor.energyzero_today_energy_next_hour_price"))
+    assert state.state == str(expected)
+    data = mock_config_entry.runtime_data.data
+    assert (data.energy_tomorrow is not None) == (
+        requests_tomorrow and not missing_tomorrow
+    )
+    assert len(data.energy_today.prices) == hours * 60 // minutes
+    diagnostics = await async_get_config_entry_diagnostics(hass, mock_config_entry)
+    assert diagnostics["energy"]["next_hour_price"] == expected
+    assert diagnostics["energy"]["current_hour_price"] == prices.current_price
+    assert diagnostics["energy"]["average_price"] == prices.average_price
+    assert (
+        diagnostics["energy"]["hours_priced_equal_or_lower"]
+        == prices.time_ranges_priced_equal_or_lower
+    )
+    assert (
+        mock_energyzero.get_electricity_prices.call_args.kwargs["interval"] == interval
+    )
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    assert len(entries) == 11
+    assert all(
+        entry.unique_id == f"12345_{entry.entity_id.removeprefix('sensor.energyzero_')}"
+        for entry in entries
+    )

--- a/tests/components/energyzero/test_interval.py
+++ b/tests/components/energyzero/test_interval.py
@@ -85,8 +85,8 @@ async def test_electricity_interval(
     )
     assert len(data.energy_today.prices) == hours * 60 // minutes
     diagnostics = await async_get_config_entry_diagnostics(hass, mock_config_entry)
-    assert diagnostics["energy"]["next_hour_price"] == expected
-    assert diagnostics["energy"]["current_hour_price"] == prices.current_price
+    assert diagnostics["energy"]["next_price"] == expected
+    assert diagnostics["energy"]["current_price"] == prices.current_price
     assert diagnostics["energy"]["average_price"] == prices.average_price
     assert (
         diagnostics["energy"]["hours_priced_equal_or_lower"]

--- a/tests/components/energyzero/test_interval.py
+++ b/tests/components/energyzero/test_interval.py
@@ -6,18 +6,16 @@ from zoneinfo import ZoneInfo
 
 from energyzero import EnergyPrices, EnergyZeroNoDataError, Interval
 from energyzero.models import TimeRange
-from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.energyzero.const import CONF_ELECTRICITY_PRICE_INTERVAL
-from homeassistant.components.energyzero.diagnostics import (
-    async_get_config_entry_diagnostics,
-)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.mark.parametrize(
@@ -26,29 +24,33 @@ from tests.common import MockConfigEntry
 )
 @pytest.mark.parametrize("missing_tomorrow", [False, True])
 @pytest.mark.parametrize(
-    ("moment", "hours", "requests_tomorrow"),
+    ("hours", "requests_tomorrow"),
     [
-        pytest.param("2026-04-10 20:32:59", 24, True, id="normal"),
-        pytest.param("2026-03-29 00:55:00", 23, False, id="spring"),
-        pytest.param("2026-10-25 00:55:00", 25, False, id="autumn"),
+        pytest.param(
+            24, True, marks=pytest.mark.freeze_time("2026-04-10 20:32:59"), id="normal"
+        ),
+        pytest.param(
+            23, False, marks=pytest.mark.freeze_time("2026-03-29 00:55:00"), id="spring"
+        ),
+        pytest.param(
+            25, False, marks=pytest.mark.freeze_time("2026-10-25 00:55:00"), id="autumn"
+        ),
     ],
 )
 async def test_electricity_interval(
     hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
     mock_config_entry: MockConfigEntry,
     mock_energyzero: MagicMock,
     entity_registry: er.EntityRegistry,
-    freezer: FrozenDateTimeFactory,
     selected: str,
     minutes: int,
     interval: Interval,
     missing_tomorrow: bool,
-    moment: str,
     hours: int,
     requests_tomorrow: bool,
 ) -> None:
     """Keep all periods on DST days and use the selected next-price step."""
-    freezer.move_to(moment)
     await hass.config.async_set_time_zone("Europe/Amsterdam")
     today = dt_util.now().date()
     start = datetime.combine(
@@ -84,7 +86,9 @@ async def test_electricity_interval(
         requests_tomorrow and not missing_tomorrow
     )
     assert len(data.energy_today.prices) == hours * 60 // minutes
-    diagnostics = await async_get_config_entry_diagnostics(hass, mock_config_entry)
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
     assert diagnostics["energy"]["next_price"] == expected
     assert diagnostics["energy"]["current_price"] == prices.current_price
     assert diagnostics["energy"]["average_price"] == prices.average_price


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Add an **Electricity price interval** option with **Hourly** (the default) and **Quarter-hourly** choices. The selection applies to today's and tomorrow's electricity market-price datasets and the existing electricity entities. Next price and its diagnostic value advance by one hour or 15 minutes respectively. Changing the option reloads the entry automatically.

Existing entity IDs and unique IDs are preserved. Gas prices and polling frequency are unchanged. This PR adds configurable entity resolution; interval selection for the `get_energy_prices` action is deliberately left to a follow-up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/orgs/home-assistant/discussions/2345; prerequisite https://github.com/home-assistant/core/pull/181492
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47973
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
