### PR TITLE
Improve error messages in remote_calendar

### DIFF
--- a/homeassistant/components/remote_calendar/coordinator.py
+++ b/homeassistant/components/remote_calendar/coordinator.py
@@ -80,5 +80,4 @@ class RemoteCalendarDataUpdateCoordinator(DataUpdateCoordinator[Calendar]):
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="unable_to_parse",
-                translation_placeholders={"err": str(err)},
             ) from err

--- a/homeassistant/components/remote_calendar/ics.py
+++ b/homeassistant/components/remote_calendar/ics.py
@@ -39,6 +39,6 @@ async def parse_calendar(hass: HomeAssistant, ics: str) -> Calendar:
     try:
         return await hass.async_add_executor_job(_compat_calendar_from_ics, ics)
     except CalendarParseError as err:
-        _LOGGER.error("Error parsing calendar information: %s", err.message)
+        _LOGGER.error("The remote calendar feed contains invalid data: %s", err.message)
         _LOGGER.debug("Additional calendar error detail: %s", str(err.detailed_error))
         raise InvalidIcsException(err.message) from err

--- a/homeassistant/components/remote_calendar/strings.json
+++ b/homeassistant/components/remote_calendar/strings.json
@@ -9,7 +9,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "forbidden": "The server understood the request but refuses to authorize it.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_ics_file": "There was a problem reading the calendar information. See the error log for additional details.",
+      "invalid_ics_file": "The remote calendar feed contains invalid data. See the error log for additional details.",
       "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]"
     },
     "step": {
@@ -47,7 +47,7 @@
       "message": "Unable to fetch calendar data. See the debug log for additional details."
     },
     "unable_to_parse": {
-      "message": "Unable to parse calendar data: {err}"
+      "message": "The remote calendar feed contains invalid data. See the error log for additional details."
     }
   },
   "title": "Remote Calendar"

--- a/tests/components/remote_calendar/test_init.py
+++ b/tests/components/remote_calendar/test_init.py
@@ -85,6 +85,7 @@ async def test_update_failed(
 async def test_calendar_parse_error(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test CalendarParseError using respx."""
     respx.get(CALENDER_URL).mock(
@@ -92,6 +93,7 @@ async def test_calendar_parse_error(
     )
     await setup_integration(hass, config_entry)
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert "The remote calendar feed contains invalid data:" in caplog.text
 
 
 @respx.mock


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve the user-facing and log error messages for the Remote Calendar integration when parsing an ICS feed fails.

Previously, parsing errors produced ambiguous messages ("There was a problem reading the calendar information" and "Unable to parse calendar data: {err}") which often led users to believe Home Assistant had an internal failure or did not support valid calendar features, rather than realizing the external provider served malformed/invalid ICS data.

This PR:
- Updates `strings.json` (`config.error.invalid_ics_file` and `exceptions.unable_to_parse`) to state clearly that the remote calendar feed contains invalid data and points users to the error log for details.
- Updates `_LOGGER.error` in `ics.py` to: `"The remote calendar feed contains invalid data: %s"`.
- Removes the unused `translation_placeholders` argument from `UpdateFailed` in `coordinator.py`.
- Adds test verification in `test_init.py` checking the error log message on parsing failures.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178736
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr