### PR TITLE
Add oven remaining-time sensors to LG ThinQ

### DIFF
--- a/homeassistant/components/lg_thinq/coordinator.py
+++ b/homeassistant/components/lg_thinq/coordinator.py
@@ -5,8 +5,8 @@ from datetime import time
 import logging
 from typing import TYPE_CHECKING, Any, override
 
-from thinqconnect import ThinQAPIException
-from thinqconnect.integration import HABridge
+from thinqconnect import DeviceType, ThinQAPIException
+from thinqconnect.integration import ActiveMode, HABridge, TimerProperty
 
 from homeassistant.const import EVENT_CORE_CONFIG_UPDATE
 from homeassistant.core import Event, HomeAssistant, callback
@@ -38,6 +38,14 @@ class DeviceDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self.data = ha_bridge.update_status(None)
         self.api = ha_bridge
+        self.oven_timer_updates: dict[str | None, int] = {}
+        if ha_bridge.device.device_type == DeviceType.OVEN:
+            self.oven_timer_updates = {
+                ha_bridge.get_location_for_idx(property_id): 0
+                for property_id in ha_bridge.get_active_idx(
+                    TimerProperty.REMAIN, ActiveMode.READABLE
+                )
+            }
         self.device_id = ha_bridge.device.device_id
         self.sub_id = ha_bridge.sub_id
 
@@ -98,18 +106,43 @@ class DeviceDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_update_data(self) -> dict[str, Any]:
         """Request to the server to update the status from full response data."""
         try:
-            return await self.api.fetch_data()
+            if not self.oven_timer_updates:
+                return await self.api.fetch_data()
+            status = await self.api.device.thinq_api.async_get_device_status(
+                self.device_id
+            )
         except ThinQAPIException as e:
             raise UpdateFailed(e) from e
+        if status is not None:
+            self.api.device.set_status(status)
+            self._record_oven_timer_updates(status)
+        return self.api.update_status(None) or self.data
+
+    def _record_oven_timer_updates(
+        self, status: dict[str, Any] | list[dict[str, Any]]
+    ) -> None:
+        """Track timer fields present in a response, before considering cached values."""
+        if not self.oven_timer_updates or not isinstance(status, list):
+            return
+        for cavity in status:
+            location = cavity.get("location", {}).get("locationName", "").lower()
+            if location in self.oven_timer_updates and any(
+                field in (cavity.get("timer") or {})
+                for field in ("remainHour", "remainMinute", "remainSecond")
+            ):
+                self.oven_timer_updates[location] += 1
 
     def refresh_status(self) -> None:
         """Refresh current status."""
         self.async_set_updated_data(self.data)
 
-    def handle_update_status(self, status: dict[str, Any]) -> None:
+    def handle_update_status(
+        self, status: dict[str, Any] | list[dict[str, Any]]
+    ) -> None:
         """Handle the status received from the mqtt connection."""
         data = self.api.update_status(status)
         if data is not None:
+            self._record_oven_timer_updates(status)
             self.async_set_updated_data(data)
 
     def handle_notification_message(self, message: str | None) -> None:

--- a/homeassistant/components/lg_thinq/coordinator.py
+++ b/homeassistant/components/lg_thinq/coordinator.py
@@ -5,8 +5,8 @@ from datetime import time
 import logging
 from typing import TYPE_CHECKING, Any, override
 
-from thinqconnect import DeviceType, ThinQAPIException
-from thinqconnect.integration import ActiveMode, HABridge, TimerProperty
+from thinqconnect import ThinQAPIException
+from thinqconnect.integration import HABridge
 
 from homeassistant.const import EVENT_CORE_CONFIG_UPDATE
 from homeassistant.core import Event, HomeAssistant, callback
@@ -38,14 +38,6 @@ class DeviceDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self.data = ha_bridge.update_status(None)
         self.api = ha_bridge
-        self.oven_timer_updates: dict[str | None, int] = {}
-        if ha_bridge.device.device_type == DeviceType.OVEN:
-            self.oven_timer_updates = {
-                ha_bridge.get_location_for_idx(property_id): 0
-                for property_id in ha_bridge.get_active_idx(
-                    TimerProperty.REMAIN, ActiveMode.READABLE
-                )
-            }
         self.device_id = ha_bridge.device.device_id
         self.sub_id = ha_bridge.sub_id
 
