### PR TITLE
Update local_todo to explicitly specify UTF-8 encoding for ICS storage

### DIFF
--- a/homeassistant/components/local_todo/store.py
+++ b/homeassistant/components/local_todo/store.py
@@ -24,7 +24,7 @@ class LocalTodoListStore:
         """Load the calendar from disk."""
         if not self._path.exists():
             return ""
-        return self._path.read_text()
+        return self._path.read_text(encoding="utf-8")
 
     async def async_store(self, ics_content: str) -> None:
         """Persist the calendar to storage."""
@@ -33,4 +33,4 @@ class LocalTodoListStore:
 
     def _store(self, ics_content: str) -> None:
         """Persist the calendar to storage."""
-        self._path.write_text(ics_content)
+        self._path.write_text(ics_content, encoding="utf-8")

--- a/tests/components/local_todo/conftest.py
+++ b/tests/components/local_todo/conftest.py
@@ -55,7 +55,9 @@ class FakeStore(LocalTodoListStore):
     def _mock_exists(self) -> bool:
         return self._mock_path.read_text.return_value is not None
 
-    def _mock_write_text(self, content: str) -> None:
+    def _mock_write_text(self, content: str, encoding: str | None = None) -> None:
+        if encoding is None:
+            content.encode("ascii")
         self._mock_path.read_text.return_value = content
 
 

--- a/tests/components/local_todo/test_todo.py
+++ b/tests/components/local_todo/test_todo.py
@@ -98,6 +98,10 @@ EXPECTED_ADD_ITEM = {
         ),
         ({ATTR_DESCRIPTION: ""}, {**EXPECTED_ADD_ITEM, "description": ""}),
         ({ATTR_DESCRIPTION: None}, EXPECTED_ADD_ITEM),
+        (
+            {ATTR_ITEM: "测试主卧清扫"},
+            {**EXPECTED_ADD_ITEM, "summary": "测试主卧清扫"},
+        ),
     ],
 )
 async def test_add_item(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Explicitly specify `encoding="utf-8"` when reading and writing `.ics` files in `LocalTodoListStore`.

Per RFC 5545 §3.1.4 and §3.1.5, the charset of an iCalendar stream must always be UTF-8. Without explicitly specifying `encoding="utf-8"`, Python's `Path.read_text()` and `Path.write_text()` default to the system locale encoding (`locale.getencoding()`), which can be ASCII/POSIX in some environments (e.g., minimal container or Supervised setups). In those environments, saving or loading items containing non-ASCII characters raises `UnicodeEncodeError` or `UnicodeDecodeError`.

This change:
1. Adds `encoding="utf-8"` to `LocalTodoListStore._load` and `LocalTodoListStore._store`.
2. Updates `FakeStore._mock_write_text` in test fixtures to simulate default ASCII encoding behavior when `encoding` is omitted.
3. Parametrizes `test_add_item` with non-ASCII characters (`"测试主卧清扫"`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181357
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr