### PR TITLE
Repair local_todo malformed ICS files with CRLF newlines on setup

### DIFF
--- a/homeassistant/components/local_todo/todo.py
+++ b/homeassistant/components/local_todo/todo.py
@@ -85,6 +85,7 @@ async def async_setup_entry(
     store = config_entry.runtime_data
     ics = await store.async_load()
 
+    migrated = False
     try:
         with async_pause_setup(hass, SetupPhases.WAIT_IMPORT_PACKAGES):
             # calendar_from_ics will dynamically load packages
@@ -106,9 +107,9 @@ async def async_setup_entry(
             name,
         )
         migrated = True
-    else:
-        # File loaded cleanly; check if due date migration is required
-        migrated = _migrate_calendar(calendar)
+
+    if _migrate_calendar(calendar):
+        migrated = True
     calendar.prodid = PRODID
 
     entity = LocalTodoListEntity(store, calendar, name, unique_id=config_entry.entry_id)

--- a/homeassistant/components/local_todo/todo.py
+++ b/homeassistant/components/local_todo/todo.py
@@ -7,6 +7,7 @@ from typing import override
 
 from ical.calendar import Calendar
 from ical.calendar_stream import IcsCalendarStream
+from ical.exceptions import CalendarParseError
 from ical.store import TodoStore
 from ical.todo import Todo, TodoStatus
 
@@ -63,6 +64,16 @@ def _migrate_calendar(calendar: Calendar) -> bool:
     return migrated
 
 
+def _repair_legacy_crlf_newlines(content: str) -> str:
+    r"""Repair ICS content corrupted by CRLF newlines from ical <= 12.1.3.
+
+    In ical <= 12.1.3, TextEncoder escaped \n to \\n but left \r unescaped.
+    When read with Python's universal newlines mode (newline=None), any lone \r
+    before \\n was converted into \n\\n, breaking property line parsing.
+    """
+    return content.replace("\r\\n", "\\n").replace("\n\\n", "\\n").replace("\r", "")
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: LocalTodoConfigEntry,
@@ -70,20 +81,36 @@ async def async_setup_entry(
 ) -> None:
     """Set up the local_todo todo platform."""
 
+    name = config_entry.data[CONF_TODO_LIST_NAME]
     store = config_entry.runtime_data
     ics = await store.async_load()
 
-    with async_pause_setup(hass, SetupPhases.WAIT_IMPORT_PACKAGES):
-        # calendar_from_ics will dynamically load packages
-        # the first time it is called, so we need to do it
-        # in a separate thread to avoid blocking the event loop
-        calendar: Calendar = await hass.async_add_import_executor_job(
-            IcsCalendarStream.calendar_from_ics, ics
+    try:
+        with async_pause_setup(hass, SetupPhases.WAIT_IMPORT_PACKAGES):
+            # calendar_from_ics will dynamically load packages
+            # the first time it is called, so we need to do it
+            # in a separate thread to avoid blocking the event loop
+            calendar: Calendar = await hass.async_add_import_executor_job(
+                IcsCalendarStream.calendar_from_ics, ics
+            )
+    except CalendarParseError:
+        # Attempt to repair malformed newlines from ical <= 12.1.3 CRLF bug
+        repaired_ics = _repair_legacy_crlf_newlines(ics)
+        if repaired_ics == ics:
+            raise
+        calendar = await hass.async_add_import_executor_job(
+            IcsCalendarStream.calendar_from_ics, repaired_ics
         )
-    migrated = _migrate_calendar(calendar)
+        _LOGGER.warning(
+            "Repaired malformed iCalendar file for to-do list %s",
+            name,
+        )
+        migrated = True
+    else:
+        # File loaded cleanly; check if due date migration is required
+        migrated = _migrate_calendar(calendar)
     calendar.prodid = PRODID
 
-    name = config_entry.data[CONF_TODO_LIST_NAME]
     entity = LocalTodoListEntity(store, calendar, name, unique_id=config_entry.entry_id)
     async_add_entities([entity], True)
 

--- a/tests/components/local_todo/test_todo.py
+++ b/tests/components/local_todo/test_todo.py
@@ -970,6 +970,53 @@ async def test_repair_legacy_crlf_on_setup(
     assert "\n\\n" not in re_saved
 
 
+@pytest.mark.parametrize(
+    "ics_content",
+    [
+        (
+            "BEGIN:VCALENDAR\n"
+            "PRODID:-//homeassistant.io//local_todo 1.0//EN\n"
+            "VERSION:2.0\n"
+            "BEGIN:VTODO\n"
+            "DTSTAMP:20231024T014011\n"
+            "UID:077cb7f2-6c89-11ee-b2a9-0242ac110002\n"
+            "CREATED:20231017T010348\n"
+            "SEQUENCE:1\n"
+            "STATUS:NEEDS-ACTION\n"
+            "SUMMARY:Task\n"
+            "DESCRIPTION:Line 1\n\\nLine 2\n"
+            "DUE:20231023\n"
+            "END:VTODO\n"
+            "END:VCALENDAR\n"
+        )
+    ],
+)
+async def test_repair_and_migrate_legacy_due_date(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    ws_get_items: WsGetItemsType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that repaired legacy 1.0 calendars also undergo due date migration."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        f"Repaired malformed iCalendar file for to-do list {TODO_NAME}" in caplog.text
+    )
+
+    items = await ws_get_items()
+    assert len(items) == 1
+    assert items[0]["description"] == "Line 1\nLine 2"
+    assert items[0]["due"] == "2023-10-23"
+
+    store = config_entry.runtime_data
+    re_saved = store._mock_path.read_text.return_value
+    assert "PRODID:-//homeassistant.io//local_todo 2.0//EN" in re_saved
+    assert "DUE;VALUE=DATE:20231024" in re_saved
+
+
 async def test_description_newlines_preserved(
     hass: HomeAssistant,
     setup_integration: None,

--- a/tests/components/local_todo/test_todo.py
+++ b/tests/components/local_todo/test_todo.py
@@ -23,8 +23,9 @@ from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from .conftest import TEST_ENTITY
+from .conftest import TEST_ENTITY, TODO_NAME
 
+from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
 
 type WsGetItemsType = Callable[[], Coroutine[Any, Any, list[dict[str, str]]]]
@@ -873,3 +874,172 @@ async def test_reset_item_via_update(
     state = hass.states.get(TEST_ENTITY)
     assert state
     assert state.state == "1"
+
+
+@pytest.mark.parametrize(
+    ("ics_content", "expected_description"),
+    [
+        pytest.param(
+            (
+                "BEGIN:VCALENDAR\n"
+                "PRODID:-//homeassistant.io//local_todo 2.0//EN\n"
+                "VERSION:2.0\n"
+                "BEGIN:VTODO\n"
+                "DTSTAMP:20260205T183141Z\n"
+                "UID:077cb7f2-6c89-11ee-b2a9-0242ac110002\n"
+                "CREATED:20260205T183141Z\n"
+                "SEQUENCE:0\n"
+                "STATUS:NEEDS-ACTION\n"
+                "SUMMARY:Notizen\n"
+                "DESCRIPTION:Einkaufsliste\n\\nMilch\n\\nBrot\n"
+                "END:VTODO\n"
+                "END:VCALENDAR\n"
+            ),
+            "Einkaufsliste\nMilch\nBrot",
+            id="universal_newlines",
+        ),
+        pytest.param(
+            (
+                "BEGIN:VCALENDAR\r\n"
+                "PRODID:-//homeassistant.io//local_todo 2.0//EN\r\n"
+                "VERSION:2.0\r\n"
+                "BEGIN:VTODO\r\n"
+                "DTSTAMP:20260205T183141Z\r\n"
+                "UID:077cb7f2-6c89-11ee-b2a9-0242ac110002\r\n"
+                "CREATED:20260205T183141Z\r\n"
+                "SEQUENCE:0\r\n"
+                "STATUS:NEEDS-ACTION\r\n"
+                "SUMMARY:Notizen\r\n"
+                "DESCRIPTION:Einkaufsliste\r\\nMilch\r\\nBrot\r\n"
+                "END:VTODO\r\n"
+                "END:VCALENDAR\r\n"
+            ),
+            "Einkaufsliste\nMilch\nBrot",
+            id="raw_crlf",
+        ),
+        pytest.param(
+            (
+                "BEGIN:VCALENDAR\n"
+                "PRODID:-//homeassistant.io//local_todo 2.0//EN\n"
+                "VERSION:2.0\n"
+                "BEGIN:VTODO\n"
+                "DTSTAMP:20260205T183141Z\n"
+                "UID:077cb7f2-6c89-11ee-b2a9-0242ac110002\n"
+                "CREATED:20260205T183141Z\n"
+                "SEQUENCE:0\n"
+                "STATUS:NEEDS-ACTION\n"
+                "SUMMARY:Notizen\n"
+                "DESCRIPTION:Line 1\n\\n\n\\nLine 2\n"
+                "END:VTODO\n"
+                "END:VCALENDAR\n"
+            ),
+            "Line 1\n\nLine 2",
+            id="consecutive_newlines",
+        ),
+    ],
+)
+async def test_repair_legacy_crlf_on_setup(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    ws_get_items: WsGetItemsType,
+    caplog: pytest.LogCaptureFixture,
+    expected_description: str,
+) -> None:
+    """Test repairing malformed ICS content from ical <= 12.1.3 CRLF bug on setup."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        f"Repaired malformed iCalendar file for to-do list {TODO_NAME}" in caplog.text
+    )
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state is not None
+    assert state.state == "1"
+
+    items = await ws_get_items()
+    assert len(items) == 1
+    assert items[0]["summary"] == "Notizen"
+    assert items[0]["description"] == expected_description
+
+    # Verify that the file was re-saved cleanly to storage without any invalid lines
+    store = config_entry.runtime_data
+    re_saved = store._mock_path.read_text.return_value
+    assert "\r" not in re_saved
+    assert "\n\\n" not in re_saved
+
+
+async def test_description_newlines_preserved(
+    hass: HomeAssistant,
+    setup_integration: None,
+    config_entry: MockConfigEntry,
+    ws_get_items: WsGetItemsType,
+) -> None:
+    """Test that newlines in descriptions are preserved through service calls and reload."""
+    description = "Line 1\nLine 2\n\nLine 3"
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.ADD_ITEM,
+        {
+            ATTR_ITEM: "Item 1",
+            ATTR_DESCRIPTION: description,
+        },
+        target={ATTR_ENTITY_ID: TEST_ENTITY},
+        blocking=True,
+    )
+
+    items = await ws_get_items()
+    assert len(items) == 1
+    assert items[0]["description"] == description
+
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.UPDATE_ITEM,
+        {
+            ATTR_ITEM: items[0]["uid"],
+            ATTR_DESCRIPTION: f"Updated\n{description}",
+        },
+        target={ATTR_ENTITY_ID: TEST_ENTITY},
+        blocking=True,
+    )
+
+    items = await ws_get_items()
+    assert len(items) == 1
+    assert items[0]["description"] == f"Updated\n{description}"
+
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    items = await ws_get_items()
+    assert len(items) == 1
+    assert items[0]["description"] == f"Updated\n{description}"
+
+
+async def test_crlf_description_preserved_on_reload(
+    hass: HomeAssistant,
+    setup_integration: None,
+    config_entry: MockConfigEntry,
+    ws_get_items: WsGetItemsType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that items added with CRLF descriptions are saved cleanly and load on reload."""
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.ADD_ITEM,
+        {
+            ATTR_ITEM: "Item CRLF",
+            ATTR_DESCRIPTION: "Line 1\r\nLine 2\r\n\r\nLine 3",
+        },
+        target={ATTR_ENTITY_ID: TEST_ENTITY},
+        blocking=True,
+    )
+
+    # After reload from storage, newlines are preserved as LF and no repair warning is logged
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    items = await ws_get_items()
+    assert len(items) == 1
+    assert items[0]["description"] == "Line 1\nLine 2\n\nLine 3"
+    assert "Repaired malformed iCalendar file" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Repair previously written malformed ICS files with CRLF newlines on setup.

In `ical <= 12.1.3`, `TextEncoder` escaped `\n` to `\\n` but did not escape or strip `\r`. When descriptions/notes containing CRLF line breaks (e.g. from web form submissions or paste) were saved to disk, they contained raw `\r` followed by `\\n`. The error would be raised as: `CalendarParseError: Invalid property line, expected (';', ':') after property name`

This PR catches `CalendarParseError` in `local_todo` setup, repairs the bad text.sequences, re-parses, logs a warning, and  saves the clean RFC 5545 content back to disk.

Tests are added that (a) reproduce the current issue and verify the repair works and (b) explicitly exercise the newline cases just to show the existing go-forward code is already correct, and that no new regressions are introduced.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #162335
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr