### PR TITLE
Fix swallowed exceptions in action handlers for NETGEAR LTE

### DIFF
--- a/homeassistant/components/netgear_lte/notify.py
+++ b/homeassistant/components/netgear_lte/notify.py
@@ -8,9 +8,10 @@ from eternalegypt.eternalegypt import Modem
 from homeassistant.components.notify import ATTR_TARGET, BaseNotificationService
 from homeassistant.const import CONF_RECIPIENT
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import CONF_NOTIFY, LOGGER
+from .const import CONF_NOTIFY, DOMAIN, LOGGER
 
 
 async def async_get_service(
@@ -57,6 +58,9 @@ class NetgearNotifyService(BaseNotificationService):
         for target in targets:
             try:
                 await self.modem.sms(target, message)
-            # pylint: disable-next=home-assistant-action-swallowed-exception
-            except eternalegypt.Error:
-                LOGGER.error("Unable to send to %s", target)
+            except eternalegypt.Error as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="send_message_failed",
+                    translation_placeholders={"target": target},
+                ) from err

--- a/homeassistant/components/netgear_lte/strings.json
+++ b/homeassistant/components/netgear_lte/strings.json
@@ -74,6 +74,9 @@
   "exceptions": {
     "config_entry_not_found": {
       "message": "Failed to perform action \"{service}\". Config entry for target not found"
+    },
+    "send_message_failed": {
+      "message": "Failed to send SMS to {target}."
     }
   },
   "services": {

--- a/tests/components/netgear_lte/test_notify.py
+++ b/tests/components/netgear_lte/test_notify.py
@@ -2,15 +2,21 @@
 
 from unittest.mock import patch
 
+import eternalegypt
+import pytest
+
+from homeassistant.components.netgear_lte.const import DOMAIN
 from homeassistant.components.notify import (
     ATTR_MESSAGE,
     ATTR_TARGET,
     DOMAIN as NOTIFY_DOMAIN,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 ICON_PATH = "/some/path"
 MESSAGE = "one, two, testing, testing"
+TARGET = "5555555556"
 
 
 async def test_notify(hass: HomeAssistant, setup_integration: None) -> None:
@@ -23,8 +29,33 @@ async def test_notify(hass: HomeAssistant, setup_integration: None) -> None:
             "netgear_lm1200",
             {
                 ATTR_MESSAGE: MESSAGE,
-                ATTR_TARGET: "5555555556",
+                ATTR_TARGET: TARGET,
             },
             blocking=True,
         )
     assert len(mock.mock_calls) == 1
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_notify_error(hass: HomeAssistant) -> None:
+    """Test that a failed send raises an error with a translation key."""
+    with (
+        patch(
+            "homeassistant.components.netgear_lte.eternalegypt.Modem.sms",
+            side_effect=eternalegypt.Error,
+        ),
+        pytest.raises(HomeAssistantError) as exc_info,
+    ):
+        await hass.services.async_call(
+            NOTIFY_DOMAIN,
+            "netgear_lm1200",
+            {
+                ATTR_MESSAGE: MESSAGE,
+                ATTR_TARGET: TARGET,
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "send_message_failed"
+    assert exc_info.value.translation_placeholders == {"target": TARGET}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When sending an SMS to a target fails, the notify service only logged the error and returned, so the service call completed as if it had succeeded. It now raises HomeAssistantError with a translated message naming the failed target, so the call fails at the first target that cannot be sent. A test for the failure case is added.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170629
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
