### PR TITLE
Bump ZHA to 2.2.2, zha-quirks to 2.2.2

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==2.2.1", "zha-quirks==2.2.1"],
+  "requirements": ["zha==2.2.2", "zha-quirks==2.2.2"],
   "usb": [
     {
       "description": "*2652*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3540,10 +3540,10 @@ zeroconf==0.151.3
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha-quirks==2.2.1
+zha-quirks==2.2.2
 
 # homeassistant.components.zha
-zha==2.2.1
+zha==2.2.2
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.19


### PR DESCRIPTION
## Proposed change

This PR bumps the following libraries that need to be bumped together for the bugfix to take effect:

- ZHA [2.2.2](https://github.com/zigpy/zha/releases/tag/2.2.2)
  full diff: https://github.com/zigpy/zha/compare/2.2.1...2.2.2
- zha-quirks [2.2.2](https://github.com/zigpy/zha-device-handlers/releases/tag/2.2.2)
  full diff: https://github.com/zigpy/zha-device-handlers/compare/2.2.1...2.2.2

This dependency upgrade is bundled with it: 
- `zigpy` [2.2.0](https://github.com/zigpy/zigpy/releases/tag/2.2.0)
  full diff: https://github.com/zigpy/zigpy/compare/2.1.0...2.2.0

### Changes in these releases

Relevant changes in these releases for HA Core:
- An issue is fixed where the Tuya spell to unlock full device functionality had its last read split into a separate request (thanks @abmantis!)

Note about other zigpy changes (irrelevant for HA Core):
- The new zigpy version includes some more changes that are currently not used in the ZHA libraries nor HA Core, so it is safe to have them included.


## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
