### PR TITLE
Apply backup retention by days when a backup completes

### DIFF
--- a/homeassistant/components/backup/config.py
+++ b/homeassistant/components/backup/config.py
@@ -329,91 +329,7 @@ class RetentionConfig(BaseRetentionConfig):
             """Delete backups older than days."""
             self._schedule_next(manager)
 
-            def _delete_filter(
-                backups: dict[str, ManagerBackup],
-            ) -> dict[str, ManagerBackup]:
-                """Return backups older than days to delete."""
-                # we need to check here since we await before
-                # this filter is applied
-                agents_retention = {
-                    agent_id: agent_config.retention
-                    for agent_id, agent_config in manager.config.data.agents.items()
-                }
-                has_agents_retention = any(
-                    agent_retention for agent_retention in agents_retention.values()
-                )
-                has_agents_retention_days = any(
-                    agent_retention and agent_retention.days is not None
-                    for agent_retention in agents_retention.values()
-                )
-                if (global_days := self.days) is None and not has_agents_retention_days:
-                    # No global retention days and no agent retention days
-                    return {}
-
-                now = dt_util.utcnow()
-                if global_days is not None and not has_agents_retention:
-                    # Return early to avoid the longer filtering below.
-                    return {
-                        backup_id: backup
-                        for backup_id, backup in backups.items()
-                        if dt_util.parse_datetime(backup.date, raise_on_error=True)
-                        + timedelta(days=global_days)
-                        < now
-                    }
-
-                # If there are any agent retention settings, we need to check
-                # the retention settings, for every backup and agent combination.
-
-                backups_to_delete = {}
-
-                for backup_id, backup in backups.items():
-                    backup_date = dt_util.parse_datetime(
-                        backup.date, raise_on_error=True
-                    )
-                    delete_from_agents = set(backup.agents)
-                    for agent_id in backup.agents:
-                        agent_retention = agents_retention.get(agent_id)
-                        if agent_retention is None:
-                            # This agent does not have a retention setting,
-                            # so the global retention setting should be used.
-                            if global_days is None:
-                                # This agent does not have a retention setting
-                                # and the global retention days setting is None,
-                                # so this backup should not be deleted.
-                                delete_from_agents.discard(agent_id)
-                                continue
-                            days = global_days
-                        elif (agent_days := agent_retention.days) is None:
-                            # This agent has a retention setting
-                            # where days is set to None,
-                            # so the backup should not be deleted.
-                            delete_from_agents.discard(agent_id)
-                            continue
-                        else:
-                            # This agent has a retention setting
-                            # where days is set to a number,
-                            # so that setting should be used.
-                            days = agent_days
-                        if backup_date + timedelta(days=days) >= now:
-                            # This backup is not older than the retention days,
-                            # so this agent should not be deleted.
-                            delete_from_agents.discard(agent_id)
-
-                    filtered_backup = replace(
-                        backup,
-                        agents={
-                            agent_id: agent_backup_status
-                            for agent_id, agent_backup_status in backup.agents.items()
-                            if agent_id in delete_from_agents
-                        },
-                    )
-                    backups_to_delete[backup_id] = filtered_backup
-
-                return backups_to_delete
-
-            await manager.async_delete_filtered_backups(
-                include_filter=_automatic_backups_filter, delete_filter=_delete_filter
-            )
+            await delete_backups_older_than_configured_days(manager)
 
         manager.remove_next_delete_event = async_call_later(
             manager.hass, timedelta(days=1), _delete_backups
@@ -655,6 +571,102 @@ def _automatic_backups_filter(
         for backup_id, backup in backups.items()
         if backup.with_automatic_settings
     }
+
+
+async def delete_backups_older_than_configured_days(manager: BackupManager) -> None:
+    """Delete backups older than the configured retention days."""
+    if manager.config.data.retention.days is None and not any(
+        agent_config.retention and agent_config.retention.days is not None
+        for agent_config in manager.config.data.agents.values()
+    ):
+        # Nothing is configured to expire, so do not pay for listing the backups.
+        return
+
+    def _delete_filter(
+        backups: dict[str, ManagerBackup],
+    ) -> dict[str, ManagerBackup]:
+        """Return backups older than days to delete."""
+        # we need to check here since we await before
+        # this filter is applied
+        agents_retention = {
+            agent_id: agent_config.retention
+            for agent_id, agent_config in manager.config.data.agents.items()
+        }
+        has_agents_retention = any(
+            agent_retention for agent_retention in agents_retention.values()
+        )
+        has_agents_retention_days = any(
+            agent_retention and agent_retention.days is not None
+            for agent_retention in agents_retention.values()
+        )
+        if (
+            global_days := manager.config.data.retention.days
+        ) is None and not has_agents_retention_days:
+            # No global retention days and no agent retention days
+            return {}
+
+        now = dt_util.utcnow()
+        if global_days is not None and not has_agents_retention:
+            # Return early to avoid the longer filtering below.
+            return {
+                backup_id: backup
+                for backup_id, backup in backups.items()
+                if dt_util.parse_datetime(backup.date, raise_on_error=True)
+                + timedelta(days=global_days)
+                < now
+            }
+
+        # If there are any agent retention settings, we need to check
+        # the retention settings, for every backup and agent combination.
+
+        backups_to_delete = {}
+
+        for backup_id, backup in backups.items():
+            backup_date = dt_util.parse_datetime(backup.date, raise_on_error=True)
+            delete_from_agents = set(backup.agents)
+            for agent_id in backup.agents:
+                agent_retention = agents_retention.get(agent_id)
+                if agent_retention is None:
+                    # This agent does not have a retention setting,
+                    # so the global retention setting should be used.
+                    if global_days is None:
+                        # This agent does not have a retention setting
+                        # and the global retention days setting is None,
+                        # so this backup should not be deleted.
+                        delete_from_agents.discard(agent_id)
+                        continue
+                    days = global_days
+                elif (agent_days := agent_retention.days) is None:
+                    # This agent has a retention setting
+                    # where days is set to None,
+                    # so the backup should not be deleted.
+                    delete_from_agents.discard(agent_id)
+                    continue
+                else:
+                    # This agent has a retention setting
+                    # where days is set to a number,
+                    # so that setting should be used.
+                    days = agent_days
+                if backup_date + timedelta(days=days) >= now:
+                    # This backup is not older than the retention days,
+                    # so this agent should not be deleted.
+                    delete_from_agents.discard(agent_id)
+
+            filtered_backup = replace(
+                backup,
+                agents={
+                    agent_id: agent_backup_status
+                    for agent_id, agent_backup_status in backup.agents.items()
+                    if agent_id in delete_from_agents
+                },
+            )
+            backups_to_delete[backup_id] = filtered_backup
+
+        return backups_to_delete
+
+    await manager.async_delete_filtered_backups(
+        include_filter=_automatic_backups_filter, delete_filter=_delete_filter
+    )
 
 
 async def delete_backups_exceeding_configured_count(manager: BackupManager) -> None:

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -47,6 +47,7 @@ from .config import (
     CreateBackupParametersDict,
     check_unavailable_agents,
     delete_backups_exceeding_configured_count,
+    delete_backups_older_than_configured_days,
 )
 from .const import (
     BUF_SIZE,
@@ -1308,6 +1309,11 @@ class BackupManager:
                 )
             )
             await delete_backups_exceeding_configured_count(self)
