### PR TITLE
Bound Tessie energy site first refresh with a timeout

### DIFF
--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -32,6 +32,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import DOMAIN, MODELS
 from .coordinator import (
+    FIRST_REFRESH_TIMEOUT,
     TessieEnergyHistoryCoordinator,
     TessieEnergySiteInfoCoordinator,
     TessieEnergySiteLiveCoordinator,
@@ -194,23 +195,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
                     )
                 )
 
-        # Populate coordinator data before forwarding to platforms
-        await asyncio.gather(
-            *(
-                energysite.live_coordinator.async_config_entry_first_refresh()
-                for energysite in energysites
-                if energysite.live_coordinator is not None
-            ),
-            *(
-                energysite.info_coordinator.async_config_entry_first_refresh()
-                for energysite in energysites
-            ),
-            *(
-                energysite.history_coordinator.async_config_entry_first_refresh()
-                for energysite in energysites
-                if energysite.history_coordinator is not None
-            ),
-        )
+        # Populate coordinator data before forwarding to platforms. Bound the first
+        # refresh so a stalled energy site retries instead of blocking HA startup.
+        try:
+            async with asyncio.timeout(FIRST_REFRESH_TIMEOUT):
+                await asyncio.gather(
+                    *(
+                        energysite.live_coordinator.async_config_entry_first_refresh()
+                        for energysite in energysites
+                        if energysite.live_coordinator is not None
+                    ),
+                    *(
+                        energysite.info_coordinator.async_config_entry_first_refresh()
+                        for energysite in energysites
+                    ),
+                    *(
+                        energysite.history_coordinator.async_config_entry_first_refresh()
+                        for energysite in energysites
+                        if energysite.history_coordinator is not None
+                    ),
+                )
+        except TimeoutError as err:
+            raise ConfigEntryNotReady("Timed out waiting for energy site data") from err
 
     entry.runtime_data = TessieData(vehicles, energysites)
 

--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -26,6 +26,10 @@ TESSIE_SYNC_INTERVAL = 10
 TESSIE_FLEET_API_SYNC_INTERVAL = timedelta(seconds=30)
 TESSIE_ENERGY_HISTORY_INTERVAL = timedelta(seconds=60)
 
+# Kept well under HA's stage-2 setup budget (SLOW_SETUP_MAX_WAIT, 300s) so a stalled
+# first refresh raises ConfigEntryNotReady and retries instead of a non-retried setup error.
+FIRST_REFRESH_TIMEOUT = 60
+
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/tests/components/tessie/test_init.py
+++ b/tests/components/tessie/test_init.py
@@ -1,5 +1,6 @@
 """Test the Tessie init."""
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 from aiohttp import ClientConnectionError, ClientError
@@ -154,6 +155,25 @@ async def test_aiohttp_client_error_on_live_status_retries(
     ):
         entry = await setup_platform(hass)
     assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_energy_first_refresh_timeout(hass: HomeAssistant) -> None:
+    """Test a slow energy site first refresh retries instead of blocking setup."""
+    never = asyncio.Event()
+
+    async def _hang(*args: object, **kwargs: object) -> None:
+        await never.wait()
+
+    # site_info() is only awaited by the info coordinator's first refresh, so setup
+    # reaches the bounded gather instead of hanging on the inline live_status() call.
+    with (
+        patch("tesla_fleet_api.tessie.EnergySite.site_info", side_effect=_hang),
+        patch("homeassistant.components.tessie.FIRST_REFRESH_TIMEOUT", 0),
+    ):
+        entry = await setup_platform(hass)
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    never.set()
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")


### PR DESCRIPTION
## Breaking change


## Proposed change

The energy site coordinator first refreshes in `async_setup_entry` were unbounded. If one
stalled, Home Assistant's 300 s stage-2 setup budget would cancel the config entry into
`setup_error` — a state that is never retried — leaving every Tessie entity `unavailable` until
the user reloaded the entry by hand.

This bounds those first refreshes with `asyncio.timeout` and raises `ConfigEntryNotReady` on
timeout, so a slow cloud response lands the entry in `setup_retry` and it recovers on its own.
The bound (60 s) is kept well under the stage-2 budget so the entry retries rather than being
cancelled.

Unlike Tesla Fleet, Tessie has no vehicle first refresh during setup — vehicle coordinators are
seeded directly from `list_vehicles`' cached state — so only the energy site coordinators are
bounded here.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
