### PR TITLE
Bump aiowatttime to 2024.6.0

### DIFF
--- a/homeassistant/components/watttime/config_flow.py
+++ b/homeassistant/components/watttime/config_flow.py
@@ -145,7 +145,7 @@ class WattTimeConfigFlow(ConfigFlow, domain=DOMAIN):
 
         try:
             grid_region = await self._client.emissions.async_get_grid_region(
-                user_input[CONF_LATITUDE], user_input[CONF_LONGITUDE]
+                user_input[CONF_LATITUDE], user_input[CONF_LONGITUDE], "co2_moer"
             )
         except CoordinatesNotFoundError:
             return self.async_show_form(
@@ -168,8 +168,8 @@ class WattTimeConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_PASSWORD: self._data[CONF_PASSWORD],
                 CONF_LATITUDE: user_input[CONF_LATITUDE],
                 CONF_LONGITUDE: user_input[CONF_LONGITUDE],
-                CONF_BALANCING_AUTHORITY: grid_region["name"],
-                CONF_BALANCING_AUTHORITY_ABBREV: grid_region["abbrev"],
+                CONF_BALANCING_AUTHORITY: grid_region["region_full_name"],
+                CONF_BALANCING_AUTHORITY_ABBREV: grid_region["region"],
             },
         )
 

--- a/homeassistant/components/watttime/coordinator.py
+++ b/homeassistant/components/watttime/coordinator.py
@@ -4,23 +4,23 @@ from datetime import timedelta
 from typing import override
 
 from aiowatttime import Client
-from aiowatttime.emissions import RealTimeEmissionsResponseType
 from aiowatttime.errors import InvalidCredentialsError, WattTimeError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, LOGGER
+from .const import CONF_BALANCING_AUTHORITY_ABBREV, DOMAIN, LOGGER
 
 DEFAULT_UPDATE_INTERVAL = timedelta(minutes=5)
 
+type WattTimeData = dict[str, StateType]
 type WattTimeConfigEntry = ConfigEntry[WattTimeCoordinator]
 
 
-class WattTimeCoordinator(DataUpdateCoordinator[RealTimeEmissionsResponseType]):
+class WattTimeCoordinator(DataUpdateCoordinator[WattTimeData]):
     """Coordinator for WattTime data updates."""
 
     config_entry: WattTimeConfigEntry
@@ -42,12 +42,11 @@ class WattTimeCoordinator(DataUpdateCoordinator[RealTimeEmissionsResponseType]):
         self.client = client
 
     @override
-    async def _async_update_data(self) -> RealTimeEmissionsResponseType:
+    async def _async_update_data(self) -> WattTimeData:
         """Get the latest realtime emissions data."""
         try:
-            return await self.client.emissions.async_get_realtime_emissions(
-                self.config_entry.data[CONF_LATITUDE],
-                self.config_entry.data[CONF_LONGITUDE],
+            data = await self.client.emissions.async_get_realtime_emissions(
+                self.config_entry.data[CONF_BALANCING_AUTHORITY_ABBREV]
             )
         except InvalidCredentialsError as err:
             raise ConfigEntryAuthFailed("Invalid username/password") from err
@@ -55,3 +54,5 @@ class WattTimeCoordinator(DataUpdateCoordinator[RealTimeEmissionsResponseType]):
             raise UpdateFailed(
                 f"Error while requesting data from WattTime: {err}"
             ) from err
+
+        return {"percent": data["data"][0]["value"]}

--- a/homeassistant/components/watttime/manifest.json
+++ b/homeassistant/components/watttime/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["aiowatttime"],
-  "requirements": ["aiowatttime==0.1.1"]
+  "requirements": ["aiowatttime==2024.6.0"]
 }

--- a/homeassistant/components/watttime/sensor.py
+++ b/homeassistant/components/watttime/sensor.py
@@ -1,7 +1,7 @@
 """Support for WattTime sensors."""
 
 from collections.abc import Mapping
-from typing import Any, cast, override
+from typing import Any, override
 
 from homeassistant.components.sensor import (
     SensorEntity,
@@ -110,4 +110,4 @@ class RealtimeEmissionsSensor(CoordinatorEntity[WattTimeCoordinator], SensorEnti
     @override
     def native_value(self) -> StateType:
         """Return the value reported by the sensor."""
-        return cast(StateType, self.coordinator.data[self.entity_description.key])
+        return self.coordinator.data[self.entity_description.key]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -480,7 +480,7 @@ aiovodafone==3.3.2
 aiowaqi==3.1.0
 
 # homeassistant.components.watttime
-aiowatttime==0.1.1
+aiowatttime==2024.6.0
 
 # homeassistant.components.webdav
 aiowebdav2==0.6.2

--- a/tests/components/watttime/fixtures/grid_region_data.json
+++ b/tests/components/watttime/fixtures/grid_region_data.json
@@ -1,5 +1,5 @@
 {
-  "id": 263,
-  "abbrev": "PJM_NJ",
-  "name": "PJM New Jersey"
+  "region": "PJM_NJ",
+  "region_full_name": "PJM New Jersey",
+  "signal_type": "co2_moer"
 }

--- a/tests/components/watttime/fixtures/realtime_emissions_data.json
+++ b/tests/components/watttime/fixtures/realtime_emissions_data.json
@@ -1,7 +1,11 @@
 {
-  "freq": "300",
-  "ba": "CAISO_NORTH",
-  "percent": "53",
-  "moer": "850.743982",
-  "point_time": "2019-01-29T14:55:00.00Z"
+  "data": [{ "point_time": "2024-06-18T18:40:00+00:00", "value": 96.0 }],
+  "meta": {
+    "data_point_period_seconds": 300,
+    "region": "PJM_NJ",
+    "signal_type": "co2_moer",
+    "units": "percentile",
+    "warnings": [],
+    "model": { "date": "2022-10-01" }
+  }
 }

--- a/tests/components/watttime/snapshots/test_diagnostics.ambr
+++ b/tests/components/watttime/snapshots/test_diagnostics.ambr
@@ -2,11 +2,7 @@
 # name: test_entry_diagnostics
   dict({
     'data': dict({
-      'ba': 'CAISO_NORTH',
-      'freq': '300',
-      'moer': '850.743982',
-      'percent': '53',
-      'point_time': '2019-01-29T14:55:00.00Z',
+      'percent': 96.0,
     }),
     'entry': dict({
       'data': dict({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

WattTime's v3 API no longer returns the raw marginal operating emissions rate from its real-time endpoint. The Marginal operating emissions rate sensor is no longer provided after this update; the relative marginal emissions intensity sensor remains available.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump aiowatttime from 0.1.1 to 2024.6.0 and update WattTime for the library's v3 API. The integration now reads v3 region fields and exposes the signal index through the existing relative marginal emissions intensity sensor.

Release notes: https://github.com/bachya/aiowatttime/releases/tag/2024.06.0

Full diff: https://github.com/bachya/aiowatttime/compare/0.1.1...2024.06.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr