### PR TITLE
Fix gas and water counter channels on Velbus input modules

### DIFF
--- a/homeassistant/components/velbus/sensor.py
+++ b/homeassistant/components/velbus/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
+from homeassistant.const import UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -36,12 +37,21 @@ class VelbusSensorEntityDescription(SensorEntityDescription):
 
 
 SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
+    # Instantaneous value of an electricity counter channel (power, W).
     "power": VelbusSensorEntityDescription(
         key="power",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda channel: float(channel.get_counter_state()),
         unit_fn=lambda channel: channel.get_unit(),
+    ),
+    # Instantaneous value of a gas/water counter channel (flow rate, m³/h or L/h).
+    "flow": VelbusSensorEntityDescription(
+        key="flow",
+        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda channel: float(channel.get_state()),
+        unit_fn=lambda channel: channel.get_counter_unit(),
     ),
     "temperature": VelbusSensorEntityDescription(
         key="temperature",
@@ -54,8 +64,9 @@ SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
         state_class=SensorStateClass.MEASUREMENT,
         unit_fn=lambda channel: channel.get_unit(),
     ),
-    "counter": VelbusSensorEntityDescription(
-        key="counter",
+    # Accumulating total of an electricity counter channel (energy, kWh).
+    "energy": VelbusSensorEntityDescription(
+        key="energy",
         device_class=SensorDeviceClass.ENERGY,
         icon="mdi:counter",
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -65,6 +76,26 @@ SENSOR_DESCRIPTIONS: dict[str, VelbusSensorEntityDescription] = {
             else None
         ),
         unit_fn=lambda channel: channel.get_counter_unit(),
+        unique_id_suffix="-counter",
+    ),
+    # Accumulating total of a gas counter channel (volume, m³).
+    "gas": VelbusSensorEntityDescription(
+        key="gas",
+        device_class=SensorDeviceClass.GAS,
+        icon="mdi:counter",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfVolume.CUBIC_METERS,
+        value_fn=lambda channel: float(channel.get_counter_state()),
+        unique_id_suffix="-counter",
+    ),
+    # Accumulating total of a water counter channel (volume, L).
+    "water": VelbusSensorEntityDescription(
+        key="water",
+        device_class=SensorDeviceClass.WATER,
+        icon="mdi:counter",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement=UnitOfVolume.LITERS,
+        value_fn=lambda channel: float(channel.get_counter_state()),
         unique_id_suffix="-counter",
     ),
 }
@@ -79,21 +110,23 @@ async def async_setup_entry(
     await entry.runtime_data.scan_task
     entities: list[VelbusSensor] = []
     for channel in entry.runtime_data.controller.get_all_sensor():
-        # Determine which description to use for the main sensor
         if channel.is_counter_channel():
-            description = SENSOR_DESCRIPTIONS["power"]
-        elif channel.is_temperature():
-            description = SENSOR_DESCRIPTIONS["temperature"]
-        else:
-            description = SENSOR_DESCRIPTIONS["measurement"]
-
-        entities.append(VelbusSensor(channel, description))
-
-        # Add counter entity if applicable
-        if channel.is_counter_channel():
+            # A counter channel exposes two entities: an instantaneous reading
+            # and an accumulating total. The medium decides which pair to use.
+            if channel.is_gas():
+                main_key, total_key = "flow", "gas"
+            elif channel.is_water():
+                main_key, total_key = "flow", "water"
+            else:  # electricity, or unit not yet known
+                main_key, total_key = "power", "energy"
+            entities.append(VelbusSensor(channel, SENSOR_DESCRIPTIONS[main_key]))
             entities.append(
-                VelbusSensor(channel, SENSOR_DESCRIPTIONS["counter"], is_counter=True)
+                VelbusSensor(channel, SENSOR_DESCRIPTIONS[total_key], is_counter=True)
             )
+        elif channel.is_temperature():
+            entities.append(VelbusSensor(channel, SENSOR_DESCRIPTIONS["temperature"]))
+        else:
+            entities.append(VelbusSensor(channel, SENSOR_DESCRIPTIONS["measurement"]))
 
     async_add_entities(entities)
 

--- a/tests/components/velbus/conftest.py
+++ b/tests/components/velbus/conftest.py
@@ -33,6 +33,8 @@ def mock_controller(
     mock_temperature: AsyncMock,
     mock_select: AsyncMock,
     mock_buttoncounter: AsyncMock,
+    mock_gascounter: AsyncMock,
+    mock_watercounter: AsyncMock,
     mock_sensornumber: AsyncMock,
     mock_lightsensor: AsyncMock,
     mock_dimmer: AsyncMock,
@@ -57,6 +59,8 @@ def mock_controller(
         cont.get_all_select.return_value = [mock_select]
         cont.get_all_sensor.return_value = [
             mock_buttoncounter,
+            mock_gascounter,
+            mock_watercounter,
             mock_temperature,
             mock_sensornumber,
             mock_lightsensor,
@@ -209,9 +213,67 @@ def mock_buttoncounter() -> AsyncMock:
     channel.is_temperature.return_value = False
     channel.get_state.return_value = 100
     channel.get_unit.return_value = "W"
+    channel.is_gas.return_value = False
+    channel.is_water.return_value = False
+    channel.is_electricity.return_value = True
     channel.get_counter_state.return_value = 100
     type(channel).energy = PropertyMock(return_value=100.0)
     channel.get_counter_unit.return_value = "kWh"
+    return channel
+
+
+@pytest.fixture
+def mock_gascounter() -> AsyncMock:
+    """Mock a VMB7IN gas counter channel (m³)."""
+    channel = AsyncMock(spec=ButtonCounter)
+    channel.get_categories.return_value = ["sensor"]
+    channel.get_name.return_value = "GasCounter"
+    channel.get_module_address.return_value = 88
+    channel.get_channel_number.return_value = 5
+    channel.get_module_type_name.return_value = "VMB7IN"
+    channel.get_module_type.return_value = 4
+    channel.get_full_name.return_value = "Input"
+    channel.get_module_sw_version.return_value = "1.0.0"
+    channel.get_module_serial.return_value = "a1b2c3d4e5f6"
+    channel.is_sub_device.return_value = True
+    channel.is_counter_channel.return_value = True
+    channel.is_temperature.return_value = False
+    channel.is_gas.return_value = True
+    channel.is_water.return_value = False
+    channel.is_electricity.return_value = False
+    channel.get_state.return_value = 5.0
+    channel.get_unit.return_value = "m3"
+    channel.get_counter_state.return_value = 1234.0
+    # A gas counter does not expose energy (kWh); energy is only valid for kWh.
+    type(channel).energy = PropertyMock(return_value=None)
+    channel.get_counter_unit.return_value = "m³/h"
+    return channel
+
+
+@pytest.fixture
+def mock_watercounter() -> AsyncMock:
+    """Mock a VMB7IN water counter channel (L)."""
+    channel = AsyncMock(spec=ButtonCounter)
+    channel.get_categories.return_value = ["sensor"]
+    channel.get_name.return_value = "WaterCounter"
+    channel.get_module_address.return_value = 88
+    channel.get_channel_number.return_value = 4
+    channel.get_module_type_name.return_value = "VMB7IN"
+    channel.get_module_type.return_value = 4
+    channel.get_full_name.return_value = "Input"
+    channel.get_module_sw_version.return_value = "1.0.0"
+    channel.get_module_serial.return_value = "a1b2c3d4e5f6"
+    channel.is_sub_device.return_value = True
+    channel.is_counter_channel.return_value = True
+    channel.is_temperature.return_value = False
+    channel.is_gas.return_value = False
+    channel.is_water.return_value = True
+    channel.is_electricity.return_value = False
+    channel.get_state.return_value = 2.5
+    channel.get_unit.return_value = "L"
+    channel.get_counter_state.return_value = 5678.0
+    type(channel).energy = PropertyMock(return_value=None)
+    channel.get_counter_unit.return_value = "L/h"
     return channel
 
 

--- a/tests/components/velbus/snapshots/test_init.ambr
+++ b/tests/components/velbus/snapshots/test_init.ambr
@@ -239,6 +239,62 @@
       'identifiers': set({
         tuple(
           'velbus',
+          '88-4',
+        ),
+      }),
+      'labels': set({
+      }),
+      'manufacturer': 'Velleman',
+      'model': 'VMB7IN',
+      'model_id': '4',
+      'name': 'Input',
+      'name_by_user': None,
+      'serial_number': 'a1b2c3d4e5f6',
+      'sw_version': '1.0.0',
+      'via_device_id': <ANY>,
+    }),
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'velbus',
+          '88-5',
+        ),
+      }),
+      'labels': set({
+      }),
+      'manufacturer': 'Velleman',
+      'model': 'VMB7IN',
+      'model_id': '4',
+      'name': 'Input',
+      'name_by_user': None,
+      'serial_number': 'a1b2c3d4e5f6',
+      'sw_version': '1.0.0',
+      'via_device_id': <ANY>,
+    }),
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'velbus',
           '88-55',
         ),
       }),

