### PR TITLE
Invalidate the cached state views when only last_reported changes

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -2476,7 +2476,18 @@ class StateMachine:
             # mypy does not understand this is only possible if old_state is not None
             old_last_reported = old_state.last_reported  # type: ignore[union-attr]
             old_state.last_reported = now  # type: ignore[union-attr]
-            old_state._cache["last_reported_timestamp"] = timestamp  # type: ignore[union-attr] # noqa: SLF001
+            cache = old_state._cache  # type: ignore[union-attr] # noqa: SLF001
+            cache["last_reported_timestamp"] = timestamp
+            # last_reported is part of the dict and JSON representations, so the
+            # cached ones no longer match the state we just mutated and have to be
+            # rebuilt on the next read. They all go through _as_dict, so nothing
+            # else can be cached while it is not. The compressed representations
+            # carry no last_reported and stay valid.
+            if "_as_dict" in cache:
+                del cache["_as_dict"]
+                cache.pop("_as_read_only_dict", None)
+                cache.pop("as_dict_json", None)
+                cache.pop("json_fragment", None)
             # Avoid creating an EventStateReportedData
             self._bus.async_fire_internal(  # type: ignore[misc]
                 EVENT_STATE_REPORTED,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3615,3 +3615,30 @@ async def test_async_set_updates_last_reported(hass: HomeAssistant) -> None:
         assert state.last_reported_timestamp != last_reported_timestamp
         last_reported = state.last_reported
         last_reported_timestamp = state.last_reported_timestamp
+
+
+async def test_async_set_updates_last_reported_in_serialized_state(
+    hass: HomeAssistant,
+) -> None:
+    """Test the dict and JSON views follow last_reported on a same-state write.
+
+    A write that changes neither the state nor the attributes mutates the
+    existing State in place. Anything serialized from it beforehand is cached,
+    so it has to be dropped or `/api/states` and the websocket `get_states`
+    keep serving the last_reported the entity had when it last changed.
+    """
+    hass.states.async_set("light.bowl", "on", {})
+    state = hass.states.get("light.bowl")
+    assert state is not None
+
+    # Reading these is what fills the caches the same-state write invalidates.
+    assert state.as_dict()["last_reported"] == state.last_reported.isoformat()
+    stale_json = state.as_dict_json
+    stale_fragment = state.json_fragment
+
+    hass.states.async_set("light.bowl", "on", {})
+
+    assert state.as_dict()["last_reported"] == state.last_reported.isoformat()
+    assert state.as_dict_json != stale_json
+    assert state.last_reported.isoformat().encode() in state.as_dict_json
+    assert state.json_fragment is not stale_fragment


### PR DESCRIPTION
## Proposed change

A write that changes neither the state nor the attributes takes the fast path in `async_set_internal`, which mutates `last_reported` on the existing `State` in place. `last_reported` is part of `_as_dict`, so anything already serialized from that state stays cached with the old value, and `/api/states` and the websocket `get_states` keep serving the `last_reported` the entity had when it last changed. The template engine reads the live object, which is why the value is right there and wrong only in the JSON views.

`_as_read_only_dict`, `as_dict_json` and `json_fragment` all go through `_as_dict`, so none of them can be cached while it is not, and one membership test is enough to skip the whole thing. Entities nothing has serialized pay only that test. The compressed representations carry no `last_reported` and are left alone.

The added test fails without the change, serving a `last_reported` two ticks behind the one on the state object.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #181392
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
