### PR TITLE
Add Remote Now Playing session support

### DIFF
--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -50,6 +50,8 @@ from .const import (
     DATA_LIVE_ACTIVITY_TOKENS,
     DATA_PENDING_UPDATES,
     DATA_PUSH_CHANNEL,
+    DATA_REMOTE_MEDIA_MANAGER,
+    DATA_REMOTE_MEDIA_SESSIONS,
     DATA_STORE,
     DOMAIN,
     SENSOR_TYPES,
@@ -60,6 +62,12 @@ from .const import (
 from .helpers import async_is_local_only_user, savable_state
 from .http_api import RegistrationsView
 from .live_activity.store import async_cleanup_expired_live_activity_tokens
+from .remote_media import (
+    async_registration_updated as async_remote_media_registration_updated,
+    async_remove_entry as async_remote_media_remove_entry,
+    async_setup_entry as async_remote_media_setup_entry,
+    async_unload_entry as async_remote_media_unload_entry,
+)
 from .timers import async_handle_timer_event
 from .util import async_create_cloud_hook, supports_push
 from .webhook import handle_webhook
@@ -82,7 +90,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if (app_config := await store.async_load()) is None or not isinstance(
         app_config, dict
     ):
-        app_config = {DATA_DELETED_IDS: [], DATA_LIVE_ACTIVITY_TOKENS: {}}
+        app_config = {
+            DATA_DELETED_IDS: [],
+            DATA_LIVE_ACTIVITY_TOKENS: {},
+            DATA_REMOTE_MEDIA_SESSIONS: {},
+        }
 
     hass.data[DOMAIN] = {
         DATA_CONFIG_ENTRIES: {},
@@ -90,6 +102,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         DATA_DEVICES: {},
         DATA_LIVE_ACTIVITY_TOKENS: app_config[DATA_LIVE_ACTIVITY_TOKENS],
         DATA_LIVE_ACTIVITY_CLEANUP_CANCEL: None,
+        DATA_REMOTE_MEDIA_SESSIONS: app_config.get(DATA_REMOTE_MEDIA_SESSIONS, {}),
+        DATA_REMOTE_MEDIA_MANAGER: None,
         DATA_PUSH_CHANNEL: {},
         DATA_STORE: store,
         DATA_PENDING_UPDATES: {sensor_type: {} for sensor_type in SENSOR_TYPES},
@@ -228,9 +242,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         )
 
+    # Resume any Follow relationships this registration had, now that its push configuration is
+    # available. Done per entry so a stored session is never mistaken for an orphan just because
+    # config entries have not been set up yet.
+    async_remote_media_setup_entry(hass, entry)
+
+    # `update_registration` is where an install that had no push configuration gains one, and a
+    # Follow relationship stored without one is waiting for exactly that. This does not reload the
+    # entry; it only lets the relationship start being watched.
+    entry.async_on_unload(entry.add_update_listener(_async_registration_updated))
+
     await hass_notify.async_reload(hass, DOMAIN)
 
     return True
+
+
+async def _async_registration_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """React to a registration's own data changing."""
+    async_remote_media_registration_updated(hass, entry)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -240,6 +269,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False
 
     webhook_id = entry.data[CONF_WEBHOOK_ID]
+
+    # A reload is not the user stopping following: detach the listeners and keep the sessions.
+    async_remote_media_unload_entry(hass, entry)
 
     webhook_unregister(hass, webhook_id)
     del hass.data[DOMAIN][DATA_CONFIG_ENTRIES][webhook_id]
@@ -254,6 +286,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     webhook_id = entry.data[CONF_WEBHOOK_ID]
     hass.data[DOMAIN][DATA_DELETED_IDS].append(webhook_id)
     hass.data[DOMAIN][DATA_LIVE_ACTIVITY_TOKENS].pop(webhook_id, None)
+    async_remote_media_remove_entry(hass, entry)
     store = hass.data[DOMAIN][DATA_STORE]
     await store.async_save(savable_state(hass))
 
@@ -275,4 +308,6 @@ class _MobileAppStore(Store[dict[str, Any]]):
         """Migrate mobile_app storage to the current version."""
         if old_major_version == 1 and old_minor_version < 2:
             old_data.setdefault(DATA_LIVE_ACTIVITY_TOKENS, {})
+        if old_major_version == 1 and old_minor_version < 3:
+            old_data.setdefault(DATA_REMOTE_MEDIA_SESSIONS, {})
         return old_data

--- a/homeassistant/components/mobile_app/const.py
+++ b/homeassistant/components/mobile_app/const.py
@@ -8,7 +8,7 @@ DOMAIN = "mobile_app"
 
 STORAGE_KEY = DOMAIN
 STORAGE_VERSION = 1
-STORAGE_VERSION_MINOR = 2
+STORAGE_VERSION_MINOR = 3
 STORAGE_SAVE_DELAY_SECONDS = 10
 
 CONF_CLOUDHOOK_URL = "cloudhook_url"
@@ -22,6 +22,11 @@ DATA_DEVICES = "devices"
 
 DATA_LIVE_ACTIVITY_TOKENS = "live_activity_tokens"
 DATA_LIVE_ACTIVITY_CLEANUP_CANCEL = "live_activity_cleanup_cancel"
+
+# Persisted Remote Now Playing sessions, keyed by the webhook id that registered them.
+DATA_REMOTE_MEDIA_SESSIONS = "remote_media_sessions"
+# The runtime manager holding their state listeners. Never persisted.
+DATA_REMOTE_MEDIA_MANAGER = "remote_media_manager"
 DATA_STORE = "store"
 DATA_NOTIFY = "notify"
 DATA_PUSH_CHANNEL = "push_channel"

--- a/homeassistant/components/mobile_app/helpers.py
+++ b/homeassistant/components/mobile_app/helpers.py
@@ -33,6 +33,7 @@ from .const import (
     CONF_USER_ID,
     DATA_DELETED_IDS,
     DATA_LIVE_ACTIVITY_TOKENS,
+    DATA_REMOTE_MEDIA_SESSIONS,
     DOMAIN,
 )
 
@@ -176,6 +177,7 @@ def savable_state(hass: HomeAssistant) -> dict:
     return {
         DATA_DELETED_IDS: domain_data[DATA_DELETED_IDS],
         DATA_LIVE_ACTIVITY_TOKENS: domain_data[DATA_LIVE_ACTIVITY_TOKENS],
+        DATA_REMOTE_MEDIA_SESSIONS: domain_data[DATA_REMOTE_MEDIA_SESSIONS],
     }
 
 

--- a/homeassistant/components/mobile_app/remote_media/__init__.py
+++ b/homeassistant/components/mobile_app/remote_media/__init__.py
@@ -1,0 +1,71 @@
+"""Remote Now Playing: keep an iOS Now Playing card current without the app running.
+
+The Home Assistant app can follow one `media_player`, and iOS 27 gives each followed session its
+own APNs update token. This package stores those tokens, watches the players they belong to, and
+pushes meaningful changes through the registration's existing push URL.
+"""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_WEBHOOK_ID
+from homeassistant.core import HomeAssistant, callback
+
+# Imported so the webhook command registrations in the submodule run on import.
+from . import webhook  # noqa: F401
+from .manager import async_get_manager
+from .store import async_load_sessions, async_remove_registration
+
+__all__ = [
+    "async_registration_updated",
+    "async_remove_entry",
+    "async_remove_registration",
+    "async_setup_entry",
+    "async_unload_entry",
+]
+
+
+@callback
+def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Resume this registration's Follow relationships.
+
+    Per config entry rather than at integration startup, so a stored session is never mistaken for
+    an orphan just because entries have not been set up yet.
+    """
+    sessions = async_load_sessions(hass, entry.data[CONF_WEBHOOK_ID])
+    if not sessions:
+        return
+    async_get_manager(hass).async_restore(entry, sessions)
+
+
+@callback
+def async_registration_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Pick up relationships this registration can be pushed to now.
+
+    `update_registration` is where an install that had no push configuration gains one. Nothing new
+    is followed: only sessions already stored for this registration.
+    """
+    async_get_manager(hass).async_registration_updated(entry)
+
+
+@callback
+def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Detach this registration's listeners, keeping the relationships themselves.
+
+    A reload or a shutdown is not the user stopping following, so nothing is removed and no `end`
+    is sent.
+    """
+    async_get_manager(hass).async_unload_registration(entry.data[CONF_WEBHOOK_ID])
+
+
+@callback
+def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Forget this registration's Follow relationships for good.
+
+    Telling the phone is best effort: a relay outage must not hold up deleting a config entry.
+    """
+    webhook_id = entry.data[CONF_WEBHOOK_ID]
+    manager = async_get_manager(hass)
+    # The entry is passed in because Home Assistant unloads a config entry before removing one, so
+    # it is no longer in `DATA_CONFIG_ENTRIES` to look its push configuration up in.
+    manager.async_end_registration(entry)
+    manager.async_unload_registration(webhook_id)
+    async_remove_registration(hass, webhook_id)

--- a/homeassistant/components/mobile_app/remote_media/const.py
+++ b/homeassistant/components/mobile_app/remote_media/const.py
@@ -1,0 +1,115 @@
+"""Constants for Remote Now Playing.
+
+The wire keys here are one half of a cross-repository protocol: the Home Assistant iOS app decodes
+them with `RemoteMediaSessionAttributes`, so every name and casing below is copied from the Swift
+`CodingKeys` rather than chosen. See `tests/components/mobile_app/remote_media/test_mapper.py`,
+which asserts the encoded shape against that contract.
+"""
+
+# Webhook commands the iOS app calls. Named in `RemoteMediaSessionRegistration` and
+# `RemoteMediaSessionDismissal` on the client side.
+WEBHOOK_TYPE_TOKEN = "remote_media_session_token"
+WEBHOOK_TYPE_DISMISSED = "remote_media_session_dismissed"
+
+# Webhook payload keys, from the Swift `CodingKeys` of those two types.
+# `entity_id` is `homeassistant.const.ATTR_ENTITY_ID`, imported where it is used.
+ATTR_SESSION_ID = "session_id"
+ATTR_GENERATION = "generation"
+ATTR_GENERATION_SEQUENCE = "generation_sequence"
+ATTR_SERVER_ID_KEY = "server_id"
+ATTR_PUSH_TOKEN = "push_token"
+ATTR_SCHEMA_VERSION = "schema_version"
+
+# The only schema the iOS app emits (`RemoteMediaSessionRegistration.currentSchemaVersion`).
+SUPPORTED_SCHEMA_VERSIONS = frozenset({1})
+
+# Bounds for the values a client may send. A session identifier and a generation are short
+# machine-generated strings, and the update token was 80 bytes on the platform it was measured on;
+# the ceilings are generous multiples so a future change does not need a Core release.
+MAX_SESSION_ID_LENGTH = 512
+MAX_GENERATION_LENGTH = 128
+MAX_SERVER_ID_LENGTH = 128
+MAX_PUSH_TOKEN_LENGTH = 512
+
+# The largest Follow sequence that survives the trip back to the device. The push relay is a Node
+# process, so a JSON number there is a double: a larger value would reach the phone rounded, and
+# two relationships that round to the same value would be indistinguishable. Matches Swift
+# `RemoteMediaFollowLifetime.maximumSequence`.
+MAX_GENERATION_SEQUENCE = 9_007_199_254_740_991
+
+# Relay request keys, from the committed `functions/now-playing.js` contract.
+ATTR_NOW_PLAYING = "now_playing"
+ATTR_NOW_PLAYING_TOKEN = "now_playing_token"
+ATTR_EVENT = "event"
+ATTR_TIMESTAMP = "timestamp"
+ATTR_ATTRIBUTES = "attributes"
+ATTR_REGISTRATION_INFO = "registration_info"
+
+EVENT_UPDATE = "update"
+EVENT_END = "end"
+
+# Attributes keys, from Swift `RemoteMediaSessionAttributes.CodingKeys`. camelCase here and
+# snake_case on the webhook, deliberately: this side is Swift `Codable`, that side is the
+# `mobile_app` payload convention. `id` and `state` are `homeassistant.const`'s.
+ATTR_SNAPSHOT = "snapshot"
+ATTR_WIRE_GENERATION_SEQUENCE = "generationSequence"
+
+# Snapshot keys, from Swift `RemoteMediaSnapshot.CodingKeys`. camelCase, deliberately.
+ATTR_SELECTION = "selection"
+ATTR_SERVER_ID = "serverId"
+ATTR_WIRE_ENTITY_ID = "entityId"
+ATTR_DEVICE_NAME = "deviceName"
+ATTR_DEVICE_CLASS = "deviceClass"
+ATTR_TITLE = "title"
+ATTR_ARTIST = "artist"
+ATTR_ALBUM = "album"
+ATTR_CONTENT_ID = "contentId"
+ATTR_DURATION = "duration"
+ATTR_POSITION = "position"
+ATTR_POSITION_UPDATED_AT_UNIX = "positionUpdatedAtUnix"
+ATTR_ARTWORK = "artwork"
+# The key inside `artwork`. Matches Swift `RemoteMediaArtworkDescriptor.CodingKeys.url`.
+ATTR_ARTWORK_URL = "url"
+ATTR_VOLUME = "volume"
+ATTR_IS_MUTED = "isMuted"
+ATTR_FEATURES = "features"
+
+# How long several state events are allowed to settle into one push. Integrations emit sequences
+# like `playing A` -> `idle` (blank) -> `playing B` within milliseconds, and the card should learn
+# the outcome rather than each contradictory step.
+COALESCE_SECONDS = 0.2
+
+# How far a reported position may differ from where ordinary playback would have reached before it
+# counts as a seek rather than as progress. Generous enough to absorb integration rounding and
+# clock skew, tight enough to catch the usual 10, 15 and 30 second skips.
+SEEK_TOLERANCE_SECONDS = 3.0
+
+# Smallest volume movement worth a push, on the 0..1 scale the wire uses.
+VOLUME_CHANGE_THRESHOLD = 0.02
+
+# How long to stay quiet after the relay reports a condition that will not change on its own: a
+# deployment that does not serve this app, a credential fault, an oversized payload. Without this
+# every state change of a playing media player would log the same failure.
+CONFIGURATION_BACKOFF_SECONDS = 3600
+
+# How long to stay quiet after being told to slow down.
+RATE_LIMIT_BACKOFF_SECONDS = 900
+
+# Relay `errorType` values, from `functions/now-playing.js` and `functions/handlers.js`.
+ERROR_INVALID_TOKEN = "InvalidToken"
+ERROR_UNSUPPORTED_APP = "UnsupportedApp"
+ERROR_TOPIC_MISMATCH = "TopicMismatch"
+ERROR_PROVIDER_AUTH = "ProviderAuth"
+ERROR_PAYLOAD_TOO_LARGE = "PayloadTooLarge"
+ERROR_RATE_LIMITED = "RateLimited"
+ERROR_APNS_RATE_LIMITED = "ApnsRateLimited"
+ERROR_APNS_UNAVAILABLE = "ApnsUnavailable"
+ERROR_NOT_CONFIGURED = "NowPlayingNotConfigured"
+
+# How long to wait before offering an undelivered update again, doubling up to the maximum while it
+# keeps failing. A retry of one specific update rather than a poll: armed only while a snapshot is
+# owed, and stopped as soon as one is delivered or superseded. It exists because "the next state
+# change will carry it" is not true of an integration that emits an event only when something
+# changes — there, a track change that failed to send waits until the user touches the speaker.
+RETRY_BACKOFF_SECONDS = 30
+MAXIMUM_RETRY_BACKOFF_SECONDS = 900

--- a/homeassistant/components/mobile_app/remote_media/manager.py
+++ b/homeassistant/components/mobile_app/remote_media/manager.py
@@ -1,0 +1,869 @@
+"""Watch followed players and push only what matters.
+
+Core is the primary traffic shaper for Remote Now Playing. The relay has a safety ceiling, but a
+playing media player emits a state event every few seconds and almost none of them are worth
+waking a phone for: the card advances its own position from `position` and
+`positionUpdatedAtUnix`, so ordinary progress needs no push at all.
+
+Three mechanisms, in order:
+
+* the reducer keeps a meaningful picture across the noise integrations emit,
+* a short coalescing window collapses a burst of contradictory events into its outcome,
+* a change test decides whether the outcome differs from what the card already shows.
+"""
+
+from dataclasses import replace
+import logging
+import time
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ID
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    Event,
+    EventStateChangedData,
+    HomeAssistant,
+    callback,
+)
+from homeassistant.helpers.entity_registry import EventEntityRegistryUpdatedData
+from homeassistant.helpers.event import (
+    async_call_later,
+    async_track_entity_registry_updated_event,
+    async_track_state_change_event,
+)
+
+from ..const import (
+    ATTR_APP_DATA,
+    ATTR_PUSH_TOKEN,
+    ATTR_PUSH_URL,
+    ATTR_WEBHOOK_ID,
+    DATA_CONFIG_ENTRIES,
+    DATA_REMOTE_MEDIA_MANAGER,
+    DOMAIN,
+)
+from .const import (
+    ATTR_GENERATION,
+    ATTR_SNAPSHOT,
+    ATTR_WIRE_GENERATION_SEQUENCE,
+    COALESCE_SECONDS,
+    CONFIGURATION_BACKOFF_SECONDS,
+    EVENT_END,
+    EVENT_UPDATE,
+    MAXIMUM_RETRY_BACKOFF_SECONDS,
+    RATE_LIMIT_BACKOFF_SECONDS,
+    RETRY_BACKOFF_SECONDS,
+    SEEK_TOLERANCE_SECONDS,
+    VOLUME_CHANGE_THRESHOLD,
+)
+from .mapper import snapshot_from_state
+from .model import RemoteMediaSession, RemoteMediaSnapshot
+from .push import PushOutcome, async_send
+from .reducer import reduce_snapshot
+from .store import async_load_sessions, async_remove_session, async_save_session
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def is_meaningful_change(
+    published: RemoteMediaSnapshot | None, candidate: RemoteMediaSnapshot
+) -> bool:
+    """Whether `candidate` differs from what the card already shows in a way worth a push.
+
+    The expensive mistake here is pushing ordinary progress. A playing track reports a new
+    `media_position` and `media_position_updated_at` every few seconds, and the card is already
+    extrapolating between them, so those updates carry no information. A seek does — and it is
+    told apart by comparing the reported position against where playback would have reached.
+    """
+    if published is None:
+        return True
+    # The card issues its commands against the selection it was given, so a player that has been
+    # renamed has to be sent even when nothing about the media changed.
+    if published.entity_id != candidate.entity_id:
+        return True
+    if published.server_id != candidate.server_id:
+        return True
+    if published.track_id != candidate.track_id:
+        return True
+    # The same track can change its cover — a station updating its art, or an integration that
+    # reports the picture a moment after the metadata.
+    if published.artwork_url != candidate.artwork_url:
+        return True
+    if published.playback != candidate.playback:
+        return True
+    if published.features != candidate.features:
+        return True
+    if published.duration != candidate.duration:
+        return True
+    if published.device_name != candidate.device_name:
+        return True
+    if published.device_class != candidate.device_class:
+        return True
+    if published.is_muted != candidate.is_muted:
+        return True
+    if _volume_moved(published.volume, candidate.volume):
+        return True
+    return _position_jumped(published, candidate)
+
+
+def _volume_moved(previous: float | None, current: float | None) -> bool:
+    """Whether the volume changed enough to matter."""
+    if previous is None or current is None:
+        return previous is not current
+    return abs(previous - current) >= VOLUME_CHANGE_THRESHOLD
+
+
+def _position_jumped(
+    published: RemoteMediaSnapshot, candidate: RemoteMediaSnapshot
+) -> bool:
+    """Whether the position moved somewhere playback would not have taken it.
+
+    While playing, the position expected now is the last one plus the time since it was measured.
+    A report inside `SEEK_TOLERANCE_SECONDS` of that is progress and is ignored; further away is a
+    seek and is worth a push. While not playing, any real movement is a seek.
+    """
+    if candidate.position is None:
+        # Losing a position is only interesting if we had one to lose.
+        return published.position is not None
+    if published.position is None:
+        return True
+
+    elapsed = 0.0
+    if published.playback == "playing":
+        if (
+            published.position_updated_at_unix is not None
+            and candidate.position_updated_at_unix is not None
+        ):
+            elapsed = max(
+                0.0,
+                candidate.position_updated_at_unix - published.position_updated_at_unix,
+            )
+        else:
+            # No timestamps to reason with: treat progress as unknowable rather than as a seek.
+            return False
+
+    expected = published.position + elapsed
+    return abs(candidate.position - expected) > SEEK_TOLERANCE_SECONDS
+
+
+def _with_entity_id(
+    snapshot: RemoteMediaSnapshot | None, entity_id: str
+) -> RemoteMediaSnapshot | None:
+    """Return `snapshot` describing `entity_id`, or None if there was no snapshot."""
+    if snapshot is None or snapshot.entity_id == entity_id:
+        return snapshot
+    return replace(snapshot, entity_id=entity_id)
+
+
+@callback
+def can_cloud_push(entry: ConfigEntry) -> bool:
+    """Whether this registration can be reached through the push relay at all.
+
+    A registration without a push URL and token is local-push only. Following a player for it would
+    mean shaping traffic forever to produce requests that can never be sent.
+    """
+    app_data = entry.data.get(ATTR_APP_DATA, {})
+    return bool(app_data.get(ATTR_PUSH_URL)) and bool(app_data.get(ATTR_PUSH_TOKEN))
+
+
+class RemoteMediaSessionPublisher:
+    """One Follow relationship: its sticky state, its clock, and its single sender.
+
+    Sends are serialised: a burst produces one request in flight and, when it finishes, one more
+    carrying the newest desired state, never a queue of stale ones.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        webhook_id: str,
+        session: RemoteMediaSession,
+    ) -> None:
+        """Set up a publisher for a stored session."""
+        self.hass = hass
+        self.webhook_id = webhook_id
+        self.session = session
+        # What the card is believed to show, and what we would like it to show.
+        self._effective: RemoteMediaSnapshot | None = session.last_snapshot
+        self._published: RemoteMediaSnapshot | None = session.last_snapshot
+        self._pending: RemoteMediaSnapshot | None = None
+        # The newest snapshot waiting to go out. Replaced rather than queued, so a burst of
+        # changes can never become a backlog of stale requests.
+        self._desired: RemoteMediaSnapshot | None = None
+        self._in_flight: RemoteMediaSnapshot | None = None
+        self._cancel_coalesce: CALLBACK_TYPE | None = None
+        # Armed only while an update is actually owed. See `RETRY_BACKOFF_SECONDS`.
+        self._cancel_retry: CALLBACK_TYPE | None = None
+        self._retry_delay = RETRY_BACKOFF_SECONDS
+        self._sending = False
+        self._quiet_until = 0.0
+        self._reported_misconfiguration: str | None = None
+        self._removed = False
+
+    @property
+    def entity_id(self) -> str:
+        """The followed player."""
+        return self.session.entity_id
+
+    @callback
+    def async_shutdown(self) -> None:
+        """Retire the publisher and drop timers so nothing fires after it is gone."""
+        self._removed = True
+        if self._cancel_coalesce is not None:
+            self._cancel_coalesce()
+            self._cancel_coalesce = None
+        if self._cancel_retry is not None:
+            self._cancel_retry()
+            self._cancel_retry = None
+
+    @callback
+    def async_rename_entity(self, entity_id: str) -> None:
+        """Point this relationship at the same player under a new entity id.
+
+        Nothing the phone identifies the session by changes, and neither does the sticky picture of
+        what is playing.
+        """
+        self.session.entity_id = entity_id
+        self._effective = _with_entity_id(self._effective, entity_id)
+        self._pending = _with_entity_id(self._pending, entity_id)
+        self._desired = _with_entity_id(self._desired, entity_id)
+        # `_published` keeps the old name: it records what the phone was last told, and that
+        # difference is what makes the rename a change worth pushing.
+
+    @callback
+    def async_apply(self, snapshot: RemoteMediaSnapshot | None) -> None:
+        """Fold one report into the effective state and consider publishing it.
+
+        Every report is reduced, because that is how the sticky picture accumulates; only the
+        outcome of a settling window is considered for a push.
+        """
+        if self._removed or snapshot is None:
+            return
+
+        reduced = reduce_snapshot(self._effective, snapshot)
+        if reduced is None:
+            # Nothing meaningful has ever been seen for this player. Stay registered and wait.
+            return
+        self._effective = reduced
+        self._pending = reduced
+
+        if self._cancel_coalesce is None:
+            self._cancel_coalesce = async_call_later(
+                self.hass, COALESCE_SECONDS, self._async_coalesced
+            )
+
+    @callback
+    def _async_coalesced(self, _now: Any) -> None:
+        """Publish the settled outcome of a burst, if it says anything new."""
+        self._cancel_coalesce = None
+        pending = self._pending
+        self._pending = None
+        if pending is None or self._removed:
+            return
+        if not is_meaningful_change(self._published, pending):
+            if self._in_flight is not None:
+                # The phone may still receive the older in-flight snapshot. Keep the settled
+                # state as a supersession marker until that result is known.
+                self._desired = pending
+            else:
+                self._desired = None
+                if self._cancel_retry is not None:
+                    self._cancel_retry()
+                    self._cancel_retry = None
+            return
+        self.async_publish(pending)
+
+    @callback
+    def async_publish(self, snapshot: RemoteMediaSnapshot) -> None:
+        """Queue a snapshot for delivery, coalescing with anything already in flight."""
+        if self._removed:
+            return
+        self._desired = snapshot
+        if self._sending:
+            # The in-flight send picks up whatever is newest when it finishes.
+            return
+        self.hass.async_create_task(
+            self._async_drain(), name=f"remote_media publish {self.session.session_id}"
+        )
+
+    async def _async_drain(self) -> None:
+        """Send the newest desired snapshot until nothing newer is waiting.
+
+        What is owed stays in `_desired` until it has been delivered. An update the relay refused,
+        or one held back by a quiet period, is still the current state of the player, so it is
+        offered again rather than discarded in the hope the player says something else soon.
+        """
+        if self._sending:
+            return
+        self._sending = True
+        try:
+            while not self._removed:
+                snapshot = self._desired
+                if snapshot is None:
+                    return
+                if (quiet_for := self._quiet_until - time.time()) > 0:
+                    # Still owed, so it is left in place and offered again when the quiet period
+                    # ends rather than waiting on a state change that may never come.
+                    self._async_schedule_retry(quiet_for)
+                    return
+                self._desired = None
+                self._in_flight = snapshot
+                try:
+                    outcome = await self._async_send(EVENT_UPDATE, snapshot)
+                except Exception:
+                    # The send itself came apart. The snapshot is no less current for it, so it
+                    # is treated exactly like a refusal rather than vanishing with the traceback.
+                    _LOGGER.exception(
+                        "Could not send a Remote Now Playing update for %s",
+                        self.entity_id,
+                    )
+                    outcome = None
+                finally:
+                    self._in_flight = None
+                if outcome is PushOutcome.DELIVERED:
+                    if self._desired is not None and not is_meaningful_change(
+                        self._published, self._desired
+                    ):
+                        self._desired = None
+                    continue
+                if self._removed:
+                    return
+                if self._desired is None:
+                    # Nothing newer arrived while that was failing, so this is still what the
+                    # phone is missing. Anything newer is already in `_desired` and supersedes it.
+                    self._desired = snapshot
+                if not is_meaningful_change(self._published, self._desired):
+                    self._desired = None
+                    return
+                # Never before a quiet period is over, or the timer is spent on a send that is
+                # only going to be held back again.
+                self._async_schedule_retry(
+                    max(self._retry_delay, self._quiet_until - time.time())
+                )
+                self._retry_delay = min(
+                    self._retry_delay * 2, MAXIMUM_RETRY_BACKOFF_SECONDS
+                )
+                return
+        finally:
+            self._sending = False
+
+    @callback
+    def _async_schedule_retry(self, delay: float) -> None:
+        """Offer the outstanding update again after `delay`.
+
+        One timer at a time, and only while something is owed: re-arming on every failure would
+        stack timers, and arming with nothing outstanding would be a poll.
+        """
+        if self._removed or self._cancel_retry is not None:
+            return
+        self._cancel_retry = async_call_later(
+            self.hass, max(delay, 0.0), self._async_retry
+        )
+
+    @callback
+    def _async_retry(self, _now: Any) -> None:
+        """Put the outstanding update back through the ordinary send path."""
+        self._cancel_retry = None
+        if self._removed or (snapshot := self._desired) is None:
+            return
+        self.async_publish(snapshot)
+
+    async def async_send_end(self, entry: ConfigEntry | None = None) -> None:
+        """Tell the card its session is over. Best effort: cleanup never depends on this.
+
+        `entry` is passed in when the registration is being removed, because unloading has already
+        taken it out of `DATA_CONFIG_ENTRIES` by then.
+        """
+        if (snapshot := self._effective) is None:
+            snapshot = self._published
+        await self._async_send(EVENT_END, snapshot, mark_published=False, entry=entry)
+
+    async def _async_send(
+        self,
+        event: str,
+        snapshot: RemoteMediaSnapshot | None,
+        *,
+        mark_published: bool = True,
+        entry: ConfigEntry | None = None,
+    ) -> PushOutcome | None:
+        """Build attributes, send them, and act on the answer.
+
+        Returns what the relay said, so the caller can tell an update that landed from one that is
+        still owed. `None` means there was no registration to send through at all.
+        """
+        if mark_published and self._removed:
+            return None
+        if entry is None:
+            entry = self._entry()
+        if entry is None:
+            return None
+
+        timestamp = self._next_timestamp()
+        attributes = self.build_attributes(event, snapshot)
+        result = await async_send(
+            self.hass,
+            entry,
+            self.session.session_id,
+            self.session.push_token,
+            event,
+            timestamp,
+            attributes,
+        )
+
+        # A replacement or teardown may have retired this publisher while the transport was
+        # waiting. Its result belongs to the old lifetime and must not change the new session's
+        # persisted token, snapshot, or retry state.
+        if self._removed:
+            return result.outcome
+
+        # The clock advances even on failure, so a retry can never reuse an ordering value APNs
+        # has already seen for this session.
+        self.session.last_timestamp = timestamp
+
+        if result.outcome is PushOutcome.DELIVERED:
+            self._reported_misconfiguration = None
+            self._retry_delay = RETRY_BACKOFF_SECONDS
+            if mark_published and snapshot is not None:
+                self._published = snapshot
+                self.session.last_snapshot = snapshot
+            if mark_published:
+                async_save_session(self.hass, self.webhook_id, self.session)
+            return result.outcome
+
+        if result.outcome is PushOutcome.REMOVE:
+            _LOGGER.debug(
+                "Push relay reports the Remote Now Playing token for session %s is no longer"
+                " valid; removing the registration",
+                self.session.session_id,
+            )
+            async_get_manager(self.hass).async_remove_invalid_token(self)
+            return result.outcome
+
+        if result.outcome is PushOutcome.BACK_OFF:
+            self._quiet_until = time.time() + RATE_LIMIT_BACKOFF_SECONDS
+            _LOGGER.debug(
+                "Remote Now Playing updates for session %s are rate limited; pausing",
+                self.session.session_id,
+            )
+        elif result.outcome is PushOutcome.MISCONFIGURED:
+            self._quiet_until = time.time() + CONFIGURATION_BACKOFF_SECONDS
+            # Complained about once per condition, not once per state change of a playing player.
+            if self._reported_misconfiguration != result.error_type:
+                self._reported_misconfiguration = result.error_type
+                _LOGGER.warning(
+                    "The push relay will not deliver Remote Now Playing updates for %s: %s."
+                    " Keeping the registration and pausing updates",
+                    self.entity_id,
+                    result.error_type,
+                )
+
+        if mark_published:
+            async_save_session(self.hass, self.webhook_id, self.session)
+        return result.outcome
+
+    def build_attributes(
+        self, event: str, snapshot: RemoteMediaSnapshot | None
+    ) -> dict[str, Any]:
+        """Return the attributes object the iOS app decodes.
+
+        `id` is the identifier the app registered, echoed verbatim: iOS routes the push by it, and
+        a payload without it is accepted by APNs and then discarded by the device. The relationship
+        travels with it so a cold-launched extension can register its token against the right one.
+        """
+        attributes: dict[str, Any] = {
+            ATTR_ID: self.session.session_id,
+            ATTR_GENERATION: self.session.generation,
+        }
+        if self.session.generation_sequence is not None:
+            attributes[ATTR_WIRE_GENERATION_SEQUENCE] = self.session.generation_sequence
+        if event == EVENT_END:
+            # Ending needs only the identity, and the app may already have torn the session down.
+            return attributes
+        if snapshot is not None:
+            attributes[ATTR_SNAPSHOT] = snapshot.as_wire()
+        return attributes
+
+    def _next_timestamp(self) -> int:
+        """Return the next strictly increasing ordering value for this session.
+
+        APNs sequences a session's pushes by this, and several meaningful changes can land inside
+        one second, so wall-clock seconds alone would let the device apply them out of order. It
+        is persisted, so a restart cannot go backwards either. Not to be confused with
+        `positionUpdatedAtUnix`, which is when playback position was measured.
+        """
+        now = int(time.time())
+        previous = self.session.last_timestamp
+        return now if previous is None else max(now, previous + 1)
+
+    def _entry(self) -> ConfigEntry | None:
+        """The config entry that owns this session, if it is still loaded."""
+        # pylint: disable-next=home-assistant-use-runtime-data
+        return self.hass.data[DOMAIN][DATA_CONFIG_ENTRIES].get(self.webhook_id)
+
+
+class RemoteMediaEntityWatcher:
+    """One Home Assistant state listener, shared by every session following the same player.
+
+    Two devices can follow the same speaker, so the watcher maps each event once and hands the
+    result to every publisher.
+
+    It also watches the entity registry, which is where the difference between "gone for a moment"
+    and "gone" lives: a state going to `None` is transient, a registry removal is not, and a
+    registry rename is the same entity that a relationship should follow.
+    """
+
+    def __init__(self, hass: HomeAssistant, entity_id: str) -> None:
+        """Set up a watcher with no subscribers yet."""
+        self.hass = hass
+        self.entity_id = entity_id
+        self.publishers: dict[tuple[str, str], RemoteMediaSessionPublisher] = {}
+        self._unsubscribe: CALLBACK_TYPE | None = None
+        self._unsubscribe_registry: CALLBACK_TYPE | None = None
+
+    @callback
+    def async_add(
+        self, key: tuple[str, str], publisher: RemoteMediaSessionPublisher
+    ) -> None:
+        """Start following, and start listening if this is the first subscriber."""
+        self.publishers[key] = publisher
+        if self._unsubscribe is None:
+            self._unsubscribe = async_track_state_change_event(
+                self.hass, [self.entity_id], self._async_state_changed
+            )
+        if self._unsubscribe_registry is None:
+            self._unsubscribe_registry = async_track_entity_registry_updated_event(
+                self.hass, [self.entity_id], self._async_registry_updated
+            )
+
+    @callback
+    def async_remove(self, key: tuple[str, str]) -> bool:
+        """Stop following, returning whether the watcher is now unused."""
+        self.publishers.pop(key, None)
+        if self.publishers:
+            return False
+        self.async_shutdown()
+        return True
+
+    @callback
+    def async_shutdown(self) -> None:
+        """Detach the listeners."""
+        if self._unsubscribe is not None:
+            self._unsubscribe()
+            self._unsubscribe = None
+        if self._unsubscribe_registry is not None:
+            self._unsubscribe_registry()
+            self._unsubscribe_registry = None
+
+    @callback
+    def async_reconcile(self) -> None:
+        """Feed the player's current state to every subscriber.
+
+        Used when a session is registered and after a restart, so the card is brought up to date
+        without waiting for the player to change.
+        """
+        if (state := self.hass.states.get(self.entity_id)) is None:
+            return
+        for publisher in list(self.publishers.values()):
+            publisher.async_apply(
+                snapshot_from_state(state, publisher.session.server_id)
+            )
+
+    @callback
+    def _async_state_changed(self, event: Event[EventStateChangedData]) -> None:
+        """Handle one state change for the followed player."""
+        new_state = event.data["new_state"]
+
+        if new_state is None:
+            # Transient by definition. An integration reload, a platform reload and startup
+            # ordering all remove and restore entities, and there is no length of time that tells
+            # those apart from a deletion — the registry does that, so this waits. The card keeps
+            # showing what it had; the user can always stop following.
+            _LOGGER.debug(
+                "%s has no state for the moment; keeping the Remote Now Playing sessions"
+                " following it",
+                self.entity_id,
+            )
+            return
+
+        for publisher in list(self.publishers.values()):
+            publisher.async_apply(
+                snapshot_from_state(new_state, publisher.session.server_id)
+            )
+
+    @callback
+    def _async_registry_updated(
+        self, event: Event[EventEntityRegistryUpdatedData]
+    ) -> None:
+        """Act on the entity registry, which is where permanence is decided."""
+        data = event.data
+        manager = async_get_manager(self.hass)
+
+        if data["action"] == "remove":
+            _LOGGER.debug(
+                "%s has been removed from the entity registry; ending the Remote Now Playing"
+                " sessions following it",
+                self.entity_id,
+            )
+            for key in list(self.publishers):
+                manager.async_end_session(*key)
+            return
+
+        if data["action"] != "update":
+            return
+        if (old_entity_id := data.get("old_entity_id")) is None:
+            return
+        # A rename. The relationship is with the player, not with the string, so it moves — and
+        # the session identifier, the relationship and the push token all stay as they are,
+        # because none of them has anything to do with what the entity is called.
+        _LOGGER.debug(
+            "%s has been renamed to %s; moving the Remote Now Playing sessions following it",
+            old_entity_id,
+            data["entity_id"],
+        )
+        manager.async_rename_entity(old_entity_id, data["entity_id"])
+
+
+class RemoteMediaManager:
+    """Owns every active Follow relationship and the listeners behind them."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Set up an empty manager."""
+        self.hass = hass
+        self.publishers: dict[tuple[str, str], RemoteMediaSessionPublisher] = {}
+        self.watchers: dict[str, RemoteMediaEntityWatcher] = {}
+        # Relationships stored for a registration that cannot be pushed to. Kept so the phone
+        # does not have to notice and re-register, watched only once it can be reached.
+        self.dormant: dict[tuple[str, str], RemoteMediaSession] = {}
+
+    @callback
+    def async_restore(
+        self, entry: ConfigEntry, sessions: list[RemoteMediaSession]
+    ) -> None:
+        """Bring one registration's stored sessions back after a restart or reload."""
+        webhook_id = entry.data[ATTR_WEBHOOK_ID]
+        for session in sessions:
+            self.async_add(webhook_id, session, entry, reconcile=True)
+
+    @callback
+    def async_add(
+        self,
+        webhook_id: str,
+        session: RemoteMediaSession,
+        entry: ConfigEntry,
+        *,
+        reconcile: bool,
+    ) -> RemoteMediaSessionPublisher | None:
+        """Start following for one session, replacing any publisher it supersedes.
+
+        Returns `None` for a registration with no way of being pushed to: the relationship is
+        remembered, but nothing is watched, reduced or coalesced for it. See
+        `async_registration_updated` for how it starts once the registration gains push.
+        """
+        key = (webhook_id, session.session_id)
+        if (existing := self.publishers.get(key)) is not None:
+            self._async_detach(key, existing)
+        self.dormant.pop(key, None)
+
+        if not can_cloud_push(entry):
+            _LOGGER.debug(
+                "Keeping the Remote Now Playing registration for %s without watching it: this"
+                " Home Assistant registration has no cloud push configuration",
+                session.entity_id,
+            )
+            self.dormant[key] = session
+            return None
+
+        publisher = RemoteMediaSessionPublisher(self.hass, webhook_id, session)
+        self.publishers[key] = publisher
+
+        watcher = self.watchers.get(session.entity_id)
+        if watcher is None:
+            watcher = RemoteMediaEntityWatcher(self.hass, session.entity_id)
+            self.watchers[session.entity_id] = watcher
+        watcher.async_add(key, publisher)
+
+        if reconcile:
+            watcher.async_reconcile()
+        return publisher
+
+    @callback
+    def async_registration_updated(self, entry: ConfigEntry) -> None:
+        """Start watching relationships this registration can now be pushed to.
+
+        Called when `update_registration` changes a registration's app data, which is where a
+        Companion install that had no push gains it. Nothing here starts a relationship the user
+        did not ask for: only sessions already stored for this registration are picked up.
+        """
+        webhook_id = entry.data[ATTR_WEBHOOK_ID]
+        if not can_cloud_push(entry):
+            for key in [key for key in self.publishers if key[0] == webhook_id]:
+                publisher = self.publishers[key]
+                self._async_detach(key, publisher)
+                self.dormant[key] = publisher.session
+            return
+
+        waiting = [key for key in self.dormant if key[0] == webhook_id]
+        if not waiting:
+            return
+        for key in waiting:
+            session = self.dormant[key]
+            _LOGGER.debug(
+                "This Home Assistant registration can be pushed to now; following %s for Remote"
+                " Now Playing",
+                session.entity_id,
+            )
+            self.async_add(webhook_id, session, entry, reconcile=True)
+
+    @callback
+    def async_rename_entity(self, old_entity_id: str, new_entity_id: str) -> None:
+        """Follow the same player under its new entity id.
+
+        The relationship is with the player, so only the stored entity id, the listener it hangs
+        off and the snapshot the card next sees change.
+        """
+        if old_entity_id == new_entity_id:
+            return
+
+        if (watcher := self.watchers.get(old_entity_id)) is not None:
+            moved = self.watchers.get(new_entity_id)
+            if moved is None:
+                moved = RemoteMediaEntityWatcher(self.hass, new_entity_id)
+                self.watchers[new_entity_id] = moved
+            for key, publisher in list(watcher.publishers.items()):
+                publisher.async_rename_entity(new_entity_id)
+                async_save_session(self.hass, key[0], publisher.session)
+                if watcher.async_remove(key):
+                    self.watchers.pop(old_entity_id, None)
+                moved.async_add(key, publisher)
+            # The card carries the entity it should send commands to, so the phone has to be told
+            # the new name — the snapshot differing by selection alone is a meaningful change.
+            moved.async_reconcile()
+
+        for key, session in list(self.dormant.items()):
+            if session.entity_id == old_entity_id:
+                session.entity_id = new_entity_id
+                async_save_session(self.hass, key[0], session)
+
+    @callback
+    def async_get(
+        self, webhook_id: str, session_id: str
+    ) -> RemoteMediaSessionPublisher | None:
+        """The publisher for one session, if it is being watched."""
+        return self.publishers.get((webhook_id, session_id))
+
+    @callback
+    def async_is_known(self, webhook_id: str, session_id: str) -> bool:
+        """Whether this relationship is set up at all, watched or dormant.
+
+        A stored session that neither knows about is one this run has not picked up yet, so an
+        otherwise identical re-registration has to be allowed to attach it.
+        """
+        key = (webhook_id, session_id)
+        return key in self.publishers or key in self.dormant
+
+    @callback
+    def async_end_session(
+        self, webhook_id: str, session_id: str, entry: ConfigEntry | None = None
+    ) -> None:
+        """Remove one session and tell the card, best effort.
+
+        `entry` is only needed when the owning registration is being removed, because unloading
+        has already taken it out of `DATA_CONFIG_ENTRIES` by then.
+        """
+        key = (webhook_id, session_id)
+        if (publisher := self.publishers.get(key)) is None:
+            if self.dormant.pop(key, None) is not None:
+                # Nothing was ever watched and nothing can be pushed to, so there is no card to
+                # tell — just forget the relationship.
+                async_remove_session(self.hass, webhook_id, session_id)
+            return
+        self.hass.async_create_task(
+            self._async_end(publisher, entry), name=f"remote_media end {session_id}"
+        )
+        async_remove_session(self.hass, webhook_id, session_id)
+        self._async_detach(key, publisher)
+
+    @callback
+    def async_remove_invalid_token(
+        self, publisher: RemoteMediaSessionPublisher
+    ) -> None:
+        """Remove and detach a session whose relay token is no longer valid."""
+        key = (publisher.webhook_id, publisher.session.session_id)
+        async_remove_session(self.hass, *key)
+        self.dormant.pop(key, None)
+        if self.publishers.get(key) is publisher:
+            self._async_detach(key, publisher)
+        else:
+            publisher.async_shutdown()
+
+    @callback
+    def async_end_registration(self, entry: ConfigEntry) -> None:
+        """Tell every card this registration owns that it is over, best effort.
+
+        Works from stored state rather than from live publishers, because unloading has already
+        detached them all by the time a removal runs.
+        """
+        webhook_id = entry.data[ATTR_WEBHOOK_ID]
+        for session in async_load_sessions(self.hass, webhook_id):
+            key = (webhook_id, session.session_id)
+            if key in self.dormant:
+                # Never reachable, so there is no card to tell.
+                continue
+            publisher = self.publishers.get(key) or RemoteMediaSessionPublisher(
+                self.hass, webhook_id, session
+            )
+            self.hass.async_create_task(
+                self._async_end(publisher, entry),
+                name=f"remote_media end {session.session_id}",
+            )
+
+    async def _async_end(
+        self, publisher: RemoteMediaSessionPublisher, entry: ConfigEntry | None = None
+    ) -> None:
+        """Send `end` without letting a failure hold up cleanup."""
+        try:
+            await publisher.async_send_end(entry)
+        except Exception:
+            _LOGGER.debug(
+                "Could not tell the phone its Remote Now Playing session ended",
+                exc_info=True,
+            )
+
+    @callback
+    def async_unload_registration(self, webhook_id: str) -> None:
+        """Detach one registration's listeners, keeping its stored sessions.
+
+        Used when a config entry unloads. The Follow relationship is not over, so only the runtime
+        goes — listeners, timers and in-flight bookkeeping — and it is rebuilt from stored state
+        when the entry is set up again.
+        """
+        for key in [key for key in self.publishers if key[0] == webhook_id]:
+            publisher = self.publishers[key]
+            self._async_detach(key, publisher)
+        # A dormant relationship has no runtime to drop, but it must not be left pointing at an
+        # entry that is gone: it is picked up again from the store when the entry returns.
+        for key in [key for key in self.dormant if key[0] == webhook_id]:
+            del self.dormant[key]
+
+    @callback
+    def _async_detach(
+        self, key: tuple[str, str], publisher: RemoteMediaSessionPublisher
+    ) -> None:
+        """Take one publisher off its watcher, dropping the listener if it was the last."""
+        self.publishers.pop(key, None)
+        publisher.async_shutdown()
+        if (watcher := self.watchers.get(publisher.entity_id)) is None:
+            return
+        if watcher.async_remove(key):
+            del self.watchers[publisher.entity_id]
+
+
+@callback
+def async_get_manager(hass: HomeAssistant) -> RemoteMediaManager:
+    """Return the manager, creating it on first use."""
+    # pylint: disable-next=home-assistant-use-runtime-data
+    domain_data = hass.data[DOMAIN]
+    if (manager := domain_data.get(DATA_REMOTE_MEDIA_MANAGER)) is None:
+        manager = RemoteMediaManager(hass)
+        domain_data[DATA_REMOTE_MEDIA_MANAGER] = manager
+    return manager

--- a/homeassistant/components/mobile_app/remote_media/mapper.py
+++ b/homeassistant/components/mobile_app/remote_media/mapper.py
@@ -1,0 +1,163 @@
+"""Turn a Home Assistant `media_player` state into the iOS wire snapshot.
+
+A deliberate mirror of Swift `RemoteMediaSnapshotMapper`, including its clamping and its rule that
+a position without a timestamp is not a position: the app maps the same entity from its own
+websocket feed, and a card that disagreed would change appearance depending on whether the phone
+happens to be awake.
+"""
+
+from datetime import datetime
+import math
+from typing import Any
+from urllib.parse import urlparse
+
+from homeassistant.components.media_player import (
+    ATTR_MEDIA_ALBUM_NAME,
+    ATTR_MEDIA_ARTIST,
+    ATTR_MEDIA_CONTENT_ID,
+    ATTR_MEDIA_DURATION,
+    ATTR_MEDIA_POSITION,
+    ATTR_MEDIA_POSITION_UPDATED_AT,
+    ATTR_MEDIA_TITLE,
+    ATTR_MEDIA_VOLUME_LEVEL,
+    ATTR_MEDIA_VOLUME_MUTED,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_PICTURE,
+    ATTR_FRIENDLY_NAME,
+    ATTR_SUPPORTED_FEATURES,
+)
+from homeassistant.core import State
+from homeassistant.util import dt as dt_util
+
+from .model import RemoteMediaSnapshot
+
+MEDIA_PLAYER_PREFIX = "media_player."
+
+
+def snapshot_from_state(state: State, server_id: str) -> RemoteMediaSnapshot | None:
+    """Return the wire snapshot for a media player state, or None if it is not one."""
+    if not state.entity_id.startswith(MEDIA_PLAYER_PREFIX):
+        return None
+
+    attributes = state.attributes
+    # Zero or negative is not a duration; the app drops it so the card shows no scrubber.
+    duration = _finite(attributes.get(ATTR_MEDIA_DURATION))
+    if duration is not None and duration <= 0:
+        duration = None
+
+    position = _finite(attributes.get(ATTR_MEDIA_POSITION))
+    if position is not None:
+        position = min(duration, max(0.0, position)) if duration else max(0.0, position)
+
+    # Without a position there is nothing for the timestamp to date, and sending one would let the
+    # card extrapolate from a value it does not have.
+    updated_at = (
+        _unix_seconds(attributes.get(ATTR_MEDIA_POSITION_UPDATED_AT))
+        if position is not None
+        else None
+    )
+
+    volume = _finite(attributes.get(ATTR_MEDIA_VOLUME_LEVEL))
+    if volume is not None:
+        volume = min(1.0, max(0.0, volume))
+
+    features = attributes.get(ATTR_SUPPORTED_FEATURES)
+    muted = attributes.get(ATTR_MEDIA_VOLUME_MUTED)
+
+    return RemoteMediaSnapshot(
+        artwork_url=_public_artwork(attributes.get(ATTR_ENTITY_PICTURE)),
+        server_id=server_id,
+        entity_id=state.entity_id,
+        device_name=_non_empty(attributes.get(ATTR_FRIENDLY_NAME)) or state.entity_id,
+        state=state.state,
+        device_class=_non_empty(attributes.get(ATTR_DEVICE_CLASS)),
+        title=_non_empty(attributes.get(ATTR_MEDIA_TITLE)),
+        artist=_non_empty(attributes.get(ATTR_MEDIA_ARTIST)),
+        album=_non_empty(attributes.get(ATTR_MEDIA_ALBUM_NAME)),
+        content_id=_non_empty(attributes.get(ATTR_MEDIA_CONTENT_ID)),
+        duration=duration,
+        position=position,
+        position_updated_at_unix=updated_at,
+        volume=volume,
+        is_muted=muted if isinstance(muted, bool) else None,
+        features=max(0, _int(features) or 0),
+    )
+
+
+def _public_artwork(value: Any) -> str | None:
+    """Return an artwork source the phone may fetch with no credentials, or None.
+
+    This value is serialized through Apple's infrastructure and echoed back by the push relay, so
+    whatever is put here is effectively public. An absolute HTTPS URL with no query and no userinfo
+    — how most integrations expose album art on the service's own CDN — is passed through; anything
+    else is refused, because a `/api/media_player_proxy/...` path carries a signed token, and the
+    phone showing no artwork is better than giving that away.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    parsed = urlparse(value)
+    if parsed.scheme.lower() != "https":
+        # Relative paths are Home Assistant's own proxy, and plain HTTP is not somewhere to send a
+        # phone that may be on any network.
+        return None
+    if parsed.username or parsed.password:
+        return None
+    if not parsed.hostname:
+        return None
+    if parsed.query:
+        # Where the signed token lives. A source that needs one is not a public reference.
+        return None
+    return value
+
+
+def _finite(value: Any) -> float | None:
+    """Return a usable float, or None. Mirrors the Swift mapper's `finite`."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        candidate = float(value)
+    elif isinstance(value, str):
+        try:
+            candidate = float(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    return candidate if math.isfinite(candidate) else None
+
+
+def _int(value: Any) -> int | None:
+    """Return a usable int, or None."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _non_empty(value: Any) -> str | None:
+    """Return a non-empty string, or None."""
+    return value if isinstance(value, str) and value else None
+
+
+def _unix_seconds(value: Any) -> float | None:
+    """Return seconds since 1970 for a Home Assistant timestamp attribute.
+
+    Never Swift's 2001 reference epoch: the app decodes Unix seconds so that Core does not have to
+    reproduce `JSONEncoder`'s `Date` encoding.
+    """
+    if isinstance(value, datetime):
+        return value.timestamp()
+    if isinstance(value, str):
+        parsed = dt_util.parse_datetime(value)
+        return parsed.timestamp() if parsed else None
+    return None

--- a/homeassistant/components/mobile_app/remote_media/model.py
+++ b/homeassistant/components/mobile_app/remote_media/model.py
@@ -1,0 +1,282 @@
+"""JSON-safe values that make up a Remote Now Playing session.
+
+Plain dataclasses over primitives, because two consumers read them: the `mobile_app` store, which
+serializes dictionaries, and the iOS app, which decodes the wire schema. Runtime objects live in
+`manager.py` and never reach either.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Self
+
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_STATE
+
+from .const import (
+    ATTR_ALBUM,
+    ATTR_ARTIST,
+    ATTR_ARTWORK,
+    ATTR_ARTWORK_URL,
+    ATTR_CONTENT_ID,
+    ATTR_DEVICE_CLASS,
+    ATTR_DEVICE_NAME,
+    ATTR_DURATION,
+    ATTR_FEATURES,
+    ATTR_GENERATION,
+    ATTR_GENERATION_SEQUENCE,
+    ATTR_IS_MUTED,
+    ATTR_POSITION,
+    ATTR_POSITION_UPDATED_AT_UNIX,
+    ATTR_PUSH_TOKEN,
+    ATTR_SCHEMA_VERSION,
+    ATTR_SELECTION,
+    ATTR_SERVER_ID,
+    ATTR_SERVER_ID_KEY,
+    ATTR_SESSION_ID,
+    ATTR_TITLE,
+    ATTR_VOLUME,
+    ATTR_WIRE_ENTITY_ID,
+)
+
+# Playback states the iOS `RemoteMediaPlaybackState` collapses to "not reporting". Anything the
+# reducer sees that is not a known media player state lands here too.
+INDETERMINATE_STATES = frozenset({"unavailable", "unknown"})
+# Collapsed to "stopped": the card still shows its media, it is just not advancing.
+STOPPED_STATES = frozenset({"idle", "off", "standby"})
+PLAYING_STATES = frozenset({"playing", "buffering"})
+PAUSED_STATES = frozenset({"paused"})
+
+
+def collapsed_playback(state: str) -> str:
+    """Return the playback state the card renders, ignoring how the integration spelled it.
+
+    Mirrors Swift `RemoteMediaPlaybackState(homeAssistantState:)`. Integrations differ — some pass
+    through `idle` on the way from `playing` to `paused` — and collapsing that here keeps the
+    variation out of the decision to push.
+    """
+    if state in PLAYING_STATES:
+        return "playing"
+    if state in PAUSED_STATES:
+        return "paused"
+    if state in STOPPED_STATES:
+        return "stopped"
+    return "indeterminate"
+
+
+@dataclass(frozen=True, slots=True)
+class RemoteMediaSnapshot:
+    """One followed player's state, in the exact shape the iOS app decodes.
+
+    Field names are Python; `as_wire()` produces the camelCase keys of Swift `RemoteMediaSnapshot`.
+    """
+
+    server_id: str
+    entity_id: str
+    device_name: str
+    state: str
+    device_class: str | None = None
+    title: str | None = None
+    artist: str | None = None
+    album: str | None = None
+    content_id: str | None = None
+    duration: float | None = None
+    position: float | None = None
+    position_updated_at_unix: float | None = None
+    volume: float | None = None
+    is_muted: bool | None = None
+    features: int = 0
+    # A credential-free absolute HTTPS source the phone may fetch artwork from, when the
+    # integration exposes one. Never a Home Assistant proxy path: see `mapper._public_artwork`.
+    artwork_url: str | None = None
+
+    @property
+    def has_meaningful_media(self) -> bool:
+        """Whether this describes an actual piece of media.
+
+        Mirrors Swift `hasMeaningfulMedia`. The card hangs on this rather than on playback state,
+        because a paused player still has something to show.
+        """
+        return any(
+            value is not None
+            for value in (
+                self.content_id,
+                self.title,
+                self.artist,
+                self.album,
+                self.duration,
+            )
+        )
+
+    @property
+    def track_id(self) -> str:
+        """A deterministic identity for the current track.
+
+        Byte-for-byte the Swift `trackId`: each component length-prefixed by its UTF-8 byte count,
+        so no combination of values can collide with another. Metadata joins the content id because
+        integrations reuse a stream URL across tracks.
+        """
+        return "".join(
+            f"{len((value or '').encode())}:{value or ''}"
+            for value in (self.content_id, self.title, self.artist, self.album)
+        )
+
+    @property
+    def playback(self) -> str:
+        """The collapsed playback state."""
+        return collapsed_playback(self.state)
+
+    def as_wire(self) -> dict[str, Any]:
+        """Return the snapshot as the iOS decoder expects it.
+
+        `selection`, `deviceName`, `state` and `features` are always present because Swift decodes
+        them unconditionally; everything else is omitted when absent, which keeps the payload inside
+        the relay's 4096-byte ceiling. `artwork` carries a credential-free source and never a token:
+        see `mapper._public_artwork`.
+        """
+        wire: dict[str, Any] = {
+            ATTR_SELECTION: {
+                ATTR_SERVER_ID: self.server_id,
+                ATTR_WIRE_ENTITY_ID: self.entity_id,
+            },
+            ATTR_DEVICE_NAME: self.device_name,
+            ATTR_STATE: self.state,
+            ATTR_FEATURES: self.features,
+        }
+        optional: dict[str, Any] = {
+            ATTR_DEVICE_CLASS: self.device_class,
+            ATTR_TITLE: self.title,
+            ATTR_ARTIST: self.artist,
+            ATTR_ALBUM: self.album,
+            ATTR_CONTENT_ID: self.content_id,
+            ATTR_DURATION: self.duration,
+            ATTR_POSITION: self.position,
+            ATTR_POSITION_UPDATED_AT_UNIX: self.position_updated_at_unix,
+            ATTR_VOLUME: self.volume,
+            ATTR_IS_MUTED: self.is_muted,
+        }
+        wire.update(
+            {key: value for key, value in optional.items() if value is not None}
+        )
+        if self.artwork_url is not None:
+            wire[ATTR_ARTWORK] = {ATTR_ARTWORK_URL: self.artwork_url}
+        return wire
+
+    def as_storage(self) -> dict[str, Any]:
+        """Return the snapshot as persisted, so sticky state survives a restart."""
+        return {
+            "server_id": self.server_id,
+            "entity_id": self.entity_id,
+            "device_name": self.device_name,
+            "state": self.state,
+            "device_class": self.device_class,
+            "title": self.title,
+            "artist": self.artist,
+            "album": self.album,
+            "content_id": self.content_id,
+            "duration": self.duration,
+            "position": self.position,
+            "position_updated_at_unix": self.position_updated_at_unix,
+            "volume": self.volume,
+            "is_muted": self.is_muted,
+            "features": self.features,
+            "artwork_url": self.artwork_url,
+        }
+
+    @classmethod
+    def from_storage(cls, data: dict[str, Any]) -> Self | None:
+        """Rebuild a persisted snapshot, or return None when it cannot be trusted."""
+        try:
+            return cls(
+                server_id=data["server_id"],
+                entity_id=data["entity_id"],
+                device_name=data["device_name"],
+                state=data["state"],
+                device_class=data.get("device_class"),
+                title=data.get("title"),
+                artist=data.get("artist"),
+                album=data.get("album"),
+                content_id=data.get("content_id"),
+                duration=data.get("duration"),
+                position=data.get("position"),
+                position_updated_at_unix=data.get("position_updated_at_unix"),
+                volume=data.get("volume"),
+                is_muted=data.get("is_muted"),
+                features=data.get("features", 0),
+                artwork_url=data.get("artwork_url"),
+            )
+        except KeyError, TypeError:
+            return None
+
+
+@dataclass(slots=True)
+class RemoteMediaSession:
+    """A Follow relationship, as persisted.
+
+    Owned by the `mobile_app` config entry whose encrypted webhook registered it. The ordinary
+    Companion push token is deliberately absent: it is read from that config entry when sending, so
+    this store never holds a second copy of it.
+
+    `session_id` is Apple's identifier for the session and is treated as opaque — echoed into the
+    attributes that route a push, used as a storage key, and never parsed.
+    """
+
+    session_id: str
+    generation: str
+    # Where this relationship sits in the order the app created them. Ordering is the whole point
+    # of it: a registration for a relationship the user has already replaced can arrive after the
+    # replacement's, and a random generation gives no way to tell which is which. `None` only for
+    # a session stored before this field existed, which no released build ever wrote.
+    generation_sequence: int | None
+    entity_id: str
+    server_id: str
+    push_token: str
+    schema_version: int
+    last_timestamp: int | None = None
+    last_snapshot: RemoteMediaSnapshot | None = None
+
+    def as_storage(self) -> dict[str, Any]:
+        """Return the session as persisted."""
+        return {
+            ATTR_SESSION_ID: self.session_id,
+            ATTR_GENERATION: self.generation,
+            ATTR_GENERATION_SEQUENCE: self.generation_sequence,
+            ATTR_ENTITY_ID: self.entity_id,
+            ATTR_SERVER_ID_KEY: self.server_id,
+            ATTR_PUSH_TOKEN: self.push_token,
+            ATTR_SCHEMA_VERSION: self.schema_version,
+            "last_timestamp": self.last_timestamp,
+            "last_snapshot": (
+                self.last_snapshot.as_storage() if self.last_snapshot else None
+            ),
+        }
+
+    @classmethod
+    def from_storage(cls, data: dict[str, Any]) -> Self | None:
+        """Rebuild a persisted session, or return None when it cannot be trusted."""
+        try:
+            stored_snapshot = data.get("last_snapshot")
+            sequence = data.get(ATTR_GENERATION_SEQUENCE)
+            return cls(
+                session_id=data[ATTR_SESSION_ID],
+                generation=data[ATTR_GENERATION],
+                generation_sequence=sequence if isinstance(sequence, int) else None,
+                entity_id=data[ATTR_ENTITY_ID],
+                server_id=data[ATTR_SERVER_ID_KEY],
+                push_token=data[ATTR_PUSH_TOKEN],
+                schema_version=data[ATTR_SCHEMA_VERSION],
+                last_timestamp=data.get("last_timestamp"),
+                last_snapshot=(
+                    RemoteMediaSnapshot.from_storage(stored_snapshot)
+                    if isinstance(stored_snapshot, dict)
+                    else None
+                ),
+            )
+        except KeyError, TypeError:
+            return None
+
+    def describes_same_lifetime(self, generation: str, sequence: int) -> bool:
+        """Whether this is the relationship `generation` and `sequence` name.
+
+        Both, never one: two relationships with the same sequence are a conflict rather than a
+        match, and the same generation at a different sequence is not something the app can
+        produce.
+        """
+        return self.generation == generation and self.generation_sequence == sequence

--- a/homeassistant/components/mobile_app/remote_media/push.py
+++ b/homeassistant/components/mobile_app/remote_media/push.py
@@ -1,0 +1,200 @@
+"""Send one Remote Now Playing update through the Home Assistant push relay.
+
+Deliberately not `notify._send_message`: that collapses every relay failure into a generic
+`HomeAssistantError`, and this caller has to tell a dead session token — the one condition that
+removes a registration — from a relay configuration fault, which must not.
+
+The relay owns everything about APNs; Core never sends a topic, a host, or provider configuration.
+"""
+
+import asyncio
+from dataclasses import dataclass
+from enum import Enum
+from http import HTTPStatus
+import logging
+from typing import Any
+
+from aiohttp import ClientError, ClientResponseError
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from ..const import (
+    ATTR_APP_DATA,
+    ATTR_APP_ID,
+    ATTR_APP_VERSION,
+    ATTR_OS_VERSION,
+    ATTR_PUSH_TOKEN,
+    ATTR_PUSH_URL,
+    ATTR_WEBHOOK_ID,
+)
+from .const import (
+    ATTR_ATTRIBUTES,
+    ATTR_EVENT,
+    ATTR_NOW_PLAYING,
+    ATTR_NOW_PLAYING_TOKEN,
+    ATTR_REGISTRATION_INFO,
+    ATTR_TIMESTAMP,
+    ERROR_APNS_RATE_LIMITED,
+    ERROR_APNS_UNAVAILABLE,
+    ERROR_INVALID_TOKEN,
+    ERROR_NOT_CONFIGURED,
+    ERROR_PAYLOAD_TOO_LARGE,
+    ERROR_PROVIDER_AUTH,
+    ERROR_RATE_LIMITED,
+    ERROR_TOPIC_MISMATCH,
+    ERROR_UNSUPPORTED_APP,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+RELAY_TIMEOUT_SECONDS = 15
+
+
+class PushOutcome(Enum):
+    """What Core should do about a relay result.
+
+    Only `REMOVE` means the user's session token is dead. A topic mismatch, a credential fault or a
+    deployment that does not serve this build are all problems on our side of the wire, and deleting
+    a registration over one would silently stop a feature the user never turned off.
+    """
+
+    DELIVERED = "delivered"
+    # The session token will never work again. This is the only outcome that unregisters.
+    REMOVE = "remove"
+    # Transient. Try again when something meaningful next changes.
+    RETRY = "retry"
+    # Told to slow down. Stay quiet for a while.
+    BACK_OFF = "back_off"
+    # A configuration or programming fault that will not resolve on its own. Keep the
+    # registration, complain once, and stop sending for a long while.
+    MISCONFIGURED = "misconfigured"
+
+
+# Relay `errorType` to outcome. Anything unrecognised is treated as retryable rather than as a
+# reason to delete a registration, because a relay that grows a new error must not cost users
+# their sessions.
+_OUTCOMES: dict[str, PushOutcome] = {
+    ERROR_INVALID_TOKEN: PushOutcome.REMOVE,
+    ERROR_UNSUPPORTED_APP: PushOutcome.MISCONFIGURED,
+    ERROR_TOPIC_MISMATCH: PushOutcome.MISCONFIGURED,
+    ERROR_PROVIDER_AUTH: PushOutcome.MISCONFIGURED,
+    ERROR_NOT_CONFIGURED: PushOutcome.MISCONFIGURED,
+    ERROR_PAYLOAD_TOO_LARGE: PushOutcome.MISCONFIGURED,
+    ERROR_RATE_LIMITED: PushOutcome.BACK_OFF,
+    ERROR_APNS_RATE_LIMITED: PushOutcome.BACK_OFF,
+    ERROR_APNS_UNAVAILABLE: PushOutcome.RETRY,
+    # Request-shape refusals. Core built the request, so these are our bug, not the token's.
+    "AmbiguousRequest": PushOutcome.MISCONFIGURED,
+    "InvalidNowPlayingToken": PushOutcome.MISCONFIGURED,
+    "InvalidNowPlayingRequest": PushOutcome.MISCONFIGURED,
+    "UnsupportedNowPlayingEvent": PushOutcome.MISCONFIGURED,
+    "InvalidNowPlayingTimestamp": PushOutcome.MISCONFIGURED,
+    "InvalidNowPlayingAttributes": PushOutcome.MISCONFIGURED,
+    "MissingNowPlayingSessionId": PushOutcome.MISCONFIGURED,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class PushResult:
+    """The relay's answer, reduced to what the caller acts on."""
+
+    outcome: PushOutcome
+    error_type: str | None = None
+    status: int | None = None
+
+
+def build_request(
+    entry: ConfigEntry,
+    now_playing_token: str,
+    event: str,
+    timestamp: int,
+    attributes: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the relay request body.
+
+    `push_token` stays the ordinary Companion token, which is the registration and rate-limit
+    identity; `now_playing_token` is only the destination.
+    """
+    app_data = entry.data[ATTR_APP_DATA]
+    registration_info = {
+        ATTR_APP_ID: entry.data[ATTR_APP_ID],
+        ATTR_APP_VERSION: entry.data[ATTR_APP_VERSION],
+        ATTR_WEBHOOK_ID: entry.data[ATTR_WEBHOOK_ID],
+    }
+    if ATTR_OS_VERSION in entry.data:
+        registration_info[ATTR_OS_VERSION] = entry.data[ATTR_OS_VERSION]
+
+    return {
+        ATTR_PUSH_TOKEN: app_data[ATTR_PUSH_TOKEN],
+        ATTR_NOW_PLAYING_TOKEN: now_playing_token,
+        ATTR_NOW_PLAYING: {
+            ATTR_EVENT: event,
+            ATTR_TIMESTAMP: timestamp,
+            ATTR_ATTRIBUTES: attributes,
+        },
+        ATTR_REGISTRATION_INFO: registration_info,
+    }
+
+
+async def async_send(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    session_id: str,
+    now_playing_token: str,
+    event: str,
+    timestamp: int,
+    attributes: dict[str, Any],
+) -> PushResult:
+    """Send one `update` or `end`, and classify the answer.
+
+    A relay refusal is a value rather than an exception, because the caller has to keep a session
+    alive through a bad relay day. Nothing here logs a token.
+    """
+    app_data = entry.data.get(ATTR_APP_DATA, {})
+    if not app_data.get(ATTR_PUSH_URL) or not app_data.get(ATTR_PUSH_TOKEN):
+        # A registration that never had cloud push. Nothing to do and nothing to complain about
+        # repeatedly.
+        return PushResult(PushOutcome.MISCONFIGURED, error_type="NoPushRegistration")
+
+    body = build_request(entry, now_playing_token, event, timestamp, attributes)
+    session = async_get_clientsession(hass)
+
+    try:
+        async with asyncio.timeout(RELAY_TIMEOUT_SECONDS):
+            response = await session.post(app_data[ATTR_PUSH_URL], json=body)
+            status = response.status
+            try:
+                result = await response.json()
+            except ValueError, ClientResponseError:
+                result = {}
+    except TimeoutError:
+        _LOGGER.debug(
+            "Timed out sending Remote Now Playing %s for session %s", event, session_id
+        )
+        return PushResult(PushOutcome.RETRY, error_type="Timeout")
+    except ClientError as err:
+        _LOGGER.debug(
+            "Could not reach the push relay for Remote Now Playing %s (session %s): %s",
+            event,
+            session_id,
+            err,
+        )
+        return PushResult(PushOutcome.RETRY, error_type="Unreachable")
+
+    if status in (HTTPStatus.OK, HTTPStatus.CREATED, HTTPStatus.ACCEPTED):
+        return PushResult(PushOutcome.DELIVERED, status=status)
+
+    error_type = result.get("errorType") if isinstance(result, dict) else None
+    outcome = _OUTCOMES.get(error_type) if error_type else None
+    if outcome is None:
+        # No recognised classification. A server error is worth retrying; anything else is not
+        # going to change by repeating it, but it is still not grounds for deleting a token.
+        outcome = (
+            PushOutcome.RETRY
+            if status >= HTTPStatus.INTERNAL_SERVER_ERROR
+            else PushOutcome.MISCONFIGURED
+        )
+
+    return PushResult(outcome, error_type=error_type, status=status)

--- a/homeassistant/components/mobile_app/remote_media/reducer.py
+++ b/homeassistant/components/mobile_app/remote_media/reducer.py
@@ -1,0 +1,38 @@
+"""Keep a followed player's card meaningful across the states integrations actually emit.
+
+Not an optimisation: when an APNs push cold-launches the RemoteMedia extension, that process has no
+prior snapshot, so the pushed attributes are the whole truth. A transient `idle` with blank metadata
+sent as if it were the complete picture leaves the user an empty card.
+
+A mirror of Swift `RemoteMediaSnapshotReducer`. The rules are a general resilience policy and
+deliberately not keyed on any integration.
+"""
+
+from dataclasses import replace
+
+from .model import RemoteMediaSnapshot
+
+
+def reduce_snapshot(
+    previous: RemoteMediaSnapshot | None, incoming: RemoteMediaSnapshot
+) -> RemoteMediaSnapshot | None:
+    """Return what the card should show, or None if nothing meaningful has been seen yet."""
+    if incoming.has_meaningful_media:
+        # Taken wholesale, so a new track keeps none of the previous one's identity: the app pairs
+        # artwork with the track it belongs to, and mixing them shows the last song's cover over
+        # this one's title.
+        return incoming
+
+    # Nothing meaningful in this report. With nothing to fall back on there is nothing to show;
+    # the player stays followed, so the next meaningful report starts the card.
+    if previous is None or not previous.has_meaningful_media:
+        return None
+
+    # Keep the media and describe the transition. `unavailable` and `unknown` mean the integration
+    # stopped reporting, which is not the same as having stopped, so the last known playback state
+    # is kept rather than a new one invented. Position is held too: extrapolating from a blank
+    # report would make the card scrub while nothing is playing.
+    retained_state = (
+        previous.state if incoming.playback == "indeterminate" else incoming.state
+    )
+    return replace(previous, state=retained_state)

--- a/homeassistant/components/mobile_app/remote_media/store.py
+++ b/homeassistant/components/mobile_app/remote_media/store.py
@@ -1,0 +1,97 @@
+"""Persistence for Remote Now Playing sessions.
+
+Uses the existing `mobile_app` store, the same way `live_activity` does, so a Follow relationship
+survives a restart without the phone re-registering. Keyed by the webhook id of the config entry
+that owns them, which is also how config-entry removal cleans them up.
+"""
+
+from functools import partial
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant, callback
+
+from ..const import (
+    DATA_REMOTE_MEDIA_SESSIONS,
+    DATA_STORE,
+    DOMAIN,
+    STORAGE_SAVE_DELAY_SECONDS,
+)
+from ..helpers import savable_state
+from .model import RemoteMediaSession
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@callback
+def async_sessions_for(
+    hass: HomeAssistant, webhook_id: str
+) -> dict[str, dict[str, Any]]:
+    """Return the stored sessions for one registration, keyed by session id."""
+    # pylint: disable-next=home-assistant-use-runtime-data
+    return hass.data[DOMAIN][DATA_REMOTE_MEDIA_SESSIONS].get(webhook_id, {})
+
+
+@callback
+def async_load_sessions(
+    hass: HomeAssistant, webhook_id: str
+) -> list[RemoteMediaSession]:
+    """Return the usable stored sessions for one registration.
+
+    A stored entry that cannot be rebuilt is dropped rather than raised: the store is shared with
+    the rest of `mobile_app`, and one malformed session must not stop a registration from loading.
+    """
+    sessions = []
+    for session_id, data in async_sessions_for(hass, webhook_id).items():
+        if (session := RemoteMediaSession.from_storage(data)) is None:
+            _LOGGER.warning(
+                "Discarding unreadable Remote Now Playing session %s", session_id
+            )
+            continue
+        sessions.append(session)
+    return sessions
+
+
+@callback
+def async_save_session(
+    hass: HomeAssistant, webhook_id: str, session: RemoteMediaSession
+) -> None:
+    """Store or replace one session and schedule a save."""
+    # pylint: disable-next=home-assistant-use-runtime-data
+    domain_data = hass.data[DOMAIN]
+    domain_data[DATA_REMOTE_MEDIA_SESSIONS].setdefault(webhook_id, {})[
+        session.session_id
+    ] = session.as_storage()
+    domain_data[DATA_STORE].async_delay_save(
+        partial(savable_state, hass), STORAGE_SAVE_DELAY_SECONDS
+    )
+
+
+@callback
+def async_remove_session(hass: HomeAssistant, webhook_id: str, session_id: str) -> bool:
+    """Remove one session, returning whether it existed."""
+    # pylint: disable-next=home-assistant-use-runtime-data
+    domain_data = hass.data[DOMAIN]
+    sessions = domain_data[DATA_REMOTE_MEDIA_SESSIONS]
+    if (registration := sessions.get(webhook_id)) is None:
+        return False
+    if registration.pop(session_id, None) is None:
+        return False
+    if not registration:
+        del sessions[webhook_id]
+    domain_data[DATA_STORE].async_delay_save(
+        partial(savable_state, hass), STORAGE_SAVE_DELAY_SECONDS
+    )
+    return True
+
+
+@callback
+def async_remove_registration(hass: HomeAssistant, webhook_id: str) -> None:
+    """Forget every session belonging to one registration."""
+    # pylint: disable-next=home-assistant-use-runtime-data
+    domain_data = hass.data[DOMAIN]
+    if domain_data[DATA_REMOTE_MEDIA_SESSIONS].pop(webhook_id, None) is None:
+        return
+    domain_data[DATA_STORE].async_delay_save(
+        partial(savable_state, hass), STORAGE_SAVE_DELAY_SECONDS
+    )

--- a/homeassistant/components/mobile_app/remote_media/webhook.py
+++ b/homeassistant/components/mobile_app/remote_media/webhook.py
@@ -1,0 +1,285 @@
+"""Webhook commands the iOS app uses to register and retire a Follow relationship.
+
+Both arrive over the ordinary encrypted `mobile_app` webhook, so the registration that owns a
+session is the authenticated config entry that sent the request. The payload chooses only which
+`media_player` to follow, never which registration to attach to.
+
+Not simply "last write wins": registration happens in a process whose lifetime the app does not
+control, so one describing a relationship the user has already replaced can arrive after its
+replacement's. Arrival order is a guess about that; the app's monotonic Follow sequence is not.
+"""
+
+import hashlib
+import logging
+from typing import Any
+
+from aiohttp.web import Response
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ENTITY_ID, CONF_WEBHOOK_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+
+from ..helpers import empty_okay_response
+from ..webhook import WEBHOOK_COMMANDS, WEBHOOK_PAYLOAD_REDACTORS, validate_schema
+from .const import (
+    ATTR_GENERATION,
+    ATTR_GENERATION_SEQUENCE,
+    ATTR_PUSH_TOKEN,
+    ATTR_SCHEMA_VERSION,
+    ATTR_SERVER_ID_KEY,
+    ATTR_SESSION_ID,
+    MAX_GENERATION_LENGTH,
+    MAX_GENERATION_SEQUENCE,
+    MAX_PUSH_TOKEN_LENGTH,
+    MAX_SERVER_ID_LENGTH,
+    MAX_SESSION_ID_LENGTH,
+    SUPPORTED_SCHEMA_VERSIONS,
+    WEBHOOK_TYPE_DISMISSED,
+    WEBHOOK_TYPE_TOKEN,
+)
+from .manager import async_get_manager
+from .mapper import MEDIA_PLAYER_PREFIX
+from .model import RemoteMediaSession
+from .store import async_load_sessions, async_save_session
+
+_LOGGER = logging.getLogger(__name__)
+
+TOKEN_FINGERPRINT_LENGTH = 16
+
+
+def _bounded_string(maximum: int) -> vol.All:
+    """A non-empty string no longer than `maximum`."""
+    return vol.All(cv.string, vol.Length(min=1, max=maximum))
+
+
+def _media_player_entity_id(value: Any) -> str:
+    """Validate a followed player.
+
+    Only `media_player` entities, so a registration cannot turn into a subscription to arbitrary
+    parts of the state machine.
+    """
+    entity_id = cv.entity_id(value)
+    if not entity_id.startswith(MEDIA_PLAYER_PREFIX):
+        raise vol.Invalid("Remote Now Playing can only follow a media_player entity")
+    return entity_id
+
+
+def valid_token(value: Any) -> str | None:
+    """Return the APNs update token if it is usable, else None.
+
+    Deliberately not a voluptuous validator: `validate_schema` reports a failure with
+    `humanize_error`, which echoes the offending value into an ERROR log that is on by default. A
+    rejected token would then be more exposed than an accepted one.
+    """
+    if not isinstance(value, str) or not value or len(value) > MAX_PUSH_TOKEN_LENGTH:
+        return None
+    if len(value) % 2 or not all(
+        character in "0123456789abcdefABCDEF" for character in value
+    ):
+        return None
+    return value
+
+
+def token_fingerprint(token: str) -> str:
+    """A short, non-reversible label for a session token.
+
+    Enough to correlate a session across log lines without the log becoming a place to harvest
+    APNs destinations from.
+    """
+    return hashlib.sha256(token.encode()).hexdigest()[:TOKEN_FINGERPRINT_LENGTH]
+
+
+@WEBHOOK_PAYLOAD_REDACTORS.register(WEBHOOK_TYPE_TOKEN)
+def redact_token_payload(payload: Any) -> Any:
+    """Replace the session token before the payload reaches the debug log.
+
+    `mobile_app` logs every decrypted webhook payload at debug level, and this one carries a live
+    APNs destination for the user's device.
+    """
+    if not isinstance(payload, dict) or ATTR_PUSH_TOKEN not in payload:
+        return payload
+    token = payload[ATTR_PUSH_TOKEN]
+    redacted = (
+        f"**REDACTED:{token_fingerprint(token)}**"
+        if isinstance(token, str)
+        else "**REDACTED**"
+    )
+    return {**payload, ATTR_PUSH_TOKEN: redacted}
+
+
+@WEBHOOK_COMMANDS.register(WEBHOOK_TYPE_TOKEN)
+@validate_schema(
+    {
+        vol.Required(ATTR_SESSION_ID): _bounded_string(MAX_SESSION_ID_LENGTH),
+        vol.Required(ATTR_SERVER_ID_KEY): _bounded_string(MAX_SERVER_ID_LENGTH),
+        vol.Required(ATTR_ENTITY_ID): _media_player_entity_id,
+        vol.Required(ATTR_GENERATION): _bounded_string(MAX_GENERATION_LENGTH),
+        vol.Required(ATTR_GENERATION_SEQUENCE): vol.All(
+            cv.positive_int, vol.Range(min=1, max=MAX_GENERATION_SEQUENCE)
+        ),
+        # Any value: validated in the handler so a bad one is never echoed into a log.
+        vol.Required(ATTR_PUSH_TOKEN): object,
+        vol.Required(ATTR_SCHEMA_VERSION): vol.All(
+            cv.positive_int, vol.In(SUPPORTED_SCHEMA_VERSIONS)
+        ),
+    }
+)
+async def webhook_remote_media_session_token(
+    hass: HomeAssistant, config_entry: ConfigEntry, data: dict[str, Any]
+) -> Response:
+    """Store the APNs update token for one Follow relationship and start watching its player."""
+    webhook_id = config_entry.data[CONF_WEBHOOK_ID]
+    session_id = data[ATTR_SESSION_ID]
+    entity_id = data[ATTR_ENTITY_ID]
+    server_id = data[ATTR_SERVER_ID_KEY]
+    generation = data[ATTR_GENERATION]
+    sequence = data[ATTR_GENERATION_SEQUENCE]
+
+    if (token := valid_token(data[ATTR_PUSH_TOKEN])) is None:
+        _LOGGER.warning(
+            "Ignoring a Remote Now Playing registration for %s: its update token is not"
+            " hexadecimal data of a usable length",
+            entity_id,
+        )
+        return empty_okay_response()
+
+    manager = async_get_manager(hass)
+    stored = {
+        session.session_id: session for session in async_load_sessions(hass, webhook_id)
+    }
+    previous = stored.get(session_id)
+
+    if previous is not None and previous.generation_sequence is not None:
+        if sequence < previous.generation_sequence:
+            # A registration from a relationship the user has already replaced, arriving late.
+            # Nothing about it is applied: not the token, not the entity, not the sticky state,
+            # not the ordering clock, and no listener is moved.
+            _LOGGER.debug(
+                "Ignoring a stale Remote Now Playing registration for session %s: it names"
+                " Follow %s, and %s is current",
+                session_id,
+                sequence,
+                previous.generation_sequence,
+            )
+            return empty_okay_response()
+
+        if (
+            sequence == previous.generation_sequence
+            and previous.generation != generation
+        ):
+            # Two relationships claiming one place in the order. The app increments the counter
+            # once per relationship, so this should be impossible; guessing which is newer would
+            # be exactly the heuristic the sequence exists to avoid.
+            _LOGGER.warning(
+                "Ignoring a conflicting Remote Now Playing registration for %s: Follow %s is"
+                " already held by a different session lifetime",
+                entity_id,
+                sequence,
+            )
+            return empty_okay_response()
+
+    if previous is not None and previous.describes_same_lifetime(generation, sequence):
+        if (
+            previous.push_token == token
+            and previous.entity_id == entity_id
+            and previous.server_id == server_id
+            and manager.async_is_known(webhook_id, session_id)
+        ):
+            # The same registration again: idempotent. No second listener, no second initial push.
+            return empty_okay_response()
+        # The same relationship with a replacement token: the card on the phone is the same card,
+        # so it keeps its sticky state and its ordering clock, and the old token is never used
+        # again. A registration is what supersedes a token; no dismissal is involved.
+        carried_over = previous
+    else:
+        carried_over = None
+        if previous is not None:
+            # A later relationship reusing the session identifier, which happens whenever the user
+            # follows the same player again. Nothing of the old one is carried: the track it was
+            # showing, and the ordering clock the previous APNs session was sequenced by, both
+            # belong to a session that has ended. Current state rebuilds the card from scratch.
+            _LOGGER.debug(
+                "Remote Now Playing session %s moves from Follow %s to %s",
+                session_id,
+                previous.generation_sequence,
+                sequence,
+            )
+
+    session = RemoteMediaSession(
+        session_id=session_id,
+        generation=generation,
+        generation_sequence=sequence,
+        entity_id=entity_id,
+        server_id=server_id,
+        push_token=token,
+        schema_version=data[ATTR_SCHEMA_VERSION],
+    )
+    if carried_over is not None:
+        session.last_timestamp = carried_over.last_timestamp
+        session.last_snapshot = carried_over.last_snapshot
+
+    async_save_session(hass, webhook_id, session)
+    # Attaching the listener also reconciles the player's current state, which schedules the
+    # first update through the normal publisher path. The webhook does not wait for APNs.
+    manager.async_add(webhook_id, session, config_entry, reconcile=True)
+
+    _LOGGER.debug(
+        "Following %s for Remote Now Playing (session %s, Follow %s/%s, token %s)",
+        entity_id,
+        session_id,
+        generation,
+        sequence,
+        token_fingerprint(token),
+    )
+    return empty_okay_response()
+
+
+@WEBHOOK_COMMANDS.register(WEBHOOK_TYPE_DISMISSED)
+@validate_schema(
+    {
+        vol.Required(ATTR_SESSION_ID): _bounded_string(MAX_SESSION_ID_LENGTH),
+        vol.Required(ATTR_GENERATION): _bounded_string(MAX_GENERATION_LENGTH),
+        vol.Required(ATTR_GENERATION_SEQUENCE): vol.All(
+            cv.positive_int, vol.Range(min=1, max=MAX_GENERATION_SEQUENCE)
+        ),
+    }
+)
+async def webhook_remote_media_session_dismissed(
+    hass: HomeAssistant, config_entry: ConfigEntry, data: dict[str, Any]
+) -> Response:
+    """Stop following, if the dismissal names the relationship that is current.
+
+    A dismissal can arrive long after the fact, because the app writes down what it owes and retries
+    on a later launch. Both halves have to match: an older sequence names a relationship that is
+    already over, and the same sequence with a different generation is a conflict.
+    """
+    webhook_id = config_entry.data[CONF_WEBHOOK_ID]
+    session_id = data[ATTR_SESSION_ID]
+    generation = data[ATTR_GENERATION]
+    sequence = data[ATTR_GENERATION_SEQUENCE]
+
+    stored = {
+        session.session_id: session for session in async_load_sessions(hass, webhook_id)
+    }
+    if (session := stored.get(session_id)) is None:
+        return empty_okay_response()
+
+    if not session.describes_same_lifetime(generation, sequence):
+        # Stopping and immediately re-following the same player reuses the session identifier, so
+        # acting on this would take the new relationship's token with it.
+        _LOGGER.debug(
+            "Ignoring a Remote Now Playing dismissal for session %s: it names Follow %s/%s, but"
+            " %s/%s is current",
+            session_id,
+            generation,
+            sequence,
+            session.generation,
+            session.generation_sequence,
+        )
+        return empty_okay_response()
+
+    async_get_manager(hass).async_end_session(webhook_id, session_id)
+    _LOGGER.debug("Stopped following %s for Remote Now Playing", session.entity_id)
+    return empty_okay_response()

--- a/homeassistant/components/mobile_app/webhook.py
+++ b/homeassistant/components/mobile_app/webhook.py
@@ -122,6 +122,11 @@ _LOGGER = logging.getLogger(__name__)
 
 DELAY_SAVE = 10
 
+# Optional per-type rewriters for the payload written to the debug log below, for a command whose
+# payload carries something that must not be logged. The value passed in is the decrypted webhook
+# body, so a redactor is responsible for handling a shape it does not recognise.
+WEBHOOK_PAYLOAD_REDACTORS: Registry[str, Callable[[Any], Any]] = Registry()
+
 WEBHOOK_COMMANDS: Registry[
     str, Callable[[HomeAssistant, ConfigEntry, Any], Coroutine[Any, Any, Response]]
 ] = Registry()
@@ -253,12 +258,16 @@ async def handle_webhook(
         )
         return empty_okay_response()
 
-    _LOGGER.debug(
-        "Received webhook payload from %s for type %s: %s",
-        device_name,
-        webhook_type,
-        webhook_payload,
-    )
+    if _LOGGER.isEnabledFor(logging.DEBUG):
+        loggable_payload = webhook_payload
+        if (redactor := WEBHOOK_PAYLOAD_REDACTORS.get(webhook_type)) is not None:
+            loggable_payload = redactor(webhook_payload)
+        _LOGGER.debug(
+            "Received webhook payload from %s for type %s: %s",
+            device_name,
+            webhook_type,
+            loggable_payload,
+        )
 
     # Shield so we make sure we finish the webhook, even if sender hangs up.
     return await asyncio.shield(

--- a/tests/components/mobile_app/remote_media/__init__.py
+++ b/tests/components/mobile_app/remote_media/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the mobile_app Remote Now Playing package."""

--- a/tests/components/mobile_app/remote_media/conftest.py
+++ b/tests/components/mobile_app/remote_media/conftest.py
@@ -1,0 +1,166 @@
+"""Fixtures for Remote Now Playing tests."""
+
+from typing import Any
+
+import pytest
+
+from homeassistant.components.mobile_app.const import (
+    DATA_CONFIG_ENTRIES,
+    DATA_REMOTE_MEDIA_SESSIONS,
+    DOMAIN,
+)
+from homeassistant.components.mobile_app.remote_media.model import RemoteMediaSession
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .const import (
+    ENTITY_ID,
+    GENERATION,
+    PLAYING_ATTRIBUTES,
+    PUSH_TOKEN,
+    PUSH_URL,
+    SEQUENCE,
+    SERVER_ID,
+    SESSION_ID,
+)
+
+from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+WEBHOOK_ID = "remote-media-webhook-id"
+
+# A persisted snapshot, for tests that need sticky state to already exist.
+STORED_SNAPSHOT: dict[str, Any] = {
+    "server_id": SERVER_ID,
+    "entity_id": ENTITY_ID,
+    "device_name": "Speaker",
+    "state": "playing",
+    "device_class": None,
+    "title": "First",
+    "artist": "Artist",
+    "album": "Album",
+    "content_id": "track-1",
+    "duration": 240.0,
+    "position": 10.0,
+    "position_updated_at_unix": 1788739200.0,
+    "volume": 0.4,
+    "is_muted": False,
+    "features": 84037,
+    "artwork_url": None,
+}
+
+
+def session(**overrides: Any) -> RemoteMediaSession:
+    """A stored Follow relationship."""
+    values: dict[str, Any] = {
+        "session_id": SESSION_ID,
+        "generation": GENERATION,
+        "generation_sequence": SEQUENCE,
+        "entity_id": ENTITY_ID,
+        "server_id": SERVER_ID,
+        "push_token": PUSH_TOKEN,
+        "schema_version": 1,
+    }
+    values.update(overrides)
+    return RemoteMediaSession(**values)
+
+
+def stored_session(**overrides: Any) -> dict[str, Any]:
+    """The same relationship as it is persisted, with sticky state."""
+    data: dict[str, Any] = {
+        **session().as_storage(),
+        "last_timestamp": 1788739200,
+        "last_snapshot": dict(STORED_SNAPSHOT),
+    }
+    data.update(overrides)
+    return data
+
+
+def stored_sessions(hass: HomeAssistant, webhook_id: str) -> dict[str, Any]:
+    """The persisted sessions for one registration."""
+    # pylint: disable-next=home-assistant-use-runtime-data
+    return hass.data[DOMAIN][DATA_REMOTE_MEDIA_SESSIONS].get(webhook_id, {})
+
+
+@pytest.fixture
+async def push_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> ConfigEntry:
+    """A push-capable Apple registration.
+
+    Built from a `MockConfigEntry` rather than the HTTP registration flow so the relay mock is in
+    place before any client session exists.
+    """
+    entry = MockConfigEntry(
+        data={
+            "app_data": {"push_token": "COMPANION_TOKEN", "push_url": PUSH_URL},
+            "app_id": "io.robbie.HomeAssistant",
+            "app_name": "Home Assistant",
+            "app_version": "2026.9.1",
+            "device_id": "device-1",
+            "device_name": "Test iPhone",
+            "manufacturer": "Apple",
+            "model": "iPhone",
+            "os_name": "iOS",
+            "os_version": "27.0",
+            "secret": "123abc",
+            "supports_encryption": False,
+            "user_id": "user-1",
+            "webhook_id": WEBHOOK_ID,
+        },
+        domain=DOMAIN,
+        source="registration",
+        title="Test iPhone",
+        version=1,
+    )
+    entry.add_to_hass(hass)
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    await hass.async_block_till_done()
+    # pylint: disable-next=home-assistant-use-runtime-data
+    return hass.data[DOMAIN][DATA_CONFIG_ENTRIES][WEBHOOK_ID]
+
+
+@pytest.fixture
+async def local_only_entry(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> ConfigEntry:
+    """A registration with no cloud push configuration.
+
+    Local push only, or a build that never asked for push. Core -> relay -> APNs cannot reach it,
+    so a Follow relationship for it is stored and left alone rather than watched.
+    """
+    entry = MockConfigEntry(
+        data={
+            "app_data": {},
+            "app_id": "io.robbie.HomeAssistant",
+            "app_name": "Home Assistant",
+            "app_version": "2026.9.1",
+            "device_id": "device-2",
+            "device_name": "Local iPhone",
+            "manufacturer": "Apple",
+            "model": "iPhone",
+            "os_name": "iOS",
+            "os_version": "27.0",
+            "secret": "123abc",
+            "supports_encryption": False,
+            "user_id": "user-1",
+            "webhook_id": WEBHOOK_ID,
+        },
+        domain=DOMAIN,
+        source="registration",
+        title="Local iPhone",
+        version=1,
+    )
+    entry.add_to_hass(hass)
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    await hass.async_block_till_done()
+    # pylint: disable-next=home-assistant-use-runtime-data
+    return hass.data[DOMAIN][DATA_CONFIG_ENTRIES][WEBHOOK_ID]
+
+
+@pytest.fixture
+def playing_player(hass: HomeAssistant) -> dict[str, Any]:
+    """A media player that is playing something."""
+    hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+    return dict(PLAYING_ATTRIBUTES)

--- a/tests/components/mobile_app/remote_media/const.py
+++ b/tests/components/mobile_app/remote_media/const.py
@@ -1,0 +1,63 @@
+"""Shared values for Remote Now Playing tests."""
+
+SERVER_ID = "home"
+ENTITY_ID = "media_player.speaker"
+# Apple's identifier for the session. Core treats it as opaque and never parses it: this happens
+# to be what the app builds today ("{utf8 byte count of serverId}:{serverId}{entityId}"), and the
+# tests use a realistic value precisely to prove that nothing here depends on its shape.
+SESSION_ID = "4:homemedia_player.speaker"
+GENERATION = "11111111-2222-3333-4444-555555555555"
+LATER_GENERATION = "99999999-8888-7777-6666-555555555555"
+SEQUENCE = 10
+LATER_SEQUENCE = 11
+# 80 bytes, the length observed on the platform this was measured on.
+PUSH_TOKEN = "40" + "ab" * 79
+LATER_PUSH_TOKEN = "41" + "cd" * 79
+
+PUSH_URL = "http://localhost/mock-push"
+
+
+def registration_payload(**overrides):
+    """Return a remote_media_session_token payload.
+
+    The exact keys the iOS `RemoteMediaSessionRegistration.CodingKeys` produce. Asserted literally
+    in `test_webhook.py` against `RemoteMediaRegistrationRequestTests` on the app side.
+    """
+    payload = {
+        "session_id": SESSION_ID,
+        "server_id": SERVER_ID,
+        "entity_id": ENTITY_ID,
+        "generation": GENERATION,
+        "generation_sequence": SEQUENCE,
+        "push_token": PUSH_TOKEN,
+        "schema_version": 1,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def dismissal_payload(**overrides):
+    """Return a remote_media_session_dismissed payload."""
+    payload = {
+        "session_id": SESSION_ID,
+        "generation": GENERATION,
+        "generation_sequence": SEQUENCE,
+    }
+    payload.update(overrides)
+    return payload
+
+
+PLAYING_ATTRIBUTES = {
+    "friendly_name": "Speaker",
+    "media_content_id": "track-1",
+    "media_title": "First",
+    "media_artist": "Artist",
+    "media_album_name": "Album",
+    "media_duration": 240,
+    "media_position": 10,
+    "media_position_updated_at": "2026-09-07T00:00:00+00:00",
+    "volume_level": 0.4,
+    "is_volume_muted": False,
+    "supported_features": 84037,
+    "entity_picture": "/api/media_player_proxy/media_player.speaker?token=secret",
+}

--- a/tests/components/mobile_app/remote_media/test_lifecycle.py
+++ b/tests/components/mobile_app/remote_media/test_lifecycle.py
@@ -1,0 +1,167 @@
+"""Config-entry lifecycle: unloading is not the user stopping following.
+
+The distinction matters more here than in most integrations, because the whole point of the
+feature is that it keeps working while the phone's app is not running. A reload, a restart or
+Home Assistant stopping must leave every Follow relationship exactly as it was; only removing the
+registration ends them.
+"""
+
+import asyncio
+from http import HTTPStatus
+from typing import Any
+
+from homeassistant.components.mobile_app.remote_media.manager import async_get_manager
+from homeassistant.components.mobile_app.remote_media.store import async_save_session
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from .conftest import WEBHOOK_ID, session, stored_sessions
+from .const import (
+    ENTITY_ID,
+    GENERATION,
+    PLAYING_ATTRIBUTES,
+    PUSH_TOKEN,
+    PUSH_URL,
+    SEQUENCE,
+    SESSION_ID,
+)
+
+from tests.test_util.aiohttp import AiohttpClientMocker, AiohttpClientMockResponse
+
+
+def _ends(aioclient_mock: AiohttpClientMocker) -> list:
+    """Every `end` the relay was asked to deliver."""
+    return [
+        call
+        for call in aioclient_mock.mock_calls
+        if call[2]["now_playing"]["event"] == "end"
+    ]
+
+
+async def _follow(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Start following, stored and watched."""
+    hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+    await hass.async_block_till_done()
+    following = session()
+    async_save_session(hass, WEBHOOK_ID, following)
+    async_get_manager(hass).async_add(WEBHOOK_ID, following, entry, reconcile=False)
+
+
+async def test_unloading_keeps_the_relationship_and_sends_nothing(
+    hass: HomeAssistant, push_entry: ConfigEntry, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """A reload or a shutdown is not Stop Following."""
+    aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+    await _follow(hass, push_entry)
+    manager = async_get_manager(hass)
+    assert manager.async_get(WEBHOOK_ID, SESSION_ID) is not None
+
+    assert await hass.config_entries.async_unload(push_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # The relationship, its token and its sticky state are all still there.
+    assert SESSION_ID in stored_sessions(hass, WEBHOOK_ID)
+    assert stored_sessions(hass, WEBHOOK_ID)[SESSION_ID]["push_token"] == PUSH_TOKEN
+    assert stored_sessions(hass, WEBHOOK_ID)[SESSION_ID]["generation"] == GENERATION
+    assert (
+        stored_sessions(hass, WEBHOOK_ID)[SESSION_ID]["generation_sequence"] == SEQUENCE
+    )
+    # Nothing was told the card, and nothing is being watched.
+    assert not _ends(aioclient_mock)
+    assert manager.async_get(WEBHOOK_ID, SESSION_ID) is None
+    assert ENTITY_ID not in manager.watchers
+
+
+async def test_setting_up_again_restores_and_reconciles(
+    hass: HomeAssistant, push_entry: ConfigEntry, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """The listener comes back and the card is brought up to date from current state."""
+    aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+    await _follow(hass, push_entry)
+
+    assert await hass.config_entries.async_unload(push_entry.entry_id)
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(push_entry.entry_id)
+    await hass.async_block_till_done()
+
+    manager = async_get_manager(hass)
+    publisher = manager.async_get(WEBHOOK_ID, SESSION_ID)
+    assert publisher is not None
+    assert publisher.session.push_token == PUSH_TOKEN
+    assert ENTITY_ID in manager.watchers
+    assert not _ends(aioclient_mock)
+
+
+async def test_a_reload_survives_repeatedly(
+    hass: HomeAssistant, push_entry: ConfigEntry, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Nothing accumulates: one listener and one publisher, however many reloads."""
+    aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+    await _follow(hass, push_entry)
+
+    for _ in range(3):
+        await hass.config_entries.async_reload(push_entry.entry_id)
+        await hass.async_block_till_done()
+
+    manager = async_get_manager(hass)
+    assert push_entry.state is ConfigEntryState.LOADED
+    assert len(stored_sessions(hass, WEBHOOK_ID)) == 1
+    assert len(manager.watchers[ENTITY_ID].publishers) == 1
+    assert not _ends(aioclient_mock)
+
+
+async def test_removing_the_registration_ends_everything(
+    hass: HomeAssistant, push_entry: ConfigEntry, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Removal is permanent, and tells the card best effort."""
+    aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+    await _follow(hass, push_entry)
+
+    assert await hass.config_entries.async_remove(push_entry.entry_id)
+    await hass.async_block_till_done()
+
+    manager = async_get_manager(hass)
+    assert stored_sessions(hass, WEBHOOK_ID) == {}
+    assert manager.async_get(WEBHOOK_ID, SESSION_ID) is None
+    assert ENTITY_ID not in manager.watchers
+    assert _ends(aioclient_mock)
+
+
+async def test_a_late_end_completion_does_not_restore_the_session(
+    hass: HomeAssistant, push_entry: ConfigEntry, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """An end response arriving after removal must not recreate persisted state."""
+    release = asyncio.Event()
+
+    async def slow_end(
+        method: str, url: str, data: dict[str, Any]
+    ) -> AiohttpClientMockResponse:
+        assert data["now_playing"]["event"] == "end"
+        await release.wait()
+        return AiohttpClientMockResponse(
+            method, url, status=HTTPStatus.CREATED, json={}
+        )
+
+    aioclient_mock.post(PUSH_URL, side_effect=slow_end)
+    await _follow(hass, push_entry)
+    async_get_manager(hass).async_end_session(WEBHOOK_ID, SESSION_ID)
+    await asyncio.sleep(0)
+
+    assert stored_sessions(hass, WEBHOOK_ID) == {}
+    release.set()
+    await hass.async_block_till_done()
+    assert stored_sessions(hass, WEBHOOK_ID) == {}
+
+
+async def test_a_relay_outage_cannot_block_removal(
+    hass: HomeAssistant, push_entry: ConfigEntry, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Deleting a config entry must never depend on an external service answering."""
+    aioclient_mock.post(PUSH_URL, exc=TimeoutError())
+    await _follow(hass, push_entry)
+
+    assert await hass.config_entries.async_remove(push_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert stored_sessions(hass, WEBHOOK_ID) == {}
+    assert async_get_manager(hass).async_get(WEBHOOK_ID, SESSION_ID) is None

--- a/tests/components/mobile_app/remote_media/test_manager.py
+++ b/tests/components/mobile_app/remote_media/test_manager.py
@@ -1,0 +1,1007 @@
+"""Traffic shaping, ordering and lifecycle for a followed player.
+
+Core is the primary traffic shaper. A playing media player emits a state event every few seconds
+and almost none of them are worth waking a phone for, because the card advances its own position
+between updates.
+"""
+
+import asyncio
+from http import HTTPStatus
+from typing import Any
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+
+from homeassistant.components.mobile_app.const import DATA_REMOTE_MEDIA_SESSIONS, DOMAIN
+from homeassistant.components.mobile_app.remote_media.const import (
+    COALESCE_SECONDS,
+    MAXIMUM_RETRY_BACKOFF_SECONDS,
+    RETRY_BACKOFF_SECONDS,
+)
+from homeassistant.components.mobile_app.remote_media.manager import (
+    async_get_manager,
+    is_meaningful_change,
+)
+from homeassistant.components.mobile_app.remote_media.model import (
+    RemoteMediaSession,
+    RemoteMediaSnapshot,
+)
+from homeassistant.components.mobile_app.remote_media.store import async_save_session
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from .conftest import WEBHOOK_ID, session
+from .const import (
+    ENTITY_ID,
+    GENERATION,
+    LATER_PUSH_TOKEN,
+    PLAYING_ATTRIBUTES,
+    PUSH_TOKEN,
+    PUSH_URL,
+    SEQUENCE,
+    SESSION_ID,
+)
+
+from tests.common import async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker, AiohttpClientMockResponse
+
+
+def snapshot(**overrides) -> RemoteMediaSnapshot:
+    """A playing snapshot."""
+    values = {
+        "server_id": "home",
+        "entity_id": ENTITY_ID,
+        "device_name": "Speaker",
+        "state": "playing",
+        "title": "First",
+        "artist": "Artist",
+        "album": "Album",
+        "content_id": "track-1",
+        "duration": 240.0,
+        "position": 10.0,
+        "position_updated_at_unix": 1788739200.0,
+        "volume": 0.4,
+        "is_muted": False,
+        "features": 84037,
+    }
+    values.update(overrides)
+    return RemoteMediaSnapshot(**values)
+
+
+async def _settle(hass: HomeAssistant) -> None:
+    """Let the coalescing window elapse and any send finish."""
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + dt_util.dt.timedelta(seconds=COALESCE_SECONDS + 0.1)
+    )
+    await hass.async_block_till_done()
+
+
+@pytest.fixture
+async def publisher(hass: HomeAssistant, push_entry: ConfigEntry):
+    """A publisher for a followed player, with the relay mocked to succeed."""
+    hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+    await hass.async_block_till_done()
+    return async_get_manager(hass).async_add(
+        WEBHOOK_ID, session(), push_entry, reconcile=False
+    )
+
+
+class TestMeaningfulChange:
+    """What counts as worth a push."""
+
+    def test_the_first_snapshot_always_is(self) -> None:
+        """Nothing is on the card yet."""
+        assert is_meaningful_change(None, snapshot())
+
+    def test_ordinary_progress_is_not(self) -> None:
+        """The expensive mistake. The card is already extrapolating between updates."""
+        published = snapshot(position=10.0, position_updated_at_unix=1000.0)
+        # 30 seconds later, 30 seconds further in.
+        progressed = snapshot(position=40.0, position_updated_at_unix=1030.0)
+        assert not is_meaningful_change(published, progressed)
+
+    def test_progress_with_integration_rounding_is_not(self) -> None:
+        """Reported positions drift by a second or two; that is not a seek."""
+        published = snapshot(position=10.0, position_updated_at_unix=1000.0)
+        for reported in (39.0, 40.0, 41.5, 42.9):
+            drifted = snapshot(position=reported, position_updated_at_unix=1030.0)
+            assert not is_meaningful_change(published, drifted), reported
+
+    @pytest.mark.parametrize("target", [90.0, 5.0, 0.0, 200.0])
+    def test_a_seek_is(self, target: float) -> None:
+        """A jump playback would not have made."""
+        published = snapshot(position=10.0, position_updated_at_unix=1000.0)
+        seeked = snapshot(position=target, position_updated_at_unix=1030.0)
+        assert is_meaningful_change(published, seeked)
+
+    def test_a_position_change_while_paused_is(self) -> None:
+        """Nothing is advancing, so any movement was a user."""
+        published = snapshot(
+            state="paused", position=10.0, position_updated_at_unix=1000.0
+        )
+        moved = snapshot(state="paused", position=60.0, position_updated_at_unix=1000.0)
+        assert is_meaningful_change(published, moved)
+
+    def test_a_track_change_is(self) -> None:
+        """A different song is a different card."""
+        assert is_meaningful_change(
+            snapshot(), snapshot(content_id="track-2", title="Second")
+        )
+
+    @pytest.mark.parametrize("state", ["paused", "idle", "off", "unavailable"])
+    def test_a_playback_transition_is(self, state: str) -> None:
+        """Play, pause and stop all look different."""
+        assert is_meaningful_change(snapshot(), snapshot(state=state))
+
+    def test_buffering_is_not_a_transition_from_playing(self) -> None:
+        """The card renders both as playing, so the difference is invisible."""
+        assert not is_meaningful_change(
+            snapshot(state="playing"), snapshot(state="buffering")
+        )
+
+    def test_a_relabelled_stop_is_not(self) -> None:
+        """`idle`, `off` and `standby` all render the same; swapping them says nothing."""
+        assert not is_meaningful_change(snapshot(state="idle"), snapshot(state="off"))
+
+    def test_a_capability_change_is(self) -> None:
+        """The card draws its buttons from these."""
+        assert is_meaningful_change(snapshot(), snapshot(features=1))
+
+    def test_a_meaningful_volume_change_is(self) -> None:
+        """The card shows a volume slider."""
+        assert is_meaningful_change(snapshot(volume=0.4), snapshot(volume=0.6))
+
+    def test_a_negligible_volume_change_is_not(self) -> None:
+        """Float noise is not a user."""
+        assert not is_meaningful_change(snapshot(volume=0.4), snapshot(volume=0.405))
+
+    def test_muting_is(self) -> None:
+        """Visible on the card."""
+        assert is_meaningful_change(snapshot(), snapshot(is_muted=True))
+
+    @pytest.mark.parametrize(
+        "difference",
+        [
+            {"server_id": "cabin"},
+            {"duration": 300.0},
+            {"device_name": "Kitchen speaker"},
+            {"device_class": "tv"},
+            {"artwork_url": "https://cdn.example.com/other.jpg"},
+        ],
+        ids=["server", "duration", "name", "class", "artwork"],
+    )
+    def test_anything_the_card_draws_is(self, difference: dict[str, Any]) -> None:
+        """The card renders each of these, so a change to one of them has to be sent."""
+        assert is_meaningful_change(snapshot(), snapshot(**difference))
+
+    def test_an_identical_snapshot_is_not(self) -> None:
+        """Nothing to say."""
+        assert not is_meaningful_change(snapshot(), snapshot())
+
+
+class TestTimestamps:
+    """The outer APNs ordering clock, which Core owns."""
+
+    def test_it_uses_wall_clock_seconds(self, freezer: FrozenDateTimeFactory) -> None:
+        """A session starts with no ordering value."""
+        freezer.move_to("2026-09-07 00:00:00+00:00")
+        stored = session()
+        assert stored.last_timestamp is None
+
+    async def test_two_pushes_in_one_second_still_order(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+        freezer: FrozenDateTimeFactory,
+    ) -> None:
+        """APNs sequences a session's pushes by this, and a second is a long time."""
+        freezer.move_to("2026-09-07 00:00:00+00:00")
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+
+        publisher.async_publish(snapshot())
+        await hass.async_block_till_done()
+        publisher.async_publish(snapshot(content_id="track-2", title="Second"))
+        await hass.async_block_till_done()
+
+        timestamps = [
+            call[2]["now_playing"]["timestamp"] for call in aioclient_mock.mock_calls
+        ]
+        assert len(timestamps) == 2
+        assert timestamps[1] == timestamps[0] + 1
+        assert timestamps[0] == 1788739200
+
+    async def test_a_clock_that_went_backwards_cannot_reorder(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+        freezer: FrozenDateTimeFactory,
+    ) -> None:
+        """A corrected clock must not let an older ordering value out."""
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        publisher.session.last_timestamp = 1788739200
+        freezer.move_to("2020-01-01 00:00:00+00:00")
+
+        publisher.async_publish(snapshot())
+        await hass.async_block_till_done()
+
+        sent = aioclient_mock.mock_calls[0][2]["now_playing"]["timestamp"]
+        assert sent == 1788739201
+
+    async def test_ordering_survives_a_restart(
+        self,
+        hass: HomeAssistant,
+        push_entry: ConfigEntry,
+        aioclient_mock: AiohttpClientMocker,
+        freezer: FrozenDateTimeFactory,
+    ) -> None:
+        """The clock is persisted with the session."""
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        freezer.move_to("2020-01-01 00:00:00+00:00")
+        restored = session()
+        restored.last_timestamp = 1788739500
+        publisher = async_get_manager(hass).async_add(
+            WEBHOOK_ID, restored, push_entry, reconcile=False
+        )
+
+        publisher.async_publish(snapshot())
+        await hass.async_block_till_done()
+        assert aioclient_mock.mock_calls[0][2]["now_playing"]["timestamp"] == 1788739501
+
+    async def test_sessions_have_independent_clocks(
+        self, hass: HomeAssistant, push_entry: ConfigEntry
+    ) -> None:
+        """One session's traffic must not push another's ordering forward."""
+        first = session()
+        second = RemoteMediaSession(
+            session_id="4:homemedia_player.other",
+            generation="other",
+            generation_sequence=SEQUENCE,
+            entity_id="media_player.other",
+            server_id="home",
+            push_token=PUSH_TOKEN,
+            schema_version=1,
+            last_timestamp=999,
+        )
+        manager = async_get_manager(hass)
+        manager.async_add(WEBHOOK_ID, first, push_entry, reconcile=False)
+        manager.async_add(WEBHOOK_ID, second, push_entry, reconcile=False)
+        assert first.last_timestamp is None
+        assert second.last_timestamp == 999
+
+
+class TestDelivery:
+    """One sender per session, and no queue of stale requests."""
+
+    async def test_ordinary_progress_produces_no_traffic(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """A stream of position updates from a playing track must push once, at most."""
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        base = 1788739200.0
+        for step in range(30):
+            hass.states.async_set(
+                ENTITY_ID,
+                "playing",
+                {
+                    **PLAYING_ATTRIBUTES,
+                    "media_position": 10 + step * 5,
+                    "media_position_updated_at": dt_util.utc_from_timestamp(
+                        base + step * 5
+                    ).isoformat(),
+                },
+            )
+            await _settle(hass)
+
+        # The first report is the card; nothing after it says anything new.
+        assert len(aioclient_mock.mock_calls) == 1
+
+    async def test_a_transient_sequence_coalesces_into_one_push(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """`playing A` -> `idle` blank -> `playing B` is one outcome, not three cards."""
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+        hass.states.async_set(ENTITY_ID, "idle", {"friendly_name": "Speaker"})
+        hass.states.async_set(
+            ENTITY_ID,
+            "playing",
+            {
+                **PLAYING_ATTRIBUTES,
+                "media_content_id": "track-2",
+                "media_title": "Second",
+            },
+        )
+        await _settle(hass)
+
+        assert len(aioclient_mock.mock_calls) == 1
+        sent = aioclient_mock.mock_calls[0][2]["now_playing"]["attributes"]["snapshot"]
+        assert sent["title"] == "Second"
+
+    async def test_a_slow_relay_does_not_queue_requests(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """A burst while one send is in flight results in one more, carrying the newest state."""
+        release = asyncio.Event()
+        sent: list[dict[str, Any]] = []
+
+        async def slow_relay(method, url, data):
+            sent.append(data)
+            await release.wait()
+            return AiohttpClientMockResponse(
+                method, url, status=HTTPStatus.CREATED, json={}
+            )
+
+        aioclient_mock.post(PUSH_URL, side_effect=slow_relay)
+
+        publisher.async_publish(snapshot(title="One"))
+        await asyncio.sleep(0)
+        for title in ("Two", "Three", "Four"):
+            publisher.async_publish(snapshot(content_id=title, title=title))
+        release.set()
+        await hass.async_block_till_done()
+
+        # One in flight, then exactly one more with the newest desired state — not four.
+        assert len(sent) == 2
+        assert sent[1]["now_playing"]["attributes"]["snapshot"]["title"] == "Four"
+
+    async def test_replacing_a_session_retires_its_in_flight_sender(
+        self,
+        hass: HomeAssistant,
+        push_entry: ConfigEntry,
+        aioclient_mock: AiohttpClientMocker,
+        freezer: FrozenDateTimeFactory,
+    ) -> None:
+        """A late result from an old token cannot overwrite or retry the replacement."""
+        release = asyncio.Event()
+        sent: list[dict[str, Any]] = []
+
+        async def failing_relay(
+            method: str, url: str, data: dict[str, Any]
+        ) -> AiohttpClientMockResponse:
+            sent.append(data)
+            await release.wait()
+            return AiohttpClientMockResponse(
+                method, url, status=HTTPStatus.INTERNAL_SERVER_ERROR, json={}
+            )
+
+        aioclient_mock.post(PUSH_URL, side_effect=failing_relay)
+        manager = async_get_manager(hass)
+        old_session = session()
+        async_save_session(hass, WEBHOOK_ID, old_session)
+        old_publisher = manager.async_add(
+            WEBHOOK_ID, old_session, push_entry, reconcile=False
+        )
+        assert old_publisher is not None
+        old_publisher.async_publish(snapshot(title="Old"))
+        await asyncio.sleep(0)
+
+        replacement = session(push_token=LATER_PUSH_TOKEN)
+        async_save_session(hass, WEBHOOK_ID, replacement)
+        manager.async_add(WEBHOOK_ID, replacement, push_entry, reconcile=False)
+
+        release.set()
+        await hass.async_block_till_done()
+        stored = hass.data[DOMAIN][DATA_REMOTE_MEDIA_SESSIONS][WEBHOOK_ID][SESSION_ID]
+        assert stored["push_token"] == LATER_PUSH_TOKEN
+
+        freezer.tick(dt_util.dt.timedelta(seconds=RETRY_BACKOFF_SECONDS + 1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        assert len(sent) == 1
+
+    async def test_a_stale_completion_cannot_overwrite_newer_state(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """The newest desired state is always what goes out next."""
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        publisher.async_publish(snapshot(title="Old"))
+        publisher.async_publish(snapshot(content_id="new", title="New"))
+        await hass.async_block_till_done()
+        last = aioclient_mock.mock_calls[-1][2]["now_playing"]["attributes"]["snapshot"]
+        assert last["title"] == "New"
+
+    async def test_a_dead_token_removes_the_session(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """The one relay answer that unregisters and detaches all runtime ownership."""
+        manager = async_get_manager(hass)
+        watcher = manager.watchers[ENTITY_ID]
+        aioclient_mock.post(
+            PUSH_URL, status=HTTPStatus.GONE, json={"errorType": "InvalidToken"}
+        )
+        async_save_session(hass, WEBHOOK_ID, publisher.session)
+        publisher.async_publish(snapshot())
+        await hass.async_block_till_done()
+
+        # pylint: disable-next=home-assistant-use-runtime-data
+        assert hass.data[DOMAIN][DATA_REMOTE_MEDIA_SESSIONS].get(WEBHOOK_ID, {}) == {}
+        assert publisher._removed
+        assert manager.async_get(WEBHOOK_ID, SESSION_ID) is None
+        assert ENTITY_ID not in manager.watchers
+        assert watcher.publishers == {}
+        assert watcher._unsubscribe is None
+        assert watcher._unsubscribe_registry is None
+        assert len(aioclient_mock.mock_calls) == 1
+        assert aioclient_mock.mock_calls[0][2]["now_playing"]["event"] == "update"
+
+    @pytest.mark.parametrize(
+        ("status", "error_type"),
+        [
+            (HTTPStatus.FORBIDDEN, "UnsupportedApp"),
+            (HTTPStatus.BAD_REQUEST, "TopicMismatch"),
+            (HTTPStatus.BAD_GATEWAY, "ProviderAuth"),
+            (HTTPStatus.NOT_IMPLEMENTED, "NowPlayingNotConfigured"),
+            (HTTPStatus.TOO_MANY_REQUESTS, "RateLimited"),
+            (HTTPStatus.BAD_GATEWAY, "ApnsUnavailable"),
+        ],
+    )
+    async def test_other_failures_keep_the_session(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+        status: int,
+        error_type: str,
+    ) -> None:
+        """A relay or deployment problem is not the user's session token's fault."""
+        async_save_session(hass, WEBHOOK_ID, publisher.session)
+        aioclient_mock.post(PUSH_URL, status=status, json={"errorType": error_type})
+        publisher.async_publish(snapshot())
+        await hass.async_block_till_done()
+
+        # pylint: disable-next=home-assistant-use-runtime-data
+        stored = hass.data[DOMAIN][DATA_REMOTE_MEDIA_SESSIONS][WEBHOOK_ID]
+        assert SESSION_ID in stored
+
+    async def test_a_misconfigured_relay_is_reported_once(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Not once per state change of a playing media player."""
+        aioclient_mock.post(
+            PUSH_URL, status=HTTPStatus.FORBIDDEN, json={"errorType": "UnsupportedApp"}
+        )
+        for index in range(5):
+            publisher.async_publish(snapshot(content_id=f"track-{index}"))
+            await hass.async_block_till_done()
+
+        assert caplog.text.count("will not deliver Remote Now Playing updates") == 1
+        # And it did not keep hammering the relay either.
+        assert len(aioclient_mock.mock_calls) == 1
+
+    async def test_no_token_reaches_the_log(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Neither the APNs destination nor the Companion token."""
+        aioclient_mock.post(
+            PUSH_URL, status=HTTPStatus.GONE, json={"errorType": "InvalidToken"}
+        )
+        publisher.async_publish(snapshot())
+        await hass.async_block_till_done()
+        assert PUSH_TOKEN not in caplog.text
+        assert "COMPANION_TOKEN" not in caplog.text
+
+
+class TestAnUpdateThatIsStillOwed:
+    """A snapshot that failed to go out is the current state of the player just the same.
+
+    Nothing else will re-offer it. An integration that emits a state event only when something
+    changes may say nothing more until the user touches the speaker, so the retry timer is the
+    only thing standing between a failed send and a card that is silently wrong.
+    """
+
+    @staticmethod
+    def _relay(
+        sent: list[dict[str, Any]], failures: int, release: asyncio.Event | None = None
+    ):
+        """A relay that refuses the first `failures` requests, then accepts."""
+
+        async def respond(method: str, url: str, data: dict[str, Any]):
+            sent.append(data)
+            if release is not None and len(sent) == 1:
+                await release.wait()
+            status = (
+                HTTPStatus.INTERNAL_SERVER_ERROR
+                if len(sent) <= failures
+                else HTTPStatus.CREATED
+            )
+            return AiohttpClientMockResponse(method, url, status=status, json={})
+
+        return respond
+
+    async def test_a_newer_snapshot_that_raced_a_failed_send_is_not_lost(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+        freezer: FrozenDateTimeFactory,
+    ) -> None:
+        """The track changed while the send that failed was still in flight."""
+        release = asyncio.Event()
+        sent: list[dict[str, Any]] = []
+        aioclient_mock.post(PUSH_URL, side_effect=self._relay(sent, 1, release))
+
+        publisher.async_publish(snapshot(title="One"))
+        await asyncio.sleep(0)
+        publisher.async_publish(snapshot(content_id="two", title="Two"))
+        release.set()
+        await hass.async_block_till_done()
+        assert len(sent) == 1, (
+            "the newer snapshot must not be sent into a failing relay"
+        )
+
+        # No further state change: only the retry can carry it.
+        freezer.tick(dt_util.dt.timedelta(seconds=RETRY_BACKOFF_SECONDS + 1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        assert len(sent) == 2
+        assert sent[1]["now_playing"]["attributes"]["snapshot"]["title"] == "Two"
+
+    async def test_returning_to_the_published_state_supersedes_a_failed_update(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+        freezer: FrozenDateTimeFactory,
+    ) -> None:
+        """A failed B is no longer owed after the entity settles back at published A."""
+        sent: list[dict[str, Any]] = []
+
+        async def relay(
+            method: str, url: str, data: dict[str, Any]
+        ) -> AiohttpClientMockResponse:
+            sent.append(data)
+            status = HTTPStatus.CREATED if len(sent) == 1 else HTTPStatus.BAD_GATEWAY
+            return AiohttpClientMockResponse(method, url, status=status, json={})
+
+        aioclient_mock.post(PUSH_URL, side_effect=relay)
+
+        publisher.async_apply(snapshot())
+        await _settle(hass)
+        publisher.async_apply(snapshot(content_id="track-2", title="Second"))
+        await _settle(hass)
+        publisher.async_apply(snapshot())
+        await _settle(hass)
+
+        freezer.tick(dt_util.dt.timedelta(seconds=RETRY_BACKOFF_SECONDS + 1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        assert len(sent) == 2
+        assert sent[0]["now_playing"]["attributes"]["snapshot"]["title"] == "First"
+        assert sent[1]["now_playing"]["attributes"]["snapshot"]["title"] == "Second"
+
+    async def test_a_send_that_raises_is_retried_rather_than_discarded(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+        freezer: FrozenDateTimeFactory,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An exception on the way out says nothing about whether the snapshot is current."""
+        sent: list[dict[str, Any]] = []
+
+        async def erratic(method: str, url: str, data: dict[str, Any]):
+            sent.append(data)
+            if len(sent) == 1:
+                raise ValueError("the request came apart")
+            return AiohttpClientMockResponse(
+                method, url, status=HTTPStatus.CREATED, json={}
+            )
+
+        aioclient_mock.post(PUSH_URL, side_effect=erratic)
+        publisher.async_publish(snapshot(title="One"))
+        await hass.async_block_till_done()
+        assert "Could not send a Remote Now Playing update" in caplog.text
+
+        freezer.tick(dt_util.dt.timedelta(seconds=RETRY_BACKOFF_SECONDS + 1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        assert len(sent) == 2
+        assert sent[1]["now_playing"]["attributes"]["snapshot"]["title"] == "One"
+
+    async def test_the_delay_doubles_while_it_keeps_failing(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+        freezer: FrozenDateTimeFactory,
+    ) -> None:
+        """One timer at a time, each further out than the last, and never a poll."""
+        sent: list[dict[str, Any]] = []
+        aioclient_mock.post(PUSH_URL, side_effect=self._relay(sent, 3))
+
+        publisher.async_publish(snapshot(title="One"))
+        await hass.async_block_till_done()
+        assert len(sent) == 1
+
+        # Just short of each expected delay nothing happens; just past it, exactly one attempt.
+        for expected in (RETRY_BACKOFF_SECONDS, RETRY_BACKOFF_SECONDS * 2):
+            attempts = len(sent)
+            freezer.tick(dt_util.dt.timedelta(seconds=expected - 1))
+            async_fire_time_changed(hass)
+            await hass.async_block_till_done()
+            assert len(sent) == attempts, f"retried before {expected}s had passed"
+
+            freezer.tick(dt_util.dt.timedelta(seconds=2))
+            async_fire_time_changed(hass)
+            await hass.async_block_till_done()
+            assert len(sent) == attempts + 1
+
+    async def test_the_delay_is_capped(self) -> None:
+        """A session that has been failing for a day must not wait a week."""
+        assert MAXIMUM_RETRY_BACKOFF_SECONDS == 900
+
+    async def test_ending_the_session_cancels_the_retry(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+        freezer: FrozenDateTimeFactory,
+    ) -> None:
+        """Nothing may fire for a relationship that is over."""
+        sent: list[dict[str, Any]] = []
+        aioclient_mock.post(PUSH_URL, side_effect=self._relay(sent, 99))
+
+        publisher.async_publish(snapshot(title="One"))
+        await hass.async_block_till_done()
+        assert len(sent) == 1
+
+        async_get_manager(hass).async_end_session(WEBHOOK_ID, SESSION_ID)
+        await hass.async_block_till_done()
+        after_end = len(sent)
+
+        freezer.tick(dt_util.dt.timedelta(seconds=MAXIMUM_RETRY_BACKOFF_SECONDS * 2))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        assert len(sent) == after_end, "a removed session must not keep retrying"
+
+    async def test_a_delivery_resets_the_delay(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+        freezer: FrozenDateTimeFactory,
+    ) -> None:
+        """Or a session that once had a bad day would stay slow to recover forever."""
+        sent: list[dict[str, Any]] = []
+        aioclient_mock.post(PUSH_URL, side_effect=self._relay(sent, 1))
+
+        publisher.async_publish(snapshot(title="One"))
+        await hass.async_block_till_done()
+        freezer.tick(dt_util.dt.timedelta(seconds=RETRY_BACKOFF_SECONDS + 1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        assert len(sent) == 2, "the retry should have landed"
+
+        # Failing again starts from the base delay rather than from where it left off.
+        aioclient_mock.clear_requests()
+        sent.clear()
+        aioclient_mock.post(PUSH_URL, side_effect=self._relay(sent, 1))
+        publisher.async_publish(snapshot(content_id="two", title="Two"))
+        await hass.async_block_till_done()
+        assert len(sent) == 1
+
+        freezer.tick(dt_util.dt.timedelta(seconds=RETRY_BACKOFF_SECONDS + 1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        assert len(sent) == 2
+
+
+class TestInitialSynchronisation:
+    """What happens the moment a Follow relationship is registered."""
+
+    async def test_a_new_registration_publishes_the_current_state_once(
+        self,
+        hass: HomeAssistant,
+        push_entry: ConfigEntry,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """The card is brought up to date immediately, which also proves the token."""
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+        await hass.async_block_till_done()
+
+        async_get_manager(hass).async_add(
+            WEBHOOK_ID, session(), push_entry, reconcile=True
+        )
+        await _settle(hass)
+
+        assert len(aioclient_mock.mock_calls) == 1
+        body = aioclient_mock.mock_calls[0][2]
+        assert body["now_playing"]["event"] == "update"
+        attributes = body["now_playing"]["attributes"]
+        assert attributes["id"] == SESSION_ID
+        assert attributes["generation"] == GENERATION
+        assert attributes["snapshot"]["title"] == "First"
+
+    async def test_a_player_with_nothing_playing_publishes_nothing(
+        self,
+        hass: HomeAssistant,
+        push_entry: ConfigEntry,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """No track is invented; the relationship waits for something meaningful."""
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        hass.states.async_set(ENTITY_ID, "idle", {"friendly_name": "Speaker"})
+        await hass.async_block_till_done()
+
+        async_get_manager(hass).async_add(
+            WEBHOOK_ID, session(), push_entry, reconcile=True
+        )
+        await _settle(hass)
+
+        assert len(aioclient_mock.mock_calls) == 0
+        # Still following, still listening.
+        assert async_get_manager(hass).async_get(WEBHOOK_ID, SESSION_ID) is not None
+
+    async def test_a_restored_session_does_not_re_push_what_the_card_shows(
+        self,
+        hass: HomeAssistant,
+        push_entry: ConfigEntry,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """A restart must not wake every phone whose player has not changed."""
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+        await hass.async_block_till_done()
+
+        restored = session()
+        restored.last_snapshot = snapshot()
+        restored.last_timestamp = 1788739200
+        async_get_manager(hass).async_add(
+            WEBHOOK_ID, restored, push_entry, reconcile=True
+        )
+        await _settle(hass)
+
+        assert len(aioclient_mock.mock_calls) == 0
+
+
+class TestLifecycle:
+    """Listeners, sharing and removal."""
+
+    async def test_sessions_on_the_same_player_share_one_listener(
+        self, hass: HomeAssistant, push_entry: ConfigEntry
+    ) -> None:
+        """Two devices can follow the same speaker."""
+        manager = async_get_manager(hass)
+        first = session()
+        second = session()
+        second.session_id = "4:homemedia_player.speaker#2"
+        manager.async_add(WEBHOOK_ID, first, push_entry, reconcile=False)
+        manager.async_add(WEBHOOK_ID, second, push_entry, reconcile=False)
+
+        assert len(manager.watchers) == 1
+        assert len(manager.watchers[ENTITY_ID].publishers) == 2
+
+    async def test_removing_one_keeps_the_listener_for_the_other(
+        self,
+        hass: HomeAssistant,
+        push_entry: ConfigEntry,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """The listener goes only when the last session following the player does."""
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        manager = async_get_manager(hass)
+        first = session()
+        second = session()
+        second.session_id = "4:homemedia_player.speaker#2"
+        manager.async_add(WEBHOOK_ID, first, push_entry, reconcile=False)
+        manager.async_add(WEBHOOK_ID, second, push_entry, reconcile=False)
+
+        manager.async_end_session(WEBHOOK_ID, first.session_id)
+        await hass.async_block_till_done()
+        assert ENTITY_ID in manager.watchers
+        manager.async_end_session(WEBHOOK_ID, second.session_id)
+        await hass.async_block_till_done()
+        assert ENTITY_ID not in manager.watchers
+
+    async def test_a_state_disappearance_never_ends_following(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """`new_state is None` says nothing durable.
+
+        An integration reload, a platform reload and startup ordering all produce it, and there is
+        no length of time that separates those from a deletion — so no amount of waiting is used.
+        """
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        async_save_session(hass, WEBHOOK_ID, publisher.session)
+
+        hass.states.async_remove(ENTITY_ID)
+        await hass.async_block_till_done()
+        # However long it stays gone.
+        async_fire_time_changed(hass, dt_util.utcnow() + dt_util.dt.timedelta(hours=6))
+        await hass.async_block_till_done()
+
+        assert async_get_manager(hass).async_get(WEBHOOK_ID, SESSION_ID) is not None
+        assert SESSION_ID in hass.data[DOMAIN][DATA_REMOTE_MEDIA_SESSIONS][WEBHOOK_ID]
+        # And nothing was sent about it.
+        assert not [
+            call
+            for call in aioclient_mock.mock_calls
+            if call[2]["now_playing"]["event"] == "end"
+        ]
+
+    async def test_an_entity_that_comes_back_resumes(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """The card picks up where the player did."""
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        async_save_session(hass, WEBHOOK_ID, publisher.session)
+
+        hass.states.async_remove(ENTITY_ID)
+        await hass.async_block_till_done()
+        hass.states.async_set(
+            ENTITY_ID, "playing", {**PLAYING_ATTRIBUTES, "media_title": "Second"}
+        )
+        await _settle(hass)
+
+        assert async_get_manager(hass).async_get(WEBHOOK_ID, SESSION_ID) is not None
+        titles = [
+            call[2]["now_playing"]["attributes"]["snapshot"].get("title")
+            for call in aioclient_mock.mock_calls
+        ]
+        assert "Second" in titles
+
+    async def test_a_registry_removal_ends_following(
+        self,
+        hass: HomeAssistant,
+        push_entry: ConfigEntry,
+        entity_registry: er.EntityRegistry,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """The registry is where permanence is decided, so this is the signal that ends it."""
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        entry = entity_registry.async_get_or_create(
+            "media_player", "demo", "unique-1", suggested_object_id="speaker"
+        )
+        assert entry.entity_id == ENTITY_ID
+        hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+        await hass.async_block_till_done()
+        manager = async_get_manager(hass)
+        manager.async_add(WEBHOOK_ID, session(), push_entry, reconcile=False)
+        async_save_session(hass, WEBHOOK_ID, session())
+
+        entity_registry.async_remove(ENTITY_ID)
+        await hass.async_block_till_done()
+
+        assert manager.async_get(WEBHOOK_ID, SESSION_ID) is None
+        assert ENTITY_ID not in manager.watchers
+        assert hass.data[DOMAIN][DATA_REMOTE_MEDIA_SESSIONS].get(WEBHOOK_ID, {}) == {}
+        # Best effort told the phone.
+        assert [
+            call
+            for call in aioclient_mock.mock_calls
+            if call[2]["now_playing"]["event"] == "end"
+        ]
+
+    async def test_a_registry_rename_moves_the_relationship(
+        self,
+        hass: HomeAssistant,
+        push_entry: ConfigEntry,
+        entity_registry: er.EntityRegistry,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """The relationship is with the player, not with its name.
+
+        Its identifier, its place in the order and its token all describe the Follow, none of them
+        the entity id — so a rename must not break it, and must not look like a new relationship.
+        """
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        entity_registry.async_get_or_create(
+            "media_player", "demo", "unique-1", suggested_object_id="speaker"
+        )
+        hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+        await hass.async_block_till_done()
+        manager = async_get_manager(hass)
+        stored = session()
+        manager.async_add(WEBHOOK_ID, stored, push_entry, reconcile=True)
+        await _settle(hass)
+
+        renamed = "media_player.living_room"
+        entity_registry.async_update_entity(ENTITY_ID, new_entity_id=renamed)
+        hass.states.async_set(renamed, "playing", PLAYING_ATTRIBUTES)
+        await _settle(hass)
+
+        publisher = manager.async_get(WEBHOOK_ID, SESSION_ID)
+        assert publisher is not None
+        assert publisher.session.entity_id == renamed
+        # Untouched by the rename.
+        assert publisher.session.session_id == SESSION_ID
+        assert publisher.session.generation == GENERATION
+        assert publisher.session.generation_sequence == SEQUENCE
+        assert publisher.session.push_token == PUSH_TOKEN
+        # The listener moved with it.
+        assert renamed in manager.watchers
+        assert ENTITY_ID not in manager.watchers
+        assert (
+            hass.data[DOMAIN][DATA_REMOTE_MEDIA_SESSIONS][WEBHOOK_ID][SESSION_ID][
+                "entity_id"
+            ]
+            == renamed
+        )
+        # And the phone was told, because the card issues commands against the selection.
+        selections = [
+            call[2]["now_playing"]["attributes"]["snapshot"]["selection"]["entityId"]
+            for call in aioclient_mock.mock_calls
+            if "snapshot" in call[2]["now_playing"]["attributes"]
+        ]
+        assert selections[-1] == renamed
+
+    async def test_an_entity_with_no_registry_entry_stays_dormant(
+        self,
+        hass: HomeAssistant,
+        publisher,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """Some entities have no registry entry, so there is no removal signal to wait for.
+
+        Rather than invent another timeout, the relationship simply stays. Stop Following,
+        config-entry removal and an `InvalidToken` from APNs all still clean it up.
+        """
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        async_save_session(hass, WEBHOOK_ID, publisher.session)
+        assert hass.states.get(ENTITY_ID) is not None
+
+        hass.states.async_remove(ENTITY_ID)
+        await hass.async_block_till_done()
+        async_fire_time_changed(hass, dt_util.utcnow() + dt_util.dt.timedelta(days=1))
+        await hass.async_block_till_done()
+
+        assert async_get_manager(hass).async_get(WEBHOOK_ID, SESSION_ID) is not None
+
+
+class TestCloudPushCapability:
+    """A registration Core cannot reach is remembered rather than watched.
+
+    Entering through the webhook is covered in `test_webhook.py`; this is the manager's own view.
+    """
+
+    async def test_a_dormant_relationship_can_still_be_stopped(
+        self, hass: HomeAssistant, local_only_entry: ConfigEntry
+    ) -> None:
+        """Stop Following works whether or not anything was ever watched."""
+        manager = async_get_manager(hass)
+        manager.async_add(WEBHOOK_ID, session(), local_only_entry, reconcile=False)
+        async_save_session(hass, WEBHOOK_ID, session())
+
+        manager.async_end_session(WEBHOOK_ID, SESSION_ID)
+        await hass.async_block_till_done()
+
+        assert not manager.async_is_known(WEBHOOK_ID, SESSION_ID)
+        assert hass.data[DOMAIN][DATA_REMOTE_MEDIA_SESSIONS].get(WEBHOOK_ID, {}) == {}

--- a/tests/components/mobile_app/remote_media/test_mapper.py
+++ b/tests/components/mobile_app/remote_media/test_mapper.py
@@ -1,0 +1,299 @@
+"""The wire contract Core shares with the Home Assistant iOS app.
+
+These assertions are about the encoded JSON, not about Python types. The app decodes it with
+Swift `RemoteMediaSessionAttributes`, whose `CodingKeys` name every field below, and two of those
+decodes are unconditional — a missing `selection`, `deviceName`, `state` or `features` is a
+decoding failure on the device, which looks exactly like a push that never arrived.
+"""
+
+from datetime import UTC, datetime
+import math
+from typing import Any
+
+import pytest
+
+from homeassistant.components.mobile_app.remote_media.mapper import snapshot_from_state
+from homeassistant.components.mobile_app.remote_media.model import RemoteMediaSnapshot
+from homeassistant.core import HomeAssistant
+
+from .const import ENTITY_ID, PLAYING_ATTRIBUTES, SERVER_ID
+
+
+def _snapshot(
+    hass: HomeAssistant, state: str = "playing", **attributes: Any
+) -> RemoteMediaSnapshot | None:
+    """Map a media player state through the production mapper."""
+    merged = {**PLAYING_ATTRIBUTES, **attributes}
+    hass.states.async_set(ENTITY_ID, state, merged)
+    return snapshot_from_state(hass.states.get(ENTITY_ID), SERVER_ID)
+
+
+async def test_wire_keys_are_the_swift_coding_keys(hass: HomeAssistant) -> None:
+    """The encoded snapshot uses exactly the names the app decodes."""
+    wire = _snapshot(hass).as_wire()
+    assert wire == {
+        "selection": {"serverId": "home", "entityId": ENTITY_ID},
+        "deviceName": "Speaker",
+        "state": "playing",
+        "features": 84037,
+        "title": "First",
+        "artist": "Artist",
+        "album": "Album",
+        "contentId": "track-1",
+        "duration": 240.0,
+        "position": 10.0,
+        "positionUpdatedAtUnix": 1788739200.0,
+        "volume": 0.4,
+        "isMuted": False,
+    }
+
+
+async def test_required_fields_are_always_present(hass: HomeAssistant) -> None:
+    """Swift decodes these unconditionally, so they may never be omitted."""
+    wire = _snapshot(
+        hass,
+        state="idle",
+        **dict.fromkeys(
+            (
+                "media_content_id",
+                "media_title",
+                "media_artist",
+                "media_album_name",
+                "media_duration",
+                "media_position",
+                "media_position_updated_at",
+                "volume_level",
+                "is_volume_muted",
+            )
+        ),
+    ).as_wire()
+    for key in ("selection", "deviceName", "state", "features"):
+        assert key in wire, key
+    assert wire["selection"] == {"serverId": "home", "entityId": ENTITY_ID}
+
+
+async def test_position_timestamp_is_unix_seconds(hass: HomeAssistant) -> None:
+    """Seconds since 1970, never Swift's 2001 reference epoch.
+
+    The app moved off that deliberately: reproducing `JSONEncoder`'s `Date` encoding from Python
+    would be a permanent trap. `2026-09-07T00:00:00+00:00` is 1788739200.
+    """
+    wire = _snapshot(hass).as_wire()
+    assert wire["positionUpdatedAtUnix"] == 1788739200.0
+    # The same instant in the reference epoch, which must not be what we wrote.
+    assert (
+        wire["positionUpdatedAtUnix"] != 810432000.0
+    )  # the same instant in Swift 2001 reference epoch
+    assert "positionUpdatedAt" not in wire
+
+
+async def test_nothing_sensitive_reaches_the_wire(hass: HomeAssistant) -> None:
+    """The attributes travel through Apple's infrastructure and come back in a push."""
+    wire = _snapshot(hass).as_wire()
+    encoded = repr(wire)
+    assert "entity_picture" not in encoded
+    assert "token=secret" not in encoded
+    assert "authSig" not in encoded
+    assert "bearer" not in encoded.lower()
+    assert "authorization" not in encoded.lower()
+    # Artwork is not sent at all: the iOS mapper produces none either, and the source path
+    # carries a signed token.
+    assert "artwork" not in wire
+
+
+async def test_duration_and_position_are_clamped(hass: HomeAssistant) -> None:
+    """Mirrors the Swift mapper: a non-positive duration is no duration."""
+    assert _snapshot(hass, media_duration=0).duration is None
+    assert _snapshot(hass, media_duration=-5).duration is None
+    # Position is held inside the track.
+    assert _snapshot(hass, media_position=-3).position == 0.0
+    assert _snapshot(hass, media_duration=100, media_position=500).position == 100.0
+
+
+async def test_position_without_a_timestamp_carries_no_timestamp(
+    hass: HomeAssistant,
+) -> None:
+    """A timestamp with no position would let the card extrapolate from nothing."""
+    snapshot = _snapshot(hass, media_position=None)
+    assert snapshot.position is None
+    assert snapshot.position_updated_at_unix is None
+
+
+async def test_volume_is_clamped_and_features_are_never_negative(
+    hass: HomeAssistant,
+) -> None:
+    """Integrations do report values outside the documented ranges."""
+    assert _snapshot(hass, volume_level=1.5).volume == 1.0
+    assert _snapshot(hass, volume_level=-1).volume == 0.0
+    assert _snapshot(hass, supported_features=-3).features == 0
+
+
+async def test_device_name_falls_back_to_the_entity_id(hass: HomeAssistant) -> None:
+    """`deviceName` is required, so it always has a value."""
+    assert _snapshot(hass, friendly_name=None).device_name == ENTITY_ID
+
+
+async def test_blank_metadata_is_absent_rather_than_empty(hass: HomeAssistant) -> None:
+    """An empty string is not a title; the app treats absence and emptiness differently."""
+    snapshot = _snapshot(hass, media_title="", media_artist="")
+    assert snapshot.title is None
+    assert snapshot.artist is None
+
+
+@pytest.mark.parametrize(
+    ("attributes", "expected"),
+    [
+        ({"media_duration": "240", "media_position": "10"}, (240.0, 10.0)),
+        ({"media_duration": "not a number"}, (None, 10.0)),
+        ({"media_duration": math.inf}, (None, 10.0)),
+        ({"media_duration": True, "media_position": True}, (None, None)),
+        ({"media_duration": [240], "media_position": {}}, (None, None)),
+    ],
+    ids=["numeric strings", "unparsable", "infinite", "booleans", "wrong types"],
+)
+async def test_numeric_attributes_an_integration_got_wrong(
+    hass: HomeAssistant,
+    attributes: dict[str, Any],
+    expected: tuple[float | None, float | None],
+) -> None:
+    """Whatever an integration puts in an attribute, the card gets a number or nothing."""
+    snapshot = _snapshot(hass, **attributes)
+    assert snapshot is not None
+    assert (snapshot.duration, snapshot.position) == expected
+
+
+@pytest.mark.parametrize(
+    ("supported_features", "expected"),
+    [("84037", 84037), (84037.9, 84037), (True, 0), ("nonsense", 0), (None, 0)],
+    ids=["string", "float", "boolean", "unparsable", "missing"],
+)
+async def test_features_always_reach_the_wire_as_an_integer(
+    hass: HomeAssistant, supported_features: Any, expected: int
+) -> None:
+    """`features` is decoded unconditionally, so it can never be absent or a string."""
+    snapshot = _snapshot(hass, supported_features=supported_features)
+    assert snapshot is not None
+    assert snapshot.features == expected
+
+
+@pytest.mark.parametrize(
+    ("updated_at", "expected"),
+    [
+        (datetime(2026, 9, 7, tzinfo=UTC), 1788739200.0),
+        ("2026-09-07T00:00:00+00:00", 1788739200.0),
+        ("halfway through", None),
+        (1788480000, None),
+        (None, None),
+    ],
+    ids=["datetime", "string", "unparsable", "bare number", "missing"],
+)
+async def test_the_position_timestamp_is_unix_seconds_or_absent(
+    hass: HomeAssistant, updated_at: Any, expected: float | None
+) -> None:
+    """A position the card cannot date is better than one it dates wrongly."""
+    snapshot = _snapshot(hass, media_position_updated_at=updated_at)
+    assert snapshot is not None
+    assert snapshot.position_updated_at_unix == expected
+
+
+async def test_a_muted_flag_that_is_not_a_boolean_is_dropped(
+    hass: HomeAssistant,
+) -> None:
+    """The app decodes `isMuted` as a Bool, so "false" would be a decoding failure."""
+    assert _snapshot(hass, is_volume_muted="false").is_muted is None
+
+
+async def test_only_media_players_are_mapped(hass: HomeAssistant) -> None:
+    """A registration can only follow a media player."""
+    hass.states.async_set("light.kitchen", "on", {})
+    assert snapshot_from_state(hass.states.get("light.kitchen"), SERVER_ID) is None
+
+
+async def test_track_id_matches_the_swift_construction(hass: HomeAssistant) -> None:
+    """Byte-for-byte the Swift `trackId`: each part length-prefixed by its UTF-8 byte count."""
+    snapshot = _snapshot(hass)
+    assert snapshot.track_id == "7:track-15:First6:Artist5:Album"
+
+    # Absent parts are empty, not skipped, so a shift cannot collide with a different track.
+    blank = _snapshot(
+        hass, media_content_id=None, media_artist=None, media_album_name=None
+    )
+    assert blank.track_id == "0:5:First0:0:"
+
+    # A multi-byte title is counted in bytes.
+    unicode_title = _snapshot(
+        hass,
+        media_content_id=None,
+        media_title="é",
+        media_artist=None,
+        media_album_name=None,
+    )
+    assert unicode_title.track_id == "0:2:é0:0:"
+
+
+class TestArtwork:
+    """Which artwork sources may be handed to a phone, and which may not.
+
+    The extension that renders the card holds no Home Assistant credentials and cannot be given
+    any: what goes here is serialized through Apple's infrastructure and echoed back by the push
+    relay, so it is effectively public.
+    """
+
+    @pytest.mark.parametrize(
+        "picture",
+        [
+            "https://is1-ssl.mzstatic.com/image/thumb/abc/600x600bb.jpg",
+            "https://lastfm.freetls.fastly.net/i/u/300x300/abc.png",
+        ],
+    )
+    def test_a_public_absolute_source_is_passed_through(
+        self, hass: HomeAssistant, picture: str
+    ) -> None:
+        """Many integrations expose album art on the service's own CDN. That is fetchable."""
+        hass.states.async_set(
+            ENTITY_ID, "playing", {**PLAYING_ATTRIBUTES, "entity_picture": picture}
+        )
+        snapshot = snapshot_from_state(hass.states.get(ENTITY_ID), SERVER_ID)
+        assert snapshot.artwork_url == picture
+        assert snapshot.as_wire()["artwork"] == {"url": picture}
+
+    @pytest.mark.parametrize(
+        ("label", "picture"),
+        [
+            (
+                "a signed proxy path",
+                "/api/media_player_proxy/media_player.speaker?token=secret",
+            ),
+            (
+                "a proxy path with no token",
+                "/api/media_player_proxy/media_player.speaker",
+            ),
+            (
+                "an absolute proxy URL with a token",
+                "https://ha.example.com/api/x?token=secret",
+            ),
+            ("any query at all", "https://cdn.example.com/art.jpg?sig=abc"),
+            ("plain http", "http://cdn.example.com/art.jpg"),
+            ("credentials in the authority", "https://user:pw@cdn.example.com/art.jpg"),
+            ("no host", "https:///art.jpg"),
+            ("not a string", 42),
+            ("empty", ""),
+        ],
+    )
+    def test_everything_else_is_withheld(
+        self, hass: HomeAssistant, label: str, picture: object
+    ) -> None:
+        """No token is spent to show a cover, and no phone is sent to a plaintext origin."""
+        hass.states.async_set(
+            ENTITY_ID, "playing", {**PLAYING_ATTRIBUTES, "entity_picture": picture}
+        )
+        snapshot = snapshot_from_state(hass.states.get(ENTITY_ID), SERVER_ID)
+        assert snapshot.artwork_url is None, label
+        assert "artwork" not in snapshot.as_wire(), label
+
+    def test_the_default_fixture_carries_no_artwork(self, hass: HomeAssistant) -> None:
+        """`PLAYING_ATTRIBUTES` uses the signed proxy form, which must never cross."""
+        hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+        snapshot = snapshot_from_state(hass.states.get(ENTITY_ID), SERVER_ID)
+        assert snapshot.artwork_url is None
+        assert "token" not in str(snapshot.as_wire())

--- a/tests/components/mobile_app/remote_media/test_push.py
+++ b/tests/components/mobile_app/remote_media/test_push.py
@@ -1,0 +1,258 @@
+"""The request Core sends to the push relay, and what it does with every answer."""
+
+from http import HTTPStatus
+from typing import Any
+
+from aiohttp import ClientConnectionError
+import pytest
+
+from homeassistant.components.mobile_app.const import DATA_CONFIG_ENTRIES, DOMAIN
+from homeassistant.components.mobile_app.remote_media.push import (
+    PushOutcome,
+    async_send,
+    build_request,
+)
+from homeassistant.core import HomeAssistant
+
+from .const import ENTITY_ID, PUSH_TOKEN, PUSH_URL, SESSION_ID
+
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+ATTRIBUTES: dict[str, Any] = {
+    "id": SESSION_ID,
+    "generation": "gen-1",
+    "snapshot": {
+        "selection": {"serverId": "home", "entityId": ENTITY_ID},
+        "deviceName": "Speaker",
+        "state": "playing",
+        "features": 84037,
+    },
+}
+
+
+async def test_the_request_body_is_the_relay_contract(
+    hass: HomeAssistant, push_entry
+) -> None:
+    """Exactly the fields `functions/now-playing.js` validates, and nothing more."""
+    body = build_request(push_entry, PUSH_TOKEN, "update", 1788749001, ATTRIBUTES)
+
+    assert body == {
+        # Still the ordinary Companion token: the relay's registration and metering identity.
+        "push_token": "COMPANION_TOKEN",
+        # The specialised APNs destination. Never a substitute for the one above.
+        "now_playing_token": PUSH_TOKEN,
+        "now_playing": {
+            "event": "update",
+            "timestamp": 1788749001,
+            "attributes": ATTRIBUTES,
+        },
+        "registration_info": {
+            "app_id": "io.robbie.HomeAssistant",
+            "app_version": "2026.9.1",
+            "webhook_id": push_entry.data["webhook_id"],
+            "os_version": "27.0",
+        },
+    }
+
+
+async def test_core_chooses_nothing_about_apns(hass: HomeAssistant, push_entry) -> None:
+    """The relay owns the topic, the host and the provider. Core must not name any of them."""
+    body = build_request(push_entry, PUSH_TOKEN, "update", 1788749001, ATTRIBUTES)
+    encoded = repr(body)
+    for forbidden in (
+        "topic",
+        "apns_topic",
+        "push-type",
+        "api.push.apple.com",
+        "api.sandbox.push.apple.com",
+        "production",
+        "sandbox",
+        "aps-environment",
+        "key_id",
+        "team_id",
+    ):
+        assert forbidden not in encoded, forbidden
+
+
+async def test_a_201_is_delivered(
+    hass: HomeAssistant, push_entry, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """The relay's success shape."""
+    aioclient_mock.post(
+        PUSH_URL,
+        status=HTTPStatus.CREATED,
+        json={"messageId": "APNS-1", "delivery": "nowplaying", "target": "abc"},
+    )
+    result = await async_send(
+        hass, push_entry, SESSION_ID, PUSH_TOKEN, "update", 1788749001, ATTRIBUTES
+    )
+    assert result.outcome is PushOutcome.DELIVERED
+
+
+@pytest.mark.parametrize(
+    ("status", "error_type", "outcome"),
+    [
+        # The only answer that means the user's session token is dead.
+        (HTTPStatus.GONE, "InvalidToken", PushOutcome.REMOVE),
+        # Relay deployment and credential faults. Never the token's fault.
+        (HTTPStatus.FORBIDDEN, "UnsupportedApp", PushOutcome.MISCONFIGURED),
+        (HTTPStatus.BAD_REQUEST, "TopicMismatch", PushOutcome.MISCONFIGURED),
+        (HTTPStatus.BAD_GATEWAY, "ProviderAuth", PushOutcome.MISCONFIGURED),
+        (
+            HTTPStatus.NOT_IMPLEMENTED,
+            "NowPlayingNotConfigured",
+            PushOutcome.MISCONFIGURED,
+        ),
+        # Our own request being wrong is a bug here, not a reason to unregister.
+        (HTTPStatus.BAD_REQUEST, "AmbiguousRequest", PushOutcome.MISCONFIGURED),
+        (HTTPStatus.BAD_REQUEST, "InvalidNowPlayingToken", PushOutcome.MISCONFIGURED),
+        (HTTPStatus.BAD_REQUEST, "InvalidNowPlayingRequest", PushOutcome.MISCONFIGURED),
+        (
+            HTTPStatus.BAD_REQUEST,
+            "UnsupportedNowPlayingEvent",
+            PushOutcome.MISCONFIGURED,
+        ),
+        (
+            HTTPStatus.BAD_REQUEST,
+            "InvalidNowPlayingTimestamp",
+            PushOutcome.MISCONFIGURED,
+        ),
+        (
+            HTTPStatus.BAD_REQUEST,
+            "InvalidNowPlayingAttributes",
+            PushOutcome.MISCONFIGURED,
+        ),
+        (
+            HTTPStatus.BAD_REQUEST,
+            "MissingNowPlayingSessionId",
+            PushOutcome.MISCONFIGURED,
+        ),
+        (
+            HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+            "PayloadTooLarge",
+            PushOutcome.MISCONFIGURED,
+        ),
+        # Told to slow down.
+        (HTTPStatus.TOO_MANY_REQUESTS, "RateLimited", PushOutcome.BACK_OFF),
+        (HTTPStatus.TOO_MANY_REQUESTS, "ApnsRateLimited", PushOutcome.BACK_OFF),
+        # Transient.
+        (HTTPStatus.BAD_GATEWAY, "ApnsUnavailable", PushOutcome.RETRY),
+        # Something the relay grew after this was written.
+        (HTTPStatus.BAD_REQUEST, "SomethingNewFromTheRelay", PushOutcome.MISCONFIGURED),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, "ApnsError", PushOutcome.RETRY),
+    ],
+)
+async def test_every_relay_error_type_is_classified(
+    hass: HomeAssistant,
+    push_entry,
+    aioclient_mock: AiohttpClientMocker,
+    status: int,
+    error_type: str,
+    outcome: PushOutcome,
+) -> None:
+    """The whole committed error contract, mapped to what Core does about it."""
+    aioclient_mock.post(PUSH_URL, status=status, json={"errorType": error_type})
+    result = await async_send(
+        hass, push_entry, SESSION_ID, PUSH_TOKEN, "update", 1788749001, ATTRIBUTES
+    )
+    assert result.outcome is outcome
+    assert result.error_type == error_type
+
+
+async def test_only_an_invalid_token_unregisters(
+    hass: HomeAssistant, push_entry, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """The invariant worth stating on its own.
+
+    Deleting a registration over a topic or credential fault would silently stop a feature the
+    user never turned off, and it would come back only if they noticed and re-followed.
+    """
+    for error_type in (
+        "UnsupportedApp",
+        "TopicMismatch",
+        "ProviderAuth",
+        "NowPlayingNotConfigured",
+        "PayloadTooLarge",
+        "RateLimited",
+        "ApnsRateLimited",
+        "ApnsUnavailable",
+        "ApnsError",
+        "Unrecognised",
+    ):
+        aioclient_mock.clear_requests()
+        aioclient_mock.post(
+            PUSH_URL, status=HTTPStatus.BAD_REQUEST, json={"errorType": error_type}
+        )
+        result = await async_send(
+            hass, push_entry, SESSION_ID, PUSH_TOKEN, "update", 1788749001, ATTRIBUTES
+        )
+        assert result.outcome is not PushOutcome.REMOVE, error_type
+
+
+@pytest.mark.parametrize(
+    ("exc", "error_type"),
+    [
+        (TimeoutError(), "Timeout"),
+        (ClientConnectionError("no route to host"), "Unreachable"),
+    ],
+    ids=["timeout", "connection refused"],
+)
+async def test_an_unreachable_relay_is_retryable(
+    hass: HomeAssistant,
+    push_entry,
+    aioclient_mock: AiohttpClientMocker,
+    exc: Exception,
+    error_type: str,
+) -> None:
+    """A relay outage must not cost anyone their session."""
+    aioclient_mock.post(PUSH_URL, exc=exc)
+    result = await async_send(
+        hass, push_entry, SESSION_ID, PUSH_TOKEN, "update", 1788749001, ATTRIBUTES
+    )
+    assert result.outcome is PushOutcome.RETRY
+    assert result.error_type == error_type
+
+
+async def test_a_response_that_is_not_json_is_not_fatal(
+    hass: HomeAssistant, push_entry, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """A proxy error page is still an answer."""
+    aioclient_mock.post(
+        PUSH_URL, status=HTTPStatus.BAD_GATEWAY, text="<html>gateway</html>"
+    )
+    result = await async_send(
+        hass, push_entry, SESSION_ID, PUSH_TOKEN, "update", 1788749001, ATTRIBUTES
+    )
+    assert result.outcome is PushOutcome.RETRY
+
+
+async def test_a_registration_without_cloud_push_sends_nothing(
+    hass: HomeAssistant,
+    create_registrations: tuple[dict[str, Any], dict[str, Any]],
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Local-push-only registrations have nowhere to send, and should not be retried at."""
+    entry = hass.data[DOMAIN][DATA_CONFIG_ENTRIES][
+        create_registrations[1]["webhook_id"]
+    ]
+    result = await async_send(
+        hass, entry, SESSION_ID, PUSH_TOKEN, "update", 1788749001, ATTRIBUTES
+    )
+    assert result.outcome is PushOutcome.MISCONFIGURED
+    assert aioclient_mock.call_count == 0
+
+
+async def test_an_end_event_carries_only_the_identity(
+    hass: HomeAssistant, push_entry, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Ending needs the session identity; the app may already have torn the session down."""
+    aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+    await async_send(
+        hass, push_entry, SESSION_ID, PUSH_TOKEN, "end", 1788749002, {"id": SESSION_ID}
+    )
+    sent = aioclient_mock.mock_calls[0][2]
+    assert sent["now_playing"] == {
+        "event": "end",
+        "timestamp": 1788749002,
+        "attributes": {"id": SESSION_ID},
+    }

--- a/tests/components/mobile_app/remote_media/test_reducer.py
+++ b/tests/components/mobile_app/remote_media/test_reducer.py
@@ -1,0 +1,139 @@
+"""Sticky reduction: what the card should show given what integrations actually emit.
+
+Mirrors the cases Swift `RemoteMediaSnapshotReducer` is tested against, because both sides have to
+agree. The stake is higher on the server: when an APNs push cold-launches the extension there is
+no prior snapshot on the device, so whatever Core sends is the entire card.
+"""
+
+import pytest
+
+from homeassistant.components.mobile_app.remote_media.model import RemoteMediaSnapshot
+from homeassistant.components.mobile_app.remote_media.reducer import reduce_snapshot
+
+from .const import ENTITY_ID, SERVER_ID
+
+
+def snapshot(**overrides) -> RemoteMediaSnapshot:
+    """A snapshot with playing media, unless overridden."""
+    values = {
+        "server_id": SERVER_ID,
+        "entity_id": ENTITY_ID,
+        "device_name": "Speaker",
+        "state": "playing",
+        "title": "First",
+        "artist": "Artist",
+        "album": "Album",
+        "content_id": "track-1",
+        "duration": 240.0,
+        "position": 10.0,
+        "position_updated_at_unix": 1788739200.0,
+        "volume": 0.4,
+        "is_muted": False,
+        "features": 84037,
+    }
+    values.update(overrides)
+    return RemoteMediaSnapshot(**values)
+
+
+def blank(state: str) -> RemoteMediaSnapshot:
+    """A report with no media at all, as integrations emit between tracks."""
+    return RemoteMediaSnapshot(
+        server_id=SERVER_ID,
+        entity_id=ENTITY_ID,
+        device_name="Speaker",
+        state=state,
+        features=84037,
+    )
+
+
+def test_nothing_to_show_yet() -> None:
+    """A blank first report starts no card, and does not end the relationship either."""
+    assert reduce_snapshot(None, blank("idle")) is None
+
+
+def test_a_first_real_track_is_taken_wholesale() -> None:
+    """The first meaningful report is the card."""
+    incoming = snapshot()
+    assert reduce_snapshot(None, incoming) == incoming
+
+
+def test_paused_retains_its_content() -> None:
+    """A paused player still has something to show."""
+    reduced = reduce_snapshot(snapshot(), snapshot(state="paused"))
+    assert reduced.state == "paused"
+    assert reduced.title == "First"
+
+
+@pytest.mark.parametrize("state", ["idle", "off", "standby"])
+def test_idle_with_metadata_keeps_the_media(state: str) -> None:
+    """An integration reporting `idle` while still naming a track keeps the track."""
+    reduced = reduce_snapshot(snapshot(), snapshot(state=state))
+    assert reduced.state == state
+    assert reduced.title == "First"
+    assert reduced.playback == "stopped"
+
+
+@pytest.mark.parametrize("state", ["idle", "off", "standby"])
+def test_idle_with_blank_metadata_keeps_the_previous_media(state: str) -> None:
+    """The wipe is not pushed. On a cold launch it would be the whole card."""
+    reduced = reduce_snapshot(snapshot(), blank(state))
+    assert reduced.title == "First"
+    assert reduced.content_id == "track-1"
+    assert reduced.state == state
+
+
+@pytest.mark.parametrize("state", ["unavailable", "unknown"])
+def test_not_reporting_keeps_the_previous_representation(state: str) -> None:
+    """`unavailable` means the integration stopped reporting, not that playback stopped.
+
+    An Echo drops off and comes back; showing it as stopped would be inventing a state, and
+    ending the session would lose the card for good.
+    """
+    reduced = reduce_snapshot(snapshot(), blank(state))
+    assert reduced.title == "First"
+    # The last known playback state is kept rather than replaced with the non-report.
+    assert reduced.state == "playing"
+
+
+def test_a_metadata_hole_is_not_a_new_track() -> None:
+    """Pressing Next blanks the metadata for a moment before the next track arrives."""
+    previous = snapshot()
+    during = reduce_snapshot(previous, blank("playing"))
+    assert during.title == "First"
+    # And when the real track lands it replaces everything.
+    after = reduce_snapshot(during, snapshot(content_id="track-2", title="Second"))
+    assert after.title == "Second"
+    assert after.content_id == "track-2"
+
+
+def test_a_new_track_replaces_wholesale() -> None:
+    """No part of the previous track's identity survives into a new one."""
+    reduced = reduce_snapshot(
+        snapshot(),
+        snapshot(content_id="track-2", title="Second", artist="Other", album="Later"),
+    )
+    assert (reduced.title, reduced.artist, reduced.album) == (
+        "Second",
+        "Other",
+        "Later",
+    )
+    assert reduced.track_id != snapshot().track_id
+
+
+def test_position_and_volume_do_not_make_a_new_track() -> None:
+    """Ordinary progress and a volume nudge are the same track."""
+    previous = snapshot()
+    moved = reduce_snapshot(previous, snapshot(position=90.0, volume=0.9))
+    assert moved.track_id == previous.track_id
+    assert moved.position == 90.0
+    assert moved.volume == 0.9
+
+
+def test_stopping_playback_does_not_end_following() -> None:
+    """`media_stop` is not Stop Following.
+
+    The reducer never returns "the relationship is over"; it only ever describes a card. Ending is
+    a lifecycle decision made elsewhere, from the dismissal webhook.
+    """
+    for state in ("idle", "off", "paused", "unavailable", "unknown", "standby"):
+        assert reduce_snapshot(snapshot(), blank(state)) is not None

--- a/tests/components/mobile_app/remote_media/test_store.py
+++ b/tests/components/mobile_app/remote_media/test_store.py
@@ -1,0 +1,297 @@
+"""Persistence: a Follow relationship must survive a restart without the phone re-registering."""
+
+from typing import Any
+
+import pytest
+
+from homeassistant.components.mobile_app.const import (
+    DATA_LIVE_ACTIVITY_TOKENS,
+    DATA_REMOTE_MEDIA_SESSIONS,
+    DOMAIN,
+    STORAGE_KEY,
+    STORAGE_VERSION,
+    STORAGE_VERSION_MINOR,
+)
+from homeassistant.components.mobile_app.remote_media.manager import async_get_manager
+from homeassistant.components.mobile_app.remote_media.model import (
+    RemoteMediaSession,
+    RemoteMediaSnapshot,
+)
+from homeassistant.components.mobile_app.remote_media.store import async_load_sessions
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .conftest import WEBHOOK_ID, stored_session
+from .const import ENTITY_ID, PLAYING_ATTRIBUTES, PUSH_TOKEN, SESSION_ID
+
+from tests.common import MockConfigEntry
+from tests.typing import ClientSessionGenerator
+
+
+def test_a_session_round_trips_through_storage() -> None:
+    """Everything needed to resume, and nothing that is not JSON."""
+    data = stored_session()
+    session = RemoteMediaSession.from_storage(data)
+    assert session is not None
+    assert session.as_storage() == data
+
+    # Only JSON-safe values: the store serializes dictionaries.
+    def assert_json_safe(value: Any) -> None:
+        assert value is None or isinstance(value, (str, int, float, bool, dict, list))
+        if isinstance(value, dict):
+            for key, item in value.items():
+                assert isinstance(key, str)
+                assert_json_safe(item)
+
+    assert_json_safe(session.as_storage())
+
+
+def test_the_companion_token_is_not_copied_into_the_store() -> None:
+    """It lives on the config entry; a second copy would be a second thing to leak."""
+    keys = set(stored_session())
+    assert "app_data" not in keys
+    assert keys == {
+        "session_id",
+        "generation",
+        "generation_sequence",
+        "entity_id",
+        "server_id",
+        "push_token",
+        "schema_version",
+        "last_timestamp",
+        "last_snapshot",
+    }
+
+
+@pytest.mark.parametrize(
+    "broken",
+    [
+        {"session_id": None},
+        {"generation": None},
+        {"entity_id": None},
+        {"schema_version": None},
+        {"push_token": None},
+    ],
+)
+def test_an_unreadable_session_is_discarded_not_raised(broken: dict[str, Any]) -> None:
+    """One malformed entry must not stop a registration from loading."""
+    data = stored_session()
+    for key in broken:
+        del data[key]
+    assert RemoteMediaSession.from_storage(data) is None
+
+
+async def test_an_unreadable_stored_session_does_not_stop_the_others(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The store is shared with the rest of `mobile_app`, so one bad row cannot break loading."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    # pylint: disable-next=home-assistant-use-runtime-data
+    hass.data[DOMAIN][DATA_REMOTE_MEDIA_SESSIONS][WEBHOOK_ID] = {
+        "broken": {"session_id": "broken"},
+        SESSION_ID: stored_session(),
+    }
+
+    loaded = async_load_sessions(hass, WEBHOOK_ID)
+
+    assert [session.session_id for session in loaded] == [SESSION_ID]
+    assert "Discarding unreadable Remote Now Playing session broken" in caplog.text
+
+
+def test_a_session_without_sticky_state_loads() -> None:
+    """A relationship registered but never yet pushed."""
+    session = RemoteMediaSession.from_storage(
+        stored_session(last_timestamp=None, last_snapshot=None)
+    )
+    assert session is not None
+    assert session.last_snapshot is None
+
+
+def test_an_unreadable_snapshot_does_not_lose_the_session() -> None:
+    """Losing sticky state is recoverable; losing the token is not."""
+    session = RemoteMediaSession.from_storage(
+        stored_session(last_snapshot={"bogus": 1})
+    )
+    assert session is not None
+    assert session.last_snapshot is None
+    assert session.push_token == PUSH_TOKEN
+
+
+async def test_migration_from_the_previous_minor_version(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """An existing installation gains empty Remote Now Playing storage.
+
+    Live Activity data has to come through untouched: this is the same store.
+    """
+    hass_storage[STORAGE_KEY] = {
+        "version": 1,
+        "minor_version": 2,
+        "data": {
+            "deleted_ids": ["gone"],
+            DATA_LIVE_ACTIVITY_TOKENS: {
+                "webhook-1": {"washer": {"token": "abc", "expires_at": 1e12}}
+            },
+        },
+    }
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    await hass.async_block_till_done()
+
+    # pylint: disable-next=home-assistant-use-runtime-data
+    domain_data = hass.data[DOMAIN]
+    assert domain_data[DATA_REMOTE_MEDIA_SESSIONS] == {}
+    assert domain_data[DATA_LIVE_ACTIVITY_TOKENS] == {
+        "webhook-1": {"washer": {"token": "abc", "expires_at": 1e12}}
+    }
+    assert domain_data["deleted_ids"] == ["gone"]
+
+
+async def test_a_fresh_installation_starts_empty(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """No stored data at all."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    await hass.async_block_till_done()
+    # pylint: disable-next=home-assistant-use-runtime-data
+    assert hass.data[DOMAIN][DATA_REMOTE_MEDIA_SESSIONS] == {}
+
+
+async def test_sessions_are_restored_when_their_registration_loads(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """A restart resumes following, with its sticky state and its ordering clock."""
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "minor_version": STORAGE_VERSION_MINOR,
+        "data": {
+            "deleted_ids": [],
+            DATA_LIVE_ACTIVITY_TOKENS: {},
+            DATA_REMOTE_MEDIA_SESSIONS: {WEBHOOK_ID: {SESSION_ID: stored_session()}},
+        },
+    }
+    hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+
+    entry = MockConfigEntry(
+        data={
+            "app_data": {"push_token": "COMPANION_TOKEN", "push_url": "http://x/push"},
+            "app_id": "io.robbie.HomeAssistant",
+            "app_name": "Home Assistant",
+            "app_version": "2026.9.1",
+            "device_id": "device-1",
+            "device_name": "Test iPhone",
+            "manufacturer": "Apple",
+            "model": "iPhone",
+            "os_name": "iOS",
+            "os_version": "27.0",
+            "secret": "123abc",
+            "supports_encryption": False,
+            "user_id": "user-1",
+            "webhook_id": WEBHOOK_ID,
+        },
+        domain=DOMAIN,
+        source="registration",
+        title="Test iPhone",
+        version=1,
+    )
+    entry.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    await hass.async_block_till_done()
+
+    manager = async_get_manager(hass)
+    publisher = manager.async_get(WEBHOOK_ID, SESSION_ID)
+    assert publisher is not None
+    # The listener is back, without the phone doing anything.
+    assert ENTITY_ID in manager.watchers
+    # And so is the state that stops a restart re-pushing what the card already shows.
+    assert publisher.session.last_timestamp == 1788739200
+    assert publisher.session.last_snapshot is not None
+    assert publisher.session.last_snapshot.title == "First"
+
+
+async def test_removing_a_registration_clears_its_sessions(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Deleting the mobile_app entry takes its Follow relationships with it."""
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "minor_version": STORAGE_VERSION_MINOR,
+        "data": {
+            "deleted_ids": [],
+            DATA_LIVE_ACTIVITY_TOKENS: {},
+            DATA_REMOTE_MEDIA_SESSIONS: {WEBHOOK_ID: {SESSION_ID: stored_session()}},
+        },
+    }
+    entry = MockConfigEntry(
+        data={
+            "app_data": {},
+            "app_id": "io.robbie.HomeAssistant",
+            "app_name": "Home Assistant",
+            "app_version": "2026.9.1",
+            "device_id": "device-1",
+            "device_name": "Test iPhone",
+            "manufacturer": "Apple",
+            "model": "iPhone",
+            "os_name": "iOS",
+            "os_version": "27.0",
+            "secret": "123abc",
+            "supports_encryption": False,
+            "user_id": "user-1",
+            "webhook_id": WEBHOOK_ID,
+        },
+        domain=DOMAIN,
+        source="registration",
+        title="Test iPhone",
+        version=1,
+    )
+    entry.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # pylint: disable-next=home-assistant-use-runtime-data
+    assert hass.data[DOMAIN][DATA_REMOTE_MEDIA_SESSIONS] == {}
+    assert async_get_manager(hass).async_get(WEBHOOK_ID, SESSION_ID) is None
+    assert async_get_manager(hass).watchers == {}
+
+
+async def test_nothing_expires_an_active_session(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """Apple documents no lifetime for a Remote Now Playing update token.
+
+    Unlike Live Activity tokens, which carry an `expires_at` because ActivityKit caps Dynamic
+    Island updates at twelve hours, there is nothing to age out against — so no expiry was
+    invented. A session is kept until it is dismissed, superseded, its registration goes, or the
+    relay reports the token dead.
+    """
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "minor_version": STORAGE_VERSION_MINOR,
+        "data": {
+            "deleted_ids": [],
+            DATA_LIVE_ACTIVITY_TOKENS: {},
+            DATA_REMOTE_MEDIA_SESSIONS: {WEBHOOK_ID: {SESSION_ID: stored_session()}},
+        },
+    }
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+    await hass.async_block_till_done()
+
+    stored = stored_session()
+    assert "expires_at" not in stored
+    # pylint: disable-next=home-assistant-use-runtime-data
+    assert (
+        hass.data[DOMAIN][DATA_REMOTE_MEDIA_SESSIONS][WEBHOOK_ID][SESSION_ID] == stored
+    )
+
+
+def test_a_snapshot_round_trips() -> None:
+    """Sticky state has to survive a restart or the card is rebuilt from nothing."""
+    data = stored_session()["last_snapshot"]
+    snapshot = RemoteMediaSnapshot.from_storage(data)
+    assert snapshot is not None
+    assert snapshot.as_storage() == data
+    assert snapshot.track_id == "7:track-15:First6:Artist5:Album"

--- a/tests/components/mobile_app/remote_media/test_track_change.py
+++ b/tests/components/mobile_app/remote_media/test_track_change.py
@@ -1,0 +1,444 @@
+"""A track changing on its own must reach the phone without a second state change.
+
+The physical failure this covers: an Echo advances to the next song in a station, Home Assistant's
+own state shows the new song immediately, and the Now Playing card keeps the old one until the user
+pauses or unpauses. These drive real `state_changed` events through the registered path rather than
+calling `is_meaningful_change` directly, because the comparison was never the broken part.
+"""
+
+from http import HTTPStatus
+import json
+from typing import Any
+
+from aiohttp.test_utils import TestClient
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+
+from homeassistant.components.mobile_app.const import DATA_CONFIG_ENTRIES, DOMAIN
+from homeassistant.components.mobile_app.remote_media.const import COALESCE_SECONDS
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from .conftest import stored_sessions
+from .const import (
+    ENTITY_ID,
+    PLAYING_ATTRIBUTES,
+    PUSH_URL,
+    SESSION_ID,
+    registration_payload,
+)
+
+from tests.common import async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+# What the Echo reports once the station has moved on: new identity, new metadata, and a position
+# that has restarted. Nothing here is a playback-state transition.
+NEXT_TRACK = {
+    **PLAYING_ATTRIBUTES,
+    "media_content_id": "track-2",
+    "media_title": "Kids",
+    "media_artist": "Current Joys",
+    "media_album_name": "A Different Age",
+    "media_duration": 213,
+    "media_position": 0,
+    "media_position_updated_at": "2026-09-07T00:04:00+00:00",
+}
+
+
+async def _register(client: TestClient, webhook_id: str, **overrides):
+    return await client.post(
+        f"/api/webhook/{webhook_id}",
+        json={
+            "type": "remote_media_session_token",
+            "data": registration_payload(**overrides),
+        },
+    )
+
+
+async def _settle(hass: HomeAssistant) -> None:
+    """Let the coalescing window elapse and any send finish."""
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + dt_util.dt.timedelta(seconds=COALESCE_SECONDS + 0.1)
+    )
+    await hass.async_block_till_done()
+
+
+async def _advance(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, **delta
+) -> None:
+    """Move both clocks, in steps, so scheduled retries actually come due.
+
+    `_quiet_until` is wall-clock and the timers are the event loop's, so the frozen clock has to
+    move with them. Stepped rather than jumped because a retry schedules the next one from inside
+    its own callback.
+    """
+    remaining = dt_util.dt.timedelta(**delta)
+    step = dt_util.dt.timedelta(seconds=30)
+    while remaining > dt_util.dt.timedelta(0):
+        moved = min(step, remaining)
+        remaining -= moved
+        freezer.tick(moved)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+
+def _snapshots(mock: AiohttpClientMocker) -> list[dict[str, Any]]:
+    """Every snapshot the relay was asked to deliver."""
+    return [
+        call[2]["now_playing"]["attributes"]["snapshot"]
+        for call in mock.mock_calls
+        if "snapshot" in call[2]["now_playing"]["attributes"]
+    ]
+
+
+def _stored_snapshot(hass: HomeAssistant, webhook_id: str) -> dict[str, Any] | None:
+    """The persisted `last_snapshot` for the session."""
+    stored = stored_sessions(hass, webhook_id).get(SESSION_ID)
+    return stored.get("last_snapshot") if stored else None
+
+
+@pytest.fixture
+async def following(
+    hass: HomeAssistant,
+    create_registrations: tuple[dict[str, Any], dict[str, Any]],
+    webhook_client: TestClient,
+    aioclient_mock: AiohttpClientMocker,
+) -> str:
+    """A registered Follow whose first card has already been delivered."""
+    aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+    hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+    webhook_id = create_registrations[1]["webhook_id"]
+    entry = hass.data[DOMAIN][DATA_CONFIG_ENTRIES][webhook_id]
+    hass.config_entries.async_update_entry(
+        entry,
+        data={
+            **entry.data,
+            "app_data": {"push_token": "COMPANION_TOKEN", "push_url": PUSH_URL},
+        },
+    )
+    await hass.async_block_till_done()
+    await _register(webhook_client, webhook_id)
+    await _settle(hass)
+    assert _snapshots(aioclient_mock), "the first card should have been delivered"
+    aioclient_mock.clear_requests()
+    aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+    return webhook_id
+
+
+async def test_a_station_advancing_reaches_the_phone_on_its_own(
+    hass: HomeAssistant,
+    following: str,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """The reported bug: playing -> playing, new song, no other change."""
+    hass.states.async_set(ENTITY_ID, "playing", NEXT_TRACK)
+    await _settle(hass)
+
+    sent = _snapshots(aioclient_mock)
+    assert sent, "a track change while playing must produce an update"
+    assert sent[-1]["title"] == "Kids"
+    assert sent[-1]["artist"] == "Current Joys"
+
+
+async def test_the_persisted_snapshot_follows_the_new_track(
+    hass: HomeAssistant,
+    following: str,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """`last_snapshot` is what a restart rebuilds the card from."""
+    hass.states.async_set(ENTITY_ID, "playing", NEXT_TRACK)
+    await _settle(hass)
+
+    stored = _stored_snapshot(hass, following)
+    assert stored is not None
+    assert stored["title"] == "Kids"
+
+
+async def test_metadata_only_change_with_no_position_movement(
+    hass: HomeAssistant,
+    following: str,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Some integrations rewrite only the metadata, leaving position untouched."""
+    hass.states.async_set(
+        ENTITY_ID,
+        "playing",
+        {
+            **PLAYING_ATTRIBUTES,
+            "media_content_id": "track-2",
+            "media_title": "Kids",
+            "media_artist": "Current Joys",
+        },
+    )
+    await _settle(hass)
+
+    sent = _snapshots(aioclient_mock)
+    assert sent and sent[-1]["title"] == "Kids"
+
+
+async def test_no_pause_or_play_is_needed_to_flush_it(
+    hass: HomeAssistant,
+    following: str,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """The workaround must not be the only thing that works."""
+    hass.states.async_set(ENTITY_ID, "playing", NEXT_TRACK)
+    await _settle(hass)
+    delivered_without_help = len(_snapshots(aioclient_mock))
+
+    # The user's workaround. It must add nothing, because the change already went out.
+    hass.states.async_set(ENTITY_ID, "paused", NEXT_TRACK)
+    await _settle(hass)
+    hass.states.async_set(ENTITY_ID, "playing", NEXT_TRACK)
+    await _settle(hass)
+
+    assert delivered_without_help >= 1
+    assert _snapshots(aioclient_mock)[0]["title"] == "Kids"
+
+
+async def test_a_station_advancing_through_a_transient_gap(
+    hass: HomeAssistant,
+    following: str,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """An Echo passes through a blank report between tracks."""
+    hass.states.async_set(ENTITY_ID, "playing", {"friendly_name": "Speaker"})
+    hass.states.async_set(ENTITY_ID, "playing", NEXT_TRACK)
+    await _settle(hass)
+
+    sent = _snapshots(aioclient_mock)
+    assert sent and sent[-1]["title"] == "Kids"
+
+
+async def test_a_second_advance_still_reaches_the_phone(
+    hass: HomeAssistant,
+    following: str,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Whatever unsticks the first must not be a one-off."""
+    hass.states.async_set(ENTITY_ID, "playing", NEXT_TRACK)
+    await _settle(hass)
+    hass.states.async_set(
+        ENTITY_ID,
+        "playing",
+        {**NEXT_TRACK, "media_content_id": "track-3", "media_title": "Third"},
+    )
+    await _settle(hass)
+
+    assert [snapshot["title"] for snapshot in _snapshots(aioclient_mock)] == [
+        "Kids",
+        "Third",
+    ]
+
+
+class TestASendThatDidNotLand:
+    """What happens to the track the phone never got.
+
+    Alexa-style integrations emit a state event when something changes and not otherwise, so
+    "the next state change will re-queue it" can mean "when the user next touches the speaker".
+    A track change that fails to send has to be retried on its own.
+    """
+
+    async def test_a_relay_error_does_not_lose_the_track(
+        self,
+        hass: HomeAssistant,
+        following: str,
+        aioclient_mock: AiohttpClientMocker,
+        freezer: FrozenDateTimeFactory,
+    ) -> None:
+        """The relay was briefly misconfigured; the song that changed during it is still owed."""
+        aioclient_mock.clear_requests()
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.INTERNAL_SERVER_ERROR, json={})
+        hass.states.async_set(ENTITY_ID, "playing", NEXT_TRACK)
+        await _settle(hass)
+        assert _snapshots(aioclient_mock), "it should at least have tried"
+
+        # The relay is healthy again. No further state event arrives, because nothing about the
+        # speaker changed -- it is still playing the same new song.
+        aioclient_mock.clear_requests()
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        await _advance(hass, freezer, minutes=5)
+
+        sent = _snapshots(aioclient_mock)
+        assert sent, "the track change must be retried without another state event"
+        assert sent[-1]["title"] == "Kids"
+
+    async def test_a_rate_limited_send_is_resumed_after_the_backoff(
+        self,
+        hass: HomeAssistant,
+        following: str,
+        aioclient_mock: AiohttpClientMocker,
+        freezer: FrozenDateTimeFactory,
+    ) -> None:
+        """Being told to slow down must not mean losing what was owed."""
+        aioclient_mock.clear_requests()
+        aioclient_mock.post(
+            PUSH_URL,
+            status=HTTPStatus.TOO_MANY_REQUESTS,
+            json={"errorType": "RateLimited"},
+        )
+        hass.states.async_set(ENTITY_ID, "playing", NEXT_TRACK)
+        await _settle(hass)
+
+        aioclient_mock.clear_requests()
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        await _advance(hass, freezer, hours=1)
+
+        sent = _snapshots(aioclient_mock)
+        assert sent, "the quiet period ending must flush what was waiting"
+        assert sent[-1]["title"] == "Kids"
+
+    async def test_a_track_change_during_a_quiet_period_is_not_dropped(
+        self,
+        hass: HomeAssistant,
+        following: str,
+        aioclient_mock: AiohttpClientMocker,
+        freezer: FrozenDateTimeFactory,
+    ) -> None:
+        """The song changed while Core was told to stay quiet. It is still the current song."""
+        aioclient_mock.clear_requests()
+        aioclient_mock.post(
+            PUSH_URL,
+            status=HTTPStatus.TOO_MANY_REQUESTS,
+            json={"errorType": "RateLimited"},
+        )
+        # First failure opens the quiet period.
+        hass.states.async_set(
+            ENTITY_ID, "playing", {**NEXT_TRACK, "media_title": "Filler"}
+        )
+        await _settle(hass)
+
+        # The real track change lands inside the quiet period and no further event follows.
+        hass.states.async_set(ENTITY_ID, "playing", NEXT_TRACK)
+        await _settle(hass)
+
+        aioclient_mock.clear_requests()
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        await _advance(hass, freezer, hours=1)
+
+        sent = _snapshots(aioclient_mock)
+        assert sent, "the newest state must survive the quiet period"
+        assert sent[-1]["title"] == "Kids"
+
+
+class TestArtworkOverTheWire:
+    """A cold push has to carry a source, because there is no host app to have prepared one."""
+
+    async def test_a_public_cover_reaches_the_phone(
+        self,
+        hass: HomeAssistant,
+        following: str,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """The Echo case: album art on the service's own CDN."""
+        cover = "https://is1-ssl.mzstatic.com/image/thumb/abc/600x600bb.jpg"
+        hass.states.async_set(
+            ENTITY_ID, "playing", {**NEXT_TRACK, "entity_picture": cover}
+        )
+        await _settle(hass)
+
+        sent = _snapshots(aioclient_mock)
+        assert sent and sent[-1]["artwork"] == {"url": cover}
+
+    async def test_a_signed_proxy_source_is_never_sent(
+        self,
+        hass: HomeAssistant,
+        following: str,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """The relay echoes attributes back, so a token here is a token given away."""
+        hass.states.async_set(
+            ENTITY_ID,
+            "playing",
+            {
+                **NEXT_TRACK,
+                "entity_picture": "/api/media_player_proxy/media_player.speaker?token=secret",
+            },
+        )
+        await _settle(hass)
+
+        sent = _snapshots(aioclient_mock)
+        assert sent
+        assert "artwork" not in sent[-1]
+        # The whole request, not just the snapshot: the signed value must appear nowhere in it.
+        # `push_token` and `now_playing_token` are the destination and are expected.
+        body = str(aioclient_mock.mock_calls[-1][2])
+        assert "secret" not in body
+        assert "media_player_proxy" not in body
+
+    async def test_a_new_track_changes_the_artwork_identity(
+        self,
+        hass: HomeAssistant,
+        following: str,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """Or the phone keeps showing the previous song's cover over this song's title."""
+        first = "https://cdn.example.com/first.jpg"
+        second = "https://cdn.example.com/second.jpg"
+        hass.states.async_set(
+            ENTITY_ID, "playing", {**PLAYING_ATTRIBUTES, "entity_picture": first}
+        )
+        await _settle(hass)
+        hass.states.async_set(
+            ENTITY_ID, "playing", {**NEXT_TRACK, "entity_picture": second}
+        )
+        await _settle(hass)
+
+        covers = [snapshot.get("artwork") for snapshot in _snapshots(aioclient_mock)]
+        assert {"url": first} in covers
+        assert covers[-1] == {"url": second}
+
+    async def test_a_cover_changing_alone_is_worth_sending(
+        self,
+        hass: HomeAssistant,
+        following: str,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """Some integrations report the picture a moment after the metadata."""
+        hass.states.async_set(
+            ENTITY_ID,
+            "playing",
+            {**PLAYING_ATTRIBUTES, "entity_picture": "https://cdn.example.com/a.jpg"},
+        )
+        await _settle(hass)
+        aioclient_mock.clear_requests()
+        aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+        hass.states.async_set(
+            ENTITY_ID,
+            "playing",
+            {**PLAYING_ATTRIBUTES, "entity_picture": "https://cdn.example.com/b.jpg"},
+        )
+        await _settle(hass)
+
+        sent = _snapshots(aioclient_mock)
+        assert sent and sent[-1]["artwork"] == {"url": "https://cdn.example.com/b.jpg"}
+
+    async def test_the_payload_stays_inside_the_relay_limit(
+        self,
+        hass: HomeAssistant,
+        following: str,
+        aioclient_mock: AiohttpClientMocker,
+    ) -> None:
+        """The relay refuses anything over 4096 bytes, and a URL is the longest thing added."""
+        hass.states.async_set(
+            ENTITY_ID,
+            "playing",
+            {
+                **NEXT_TRACK,
+                "media_title": "T" * 200,
+                "media_artist": "A" * 200,
+                "media_album_name": "B" * 200,
+                "entity_picture": "https://cdn.example.com/" + "c" * 400 + ".jpg",
+            },
+        )
+        await _settle(hass)
+
+        body = aioclient_mock.mock_calls[-1][2]["now_playing"]["attributes"]
+        assert (
+            len(
+                json.dumps(
+                    {"aps": {"event": "update", "timestamp": 1, "attributes": body}}
+                )
+            )
+            < 4096
+        )

--- a/tests/components/mobile_app/remote_media/test_webhook.py
+++ b/tests/components/mobile_app/remote_media/test_webhook.py
@@ -1,0 +1,701 @@
+"""The two webhook commands the iOS app calls to start and stop following a player."""
+
+from http import HTTPStatus
+import logging
+from typing import Any
+
+from aiohttp.test_utils import TestClient
+import pytest
+
+from homeassistant.components.mobile_app.const import DATA_CONFIG_ENTRIES, DOMAIN
+from homeassistant.components.mobile_app.remote_media.const import COALESCE_SECONDS
+from homeassistant.components.mobile_app.remote_media.manager import async_get_manager
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from .conftest import STORED_SNAPSHOT, stored_sessions
+from .const import (
+    ENTITY_ID,
+    GENERATION,
+    LATER_GENERATION,
+    LATER_PUSH_TOKEN,
+    LATER_SEQUENCE,
+    PLAYING_ATTRIBUTES,
+    PUSH_TOKEN,
+    PUSH_URL,
+    SEQUENCE,
+    SERVER_ID,
+    SESSION_ID,
+    dismissal_payload,
+    registration_payload,
+)
+
+from tests.common import async_fire_time_changed
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+async def _post(
+    client: TestClient, webhook_id: str, webhook_type: str, data: dict[str, Any]
+):
+    """Send one webhook command."""
+    return await client.post(
+        f"/api/webhook/{webhook_id}", json={"type": webhook_type, "data": data}
+    )
+
+
+async def _register(client: TestClient, webhook_id: str, **overrides):
+    """Register a Follow relationship."""
+    return await _post(
+        client,
+        webhook_id,
+        "remote_media_session_token",
+        registration_payload(**overrides),
+    )
+
+
+@pytest.fixture
+async def registration(
+    hass: HomeAssistant,
+    create_registrations: tuple[dict[str, Any], dict[str, Any]],
+) -> str:
+    """A push-capable registration webhook id, with the followed player present.
+
+    The shared `create_registrations` fixture makes registrations whose `app_data` is a placeholder
+    with no push configuration, and a relationship for one of those is stored without being
+    watched. Following needs a registration Core can actually reach.
+    """
+    hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+    webhook_id = create_registrations[1]["webhook_id"]
+    # pylint: disable-next=home-assistant-use-runtime-data
+    entry = hass.data[DOMAIN][DATA_CONFIG_ENTRIES][webhook_id]
+    hass.config_entries.async_update_entry(
+        entry,
+        data={
+            **entry.data,
+            "app_data": {"push_token": "COMPANION_TOKEN", "push_url": PUSH_URL},
+        },
+    )
+    await hass.async_block_till_done()
+    return webhook_id
+
+
+@pytest.fixture
+async def local_only_registration(
+    hass: HomeAssistant,
+    create_registrations: tuple[dict[str, Any], dict[str, Any]],
+) -> str:
+    """A registration with no cloud push configuration, exactly as created."""
+    hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+    await hass.async_block_till_done()
+    return create_registrations[1]["webhook_id"]
+
+
+async def test_registration_is_stored_under_the_requesting_webhook(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """A session belongs to the authenticated registration that sent it, not to the payload."""
+    resp = await _register(webhook_client, registration)
+    assert resp.status == HTTPStatus.OK
+    assert await resp.json() == {}
+
+    stored = stored_sessions(hass, registration)
+    assert set(stored) == {SESSION_ID}
+    assert stored[SESSION_ID] == {
+        "session_id": SESSION_ID,
+        "generation": GENERATION,
+        "generation_sequence": SEQUENCE,
+        "entity_id": ENTITY_ID,
+        "server_id": SERVER_ID,
+        "push_token": PUSH_TOKEN,
+        "schema_version": 1,
+        "last_timestamp": None,
+        "last_snapshot": None,
+    }
+
+
+async def test_registration_starts_watching_the_player(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """The listener attaches immediately, so the card can be brought up to date."""
+    await _register(webhook_client, registration)
+    manager = async_get_manager(hass)
+    assert manager.async_get(registration, SESSION_ID) is not None
+    assert ENTITY_ID in manager.watchers
+
+
+async def test_only_media_players_may_be_followed(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """A registration must not become a subscription to arbitrary state."""
+    resp = await _register(webhook_client, registration, entity_id="light.kitchen")
+    # mobile_app answers a refused payload with 200 and ignores it.
+    assert resp.status == HTTPStatus.OK
+    assert stored_sessions(hass, registration) == {}
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"push_token": "not-hex"},
+        {"push_token": "abc"},
+        {"push_token": ""},
+        {"push_token": "ab" * 400},
+        {"schema_version": 2},
+        {"schema_version": 0},
+        {"session_id": ""},
+        {"generation": ""},
+        {"generation": "g" * 300},
+        {"entity_id": "not_an_entity"},
+        {"server_id": ""},
+        {"server_id": "s" * 300},
+        {"generation_sequence": 0},
+        {"generation_sequence": -1},
+        {"generation_sequence": "ten"},
+        {"generation_sequence": 9_007_199_254_740_992},
+    ],
+)
+async def test_malformed_registrations_are_refused(
+    hass: HomeAssistant,
+    registration: str,
+    webhook_client: TestClient,
+    overrides: dict[str, Any],
+) -> None:
+    """Validation is shallow but not absent. Refusals answer 200 and store nothing."""
+    resp = await _register(webhook_client, registration, **overrides)
+    assert resp.status == HTTPStatus.OK
+    assert stored_sessions(hass, registration) == {}
+
+
+@pytest.mark.parametrize(
+    "session_id",
+    [
+        "4:homemedia_player.other",
+        "not-the-app-construction",
+        "a",
+        "{}",
+        "session/with/slashes",
+        "1:2:3",
+    ],
+)
+async def test_the_session_identifier_is_opaque(
+    hass: HomeAssistant,
+    registration: str,
+    webhook_client: TestClient,
+    session_id: str,
+) -> None:
+    """Apple's identifier, stored byte-for-byte and never parsed.
+
+    Core used to recover the app's server id from its shape, which coupled a Home Assistant
+    release to a private detail of the app. The app states the server explicitly instead, so any
+    non-empty identifier is acceptable and is echoed back exactly as it arrived.
+    """
+    resp = await _register(webhook_client, registration, session_id=session_id)
+    assert resp.status == HTTPStatus.OK
+
+    stored = stored_sessions(hass, registration)
+    assert set(stored) == {session_id}
+    assert stored[session_id]["session_id"] == session_id
+    # And the server the relationship is about came from the payload, not from the identifier.
+    assert stored[session_id]["server_id"] == SERVER_ID
+
+
+async def test_the_server_id_is_taken_from_the_payload(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """Whatever the app calls its server is what the snapshot's selection has to carry."""
+    await _register(
+        webhook_client,
+        registration,
+        server_id="66ecff02b21c4c788b60f11169fd7c81",
+        session_id="an-identifier-that-encodes-nothing",
+    )
+    stored = stored_sessions(hass, registration)["an-identifier-that-encodes-nothing"]
+    assert stored["server_id"] == "66ecff02b21c4c788b60f11169fd7c81"
+    publisher = async_get_manager(hass).async_get(
+        registration, "an-identifier-that-encodes-nothing"
+    )
+    assert publisher.session.server_id == "66ecff02b21c4c788b60f11169fd7c81"
+
+
+async def test_a_missing_entity_does_not_prevent_registration(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """The player may not exist yet — an integration can load after the phone registers."""
+    hass.states.async_remove(ENTITY_ID)
+    await hass.async_block_till_done()
+
+    resp = await _register(webhook_client, registration)
+    assert resp.status == HTTPStatus.OK
+    assert SESSION_ID in stored_sessions(hass, registration)
+    # Watching anyway, so the card starts as soon as the player appears.
+    assert ENTITY_ID in async_get_manager(hass).watchers
+
+
+@pytest.mark.parametrize("state", ["paused", "idle", "off", "unavailable", "unknown"])
+async def test_a_player_that_is_not_playing_can_still_be_followed(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient, state: str
+) -> None:
+    """Following is a user relationship, not a playback state."""
+    hass.states.async_set(ENTITY_ID, state, {"friendly_name": "Speaker"})
+    resp = await _register(webhook_client, registration)
+    assert resp.status == HTTPStatus.OK
+    assert SESSION_ID in stored_sessions(hass, registration)
+
+
+async def test_an_identical_registration_is_idempotent(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """The app re-registers the same token; that must not double anything up."""
+    await _register(webhook_client, registration)
+    first = async_get_manager(hass).async_get(registration, SESSION_ID)
+    await _register(webhook_client, registration)
+    assert async_get_manager(hass).async_get(registration, SESSION_ID) is first
+    assert len(stored_sessions(hass, registration)) == 1
+    assert len(async_get_manager(hass).watchers[ENTITY_ID].publishers) == 1
+
+
+async def test_a_replacement_token_supersedes_the_old_one(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """Same Follow lifetime, new token: the new one becomes the only destination."""
+    await _register(webhook_client, registration)
+    replacement = "41" + "cd" * 79
+    await _register(webhook_client, registration, push_token=replacement)
+
+    stored = stored_sessions(hass, registration)[SESSION_ID]
+    assert stored["push_token"] == replacement
+    assert stored["generation"] == GENERATION
+    publisher = async_get_manager(hass).async_get(registration, SESSION_ID)
+    assert publisher.session.push_token == replacement
+
+
+async def test_a_replacement_token_keeps_the_lifetimes_state(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """A token rotation is the same card, so its sticky state and clock survive."""
+    await _register(webhook_client, registration)
+    seeded = stored_sessions(hass, registration)[SESSION_ID]
+    seeded["last_timestamp"] = 4242
+    seeded["last_snapshot"] = STORED_SNAPSHOT
+
+    await _register(webhook_client, registration, push_token=LATER_PUSH_TOKEN)
+    stored = stored_sessions(hass, registration)[SESSION_ID]
+    assert stored["push_token"] == LATER_PUSH_TOKEN
+    assert stored["last_timestamp"] == 4242
+    assert stored["last_snapshot"] == STORED_SNAPSHOT
+
+
+async def test_a_later_follow_replaces_the_previous_one(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """Following again after stopping is a later relationship, and it wins."""
+    await _register(webhook_client, registration)
+    await _register(
+        webhook_client,
+        registration,
+        generation=LATER_GENERATION,
+        generation_sequence=LATER_SEQUENCE,
+    )
+
+    stored = stored_sessions(hass, registration)
+    assert len(stored) == 1
+    assert stored[SESSION_ID]["generation"] == LATER_GENERATION
+    assert stored[SESSION_ID]["generation_sequence"] == LATER_SEQUENCE
+    # Still exactly one listener for the player.
+    assert len(async_get_manager(hass).watchers[ENTITY_ID].publishers) == 1
+
+
+async def test_a_later_follow_starts_from_a_clean_slate(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """A new relationship is a new APNs session, so it inherits nothing from the last.
+
+    The track the old card was showing and the ordering clock the old session was sequenced by
+    both belong to a session that has ended. Carrying either would mean the first push of the new
+    relationship describes the old one, or is dropped as out of order.
+    """
+    await _register(webhook_client, registration)
+    seeded = stored_sessions(hass, registration)[SESSION_ID]
+    seeded["last_timestamp"] = 999_999
+    seeded["last_snapshot"] = STORED_SNAPSHOT
+
+    await _register(
+        webhook_client,
+        registration,
+        generation=LATER_GENERATION,
+        generation_sequence=LATER_SEQUENCE,
+        push_token=LATER_PUSH_TOKEN,
+    )
+
+    stored = stored_sessions(hass, registration)[SESSION_ID]
+    assert stored["last_timestamp"] is None
+    assert stored["last_snapshot"] is None
+    assert stored["push_token"] == LATER_PUSH_TOKEN
+
+
+async def test_a_late_registration_cannot_overwrite_a_later_follow(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """The race the sequence exists for, end to end.
+
+    Registration happens in an extension process whose lifetime the app does not control, so a
+    registration describing a relationship the user has already replaced can arrive after the
+    replacement's. Nothing about the stale one may be applied: not the token, not the entity, not
+    the sticky state, not the clock, and no listener may move.
+    """
+    # Follow A, then stop and follow again as B.
+    await _register(webhook_client, registration)
+    await _register(
+        webhook_client,
+        registration,
+        generation=LATER_GENERATION,
+        generation_sequence=LATER_SEQUENCE,
+        push_token=LATER_PUSH_TOKEN,
+    )
+    publisher = async_get_manager(hass).async_get(registration, SESSION_ID)
+
+    # A's registration finally lands.
+    resp = await _register(webhook_client, registration)
+    assert resp.status == HTTPStatus.OK
+    await hass.async_block_till_done()
+
+    stored = stored_sessions(hass, registration)[SESSION_ID]
+    assert stored["generation"] == LATER_GENERATION
+    assert stored["generation_sequence"] == LATER_SEQUENCE
+    assert stored["push_token"] == LATER_PUSH_TOKEN
+    # And the publisher B was using was left exactly where it was.
+    assert async_get_manager(hass).async_get(registration, SESSION_ID) is publisher
+    assert len(async_get_manager(hass).watchers[ENTITY_ID].publishers) == 1
+
+
+async def test_a_late_registration_cannot_move_the_followed_entity(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """A stale registration naming another player must not move the listener either."""
+    hass.states.async_set("media_player.other", "playing", PLAYING_ATTRIBUTES)
+    await _register(
+        webhook_client,
+        registration,
+        generation=LATER_GENERATION,
+        generation_sequence=LATER_SEQUENCE,
+    )
+    await _register(webhook_client, registration, entity_id="media_player.other")
+    await hass.async_block_till_done()
+
+    assert stored_sessions(hass, registration)[SESSION_ID]["entity_id"] == ENTITY_ID
+    assert "media_player.other" not in async_get_manager(hass).watchers
+
+
+async def test_one_sequence_claimed_by_two_relationships_is_refused(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """A conflict, not a race to resolve.
+
+    The app increments its counter once per relationship, so two different generations at the same
+    sequence cannot both be right — and guessing which is newer would be exactly the heuristic the
+    sequence exists to remove.
+    """
+    await _register(webhook_client, registration)
+    resp = await _register(webhook_client, registration, generation=LATER_GENERATION)
+    assert resp.status == HTTPStatus.OK
+    await hass.async_block_till_done()
+
+    stored = stored_sessions(hass, registration)[SESSION_ID]
+    assert stored["generation"] == GENERATION
+    assert stored["push_token"] == PUSH_TOKEN
+
+
+async def test_a_session_stored_without_a_sequence_accepts_an_ordered_one(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """Upgrading a development install, where a stored session predates ordering.
+
+    Nothing released ever wrote one, so this only has to be survivable: an unordered stored
+    session cannot be compared with anything, and the first ordered registration takes over.
+    """
+    await _register(webhook_client, registration)
+    stored = stored_sessions(hass, registration)
+    stored[SESSION_ID]["generation_sequence"] = None
+
+    await _register(
+        webhook_client,
+        registration,
+        generation=LATER_GENERATION,
+        generation_sequence=LATER_SEQUENCE,
+    )
+    assert stored_sessions(hass, registration)[SESSION_ID]["generation_sequence"] == (
+        LATER_SEQUENCE
+    )
+
+
+async def test_a_registration_without_push_is_stored_but_not_watched(
+    hass: HomeAssistant, local_only_registration: str, webhook_client: TestClient
+) -> None:
+    """Core cannot reach it, so watching would shape traffic for requests that cannot be sent.
+
+    The relationship is still remembered: the phone has asked to follow, and deleting it because
+    push is not configured yet would mean the user has to notice and re-follow.
+    """
+    resp = await _register(webhook_client, local_only_registration)
+    assert resp.status == HTTPStatus.OK
+
+    assert SESSION_ID in stored_sessions(hass, local_only_registration)
+    manager = async_get_manager(hass)
+    assert manager.async_get(local_only_registration, SESSION_ID) is None
+    assert ENTITY_ID not in manager.watchers
+    assert manager.async_is_known(local_only_registration, SESSION_ID)
+
+
+async def test_gaining_push_starts_watching_a_stored_relationship(
+    hass: HomeAssistant,
+    local_only_registration: str,
+    webhook_client: TestClient,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """`update_registration` is the lifecycle point where push arrives."""
+    aioclient_mock.post(PUSH_URL, status=HTTPStatus.CREATED, json={})
+    await _register(webhook_client, local_only_registration)
+    # pylint: disable-next=home-assistant-use-runtime-data
+    entry = hass.data[DOMAIN][DATA_CONFIG_ENTRIES][local_only_registration]
+    hass.config_entries.async_update_entry(
+        entry,
+        data={
+            **entry.data,
+            "app_data": {"push_token": "COMPANION_TOKEN", "push_url": PUSH_URL},
+        },
+    )
+    await hass.async_block_till_done()
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + dt_util.dt.timedelta(seconds=COALESCE_SECONDS + 0.1)
+    )
+    await hass.async_block_till_done()
+
+    manager = async_get_manager(hass)
+    assert manager.async_get(local_only_registration, SESSION_ID) is not None
+    assert ENTITY_ID in manager.watchers
+    # And the card is brought up to date, rather than waiting for the player to change.
+    assert aioclient_mock.mock_calls
+
+
+async def test_losing_push_stops_watching_but_keeps_the_relationship(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """A temporary push loss makes the follow dormant instead of retrying forever."""
+    await _register(webhook_client, registration)
+    manager = async_get_manager(hass)
+    assert manager.async_get(registration, SESSION_ID) is not None
+
+    # pylint: disable-next=home-assistant-use-runtime-data
+    entry = hass.data[DOMAIN][DATA_CONFIG_ENTRIES][registration]
+    hass.config_entries.async_update_entry(entry, data={**entry.data, "app_data": {}})
+    await hass.async_block_till_done()
+
+    assert manager.async_get(registration, SESSION_ID) is None
+    assert ENTITY_ID not in manager.watchers
+    assert manager.async_is_known(registration, SESSION_ID)
+    assert SESSION_ID in stored_sessions(hass, registration)
+
+
+async def test_a_matching_dismissal_stops_following(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """Stop Following removes the relationship."""
+    await _register(webhook_client, registration)
+    resp = await _post(
+        webhook_client,
+        registration,
+        "remote_media_session_dismissed",
+        dismissal_payload(),
+    )
+    assert resp.status == HTTPStatus.OK
+    await hass.async_block_till_done()
+
+    assert stored_sessions(hass, registration) == {}
+    assert async_get_manager(hass).async_get(registration, SESSION_ID) is None
+    # The last session for the player took its listener with it.
+    assert ENTITY_ID not in async_get_manager(hass).watchers
+
+
+async def test_a_late_dismissal_cannot_remove_a_later_follow(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """The other half of the race, end to end.
+
+    The app writes down a dismissal it could not send and retries it on a later launch, so one can
+    arrive long after the user has followed again. Both halves of the relationship have to match
+    the stored one: the sequence says it is older, and there is nothing to guess.
+    """
+    await _register(
+        webhook_client,
+        registration,
+        generation=LATER_GENERATION,
+        generation_sequence=LATER_SEQUENCE,
+    )
+    resp = await _post(
+        webhook_client,
+        registration,
+        "remote_media_session_dismissed",
+        dismissal_payload(generation=GENERATION, generation_sequence=SEQUENCE),
+    )
+    assert resp.status == HTTPStatus.OK
+    await hass.async_block_till_done()
+
+    stored = stored_sessions(hass, registration)
+    assert stored[SESSION_ID]["generation"] == LATER_GENERATION
+    assert stored[SESSION_ID]["generation_sequence"] == LATER_SEQUENCE
+    assert async_get_manager(hass).async_get(registration, SESSION_ID) is not None
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        # The right sequence but a different relationship: a conflict, not a match.
+        {"generation": LATER_GENERATION},
+        # The right relationship at the wrong place in the order.
+        {"generation_sequence": LATER_SEQUENCE},
+        {"generation_sequence": 1},
+    ],
+)
+async def test_a_dismissal_must_name_the_stored_relationship_exactly(
+    hass: HomeAssistant,
+    registration: str,
+    webhook_client: TestClient,
+    overrides: dict[str, Any],
+) -> None:
+    """Half a match is no match. Removing on one would reopen the race."""
+    await _register(webhook_client, registration)
+    resp = await _post(
+        webhook_client,
+        registration,
+        "remote_media_session_dismissed",
+        dismissal_payload(**overrides),
+    )
+    assert resp.status == HTTPStatus.OK
+    await hass.async_block_till_done()
+    assert SESSION_ID in stored_sessions(hass, registration)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"generation": ""},
+        {"generation_sequence": 0},
+        {"generation_sequence": -1},
+        {"generation_sequence": "ten"},
+    ],
+)
+async def test_malformed_dismissals_are_refused(
+    hass: HomeAssistant,
+    registration: str,
+    webhook_client: TestClient,
+    overrides: dict[str, Any],
+) -> None:
+    """A dismissal that does not describe a relationship cannot end one."""
+    await _register(webhook_client, registration)
+    resp = await _post(
+        webhook_client,
+        registration,
+        "remote_media_session_dismissed",
+        dismissal_payload(**overrides),
+    )
+    assert resp.status == HTTPStatus.OK
+    await hass.async_block_till_done()
+    assert SESSION_ID in stored_sessions(hass, registration)
+
+
+async def test_a_dismissal_for_an_unknown_session_is_harmless(
+    hass: HomeAssistant, registration: str, webhook_client: TestClient
+) -> None:
+    """Nothing to do, and nothing to complain about."""
+    resp = await _post(
+        webhook_client,
+        registration,
+        "remote_media_session_dismissed",
+        dismissal_payload(session_id="4:homemedia_player.nothing"),
+    )
+    assert resp.status == HTTPStatus.OK
+
+
+async def test_one_registration_cannot_dismiss_another(
+    hass: HomeAssistant,
+    create_registrations: tuple[dict[str, Any], dict[str, Any]],
+    webhook_client: TestClient,
+) -> None:
+    """Sessions are owned by the config entry that registered them."""
+    hass.states.async_set(ENTITY_ID, "playing", PLAYING_ATTRIBUTES)
+    owner = create_registrations[1]["webhook_id"]
+    other = create_registrations[0]["webhook_id"]
+    await _register(webhook_client, owner)
+
+    await _post(
+        webhook_client, other, "remote_media_session_dismissed", dismissal_payload()
+    )
+    await hass.async_block_till_done()
+    assert SESSION_ID in stored_sessions(hass, owner)
+
+
+async def test_the_session_token_never_reaches_the_log(
+    hass: HomeAssistant,
+    registration: str,
+    webhook_client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`mobile_app` logs every decrypted payload at debug level.
+
+    That is right for the other commands and wrong for this one: the token is a live APNs
+    destination for the user's device.
+    """
+    with caplog.at_level(logging.DEBUG):
+        await _register(webhook_client, registration)
+        await hass.async_block_till_done()
+
+    assert PUSH_TOKEN not in caplog.text
+    assert "**REDACTED" in caplog.text
+    # The rest of the payload is still there to diagnose with.
+    assert SESSION_ID in caplog.text
+    assert ENTITY_ID in caplog.text
+
+
+@pytest.mark.parametrize(
+    "bad_token",
+    ["not-hex-at-all", "abc", "ab" * 400, 12345, None, {"nested": "value"}],
+)
+async def test_a_refused_token_is_not_echoed_into_the_log(
+    hass: HomeAssistant,
+    registration: str,
+    webhook_client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+    bad_token: Any,
+) -> None:
+    """A rejected token must not be more exposed than an accepted one.
+
+    `validate_schema` reports failures with `humanize_error`, which echoes the offending value at
+    ERROR level — on by default. So the token is validated in the handler instead.
+    """
+    with caplog.at_level(logging.DEBUG):
+        resp = await _register(webhook_client, registration, push_token=bad_token)
+        await hass.async_block_till_done()
+
+    assert resp.status == HTTPStatus.OK
+    assert stored_sessions(hass, registration) == {}
+    if isinstance(bad_token, str) and len(bad_token) > 8:
+        assert bad_token not in caplog.text
+
+
+async def test_other_webhook_payloads_are_logged_unchanged(
+    hass: HomeAssistant,
+    registration: str,
+    webhook_client: TestClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The redaction is per command, not a blanket change to webhook logging."""
+    with caplog.at_level(logging.DEBUG):
+        await _post(
+            webhook_client,
+            registration,
+            "fire_event",
+            {"event_type": "test_event", "event_data": {"hello": "yo world"}},
+        )
+        await hass.async_block_till_done()
+    assert "yo world" in caplog.text
+    assert "**REDACTED" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds server-side support for iOS 27 Remote Now Playing sessions in the `mobile_app` integration.

The Companion app can register a Remote Now Playing session for a `media_player` entity. Home Assistant Core then watches that entity and sends relevant state changes through the existing mobile app push service. Sessions are persisted across Home Assistant restarts, and registration is both ordered and idempotent.

For playback progress, Core compares the current position with the expected position. This avoids sending continuous updates while media is playing normally and nothing meaningful has changed.

Artwork is only included when `entity_picture` is an absolute HTTPS URL with no credentials or query string.

The `mobile_app` storage version is also bumped to store Remote Now Playing sessions. Existing storage is migrated with an empty session mapping. APNs support for these updates is implemented in https://github.com/home-assistant/mobile-apps-fcm-push/pull/363

Testing completed locally:

- `tests/components/mobile_app/remote_media`: 242 passed
- `tests/components/mobile_app`: 408 passed
- Ruff check and format passed
- hassfest for `mobile_app` passed
- `git diff --check` passed
- changed-file prek hooks passed except for existing mypy failures
- mypy reports the same 17 unrelated errors in `matter`, `stream`, and `usb` on clean `dev`
- pylint reports one existing `E7402` in unchanged `mobile_app/webhook.py`, also reproduced on clean `dev`

I also tested the full path with Home Assistant Core, the push relay, and a physical iPhone. Remote Now Playing metadata continued updating with the Companion app closed, and the native playback controls sent commands back to Home Assistant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please, be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/orgs/home-assistant/discussions/1338
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Related push relay PR: https://github.com/home-assistant/mobile-apps-fcm-push/pull/363

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure of any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr