### PR TITLE
Fix swallowed exceptions in action handlers for Huawei LTE

### DIFF
--- a/homeassistant/components/huawei_lte/notify.py
+++ b/homeassistant/components/huawei_lte/notify.py
@@ -67,5 +67,8 @@ class HuaweiLteSmsNotificationService(BaseNotificationService):
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="send_message_failed",
-                translation_placeholders={"targets": ", ".join(targets)},
+                translation_placeholders={
+                    "targets": ", ".join(targets),
+                    "error": str(ex),
+                },
             ) from ex

--- a/homeassistant/components/huawei_lte/notify.py
+++ b/homeassistant/components/huawei_lte/notify.py
@@ -8,9 +8,11 @@ from huawei_lte_api.exceptions import ResponseErrorException
 from homeassistant.components.notify import ATTR_TARGET, BaseNotificationService
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID, CONF_RECIPIENT
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import HuaweiLteConfigEntry, Router
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,6 +63,9 @@ class HuaweiLteSmsNotificationService(BaseNotificationService):
                 phone_numbers=targets, message=message
             )
             _LOGGER.debug("Sent to %s: %s", targets, resp)
-        # pylint: disable-next=home-assistant-action-swallowed-exception
         except ResponseErrorException as ex:
-            _LOGGER.error("Could not send to %s: %s", targets, ex)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="send_message_failed",
+                translation_placeholders={"targets": ", ".join(targets)},
+            ) from ex

--- a/homeassistant/components/huawei_lte/strings.json
+++ b/homeassistant/components/huawei_lte/strings.json
@@ -380,6 +380,11 @@
       }
     }
   },
+  "exceptions": {
+    "send_message_failed": {
+      "message": "Failed to send SMS to {targets}."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/homeassistant/components/huawei_lte/strings.json
+++ b/homeassistant/components/huawei_lte/strings.json
@@ -382,7 +382,7 @@
   },
   "exceptions": {
     "send_message_failed": {
-      "message": "Failed to send SMS to {targets}."
+      "message": "Failed to send SMS to {targets}: {error}"
     }
   },
   "options": {

--- a/tests/components/huawei_lte/test_notify.py
+++ b/tests/components/huawei_lte/test_notify.py
@@ -1,0 +1,108 @@
+"""Tests for the Huawei LTE notify platform."""
+
+from unittest.mock import MagicMock, patch
+
+from huawei_lte_api.exceptions import ResponseErrorException
+import pytest
+
+from homeassistant.components.huawei_lte.const import (
+    DEFAULT_NOTIFY_SERVICE_NAME,
+    DOMAIN,
+)
+from homeassistant.components.notify import (
+    ATTR_MESSAGE,
+    ATTR_TARGET,
+    DOMAIN as NOTIFY_DOMAIN,
+)
+from homeassistant.const import CONF_RECIPIENT, CONF_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from . import magic_client
+
+from tests.common import MockConfigEntry
+
+MOCK_CONF_URL = "http://huawei-lte.example.com"
+
+pytestmark = pytest.mark.parametrize(
+    ("options", "service_data", "expected_targets"),
+    [
+        pytest.param(
+            {},
+            {ATTR_TARGET: ["+1234567890"]},
+            ["+1234567890"],
+            id="explicit_target",
+        ),
+        pytest.param(
+            {CONF_RECIPIENT: ["+1234567890", "+0987654321"]},
+            {},
+            ["+1234567890", "+0987654321"],
+            id="default_recipients",
+        ),
+    ],
+)
+
+
+async def setup_notify_service(
+    hass: HomeAssistant, options: dict[str, list[str]]
+) -> MagicMock:
+    """Set up the integration and return the mocked router client."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_URL: MOCK_CONF_URL}, options=options
+    )
+    entry.add_to_hass(hass)
+    client = magic_client()
+    with (
+        patch("homeassistant.components.huawei_lte.Connection", MagicMock()),
+        patch("homeassistant.components.huawei_lte.Client", return_value=client),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.services.has_service(NOTIFY_DOMAIN, DEFAULT_NOTIFY_SERVICE_NAME)
+    return client
+
+
+async def test_send_message(
+    hass: HomeAssistant,
+    options: dict[str, list[str]],
+    service_data: dict[str, list[str]],
+    expected_targets: list[str],
+) -> None:
+    """Test that the message is sent to the given or the configured recipients."""
+    client = await setup_notify_service(hass, options)
+
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        DEFAULT_NOTIFY_SERVICE_NAME,
+        {ATTR_MESSAGE: "Hello", **service_data},
+        blocking=True,
+    )
+
+    client.sms.send_sms.assert_called_once_with(
+        phone_numbers=expected_targets, message="Hello"
+    )
+
+
+async def test_send_message_error(
+    hass: HomeAssistant,
+    options: dict[str, list[str]],
+    service_data: dict[str, list[str]],
+    expected_targets: list[str],
+) -> None:
+    """Test that a failing send raises an error with a translation key."""
+    client = await setup_notify_service(hass, options)
+    client.sms.send_sms.side_effect = ResponseErrorException("Send failed", 100)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            NOTIFY_DOMAIN,
+            DEFAULT_NOTIFY_SERVICE_NAME,
+            {ATTR_MESSAGE: "Hello", **service_data},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "send_message_failed"
+    assert exc_info.value.translation_placeholders == {
+        "targets": ", ".join(expected_targets)
+    }

--- a/tests/components/huawei_lte/test_notify.py
+++ b/tests/components/huawei_lte/test_notify.py
@@ -104,5 +104,6 @@ async def test_send_message_error(
     assert exc_info.value.translation_domain == DOMAIN
     assert exc_info.value.translation_key == "send_message_failed"
     assert exc_info.value.translation_placeholders == {
-        "targets": ", ".join(expected_targets)
+        "targets": ", ".join(expected_targets),
+        "error": "Send failed",
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the router reported that an SMS could not be sent, the notify action only logged the error, so the caller got no feedback and automations carried on as if it had succeeded. The action now raises HomeAssistantError with a translated message naming the recipients. The integration had no notify tests, so this adds them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170694
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