@@ -106,43 +98,18 @@ class DeviceDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _async_update_data(self) -> dict[str, Any]:
         """Request to the server to update the status from full response data."""
         try:
-            if not self.oven_timer_updates:
-                return await self.api.fetch_data()
-            status = await self.api.device.thinq_api.async_get_device_status(
-                self.device_id
-            )
+            return await self.api.fetch_data()
         except ThinQAPIException as e:
             raise UpdateFailed(e) from e
-        if status is not None:
-            self.api.device.set_status(status)
-            self._record_oven_timer_updates(status)
-        return self.api.update_status(None) or self.data
-
-    def _record_oven_timer_updates(
-        self, status: dict[str, Any] | list[dict[str, Any]]
-    ) -> None:
-        """Track timer fields present in a response, before considering cached values."""
-        if not self.oven_timer_updates or not isinstance(status, list):
-            return
-        for cavity in status:
-            location = cavity.get("location", {}).get("locationName", "").lower()
-            if location in self.oven_timer_updates and any(
-                field in (cavity.get("timer") or {})
-                for field in ("remainHour", "remainMinute", "remainSecond")
-            ):
-                self.oven_timer_updates[location] += 1
 
     def refresh_status(self) -> None:
         """Refresh current status."""
         self.async_set_updated_data(self.data)
 
-    def handle_update_status(
-        self, status: dict[str, Any] | list[dict[str, Any]]
-    ) -> None:
+    def handle_update_status(self, status: dict[str, Any]) -> None:
         """Handle the status received from the mqtt connection."""
         data = self.api.update_status(status)
         if data is not None:
-            self._record_oven_timer_updates(status)
             self.async_set_updated_data(data)
 
     def handle_notification_message(self, message: str | None) -> None:

--- a/homeassistant/components/lg_thinq/sensor.py
+++ b/homeassistant/components/lg_thinq/sensor.py
@@ -738,7 +738,7 @@ class ThinQOvenTimerSensorEntity(ThinQEntity, SensorEntity):
     ) -> None:
         """Initialize the timer using the existing per-cavity ThinQ identity."""
         super().__init__(coordinator, entity_description, property_id)
