### PR TITLE
Leave the Weheat token renewal to the OAuth helper

### DIFF
--- a/homeassistant/components/weheat/__init__.py
+++ b/homeassistant/components/weheat/__init__.py
@@ -1,15 +1,13 @@
 """The Weheat integration."""
 
 import asyncio
-from http import HTTPStatus
 
-import aiohttp
 from weheat.abstractions.discovery import HeatPumpDiscovery
 from weheat.exceptions import UnauthorizedException
 
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2Session,
@@ -34,17 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: WeheatConfigEntry) -> bo
 
     session = OAuth2Session(hass, entry, implementation)
 
-    try:
-        await session.async_ensure_token_valid()
-    except aiohttp.ClientResponseError as ex:
-        LOGGER.warning("API error: %s (%s)", ex.status, ex.message)
-        if ex.status in (
-            HTTPStatus.BAD_REQUEST,
-            HTTPStatus.UNAUTHORIZED,
-            HTTPStatus.FORBIDDEN,
-        ):
-            raise ConfigEntryAuthFailed("Token not valid, trigger renewal") from ex
-        raise ConfigEntryNotReady from ex
+    await session.async_ensure_token_valid()
 
     token = session.token[CONF_ACCESS_TOKEN]
     entry.runtime_data = []

--- a/tests/components/weheat/test_init.py
+++ b/tests/components/weheat/test_init.py
@@ -7,8 +7,14 @@ import pytest
 from weheat.abstractions.discovery import HeatPumpDiscovery
 
 from homeassistant.components.weheat import UnauthorizedException
+from homeassistant.components.weheat.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import (
+    OAuth2TokenRequestConnectionError,
+    OAuth2TokenRequestError,
+    OAuth2TokenRequestReauthError,
+)
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
 )
@@ -16,7 +22,6 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 from . import setup_integration
 
 from tests.common import MockConfigEntry
-from tests.test_util.aiohttp import ClientResponseError
 
 
 async def test_setup(
@@ -41,10 +46,29 @@ async def test_setup(
 @pytest.mark.parametrize(
     ("setup_exception", "expected_setup_state"),
     [
-        (HTTPStatus.BAD_REQUEST, ConfigEntryState.SETUP_ERROR),
-        (HTTPStatus.UNAUTHORIZED, ConfigEntryState.SETUP_ERROR),
-        (HTTPStatus.FORBIDDEN, ConfigEntryState.SETUP_ERROR),
-        (HTTPStatus.GATEWAY_TIMEOUT, ConfigEntryState.SETUP_RETRY),
+        pytest.param(
+            OAuth2TokenRequestReauthError(
+                domain=DOMAIN,
+                request_info=Mock(real_url="http://example.com"),
+                status=HTTPStatus.BAD_REQUEST,
+            ),
+            ConfigEntryState.SETUP_ERROR,
+            id="logging_in_again_is_needed",
+        ),
+        pytest.param(
+            OAuth2TokenRequestError(
+                domain=DOMAIN,
+                request_info=Mock(real_url="http://example.com"),
+                status=HTTPStatus.GATEWAY_TIMEOUT,
+            ),
+            ConfigEntryState.SETUP_RETRY,
+            id="the_login_provider_answered_badly",
+        ),
+        pytest.param(
+            OAuth2TokenRequestConnectionError(domain=DOMAIN),
+            ConfigEntryState.SETUP_RETRY,
+            id="the_login_provider_could_not_be_reached",
+        ),
     ],
 )
 async def test_setup_fail(
@@ -56,14 +80,10 @@ async def test_setup_fail(
     setup_exception: Exception,
     expected_setup_state: ConfigEntryState,
 ) -> None:
-    """Test the Weheat setup with invalid token setup."""
-    with (
-        patch(
-            "homeassistant.components.weheat.OAuth2Session.async_ensure_token_valid",
-            side_effect=ClientResponseError(
-                Mock(real_url="http://example.com"), None, status=setup_exception
-            ),
-        ),
+    """Test the Weheat setup when the token cannot be renewed."""
+    with patch(
+        "homeassistant.components.weheat.OAuth2Session.async_ensure_token_valid",
+        side_effect=setup_exception,
     ):
         await setup_integration(hass, mock_config_entry)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Renewing the token talks to the login provider, but the failure was logged as an API error and then mapped onto the config entry by hand. The helper raises errors that already are a config entry auth failure or a config entry not ready and starts reauthentication itself, so the mapping repeated what it had decided, and it missed the failure that never got a response, which is not an HTTP error at all.

The setup test raises what the helper raises rather than a bare client response error, which it no longer produces, and so covers that failure for the first time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