+            # The scheduled delete only fires a day after the config is loaded,
+            # so an instance restarted more often than that never reaches it.
+            # Retention by days is applied here as well, the same way retention
+            # by copies already is.
+            await delete_backups_older_than_configured_days(self)
 
         finally:
             self._backup_task = None

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -4162,3 +4162,42 @@ async def test_upload_progress_debounced(
     ]
     assert len(remote_events) == 3
     assert remote_events[2].uploaded_bytes == remote_events[2].total_bytes
+
+
+async def test_retention_days_applied_after_backup(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    generate_backup_id: MagicMock,
+) -> None:
+    """Test retention by days is applied when a backup completes.
+
+    The scheduled delete only fires a day after the config is loaded, so an
+    instance that is restarted more often than that never reaches it and keeps
+    expired backups forever. Retention by copies has always been applied here.
+    """
+    # Both carry our instance id, so they count as automatic, and both are dated
+    # 1970, so any retention period has passed. The newest of the two is kept
+    # unconditionally, the way async_delete_filtered_backups always keeps one.
+    backup_1 = replace(TEST_BACKUP_ABC123, backup_id="backup1")
+    backup_2 = replace(TEST_BACKUP_ABC123, backup_id="backup2")
+    mock_agents = await setup_backup_integration(
+        hass,
+        remote_agents=["test.remote"],
+        backups={"test.remote": [backup_1, backup_2]},
+    )
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json_auto_id(
+        {"type": "backup/config/update", "retention": {"copies": None, "days": 1}}
+    )
+    assert (await ws_client.receive_json())["success"]
+
+    with patch("pathlib.Path.open", mock_open(read_data=b"test")):
+        await ws_client.send_json_auto_id(
+            {"type": "backup/generate", "agent_ids": ["test.remote"]}
+        )
+        assert (await ws_client.receive_json())["success"]
+        await hass.async_block_till_done()
+
+    # The clock never moved a day, so the scheduled delete has not fired.
+    assert mock_agents["test.remote"].async_delete_backup.call_count == 1


### PR DESCRIPTION
## Proposed change

Retention by days is only ever applied by a delete scheduled with `async_call_later(hass, timedelta(days=1))`. That counts from the moment the config is loaded and is not persisted, so an instance that restarts more often than once a day rearms the timer from zero every time and never reaches it. Backups then accumulate forever, which is what the issue reports for a machine that restarts nightly.

Retention by copies does not have this problem, because `delete_backups_exceeding_configured_count` is also called from the cleanup step of every backup. This applies retention by days from the same place, so the two behave alike. The scheduled delete is left as it is.

The filter moves out of the closure unchanged so both callers can use it, and the new function returns early when nothing is configured to expire, so it does not list the backups for installations that do not use it.

The added test asserts one of two expired backups is deleted right after a backup completes, without the clock ever moving a day. It fails without the change.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #181514
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