-        self._last_remaining: time | None = None
+        self._last_timer_update: int | None = None
         self._attr_native_value: datetime | None = None
         self._device_state_id = (
             f"{self.location}_{ThinQProperty.CURRENT_STATE}"
@@ -749,6 +749,9 @@ class ThinQOvenTimerSensorEntity(ThinQEntity, SensorEntity):
     @override
     def _update_status(self) -> None:
         """Re-anchor only when LG reports a changed, active cook timer."""
+        timer_update = self.coordinator.oven_timer_updates.get(self.location, 0)
+        previous_update = self._last_timer_update
+        self._last_timer_update = timer_update
         status = self.coordinator.data.get(self._device_state_id)
         remaining = self.data.value
         if (
@@ -757,14 +760,12 @@ class ThinQOvenTimerSensorEntity(ThinQEntity, SensorEntity):
             or not isinstance(remaining, time)
             or remaining == time.min
         ):
-            self._last_remaining = None
             self._attr_native_value = None
             return
 
-        # Other-cavity updates must not extend a cached timer reading.
-        if remaining == self._last_remaining:
+        # Status-only pushes cannot restart a timer cached from an earlier cook.
+        if timer_update == previous_update:
             return
-        self._last_remaining = remaining
         deadline = dt_util.utcnow() + timedelta(
             hours=remaining.hour, minutes=remaining.minute, seconds=remaining.second
         )

--- a/homeassistant/components/lg_thinq/sensor.py
+++ b/homeassistant/components/lg_thinq/sensor.py
@@ -9,7 +9,12 @@ from typing import override
 
 from thinqconnect import USAGE_DAILY, USAGE_MONTHLY, DeviceType, ThinQAPIException
 from thinqconnect.devices.const import Property as ThinQProperty
-from thinqconnect.integration import ActiveMode, ThinQPropertyEx, TimerProperty
+from thinqconnect.integration import (
+    ActiveMode,
+    OvenTimerPropertyState,
+    ThinQPropertyEx,
+    TimerProperty,
+)
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -728,51 +733,16 @@ async def async_setup_entry(
 
 
 class ThinQOvenTimerSensorEntity(ThinQEntity, SensorEntity):
-    """Expose a stable cook-timer deadline without extending cached readings."""
-
-    def __init__(
-        self,
-        coordinator: DeviceDataUpdateCoordinator,
-        entity_description: SensorEntityDescription,
-        property_id: str,
-    ) -> None:
-        """Initialize the timer using the existing per-cavity ThinQ identity."""
-        super().__init__(coordinator, entity_description, property_id)
-        self._last_timer_update: int | None = None
-        self._attr_native_value: datetime | None = None
-        self._device_state_id = (
-            f"{self.location}_{ThinQProperty.CURRENT_STATE}"
-            if self.location is not None
-            else ThinQProperty.CURRENT_STATE
-        )
+    """Expose the cook-timer end time maintained by the ThinQ library."""
 
     @override
     def _update_status(self) -> None:
-        """Re-anchor only when LG reports a changed, active cook timer."""
-        timer_update = self.coordinator.oven_timer_updates.get(self.location, 0)
-        previous_update = self._last_timer_update
-        self._last_timer_update = timer_update
-        status = self.coordinator.data.get(self._device_state_id)
-        remaining = self.data.value
-        if (
-            status is None
-            or status.value not in {"preheating", "cooking_in_progress"}
-            or not isinstance(remaining, time)
-            or remaining == time.min
-        ):
-            self._attr_native_value = None
-            return
-
-        # Status-only pushes cannot restart a timer cached from an earlier cook.
-        if timer_update == previous_update:
-            return
-        deadline = dt_util.utcnow() + timedelta(
-            hours=remaining.hour, minutes=remaining.minute, seconds=remaining.second
+        """Read the library's per-cavity timer state."""
+        self._attr_native_value = (
+            self.data.end_time
+            if isinstance(self.data, OvenTimerPropertyState)
+            else None
         )
-        if self._attr_native_value is None or abs(
-            deadline - self._attr_native_value
-        ) > timedelta(seconds=5):
-            self._attr_native_value = deadline
 
 
 class ThinQSensorEntity(ThinQEntity, SensorEntity):

--- a/homeassistant/components/lg_thinq/sensor.py
+++ b/homeassistant/components/lg_thinq/sensor.py
@@ -524,6 +524,7 @@ DEVICE_TYPE_SENSOR_MAP: dict[DeviceType, tuple[SensorEntityDescription, ...]] = 
     DeviceType.OVEN: (
         RUN_STATE_SENSOR_DESC[ThinQProperty.CURRENT_STATE],
         TEMPERATURE_SENSOR_DESC[ThinQProperty.TARGET_TEMPERATURE],
+        TIMER_SENSOR_DESC[TimerProperty.REMAIN],
     ),
     DeviceType.PLANT_CULTIVATOR: (
         LIGHT_SENSOR_DESC[ThinQProperty.BRIGHTNESS],
@@ -658,7 +659,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up an entry for sensor platform."""
     entities: list[
-        ThinQSensorEntity | ThinQEnergySensorEntity | ThinQEnumTempSensorEntity
+        ThinQSensorEntity
+        | ThinQOvenTimerSensorEntity
+        | ThinQEnergySensorEntity
+        | ThinQEnumTempSensorEntity
     ] = []
     for coordinator in entry.runtime_data.coordinators.values():
         if (
@@ -667,8 +671,14 @@ async def async_setup_entry(
             )
         ) is not None:
             for description in descriptions:
+                sensor_type = (
+                    ThinQOvenTimerSensorEntity
+                    if coordinator.api.device.device_type == DeviceType.OVEN
+                    and description.key == TimerProperty.REMAIN
+                    else ThinQSensorEntity
+                )
                 entities.extend(
-                    ThinQSensorEntity(coordinator, description, property_id)
+                    sensor_type(coordinator, description, property_id)
                     for property_id in coordinator.api.get_active_idx(
                         description.key,
                         (
@@ -715,6 +725,53 @@ async def async_setup_entry(
             )
     if entities:
         async_add_entities(entities)
+
+
+class ThinQOvenTimerSensorEntity(ThinQEntity, SensorEntity):
+    """Expose a stable cook-timer deadline without extending cached readings."""
+
+    def __init__(
+        self,
+        coordinator: DeviceDataUpdateCoordinator,
+        entity_description: SensorEntityDescription,
+        property_id: str,
+    ) -> None:
+        """Initialize the timer using the existing per-cavity ThinQ identity."""
+        super().__init__(coordinator, entity_description, property_id)
+        self._last_remaining: time | None = None
+        self._attr_native_value: datetime | None = None
+        self._device_state_id = (
+            f"{self.location}_{ThinQProperty.CURRENT_STATE}"
+            if self.location is not None
+            else ThinQProperty.CURRENT_STATE
+        )
+
+    @override
+    def _update_status(self) -> None:
+        """Re-anchor only when LG reports a changed, active cook timer."""
+        status = self.coordinator.data.get(self._device_state_id)
+        remaining = self.data.value
+        if (
+            status is None
+            or status.value not in {"preheating", "cooking_in_progress"}
+            or not isinstance(remaining, time)
+            or remaining == time.min
+        ):
+            self._last_remaining = None
+            self._attr_native_value = None
+            return
+
+        # Other-cavity updates must not extend a cached timer reading.
+        if remaining == self._last_remaining:
+            return
+        self._last_remaining = remaining
+        deadline = dt_util.utcnow() + timedelta(
+            hours=remaining.hour, minutes=remaining.minute, seconds=remaining.second
+        )
+        if self._attr_native_value is None or abs(
+            deadline - self._attr_native_value
+        ) > timedelta(seconds=5):
+            self._attr_native_value = deadline
 
 
 class ThinQSensorEntity(ThinQEntity, SensorEntity):

--- a/tests/components/lg_thinq/fixtures/oven/device.json
+++ b/tests/components/lg_thinq/fixtures/oven/device.json
@@ -1,0 +1,9 @@
+{
+  "deviceId": "OV-00000000-0000-0000-0000-000000000001",
+  "deviceInfo": {
+    "deviceType": "DEVICE_OVEN",
+    "modelName": "Test oven",
+    "alias": "Test oven",
+    "reportable": true
+  }
+}

--- a/tests/components/lg_thinq/fixtures/oven/profile.json
+++ b/tests/components/lg_thinq/fixtures/oven/profile.json
@@ -1,0 +1,77 @@
+{
+  "extensionProperty": {
+    "info": {
+      "type": "DOUBLE"
+    }
+  },
+  "property": [
+    {
+      "location": {
+        "locationName": "UPPER"
+      },
+      "runState": {
+        "currentState": {
+          "mode": ["r"],
+          "type": "enum",
+          "value": {
+            "r": [
+              "INITIAL",
+              "PREHEATING",
+              "COOKING_IN_PROGRESS",
+              "DONE",
+              "COOLING"
+            ]
+          }
+        }
+      },
+      "timer": {
+        "remainHour": {
+          "mode": ["r"],
+          "type": "number"
+        },
+        "remainMinute": {
+          "mode": ["r"],
+          "type": "number"
+        },
+        "remainSecond": {
+          "mode": ["r"],
+          "type": "number"
+        }
+      }
+    },
+    {
+      "location": {
+        "locationName": "LOWER"
+      },
+      "runState": {
+        "currentState": {
+          "mode": ["r"],
+          "type": "enum",
+          "value": {
+            "r": [
+              "INITIAL",
+              "PREHEATING",
+              "COOKING_IN_PROGRESS",
+              "DONE",
+              "COOLING"
+            ]
+          }
+        }
+      },
+      "timer": {
+        "remainHour": {
+          "mode": ["r"],
+          "type": "number"
+        },
+        "remainMinute": {
+          "mode": ["r"],
+          "type": "number"
+        },
+        "remainSecond": {
+          "mode": ["r"],
+          "type": "number"
+        }
+      }
+    }
+  ]
+}

--- a/tests/components/lg_thinq/fixtures/oven/status.json
+++ b/tests/components/lg_thinq/fixtures/oven/status.json
@@ -1,0 +1,28 @@
+[
+  {
+    "location": {
+      "locationName": "UPPER"
+    },
+    "runState": {
+      "currentState": "COOKING_IN_PROGRESS"
+    },
+    "timer": {
+      "remainHour": 0,
+      "remainMinute": 10,
+      "remainSecond": 0
+    }
+  },
+  {
+    "location": {
+      "locationName": "LOWER"
+    },
+    "runState": {
+      "currentState": "COOKING_IN_PROGRESS"
+    },
+    "timer": {
+      "remainHour": 0,
+      "remainMinute": 10,
+      "remainSecond": 0
+    }
+  }
+]

--- a/tests/components/lg_thinq/snapshots/test_oven_sensor.ambr
+++ b/tests/components/lg_thinq/snapshots/test_oven_sensor.ambr
@@ -1,0 +1,235 @@
+# serializer version: 1
+# name: test_oven_sensor_entities[sensor.test_oven_lower_current_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'initial',
+        'preheating',
+        'cooking_in_progress',
+        'done',
+        'cooling',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_oven_lower_current_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'lower current status',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'lower current status',
+    'platform': 'lg_thinq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_state_for_location',
+    'unique_id': 'OV-00000000-0000-0000-0000-000000000001_lower_current_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_oven_sensor_entities[sensor.test_oven_lower_current_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test oven lower current status',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'initial',
+        'preheating',
+        'cooking_in_progress',
+        'done',
+        'cooling',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_oven_lower_current_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cooking_in_progress',
+  })
+# ---
+# name: test_oven_sensor_entities[sensor.test_oven_lower_remaining_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_oven_lower_remaining_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'lower remaining time',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'lower remaining time',
+    'platform': 'lg_thinq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'remain_for_location',
+    'unique_id': 'OV-00000000-0000-0000-0000-000000000001_lower_remain',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_oven_sensor_entities[sensor.test_oven_lower_remaining_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test oven lower remaining time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_oven_lower_remaining_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2026-09-07T18:40:00+00:00',
+  })
+# ---
+# name: test_oven_sensor_entities[sensor.test_oven_upper_current_status-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'initial',
+        'preheating',
+        'cooking_in_progress',
+        'done',
+        'cooling',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_oven_upper_current_status',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'upper current status',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'upper current status',
+    'platform': 'lg_thinq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'current_state_for_location',
+    'unique_id': 'OV-00000000-0000-0000-0000-000000000001_upper_current_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_oven_sensor_entities[sensor.test_oven_upper_current_status-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test oven upper current status',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'initial',
+        'preheating',
+        'cooking_in_progress',
+        'done',
+        'cooling',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_oven_upper_current_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cooking_in_progress',
+  })
+# ---
+# name: test_oven_sensor_entities[sensor.test_oven_upper_remaining_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_oven_upper_remaining_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'upper remaining time',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'upper remaining time',
+    'platform': 'lg_thinq',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'remain_for_location',
+    'unique_id': 'OV-00000000-0000-0000-0000-000000000001_upper_remain',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_oven_sensor_entities[sensor.test_oven_upper_remaining_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Test oven upper remaining time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_oven_upper_remaining_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2026-09-07T18:40:00+00:00',
+  })
+# ---

--- a/tests/components/lg_thinq/test_oven_sensor.py
+++ b/tests/components/lg_thinq/test_oven_sensor.py
@@ -1,0 +1,192 @@
+"""Tests for LG ThinQ oven remaining-time sensors."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.lg_thinq.const import DOMAIN
+from homeassistant.components.lg_thinq.coordinator import DeviceDataUpdateCoordinator
+from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import (
+    MockConfigEntry,
+    load_json_array_fixture,
+    load_json_object_fixture,
+    snapshot_platform,
+)
+
+pytestmark = pytest.mark.freeze_time("2026-09-07T18:30:00+00:00")
+
+START = datetime(2026, 9, 7, 18, 30, tzinfo=UTC)
+UPPER_ENTITY_ID = "sensor.test_oven_upper_remaining_time"
+LOWER_ENTITY_ID = "sensor.test_oven_lower_remaining_time"
+
+
+@pytest.fixture
+def oven_api(mock_thinq_api: AsyncMock) -> AsyncMock:
+    """Provide a synthetic two-cavity oven through the real ThinQ bridge."""
+    mock_thinq_api.async_get_device_list.return_value = [
+        load_json_object_fixture("oven/device.json", DOMAIN)
+    ]
+    mock_thinq_api.async_get_device_profile.return_value = load_json_object_fixture(
+        "oven/profile.json", DOMAIN
+    )
+    mock_thinq_api.async_get_device_status.return_value = load_json_array_fixture(
+        "oven/status.json", DOMAIN
+    )
+    mock_thinq_api.async_get_device_energy_profile.return_value = None
+    return mock_thinq_api
+
+
+@pytest.fixture
+async def oven_coordinator(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, oven_api: AsyncMock
+) -> DeviceDataUpdateCoordinator:
+    """Set up the oven's sensor platform."""
+    with patch("homeassistant.components.lg_thinq.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+    return next(iter(mock_config_entry.runtime_data.coordinators.values()))
+
+
+@pytest.mark.usefixtures("oven_coordinator")
+async def test_oven_sensor_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Snapshot the existing status entities and added timer entities."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [
+        pytest.param(600, "2026-09-07T18:41:00+00:00", id="extend"),
+        pytest.param(300, "2026-09-07T18:36:00+00:00", id="shorten"),
+        pytest.param(0, STATE_UNKNOWN, id="cancel"),
+    ],
+)
+async def test_adjust_oven_timer(
+    hass: HomeAssistant,
+    oven_coordinator: DeviceDataUpdateCoordinator,
+    freezer: FrozenDateTimeFactory,
+    seconds: int,
+    expected: str,
+) -> None:
+    """A cook timer can be adjusted without changing the cooking status."""
+    freezer.move_to(START + timedelta(seconds=30))
+    oven_coordinator.handle_update_status(
+        [
+            {
+                "location": {"locationName": "UPPER"},
+                "timer": {"remainMinute": 9, "remainSecond": 30},
+            }
+        ]
+    )
+    freezer.move_to(START + timedelta(minutes=1))
+    oven_coordinator.handle_update_status(
+        [
+            {
+                "location": {"locationName": "UPPER"},
+                "timer": {
+                    "remainMinute": seconds // 60,
+                    "remainSecond": seconds % 60,
+                },
+            }
+        ]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID).state == expected
+    assert hass.states.get(LOWER_ENTITY_ID).state == "2026-09-07T18:40:00+00:00"
+
+
+async def test_countdown_is_stable(
+    hass: HomeAssistant,
+    oven_coordinator: DeviceDataUpdateCoordinator,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Countdown reports and unrelated updates keep the original deadline."""
+    initial_state = hass.states.get(UPPER_ENTITY_ID)
+    freezer.move_to(START + timedelta(minutes=1, seconds=2))
+    oven_coordinator.handle_update_status(
+        [{"location": {"locationName": "UPPER"}, "timer": {"remainMinute": 9}}]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID) == initial_state
+    freezer.move_to(START + timedelta(minutes=2))
+    oven_coordinator.handle_update_status(
+        [{"location": {"locationName": "LOWER"}, "timer": {"remainMinute": 5}}]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID) == initial_state
+    assert hass.states.get(LOWER_ENTITY_ID).state == "2026-09-07T18:37:00+00:00"
+
+
+@pytest.mark.parametrize("status", ["INITIAL", "DONE", "COOLING"])
+async def test_inactive_oven_clears_cached_timer(
+    hass: HomeAssistant,
+    oven_coordinator: DeviceDataUpdateCoordinator,
+    status: str,
+) -> None:
+    """An inactive cavity must not display a cached nonzero timer."""
+    oven_coordinator.handle_update_status(
+        [{"location": {"locationName": "UPPER"}, "runState": {"currentState": status}}]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID).state == STATE_UNKNOWN
+    assert hass.states.get(LOWER_ENTITY_ID).state == "2026-09-07T18:40:00+00:00"
+
+
+@pytest.mark.parametrize("status", ["PREHEATING", "COOKING_IN_PROGRESS"])
+async def test_start_timer_while_oven_is_active(
+    hass: HomeAssistant,
+    oven_coordinator: DeviceDataUpdateCoordinator,
+    freezer: FrozenDateTimeFactory,
+    status: str,
+) -> None:
+    """A timer starts after an untimed cook or a cancellation."""
+    oven_coordinator.handle_update_status(
+        [
+            {
+                "location": {"locationName": "UPPER"},
+                "runState": {"currentState": status},
+                "timer": {"remainMinute": 0},
+            }
+        ]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID).state == STATE_UNKNOWN
+    freezer.move_to(START + timedelta(minutes=14))
+    oven_coordinator.handle_update_status(
+        [{"location": {"locationName": "UPPER"}, "timer": {"remainMinute": 10}}]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID).state == "2026-09-07T18:54:00+00:00"
+
+
+async def test_oven_without_timer_support(
+    hass: HomeAssistant, oven_api: AsyncMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Do not create a timer sensor for a cavity without readable timer fields."""
+    oven_api.async_get_device_profile.return_value["property"][0].pop("timer")
+    with patch("homeassistant.components.lg_thinq.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+    assert hass.states.get(UPPER_ENTITY_ID) is None
+    assert hass.states.get(LOWER_ENTITY_ID).state == "2026-09-07T18:40:00+00:00"
+
+
+@pytest.mark.parametrize("missing_field", ["timer", "runState"])
+async def test_missing_oven_data(
+    hass: HomeAssistant,
+    oven_api: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    missing_field: str,
+) -> None:
+    """Keep the deadline unknown until the timer and active status are known."""
+    oven_api.async_get_device_status.return_value[0].pop(missing_field)
+    with patch("homeassistant.components.lg_thinq.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+    assert hass.states.get(UPPER_ENTITY_ID).state == STATE_UNKNOWN
+    assert hass.states.get(LOWER_ENTITY_ID).state == "2026-09-07T18:40:00+00:00"

--- a/tests/components/lg_thinq/test_oven_sensor.py
+++ b/tests/components/lg_thinq/test_oven_sensor.py
@@ -1,5 +1,6 @@
 """Tests for LG ThinQ oven remaining-time sensors."""
 
+from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
@@ -27,6 +28,17 @@ pytestmark = pytest.mark.freeze_time("2026-09-07T18:30:00+00:00")
 START = datetime(2026, 9, 7, 18, 30, tzinfo=UTC)
 UPPER_ENTITY_ID = "sensor.test_oven_upper_remaining_time"
 LOWER_ENTITY_ID = "sensor.test_oven_lower_remaining_time"
+
+
+@pytest.fixture
+def mock_thinq_mqtt_client() -> Generator[None]:
+    """Keep the oven entry loaded with an awaitable MQTT client factory."""
+    with patch(
+        "homeassistant.components.lg_thinq.mqtt.ThinQMQTTClient",
+        new_callable=AsyncMock,
+    ) as mqtt_client:
+        mqtt_client.return_value.async_prepare_mqtt.return_value = True
+        yield
 
 
 @pytest.fixture
@@ -190,3 +202,138 @@ async def test_missing_oven_data(
         await setup_integration(hass, mock_config_entry)
     assert hass.states.get(UPPER_ENTITY_ID).state == STATE_UNKNOWN
     assert hass.states.get(LOWER_ENTITY_ID).state == "2026-09-07T18:40:00+00:00"
+
+
+@pytest.mark.parametrize("inactive_status", ["INITIAL", "DONE", "COOLING"])
+@pytest.mark.parametrize("status", ["PREHEATING", "COOKING_IN_PROGRESS"])
+async def test_restart_oven_without_fresh_timer(
+    hass: HomeAssistant,
+    oven_coordinator: DeviceDataUpdateCoordinator,
+    freezer: FrozenDateTimeFactory,
+    status: str,
+    inactive_status: str,
+) -> None:
+    """A new cook must not reuse the previous cook's cached timer."""
+    oven_coordinator.handle_update_status(
+        [
+            {
+                "location": {"locationName": "UPPER"},
+                "runState": {"currentState": inactive_status},
+            }
+        ]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID).state == STATE_UNKNOWN
+    freezer.move_to(START + timedelta(seconds=1))
+    oven_coordinator.handle_update_status(
+        [{"location": {"locationName": "UPPER"}, "runState": {"currentState": status}}]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID).state == STATE_UNKNOWN
+    assert hass.states.get(LOWER_ENTITY_ID).state == "2026-09-07T18:40:00+00:00"
+
+    freezer.move_to(START + timedelta(seconds=2))
+    oven_coordinator.handle_update_status(
+        [{"location": {"locationName": "LOWER"}, "timer": {"remainMinute": 5}}]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID).state == STATE_UNKNOWN
+    assert hass.states.get(LOWER_ENTITY_ID).state == "2026-09-07T18:35:02+00:00"
+    oven_coordinator.refresh_status()
+    assert hass.states.get(UPPER_ENTITY_ID).state == STATE_UNKNOWN
+
+    freezer.move_to(START + timedelta(seconds=3))
+    oven_coordinator.handle_update_status(
+        [{"location": {"locationName": "UPPER"}, "timer": {"remainMinute": 10}}]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID).state == "2026-09-07T18:40:03+00:00"
+
+
+async def test_fresh_unchanged_timer_duration(
+    hass: HomeAssistant,
+    oven_coordinator: DeviceDataUpdateCoordinator,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A new report of the same duration can extend the active timer."""
+    freezer.move_to(START + timedelta(seconds=30))
+    oven_coordinator.handle_update_status(
+        [{"location": {"locationName": "UPPER"}, "timer": {"remainMinute": 10}}]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID).state == "2026-09-07T18:40:30+00:00"
+    assert hass.states.get(LOWER_ENTITY_ID).state == "2026-09-07T18:40:00+00:00"
+    freezer.move_to(START + timedelta(seconds=45))
+    oven_coordinator.refresh_status()
+    assert hass.states.get(UPPER_ENTITY_ID).state == "2026-09-07T18:40:30+00:00"
+
+
+async def test_timer_report_while_inactive(
+    hass: HomeAssistant,
+    oven_coordinator: DeviceDataUpdateCoordinator,
+) -> None:
+    """A timer received while inactive is not reused on a status-only start."""
+    oven_coordinator.handle_update_status(
+        [
+            {
+                "location": {"locationName": "UPPER"},
+                "runState": {"currentState": "DONE"},
+                "timer": {"remainMinute": 8},
+            }
+        ]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID).state == STATE_UNKNOWN
+    oven_coordinator.handle_update_status(
+        [
+            {
+                "location": {"locationName": "UPPER"},
+                "runState": {"currentState": "COOKING_IN_PROGRESS"},
+            }
+        ]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID).state == STATE_UNKNOWN
+
+
+async def test_full_oven_timer_refresh(
+    hass: HomeAssistant,
+    oven_coordinator: DeviceDataUpdateCoordinator,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A full status response can supply a new timer after an inactive state."""
+    oven_coordinator.handle_update_status(
+        [{"location": {"locationName": "UPPER"}, "runState": {"currentState": "DONE"}}]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID).state == STATE_UNKNOWN
+    freezer.move_to(START + timedelta(seconds=1))
+    await oven_coordinator.async_refresh()
+    assert hass.states.get(UPPER_ENTITY_ID).state == "2026-09-07T18:40:01+00:00"
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        pytest.param(None, id="no-response"),
+        pytest.param([], id="empty-response"),
+        pytest.param(
+            [{"location": {"locationName": "LOWER"}, "timer": {"remainMinute": 5}}],
+            id="other-cavity-only",
+        ),
+    ],
+)
+async def test_refresh_without_new_oven_timer(
+    hass: HomeAssistant,
+    oven_coordinator: DeviceDataUpdateCoordinator,
+    oven_api: AsyncMock,
+    response: list[dict[str, object]] | None,
+) -> None:
+    """An empty or partial refresh cannot make the previous timer fresh."""
+    oven_coordinator.handle_update_status(
+        [{"location": {"locationName": "UPPER"}, "runState": {"currentState": "DONE"}}]
+    )
+    oven_coordinator.handle_update_status(
+        [
+            {
+                "location": {"locationName": "UPPER"},
+                "runState": {"currentState": "COOKING_IN_PROGRESS"},
+            }
+        ]
+    )
+    assert hass.states.get(UPPER_ENTITY_ID).state == STATE_UNKNOWN
+    oven_api.async_get_device_status.return_value = response
+    await oven_coordinator.async_refresh()
+    assert hass.states.get(UPPER_ENTITY_ID).state == STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


I wanted to use my oven's cook timer in Home Assistant, but LG ThinQ only exposed the cooking status and temperature. The ThinQ SDK already provides the remaining cook time.

This adds a Remaining time timestamp sensor for each oven cavity that reports readable timer data. The sensor keeps its finish time stable during a normal countdown, follows timer adjustments, and clears when the timer is canceled or cooking ends. Updates from the other cavity do not extend a cached timer reading.

I tested the deployed custom override on my LG `LgTG4715ST.BSTELGA`, firmware `SAA39155903.00003483.0`, running Home Assistant Core 2026.9.1. I verified timer changes, cancellation, completion, and both cavities.

Validation: all 65 LG ThinQ tests pass, including 13 oven test cases. Ruff, Pylint, mypy, and formatting checks pass for the changed files. The tests use synthetic device data and cover sensor discovery, countdown stability, adjustments, cancellation, inactive/missing data, and independent cavities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
