### PR TITLE
Fix swallowed exceptions in pi_hole action handlers

### DIFF
--- a/homeassistant/components/pi_hole/strings.json
+++ b/homeassistant/components/pi_hole/strings.json
@@ -94,6 +94,14 @@
       }
     }
   },
+  "exceptions": {
+    "disable_failed": {
+      "message": "Failed to disable Pi-hole: {error}"
+    },
+    "enable_failed": {
+      "message": "Failed to enable Pi-hole: {error}"
+    }
+  },
   "issues": {
     "v5_to_v6_migration": {
       "description": "You've likely updated your Pi-hole to API v6 from v5. Some sensors changed in the new API, the daily sensors were removed, and your old API token is invalid. Provide your new app password by re-authenticating in repairs or in **Settings -> Devices & services -> Pi-hole**.",

--- a/homeassistant/components/pi_hole/switch.py
+++ b/homeassistant/components/pi_hole/switch.py
@@ -8,10 +8,11 @@ import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import SERVICE_DISABLE, SERVICE_DISABLE_ATTR_DURATION
+from .const import DOMAIN, SERVICE_DISABLE, SERVICE_DISABLE_ATTR_DURATION
 from .coordinator import PiHoleConfigEntry
 from .entity import PiHoleEntity
 
@@ -78,9 +79,12 @@ class PiHoleSwitch(PiHoleEntity, SwitchEntity):
         try:
             await self.api.enable()
             await self.async_update()
-        # pylint: disable-next=home-assistant-action-swallowed-exception
         except HoleError as err:
-            _LOGGER.error("Unable to enable Pi-hole: %s", err)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="enable_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
@@ -101,6 +105,9 @@ class PiHoleSwitch(PiHoleEntity, SwitchEntity):
         try:
             await self.api.disable(duration_seconds)
             await self.async_update()
-        # pylint: disable-next=home-assistant-action-swallowed-exception
         except HoleError as err:
-            _LOGGER.error("Unable to disable Pi-hole: %s", err)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="disable_failed",
+                translation_placeholders={"error": str(err)},
+            ) from err

--- a/tests/components/pi_hole/test_init.py
+++ b/tests/components/pi_hole/test_init.py
@@ -1,6 +1,5 @@
 """Test pi_hole component."""
 
-import logging
 from unittest.mock import ANY, AsyncMock
 
 from hole.exceptions import HoleError
@@ -23,6 +22,7 @@ from homeassistant.const import (
     CONF_SSL,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from . import (
     API_KEY,
@@ -289,7 +289,7 @@ async def test_setup_name_from_entry_title(hass: HomeAssistant) -> None:
     assert hass.states.get("sensor.my_hole_ads_blocked").name == "My Hole Ads blocked"
 
 
-async def test_switch(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
+async def test_switch(hass: HomeAssistant) -> None:
     """Test Pi-hole switch."""
     mocked_hole = _create_mocked_hole()
     entry = MockConfigEntry(
@@ -322,23 +322,29 @@ async def test_switch(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> 
 
         # Failed calls
         mocked_hole.instances[-1].enable = AsyncMock(side_effect=HoleError("Error1"))
-        await hass.services.async_call(
-            switch.DOMAIN,
-            switch.SERVICE_TURN_ON,
-            {"entity_id": SWITCH_ENTITY_ID},
-            blocking=True,
-        )
-        mocked_hole.instances[-1].disable = AsyncMock(side_effect=HoleError("Error2"))
-        await hass.services.async_call(
-            switch.DOMAIN,
-            switch.SERVICE_TURN_OFF,
-            {"entity_id": SWITCH_ENTITY_ID},
-            blocking=True,
-        )
-        errors = [x for x in caplog.records if x.levelno == logging.ERROR]
+        with pytest.raises(HomeAssistantError) as enable_error:
+            await hass.services.async_call(
+                switch.DOMAIN,
+                switch.SERVICE_TURN_ON,
+                {"entity_id": SWITCH_ENTITY_ID},
+                blocking=True,
+            )
 
-        assert errors[-2].message == "Unable to enable Pi-hole: Error1"
-        assert errors[-1].message == "Unable to disable Pi-hole: Error2"
+        mocked_hole.instances[-1].disable = AsyncMock(side_effect=HoleError("Error2"))
+        with pytest.raises(HomeAssistantError) as disable_error:
+            await hass.services.async_call(
+                switch.DOMAIN,
+                switch.SERVICE_TURN_OFF,
+                {"entity_id": SWITCH_ENTITY_ID},
+                blocking=True,
+            )
+
+    assert enable_error.value.translation_domain == pi_hole.DOMAIN
+    assert enable_error.value.translation_key == "enable_failed"
+    assert enable_error.value.translation_placeholders == {"error": "Error1"}
+    assert disable_error.value.translation_domain == pi_hole.DOMAIN
+    assert disable_error.value.translation_key == "disable_failed"
+    assert disable_error.value.translation_placeholders == {"error": "Error2"}
 
 
 async def test_disable_service_call(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Breaking change

<!-- If your PR contains a breaking change for existing users, it is important
to tell them what breaks, how to make it work again and why we did this.
This piece of text is published with the release notes, so it helps if you
write it towards our users, not us.
Note: Remove this section if this PR is NOT a breaking change. -->

## Proposed change

<!-- Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug
or resolves a feature request, be sure to link to that issue in the
additional information section. -->

failing switch actions in the pi_hole integration only logged the error, so the user got no feedback in the UI and automations kept running as if the action succeeded

this raises HomeAssistantError with a translated message instead (translation keys enable_failed / disable_failed), which is what #170632 asks for, and removes the two pylint disables

### Steps to reproduce

1. run `.venv/bin/python -m pytest tests/components/pi_hole/test_init.py::test_switch -q` on dev without the fix
2. Expected: a failing enable/disable call raises HomeAssistantError
3. Actual (raw output on untouched dev): `Failed: DID NOT RAISE <class 'homeassistant.exceptions.HomeAssistantError'>`, the call succeeds silently while the API error only shows in the logs

## Type of change

<!-- What type of change does your PR introduce to Home Assistant?
NOTE: Please, check only 1! box!
If your PR requires multiple boxes to be checked, you'll most likely need to
split it into multiple PRs. This makes things easier and faster to code review. -->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!-- Details are important, and help maintainers processing your PR.
Please be sure to fill out additional details, if applicable. -->

- This PR fixes or closes issue: fixes #170632
- This PR is related to issue: home-assistant/epics#64
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look
for before merging your code.

AI tools are welcome, but contributors are responsible for *fully*
understanding the code before submitting a PR. Please follow our AI policy:
https://developers.home-assistant.io/docs/ai_policy -->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