--- a/tests/components/velbus/snapshots/test_sensor.ambr
+++ b/tests/components/velbus/snapshots/test_sensor.ambr
@@ -116,6 +116,123 @@
     'state': '100.0',
   })
 # ---
+# name: test_entities[sensor.input_gascounter-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.input_gascounter',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'GasCounter',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLUME_FLOW_RATE: 'volume_flow_rate'>,
+    'original_icon': None,
+    'original_name': 'GasCounter',
+    'platform': 'velbus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'a1b2c3d4e5f6-5',
+    'unit_of_measurement': 'm³/h',
+  })
+# ---
+# name: test_entities[sensor.input_gascounter-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'volume_flow_rate',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Input GasCounter',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'm³/h',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.input_gascounter',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5.0',
+  })
+# ---
+# name: test_entities[sensor.input_gascounter_counter-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.input_gascounter_counter',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'GasCounter-counter',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.GAS: 'gas'>,
+    'original_icon': 'mdi:counter',
+    'original_name': 'GasCounter-counter',
+    'platform': 'velbus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'a1b2c3d4e5f6-5-counter',
+    'unit_of_measurement': <UnitOfVolume.CUBIC_METERS: 'm³'>,
+  })
+# ---
+# name: test_entities[sensor.input_gascounter_counter-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'gas',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Input GasCounter-counter',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:counter',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfVolume.CUBIC_METERS: 'm³'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.input_gascounter_counter',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1234.0',
+  })
+# ---
 # name: test_entities[sensor.input_lightsensor-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -222,6 +339,123 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '10.0',
+  })
+# ---
+# name: test_entities[sensor.input_watercounter-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.input_watercounter',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'WaterCounter',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.VOLUME_FLOW_RATE: 'volume_flow_rate'>,
+    'original_icon': None,
+    'original_name': 'WaterCounter',
+    'platform': 'velbus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'a1b2c3d4e5f6-4',
+    'unit_of_measurement': 'L/h',
+  })
+# ---
+# name: test_entities[sensor.input_watercounter-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'volume_flow_rate',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Input WaterCounter',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'L/h',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.input_watercounter',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2.5',
+  })
+# ---
+# name: test_entities[sensor.input_watercounter_counter-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.input_watercounter_counter',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'WaterCounter-counter',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WATER: 'water'>,
+    'original_icon': 'mdi:counter',
+    'original_name': 'WaterCounter-counter',
+    'platform': 'velbus',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'a1b2c3d4e5f6-4-counter',
+    'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+  })
+# ---
+# name: test_entities[sensor.input_watercounter_counter-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'water',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Input WaterCounter-counter',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:counter',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.input_watercounter_counter',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5678.0',
   })
 # ---
 # name: test_entities[sensor.living_room_temperature-entry]

