### PR TITLE
Bump pyblackbird to 0.10

### DIFF
--- a/homeassistant/components/blackbird/manifest.json
+++ b/homeassistant/components/blackbird/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "local_polling",
   "loggers": ["pyblackbird"],
   "quality_scale": "legacy",
-  "requirements": ["pyblackbird==0.6"]
+  "requirements": ["pyblackbird==0.9"]
 }

--- a/homeassistant/components/blackbird/manifest.json
+++ b/homeassistant/components/blackbird/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "local_polling",
   "loggers": ["pyblackbird"],
   "quality_scale": "legacy",
-  "requirements": ["pyblackbird==0.9"]
+  "requirements": ["pyblackbird==0.10"]
 }

--- a/homeassistant/components/blackbird/media_player.py
+++ b/homeassistant/components/blackbird/media_player.py
@@ -4,7 +4,7 @@ import logging
 from typing import override
 
 from pyblackbird import get_blackbird
-from serial import SerialException
+from serialx import SerialException
 import voluptuous as vol
 
 from homeassistant.components.media_player import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -544,9 +544,6 @@ filterwarnings = [
   # https://pypi.org/project/panasonic-viera/ - v0.4.4 - 2025-11-25
   # https://github.com/florianholzapfel/panasonic-viera/blob/0.4.4/panasonic_viera/remote_control.py#L665
   "ignore:.*invalid escape sequence:SyntaxWarning:.*panasonic_viera",
-  # https://pypi.org/project/pyblackbird/ - v0.6 - 2023-03-15
-  # https://github.com/koolsb/pyblackbird/pull/9 -> closed
-  "ignore:.*invalid escape sequence:SyntaxWarning:.*pyblackbird",
   # https://pypi.org/project/pyws66i/ - v1.1 - 2022-04-05
   "ignore:.*invalid escape sequence:SyntaxWarning:.*pyws66i",
   # https://pypi.org/project/sanix/ - v1.0.6 - 2024-05-01

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2105,7 +2105,7 @@ pybalboa==1.1.3
 pybbox==0.0.5-alpha
 
 # homeassistant.components.blackbird
-pyblackbird==0.9
+pyblackbird==0.10
 
 # homeassistant.components.bluesound
 pyblu==2.0.8

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2105,7 +2105,7 @@ pybalboa==1.1.3
 pybbox==0.0.5-alpha
 
 # homeassistant.components.blackbird
-pyblackbird==0.6
+pyblackbird==0.9
 
 # homeassistant.components.bluesound
 pyblu==2.0.8

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -124,11 +124,6 @@ FORBIDDEN_PACKAGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
     "airthings": {"airthings-cloud": {"async-timeout"}},
     "apache_kafka": {"aiokafka": {"async-timeout"}},
     "aseko_pool_live": {"gql": {"backoff"}},
-    "blackbird": {
-        # https://github.com/koolsb/pyblackbird/issues/12
-        # pyblackbird > pyserial-asyncio
-        "pyblackbird": {"pyserial-asyncio"}
-    },
     "coinbase": {"coinbase-advanced-py": {"backoff"}},
     "cmus": {
         # https://github.com/mtreinish/pycmus/issues/4


### PR DESCRIPTION
## Proposed change

pyblackbird 0.8 replaced pyserial and pyserial-asyncio with serialx, so SerialException now has to be imported from serialx. Nothing else in the integration changes.

This removes pyserial and pyserial-asyncio from the dependency tree; serialx is already a requirement of the serial integration.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Link to dependency diff: https://github.com/koolsb/pyblackbird/compare/0.6...0.10

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
