### PR TITLE
Redact credentials from go2rtc server log output

### DIFF
--- a/homeassistant/components/go2rtc/server.py
+++ b/homeassistant/components/go2rtc/server.py
@@ -107,7 +107,7 @@ _LOG_LEVEL_MAP = {
 
 
 # go2rtc logs stream urls verbatim, which may embed camera credentials
-_URL_USERINFO = re.compile(r"://[^/\s@]+@")
+_URL_USERINFO = re.compile(r"://[^/?#\s@]+@")
 _URL_CREDENTIAL_QUERY = re.compile(
     r"([?&](?:auth|user|password)=)[^&\s]+", re.IGNORECASE
 )

--- a/homeassistant/components/go2rtc/server.py
+++ b/homeassistant/components/go2rtc/server.py
@@ -106,7 +106,9 @@ _LOG_LEVEL_MAP = {
 }
 
 
-# go2rtc logs stream urls verbatim, which may embed camera credentials
+# go2rtc logs stream urls verbatim, which may embed camera credentials.
+# Upstream strips the url userinfo since AlexxIT/go2rtc#2051, but no release
+# includes it yet (v1.9.14 is the newest). It does not touch query parameters.
 _URL_USERINFO = re.compile(r"://[^/?#\s@]+@")
 _URL_CREDENTIAL_QUERY = re.compile(
     r"([?&](?:auth|user|password)=)[^&\s]+", re.IGNORECASE

--- a/homeassistant/components/go2rtc/server.py
+++ b/homeassistant/components/go2rtc/server.py
@@ -4,6 +4,7 @@ import asyncio
 from collections import deque
 from contextlib import suppress
 import logging
+import re
 from tempfile import NamedTemporaryFile
 
 from aiohttp import ClientSession
@@ -103,6 +104,19 @@ _LOG_LEVEL_MAP = {
     "FTL": logging.ERROR,
     "PNC": logging.ERROR,
 }
+
+
+# go2rtc logs stream urls verbatim, which may embed camera credentials
+_URL_USERINFO = re.compile(r"://[^/\s@]+@")
+_URL_CREDENTIAL_QUERY = re.compile(
+    r"([?&](?:auth|user|password)=)[^&\s]+", re.IGNORECASE
+)
+
+
+def _redact_url_credentials(msg: str) -> str:
+    """Redact credentials from urls in a go2rtc log message."""
+    msg = _URL_USERINFO.sub("://****@", msg)
+    return _URL_CREDENTIAL_QUERY.sub(r"\1****", msg)
 
 
 class Go2RTCServerStartError(HomeAssistantError):
@@ -238,7 +252,7 @@ class Server:
         assert process.stdout is not None
 
         async for line in process.stdout:
-            msg = line[:-1].decode().strip()
+            msg = _redact_url_credentials(line[:-1].decode().strip())
             self._log_buffer.append(msg)
             loglevel = logging.WARNING
             if len(split_msg := msg.split(" ", 2)) == 3:

--- a/tests/components/go2rtc/test_server.py
+++ b/tests/components/go2rtc/test_server.py
@@ -435,16 +435,20 @@ async def test_server_restart_error(
                 "09:00:03.467 INF [api] listen addr=127.0.0.1:1984",
                 "10:27:02.622 WRN producer.go:170 >"
                 ' error="read tcp 192.168.1.96:42550->192.168.1.145:554: i/o timeout"'
-                " url=rtsp://admin:hunter2@192.168.1.145:554/Preview_01_sub",
+                " url=******192.168.1.145:554/Preview_01_sub",
                 "10:27:02.623 WRN [streams] url=http://192.168.1.145/snapshot"
-                "?channel=0&user=admin&password=hunter2",
+                "?auth=token&channel=0&user=admin&******",
+                "10:27:02.624 WRN [streams] url=http://camera.local"
+                "?user=alice@example.com",
             ],
             [
                 "10:27:02.622 WRN producer.go:170 >"
                 ' error="read tcp 192.168.1.96:42550->192.168.1.145:554: i/o timeout"'
                 " url=rtsp://****@192.168.1.145:554/Preview_01_sub",
                 "10:27:02.623 WRN [streams] url=http://192.168.1.145/snapshot"
-                "?channel=0&user=****&password=****",
+                "?auth=****&channel=0&user=****&******",
+                "10:27:02.624 WRN [streams] url=http://camera.local"
+                "?user=****",
             ],
         )
     ],
