### PR TITLE
Bump iseo-argo-ble to 0.9.8

### DIFF
--- a/homeassistant/components/iseo_argo_ble/manifest.json
+++ b/homeassistant/components/iseo_argo_ble/manifest.json
@@ -75,5 +75,5 @@
   "iot_class": "local_polling",
   "loggers": ["iseo_argo_ble"],
   "quality_scale": "bronze",
-  "requirements": ["iseo-argo-ble==0.5.3"]
+  "requirements": ["iseo-argo-ble==0.9.8"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1426,7 +1426,7 @@ irm-kmi-api==1.1.1
 isal==1.8.0
 
 # homeassistant.components.iseo_argo_ble
-iseo-argo-ble==0.5.3
+iseo-argo-ble==0.9.8
 
 # homeassistant.components.gogogate2
 ismartgate==5.0.2


### PR DESCRIPTION
## Proposed change

Bumps `iseo-argo-ble` from 0.5.3 (the version shipped since the integration was added) to 0.9.8.

The motivating bug: gateway registration fails during config flow on locks that expose characteristic `0x0001` on more than one GATT service, with `BleakError: Multiple Characteristics with this UUID`. 0.5.3 asks bleak for the SLIP notify/write characteristics by UUID, and bleak refuses to resolve a UUID that matches several characteristics. Since 0.6.8 the library resolves them to characteristic objects against the connected GATT instead, and 0.9.7 extends that to locks that don't expose the documented ISEO service at all.

Reported downstream at FezVrasta/iseo-argo-ble#3.

Other fixes between the two versions that affect this integration:

- A refused whitelist read no longer looks like a lock with no users (it raised nothing and returned `[]`, which removed every user entity).
- The login status is checked when registering for log notifications, so a rejected login fails there instead of two commands later.
- A truncated handshake frame raises `IseoConnectionError` rather than a bare `ValueError`, so `lock.py`'s `except (TimeoutError, IseoConnectionError, OSError)` catches it.
- BlueZ-acknowledged writes are used on characteristics that don't accept write-without-response ("Failed to initiate write").
- Log pages already drained are kept when a later page fails.
- `IseoConnectionError` is raised when the connection itself fails, rather than a bleak error escaping.

No integration code changes are needed: every API this integration uses (`IseoClient(...)`, `update_ble_device`, `read_state`, `gw_open`, `setup_gateway`, `LockState`, `IseoAuthError`, `IseoConnectionError`) is unchanged in signature and behaviour.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: FezVrasta/iseo-argo-ble#3
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Release notes: https://github.com/FezVrasta/iseo-argo-ble/releases
Diff: https://github.com/FezVrasta/iseo-argo-ble/compare/v0.5.3...v0.9.8

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The manifest file has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other open pull requests in this repository.
