### PR TITLE
Bound Tesla Fleet vehicle first refresh with a timeout

### DIFF
--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -1,5 +1,6 @@
 """Tesla Fleet integration."""
 
+import asyncio
 from typing import Final
 
 import jwt
@@ -34,6 +35,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import DOMAIN, LOGGER
 from .coordinator import (
+    VEHICLE_FIRST_REFRESH_TIMEOUT,
     TeslaFleetEnergySiteHistoryCoordinator,
     TeslaFleetEnergySiteInfoCoordinator,
     TeslaFleetEnergySiteLiveCoordinator,
@@ -159,7 +161,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
                 hass, entry, api_vehicle, product, Scope.VEHICLE_LOCATION in scopes
             )
 
-            await coordinator.async_config_entry_first_refresh()
+            # A sleeping vehicle can take minutes to answer vehicle_data; bound the
+            # first refresh so setup retries instead of stalling HA's bootstrap.
+            try:
+                async with asyncio.timeout(VEHICLE_FIRST_REFRESH_TIMEOUT):
+                    await coordinator.async_config_entry_first_refresh()
+            except TimeoutError as err:
+                raise ConfigEntryNotReady(
+                    f"Timed out waiting for vehicle {vin} to respond"
+                ) from err
 
             device = DeviceInfo(
                 identifiers={(DOMAIN, vin)},

--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -36,6 +36,11 @@ VEHICLE_WAIT_SECONDS = 900
 VEHICLE_WAIT = timedelta(seconds=VEHICLE_WAIT_SECONDS)
 VEHICLE_STUCK_SECONDS = 1200
 
+# Kept well under Home Assistant's stage-2 setup budget (SLOW_SETUP_MAX_WAIT, 300s)
+# so a sleeping vehicle raises ConfigEntryNotReady and the entry retries instead of
+# being cancelled into a non-retried setup error.
+VEHICLE_FIRST_REFRESH_TIMEOUT = 60
+
 ENERGY_INTERVAL_SECONDS = 60
 ENERGY_INTERVAL = timedelta(seconds=ENERGY_INTERVAL_SECONDS)
 ENERGY_HISTORY_INTERVAL = timedelta(minutes=5)

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -1,5 +1,6 @@
 """Test the Tesla Fleet init."""
 
+import asyncio
 from copy import deepcopy
 from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
@@ -94,6 +95,26 @@ async def test_init_error(
     mock_products.side_effect = side_effect
     await setup_platform(hass, normal_config_entry)
     assert normal_config_entry.state is state
+
+
+async def test_vehicle_first_refresh_timeout(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+    mock_vehicle_data: AsyncMock,
+) -> None:
+    """Test a slow first vehicle refresh retries instead of blocking setup."""
+    never = asyncio.Event()
+
+    async def _hang(*args: object, **kwargs: object) -> None:
+        await never.wait()
+
+    mock_vehicle_data.side_effect = _hang
+
+    with patch("homeassistant.components.tesla_fleet.VEHICLE_FIRST_REFRESH_TIMEOUT", 0):
+        await setup_platform(hass, normal_config_entry)
+
+    assert normal_config_entry.state is ConfigEntryState.SETUP_RETRY
+    never.set()
 
 
 async def test_oauth_refresh_expired(


### PR DESCRIPTION
## Breaking change


## Proposed change

While a vehicle is asleep, `vehicle_data()` can take several minutes to answer. The first
refresh in `async_setup_entry` was unbounded, so Home Assistant's 300 s stage-2 setup budget
would cancel the config entry into `setup_error` — a state that is never retried — leaving every
Tesla Fleet entity `unavailable` until the user reloaded the entry by hand.

This bounds the vehicle first refresh with `asyncio.timeout` and raises `ConfigEntryNotReady` on
timeout, so a slow cloud response lands the entry in `setup_retry` and it recovers on its own.
The bound (60 s) is kept well under the stage-2 budget so the entry retries rather than being
cancelled, with headroom for multiple vehicles.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #181487
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