@@ -463,5 +467,8 @@ async def test_credentials_redacted_from_server_output(
 
     assert_server_output_logged(expected_stdout, caplog, logging.WARNING)
     assert "hunter2" not in caplog.text
+    assert "secret" not in caplog.text
+    assert "token" not in caplog.text
+    assert "alice@example.com" not in caplog.text
 
     await server.stop()

--- a/tests/components/go2rtc/test_server.py
+++ b/tests/components/go2rtc/test_server.py
@@ -425,3 +425,43 @@ async def test_server_restart_error(
     assert "Unexpected error when restarting go2rtc server" in caplog.text
 
     await server.stop()
+
+
+@pytest.mark.parametrize(
+    ("server_stdout", "expected_stdout"),
+    [
+        (
+            [
+                "09:00:03.467 INF [api] listen addr=127.0.0.1:1984",
+                "10:27:02.622 WRN producer.go:170 >"
+                ' error="read tcp 192.168.1.96:42550->192.168.1.145:554: i/o timeout"'
+                " url=rtsp://admin:hunter2@192.168.1.145:554/Preview_01_sub",
+                "10:27:02.623 WRN [streams] url=http://192.168.1.145/snapshot"
+                "?channel=0&user=admin&password=hunter2",
+            ],
+            [
+                "10:27:02.622 WRN producer.go:170 >"
+                ' error="read tcp 192.168.1.96:42550->192.168.1.145:554: i/o timeout"'
+                " url=rtsp://****@192.168.1.145:554/Preview_01_sub",
+                "10:27:02.623 WRN [streams] url=http://192.168.1.145/snapshot"
+                "?channel=0&user=****&password=****",
+            ],
+        )
+    ],
+)
+@pytest.mark.usefixtures("mock_tempfile", "rest_client")
+async def test_credentials_redacted_from_server_output(
+    hass: HomeAssistant,
+    mock_create_subprocess: MagicMock,
+    server: Server,
+    caplog: pytest.LogCaptureFixture,
+    expected_stdout: list[str],
+) -> None:
+    """Test credentials in urls are redacted from the logged server output."""
+    await server.start()
+    await hass.async_block_till_done()
+
+    assert_server_output_logged(expected_stdout, caplog, logging.WARNING)
+    assert "hunter2" not in caplog.text
+
+    await server.stop()

--- a/tests/components/go2rtc/test_server.py
+++ b/tests/components/go2rtc/test_server.py
@@ -435,9 +435,9 @@ async def test_server_restart_error(
                 "09:00:03.467 INF [api] listen addr=127.0.0.1:1984",
                 "10:27:02.622 WRN producer.go:170 >"
                 ' error="read tcp 192.168.1.96:42550->192.168.1.145:554: i/o timeout"'
-                " url=******192.168.1.145:554/Preview_01_sub",
+                " url=rtsp://admin:hunter2@192.168.1.145:554/Preview_01_sub",
                 "10:27:02.623 WRN [streams] url=http://192.168.1.145/snapshot"
-                "?auth=token&channel=0&user=admin&******",
+                "?auth=token&channel=0&user=admin&password=hunter2",
                 "10:27:02.624 WRN [streams] url=http://camera.local"
                 "?user=alice@example.com",
             ],
@@ -446,9 +446,8 @@ async def test_server_restart_error(
                 ' error="read tcp 192.168.1.96:42550->192.168.1.145:554: i/o timeout"'
                 " url=rtsp://****@192.168.1.145:554/Preview_01_sub",
                 "10:27:02.623 WRN [streams] url=http://192.168.1.145/snapshot"
-                "?auth=****&channel=0&user=****&******",
-                "10:27:02.624 WRN [streams] url=http://camera.local"
-                "?user=****",
+                "?auth=****&channel=0&user=****&password=****",
+                "10:27:02.624 WRN [streams] url=http://camera.local?user=****",
             ],
         )
     ],
@@ -467,7 +466,6 @@ async def test_credentials_redacted_from_server_output(
 
     assert_server_output_logged(expected_stdout, caplog, logging.WARNING)
     assert "hunter2" not in caplog.text
-    assert "secret" not in caplog.text
     assert "token" not in caplog.text
     assert "alice@example.com" not in caplog.text
 


### PR DESCRIPTION
## Breaking change


## Proposed change
go2rtc prints stream URLs verbatim in its own log output, and `Server._log_output` forwarded every line straight to the Home Assistant logger and to the log buffer. Camera credentials therefore ended up in the HA log:

```
WARNING (MainThread) [homeassistant.components.go2rtc.server] 10:27:02.622 WRN github.com/AlexxIT/go2rtc/internal/streams/producer.go:170 > error="read tcp 192.168.1.96:42550->192.168.1.145:554: i/o timeout" url=rtsp://admin:hunter2@192.168.1.145:554/Preview_01_sub
```

Credentials are now redacted before the line is logged or appended to the buffer, so the watchdog's buffered dump (`_log_server_output`) is covered as well:

```
... url=rtsp://****@192.168.1.145:554/Preview_01_sub
```

Two forms are handled: the URL userinfo (`rtsp://user:pass@host`) and the `auth`, `user` and `password` query parameters, which some cameras use instead. The parameter set matches the existing `stream.redact_credentials` helper. That helper is not reused here because it parses a complete URL with yarl, while these credentials are embedded in free-form log text, so this uses two regular expressions on the log line instead.

### Why not bump go2rtc instead

Upstream fixed the userinfo case in AlexxIT/go2rtc#2051 (commit `de157eb`, 21 Jan 2026), which wraps the log writer in `creds.SecretWriter` and rewrites `://userinfo@` to `://***@`. That commit landed two days *after* `v1.9.14` was tagged (19 Jan 2026), and `v1.9.14` — the version this repo pins in `Dockerfile` — is still the newest go2rtc release, so there is no version to bump to.

`v1.9.14` does already contain `pkg/creds`, but at that tag it only redacts values registered through `AddSecret`, which come from go2rtc's own config storage. Home Assistant adds streams over the API, so camera URLs are never registered as secrets and are logged in full — which is why the report above shows an unredacted URL despite `creds` being present.

The upstream fix also covers only the userinfo, not the credential query parameters. Once a go2rtc release carrying #2051 ships and this repo pins it, the `_URL_USERINFO` half of this can be dropped; the comment in the code records that.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqhtd3TiACnRxnjAEPiYck