### PR TITLE
Fix lingering tasks in insteon properties and config tests

### DIFF
--- a/tests/components/insteon/mock_devices.py
+++ b/tests/components/insteon/mock_devices.py
@@ -138,7 +138,8 @@ class MockDevices:
         device = self._devices[Address(address)]
         aldb_records = dict_to_aldb_record(records)
 
-        device.aldb.load_saved_records(ALDBStatus.LOADED, aldb_records)
+        with patch("pyinsteon.aldb.aldb_base.publish_topic", MagicMock()):
+            device.aldb.load_saved_records(ALDBStatus.LOADED, aldb_records)
 
     def fill_properties(self, address, props_dict):
         """Fill the operating flags and extended properties of a device."""

--- a/tests/components/insteon/test_api_aldb.py
+++ b/tests/components/insteon/test_api_aldb.py
@@ -74,8 +74,6 @@ def _aldb_dict(mem_addr):
     }
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_get_aldb(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
 ) -> None:
@@ -92,8 +90,6 @@ async def test_get_aldb(
         assert len(result) == 5
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_change_aldb_record(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
 ) -> None:
@@ -117,8 +113,6 @@ async def test_change_aldb_record(
         _compare_records(rec, change_rec)
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_create_aldb_record(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
 ) -> None:
@@ -142,8 +136,6 @@ async def test_create_aldb_record(
         _compare_records(rec, new_rec)
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_write_aldb(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
 ) -> None:
@@ -165,8 +157,6 @@ async def test_write_aldb(
         assert devices.async_save.call_count == 1
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_load_aldb(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
 ) -> None:
@@ -187,8 +177,6 @@ async def test_load_aldb(
         assert devices.async_save.call_count == 1
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_reset_aldb(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
 ) -> None:
@@ -220,8 +208,6 @@ async def test_reset_aldb(
         assert not devices["33.33.33"].aldb.pending_changes
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_default_links(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
 ) -> None:
@@ -297,8 +283,6 @@ async def test_notify_on_aldb_record_added(
         assert msg["event"]["type"] == "record_loaded"
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_bad_address(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data
 ) -> None:

--- a/tests/components/insteon/test_api_config.py
+++ b/tests/components/insteon/test_api_config.py
@@ -1,6 +1,5 @@
 """Test the Insteon APIs for configuring the integration."""
 
-import asyncio
 import json
 from unittest.mock import patch
 
@@ -407,7 +406,6 @@ async def test_get_broken_links(
     await devices.async_load()
     aldb_data = json.loads(await async_load_fixture(hass, "aldb_data.json", DOMAIN))
     devices.fill_aldb("33.33.33", aldb_data)
-    await asyncio.sleep(1)
     with patch.object(insteon.api.config, "devices", devices):
         await ws_client.send_json({ID: 2, TYPE: "insteon/config/get_broken_links"})
         msg = await ws_client.receive_json()
@@ -446,4 +444,3 @@ async def test_get_unknown_devices(
         assert msg["success"]
 
         assert len(msg["result"]) == 1
-        await asyncio.sleep(0.1)

--- a/tests/components/insteon/test_api_properties.py
+++ b/tests/components/insteon/test_api_properties.py
@@ -1,9 +1,8 @@
 """Test the Insteon properties APIs."""
 
-import asyncio
 import json
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from pyinsteon.config import MOMENTARY_DELAY, RELAY_MODE, TOGGLE_BUTTON
 from pyinsteon.config.extended_property import ExtendedProperty
@@ -127,7 +126,11 @@ async def test_get_read_only_properties(
     mock_read_only = ExtendedProperty(
         "44.44.44", "mock_read_only", bool, is_read_only=True
     )
-    mock_read_only.set_value(False)
+    # Setting the value publishes a pubsub topic for the device address, which
+    # would fire the status handlers of every 44.44.44 device created by earlier
+    # tests and leave their tasks lingering.
+    with patch("pyinsteon.subscriber_base.publish_topic", MagicMock()):
+        mock_read_only.set_value(False)
 
     ws_client, devices = await _setup(
         hass, hass_ws_client, "44.44.44", iolinc_properties_data
@@ -157,7 +160,6 @@ async def test_get_read_only_properties(
         msg = await ws_client.receive_json()
         assert msg["success"]
         assert len(msg["result"]["properties"]) == 15
-    await asyncio.sleep(1)
 
 
 async def test_get_unknown_properties(

--- a/tests/components/insteon/test_api_scenes.py
+++ b/tests/components/insteon/test_api_scenes.py
@@ -64,8 +64,6 @@ async def _setup(
     return ws_client, devices
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_get_scenes(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, scene_data: JsonArrayType
 ) -> None:
@@ -80,8 +78,6 @@ async def test_get_scenes(
         assert len(result["20"]) == 3
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_get_scene(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, scene_data: JsonArrayType
 ) -> None:
@@ -95,8 +91,6 @@ async def test_get_scene(
         assert len(result["devices"]) == 3
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.usefixtures("remove_json")
 async def test_save_scene(
     hass: HomeAssistant,
@@ -130,8 +124,6 @@ async def test_save_scene(
         assert result["scene_id"] == 20
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.usefixtures("remove_json")
 async def test_save_new_scene(
     hass: HomeAssistant,
@@ -165,8 +157,6 @@ async def test_save_new_scene(
         assert result["scene_id"] == 21
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.usefixtures("remove_json")
 async def test_save_scene_error(
     hass: HomeAssistant,
@@ -200,8 +190,6 @@ async def test_save_scene_error(
         assert result["scene_id"] == 20
 
 
-# This tests needs to be adjusted to remove lingering tasks
-@pytest.mark.parametrize("expected_lingering_tasks", [True])
 @pytest.mark.usefixtures("remove_json")
 async def test_delete_scene(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`test_get_read_only_properties` fails intermittently in CI with a lingering `StatusRequestCommand.async_handle_direct_ack` task.

The test seeds a mock `ExtendedProperty` for device `44.44.44` with `set_value()`, which publishes a pubsub topic under that device's address. pyinsteon's status handler subscribes to every topic under a device's address, and the async listener wrapper it registers is kept in a module-level dict, so the handlers of every `44.44.44` device created by earlier tests stay subscribed for the whole test session. The publish fires all of them, each spawning a task that sleeps briefly before returning. In a full insteon run this is 84 tasks from a single `set_value()` call. The `await asyncio.sleep(1)` added in #126404 only raced those tasks instead of preventing them.

`MockDevices.fill_aldb` has the same problem: `load_saved_records()` publishes a link-changed topic per record plus a status-changed topic, spawning 513 tasks in `test_get_broken_links`. Removing its `sleep(1)` makes the test fail deterministically with the same lingering task.

This PR wraps both calls in a patch of `publish_topic`, the same approach `MockDevices.fill_properties` already uses, and removes the sleeps that were working around it, including the trailing `sleep(0.1)` in `test_get_unknown_devices` that follows another `fill_aldb` call. None of these tests spawn any background task anymore, and the insteon test suite runs in about half the time.

Since `fill_aldb` no longer publishes, the `expected_lingering_tasks` allowances on 14 tests in `test_api_aldb.py` and `test_api_scenes.py` are no longer needed and are removed. The two notify tests in `test_api_aldb.py` keep theirs because they call `pub.sendMessage` on the device topic on purpose, and `test_add_device_api` in `test_api_device.py` keeps its allowance because it still fails without it.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #126404
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