--- a/tests/components/velbus/test_sensor.py
+++ b/tests/components/velbus/test_sensor.py
@@ -4,7 +4,19 @@ from unittest.mock import AsyncMock, PropertyMock, patch
 
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNKNOWN,
+    Platform,
+    UnitOfVolume,
+    UnitOfVolumeFlowRate,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -38,3 +50,51 @@ async def test_vmb8in_counter_energy_unavailable_when_no_energy(
     state = hass.states.get("sensor.input_buttoncounter_counter")
     assert state is not None
     assert state.state == STATE_UNKNOWN
+
+
+async def test_vmb7in_gas_counter(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test a VMB7IN gas counter reports a m³ total (regression for #179361)."""
+    await init_integration(hass, config_entry)
+
+    total = hass.states.get("sensor.input_gascounter_counter")
+    assert total is not None
+    assert total.state == "1234.0"
+    assert total.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.GAS
+    assert total.attributes[ATTR_STATE_CLASS] == SensorStateClass.TOTAL_INCREASING
+    assert total.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfVolume.CUBIC_METERS
+
+    flow = hass.states.get("sensor.input_gascounter")
+    assert flow is not None
+    assert flow.state == "5.0"
+    assert flow.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.VOLUME_FLOW_RATE
+    assert (
+        flow.attributes[ATTR_UNIT_OF_MEASUREMENT]
+        == UnitOfVolumeFlowRate.CUBIC_METERS_PER_HOUR
+    )
+
+
+async def test_vmb7in_water_counter(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> None:
+    """Test a VMB7IN water counter reports a litre total (regression for #179361)."""
+    await init_integration(hass, config_entry)
+
+    total = hass.states.get("sensor.input_watercounter_counter")
+    assert total is not None
+    assert total.state == "5678.0"
+    assert total.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.WATER
+    assert total.attributes[ATTR_STATE_CLASS] == SensorStateClass.TOTAL_INCREASING
+    assert total.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfVolume.LITERS
+
+    flow = hass.states.get("sensor.input_watercounter")
+    assert flow is not None
+    assert flow.state == "2.5"
+    assert flow.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.VOLUME_FLOW_RATE
+    assert (
+        flow.attributes[ATTR_UNIT_OF_MEASUREMENT]
+        == UnitOfVolumeFlowRate.LITERS_PER_HOUR
+    )


### PR DESCRIPTION
## Proposed change

Counter channels on Velbus input modules (VMB7IN, VMB8IN-20) can meter
electricity, gas or water, but the sensor platform assumed electricity for all of
them: the instantaneous sensor was hardcoded to `device_class: power` and the
total used `ButtonCounter.energy`, which only returns a value for kWh counters.
On a VMB7IN configured for gas (m³/h) or water (L/h) this left the total sensor
permanently `unknown` and logged an invalid-unit warning for the power sensor,
breaking existing gas/water setups after 2026.8 (regression from #168201).

The sensor pair is now chosen per channel from the metered medium:

- electricity: `power` (W) + `energy` (kWh, `total_increasing`)
- gas: `volume_flow_rate` (m) + `gas` (m³, `total_increasing`)
- water: `volume_flow_rate` (L) + `water` (L, `total_increasing`)

Medium detection uses new `is_gas()`/`is_electricity()` helpers in velbus-aio
(mirroring the existing `is_water()`). Unique IDs are unchanged, so existing
entities keep their history and no migration is required. Electricity (VMB8IN-20)
behaviour is unchanged. Gas and water regression tests are added.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #179361
- Depends on a velbus-aio release adding `is_gas()`/`is_electricity()`. The
  `manifest.json` requirement pin will be bumped to that release before this PR is
  marked ready; it is a **draft** until then.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr