### PR TITLE
Fix MCP client double initialize in config flow

### DIFF
--- a/homeassistant/components/mcp/config_flow.py
+++ b/homeassistant/components/mcp/config_flow.py
@@ -118,8 +118,15 @@ async def validate_input(
     except vol.Invalid as error:
         raise InvalidUrl from error
     try:
-        async with mcp_client(hass, url, token_manager=token_manager) as session:
-            response = await session.initialize()
+        async with mcp_client(hass, url, token_manager=token_manager) as (
+            _session,
+            response,
+        ):
+            if not response.capabilities.tools:
+                raise MissingCapabilities(
+                    f"MCP Server {url} does not support 'Tools' capability"
+                )
+            return {"title": response.serverInfo.name}
     except httpx.TimeoutException as error:
         _LOGGER.info("Timeout connecting to MCP server: %s", error)
         raise TimeoutConnectError from error
@@ -132,13 +139,6 @@ async def validate_input(
     except httpx.HTTPError as error:
         _LOGGER.info("Cannot connect to MCP server: %s", error)
         raise CannotConnect from error
-
-    if not response.capabilities.tools:
-        raise MissingCapabilities(
-            f"MCP Server {url} does not support 'Tools' capability"
-        )
-
-    return {"title": response.serverInfo.name}
 
 
 class ModelContextProtocolConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):

--- a/homeassistant/components/mcp/coordinator.py
+++ b/homeassistant/components/mcp/coordinator.py
@@ -12,6 +12,7 @@ from mcp import McpError
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
+from mcp.types import InitializeResult
 from probatio import from_openapi
 import voluptuous as vol
 
@@ -65,7 +66,7 @@ async def mcp_client(
     hass: HomeAssistant,
     url: str,
     token_manager: TokenManager | None = None,
-) -> AsyncGenerator[ClientSession]:
+) -> AsyncGenerator[tuple[ClientSession, InitializeResult]]:
     """Create an MCP client.
 
     This is an asynccontext manager that exists to wrap other async context managers
@@ -84,8 +85,8 @@ async def mcp_client(
             ) as (read_stream, write_stream, _),
             ClientSession(read_stream, write_stream) as session,
         ):
-            await session.initialize()
-            yield session
+            result = await session.initialize()
+            yield session, result
     except ExceptionGroup as streamable_err:
         main_error = streamable_err.exceptions[0]
         # Method not Allowed likely means this is not a streamable HTTP server,
@@ -109,8 +110,8 @@ async def mcp_client(
                     ) as streams,
                     ClientSession(*streams) as session,
                 ):
-                    await session.initialize()
-                    yield session
+                    result = await session.initialize()
+                    yield session, result
             except ExceptionGroup as sse_err:
                 _LOGGER.debug("Error creating SSE MCP client: %s", sse_err)
                 raise sse_err.exceptions[0] from sse_err
@@ -149,9 +150,10 @@ class ModelContextProtocolTool(llm.Tool):
         """Call the tool."""
         try:
             async with asyncio.timeout(TIMEOUT):
-                async with mcp_client(
-                    hass, self.server_url, self.token_manager
-                ) as session:
+                async with mcp_client(hass, self.server_url, self.token_manager) as (
+                    session,
+                    _,
+                ):
                     result = await session.call_tool(
                         tool_input.tool_name, tool_input.tool_args
                     )
@@ -219,7 +221,7 @@ class ModelContextProtocolCoordinator(DataUpdateCoordinator[list[llm.Tool]]):
             async with asyncio.timeout(TIMEOUT):
                 async with mcp_client(
                     self.hass, self.config_entry.data[CONF_URL], self.token_manager
-                ) as session:
+                ) as (session, _):
                     result = await session.list_tools()
         except TimeoutError as error:
             _LOGGER.debug("Timeout when listing tools: %s", error)

--- a/tests/components/mcp/test_config_flow.py
+++ b/tests/components/mcp/test_config_flow.py
@@ -5,8 +5,6 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import httpx
-from mcp import McpError
-from mcp.types import ErrorData
 import pytest
 import respx
 
@@ -130,40 +128,6 @@ async def test_form(
     assert result["result"].unique_id is None
 
     assert len(mock_setup_entry.mock_calls) == 1
-    mock_mcp_client.return_value.initialize.assert_called_once()
-
-
-async def test_initialize_called_once_in_config_flow(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_mcp_client: Mock
-) -> None:
-    """Test that initialize is called exactly once during the config flow.
-
-    Regression test for the double-initialize bug: MCP servers reject duplicate
-    initialize requests with -32600 "Invalid Request: Server already initialized".
-    """
-    response = Mock()
-    response.serverInfo.name = TEST_API_NAME
-
-    init_count = 0
-
-    async def mock_initialize() -> Mock:
-        nonlocal init_count
-        init_count += 1
-        if init_count > 1:
-            raise McpError(ErrorData(code=-32600, message="Server already initialized"))
-        return response
-
-    mock_mcp_client.return_value.initialize.side_effect = mock_initialize
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {CONF_URL: MCP_SERVER_URL},
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
     mock_mcp_client.return_value.initialize.assert_called_once()
 
 

--- a/tests/components/mcp/test_config_flow.py
+++ b/tests/components/mcp/test_config_flow.py
@@ -5,6 +5,8 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import httpx
+from mcp import McpError
+from mcp.types import ErrorData
 import pytest
 import respx
 
@@ -128,6 +130,41 @@ async def test_form(
     assert result["result"].unique_id is None
 
     assert len(mock_setup_entry.mock_calls) == 1
+    mock_mcp_client.return_value.initialize.assert_called_once()
+
+
+async def test_initialize_called_once_in_config_flow(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_mcp_client: Mock
+) -> None:
+    """Test that initialize is called exactly once during the config flow.
+
+    Regression test for the double-initialize bug: MCP servers reject duplicate
+    initialize requests with -32600 "Invalid Request: Server already initialized".
+    """
+    response = Mock()
+    response.serverInfo.name = TEST_API_NAME
+
+    init_count = 0
+
+    async def mock_initialize() -> Mock:
+        nonlocal init_count
+        init_count += 1
+        if init_count > 1:
+            raise McpError(ErrorData(code=-32600, message="Server already initialized"))
+        return response
+
+    mock_mcp_client.return_value.initialize.side_effect = mock_initialize
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_URL: MCP_SERVER_URL},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    mock_mcp_client.return_value.initialize.assert_called_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes an issue where the client invokes the MCP Server initialize twice.

Some MCP servers that are following the spec may raise an error since initialize is only supposed to be called once.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178287
- This PR is related to issue:
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
