### PR TITLE
Defer the next ViCare refresh to the API quota reset

### DIFF
--- a/homeassistant/components/vicare/coordinator.py
+++ b/homeassistant/components/vicare/coordinator.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import DEFAULT_CACHE_DURATION, DOMAIN
 from .types import ViCareConfigEntry
+from .utils import retry_after_from
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -73,11 +74,18 @@ class ViCareCoordinator(DataUpdateCoordinator[None]):
             )
         except PyViCareInvalidCredentialsError as err:
             raise ConfigEntryAuthFailed from err
+        except PyViCareRateLimitError as err:
+            raise UpdateFailed(
+                str(err),
+                retry_after=retry_after_from(
+                    err,
+                    self.update_interval or timedelta(seconds=DEFAULT_CACHE_DURATION),
+                ),
+            ) from err
         except (
             PyViCareDeviceCommunicationError,
             PyViCareInternalServerError,
             PyViCareInvalidDataError,
-            PyViCareRateLimitError,
             requests.RequestException,
         ) as err:
             raise UpdateFailed(str(err)) from err

--- a/homeassistant/components/vicare/coordinator.py
+++ b/homeassistant/components/vicare/coordinator.py
@@ -1,6 +1,6 @@
 """DataUpdateCoordinator for the ViCare integration."""
 
-from datetime import UTC, timedelta
+from datetime import timedelta
 import logging
 from typing import override
 
@@ -19,15 +19,11 @@ import requests
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util import dt as dt_util
 
 from .const import DEFAULT_CACHE_DURATION, DOMAIN
 from .types import ViCareConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
-
-# The quota window is a day, so a reset further out than that is not credible.
-MAX_RATE_LIMIT_BACKOFF = 86400
 
 
 class ViCareCoordinator(DataUpdateCoordinator[None]):
@@ -77,22 +73,11 @@ class ViCareCoordinator(DataUpdateCoordinator[None]):
             )
         except PyViCareInvalidCredentialsError as err:
             raise ConfigEntryAuthFailed from err
-        except PyViCareRateLimitError as err:
-            # limitResetDate is naive UTC. Clamped because a stale or skewed reset
-            # time would otherwise retry at once against a quota that is still spent.
-            reset = err.limitResetDate.replace(tzinfo=UTC)
-            delay = (reset - dt_util.utcnow()).total_seconds()
-            floor = self.update_interval or timedelta(seconds=DEFAULT_CACHE_DURATION)
-            raise UpdateFailed(
-                str(err),
-                retry_after=min(
-                    max(delay, floor.total_seconds()), MAX_RATE_LIMIT_BACKOFF
-                ),
-            ) from err
         except (
             PyViCareDeviceCommunicationError,
             PyViCareInternalServerError,
             PyViCareInvalidDataError,
+            PyViCareRateLimitError,
             requests.RequestException,
         ) as err:
             raise UpdateFailed(str(err)) from err

--- a/homeassistant/components/vicare/coordinator.py
+++ b/homeassistant/components/vicare/coordinator.py
@@ -82,10 +82,11 @@ class ViCareCoordinator(DataUpdateCoordinator[None]):
             # time would otherwise retry at once against a quota that is still spent.
             reset = err.limitResetDate.replace(tzinfo=UTC)
             delay = (reset - dt_util.utcnow()).total_seconds()
+            floor = self.update_interval or timedelta(seconds=DEFAULT_CACHE_DURATION)
             raise UpdateFailed(
                 str(err),
                 retry_after=min(
-                    max(delay, DEFAULT_CACHE_DURATION), MAX_RATE_LIMIT_BACKOFF
+                    max(delay, floor.total_seconds()), MAX_RATE_LIMIT_BACKOFF
                 ),
             ) from err
         except (

--- a/homeassistant/components/vicare/coordinator.py
+++ b/homeassistant/components/vicare/coordinator.py
@@ -1,6 +1,6 @@
 """DataUpdateCoordinator for the ViCare integration."""
 
-from datetime import timedelta
+from datetime import UTC, timedelta
 import logging
 from typing import override
 
@@ -19,11 +19,15 @@ import requests
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import DEFAULT_CACHE_DURATION, DOMAIN
 from .types import ViCareConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+# The quota window is a day, so a reset further out than that is not credible.
+MAX_RATE_LIMIT_BACKOFF = 86400
 
 
 class ViCareCoordinator(DataUpdateCoordinator[None]):
@@ -73,11 +77,21 @@ class ViCareCoordinator(DataUpdateCoordinator[None]):
             )
         except PyViCareInvalidCredentialsError as err:
             raise ConfigEntryAuthFailed from err
+        except PyViCareRateLimitError as err:
+            # limitResetDate is naive UTC. Clamped because a stale or skewed reset
+            # time would otherwise retry at once against a quota that is still spent.
+            reset = err.limitResetDate.replace(tzinfo=UTC)
+            delay = (reset - dt_util.utcnow()).total_seconds()
+            raise UpdateFailed(
+                str(err),
+                retry_after=min(
+                    max(delay, DEFAULT_CACHE_DURATION), MAX_RATE_LIMIT_BACKOFF
+                ),
+            ) from err
         except (
             PyViCareDeviceCommunicationError,
             PyViCareInternalServerError,
             PyViCareInvalidDataError,
-            PyViCareRateLimitError,
             requests.RequestException,
         ) as err:
             raise UpdateFailed(str(err)) from err

--- a/homeassistant/components/vicare/utils.py
+++ b/homeassistant/components/vicare/utils.py
@@ -1,6 +1,7 @@
 """ViCare helpers functions."""
 
 from collections.abc import Callable, Mapping
+from datetime import UTC, timedelta
 import logging
 from typing import Any
 
@@ -21,8 +22,11 @@ import requests
 from homeassistant.const import CONF_CLIENT_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import STORAGE_DIR
+from homeassistant.util import dt as dt_util
 
 from .const import DEFAULT_CACHE_DURATION, VICARE_TOKEN_FILENAME
+
+MAX_RATE_LIMIT_BACKOFF = 86400  # the quota window is a day
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -157,3 +161,13 @@ def filter_state(state: str) -> str | None:
 def normalize_state(state: str) -> str:
     """Return the state with underscores instead of hyphens."""
     return state.replace("-", "_")
+
+
+def retry_after_from(error: PyViCareRateLimitError, floor: timedelta) -> float:
+    """Return seconds to wait after a rate limit, clamped to [floor, one day].
+
+    limitResetDate is naive UTC and can be in the past.
+    """
+    reset = error.limitResetDate.replace(tzinfo=UTC)
+    delay = (reset - dt_util.utcnow()).total_seconds()
+    return min(max(delay, floor.total_seconds()), MAX_RATE_LIMIT_BACKOFF)

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -43,6 +43,8 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 # From a real rate limit response: 2026-09-09T00:00:04.144Z.
 QUOTA_RESET_MS = 1788912004144
 
+SENSOR_ID = "sensor.model0_outside_temperature"
+
 # 16-character zigbee IEEE address shared by the FHT fixtures.
 ZIGBEE_IEEE = "#" * 16
 
@@ -321,7 +323,7 @@ async def test_coordinator_backs_off_until_the_quota_resets(
 ) -> None:
     """Test a rate limited refresh defers the next one to the reset time."""
     freezer.move_to("2026-09-08 20:00:04+00:00")
-    fixtures: list[Fixture] = [Fixture({"type:heatpump"}, "vicare/Vitocal250A.json")]
+    fixtures: list[Fixture] = [Fixture({"type:boiler"}, "vicare/Vitodens300W.json")]
     mock_vicare = MockPyViCare(fixtures)
     service = mock_vicare.devices[0].service
 
@@ -336,9 +338,6 @@ async def test_coordinator_backs_off_until_the_quota_resets(
     ):
         await setup_integration(hass, mock_config_entry)
 
-    coordinator = mock_config_entry.runtime_data.devices[0].coordinator
-    assert coordinator is not None
-
     service.fetch_all_features.side_effect = PyViCareRateLimitError(
         {
             "extendedPayload": {
@@ -348,21 +347,23 @@ async def test_coordinator_backs_off_until_the_quota_resets(
             }
         }
     )
-    await coordinator.async_refresh()
+    freezer.tick(timedelta(seconds=DEFAULT_CACHE_DURATION * 2))
+    async_fire_time_changed(hass, fire_all=True)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert coordinator.last_update_success is False
-    assert coordinator.last_exception.retry_after == pytest.approx(4 * 3600, abs=5)
-
+    assert hass.states.get(SENSOR_ID).state == STATE_UNAVAILABLE
     calls = service.fetch_all_features.call_count
+
+    # The quota resets four hours out, so nothing may go out at the ordinary
+    # interval in between.
     freezer.tick(timedelta(seconds=DEFAULT_CACHE_DURATION * 2))
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    # Asserting on retry_after alone would pass even if scheduling ignored it.
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert service.fetch_all_features.call_count == calls
 
     freezer.tick(timedelta(hours=4))
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert service.fetch_all_features.call_count > calls
 
 
@@ -373,7 +374,7 @@ async def test_coordinator_backs_off_when_the_reset_has_passed(
 ) -> None:
     """Test a reset time in the past still defers, instead of retrying at once."""
     freezer.move_to("2026-09-09 01:00:04+00:00")
-    fixtures: list[Fixture] = [Fixture({"type:heatpump"}, "vicare/Vitocal250A.json")]
+    fixtures: list[Fixture] = [Fixture({"type:boiler"}, "vicare/Vitodens300W.json")]
     mock_vicare = MockPyViCare(fixtures)
     service = mock_vicare.devices[0].service
 
@@ -388,9 +389,6 @@ async def test_coordinator_backs_off_when_the_reset_has_passed(
     ):
         await setup_integration(hass, mock_config_entry)
 
-    coordinator = mock_config_entry.runtime_data.devices[0].coordinator
-    assert coordinator is not None
-
     service.fetch_all_features.side_effect = PyViCareRateLimitError(
         {
             "extendedPayload": {
@@ -400,15 +398,24 @@ async def test_coordinator_backs_off_when_the_reset_has_passed(
             }
         }
     )
-    await coordinator.async_refresh()
+    freezer.tick(timedelta(seconds=DEFAULT_CACHE_DURATION * 2))
+    async_fire_time_changed(hass, fire_all=True)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
-    # A zero delay would make the coordinator reschedule immediately and hammer
-    # a quota that is still spent.
-    assert coordinator.update_interval is not None
-    assert (
-        coordinator.last_exception.retry_after
-        >= coordinator.update_interval.total_seconds()
-    )
+    assert hass.states.get(SENSOR_ID).state == STATE_UNAVAILABLE
+    calls = service.fetch_all_features.call_count
+
+    # A zero delay would reschedule at once and hammer a quota that is still
+    # spent, so the wait stays at the ordinary interval.
+    freezer.tick(timedelta(seconds=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert service.fetch_all_features.call_count == calls
+
+    freezer.tick(timedelta(seconds=DEFAULT_CACHE_DURATION * 2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert service.fetch_all_features.call_count > calls
 
 
 async def test_setup_entry_invalid_credentials(

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -12,6 +12,7 @@ from PyViCare.PyViCareUtils import (
     PyViCareInvalidCredentialsError,
     PyViCareInvalidDataError,
     PyViCareNotSupportedFeatureError,
+    PyViCareRateLimitError,
 )
 
 from homeassistant.components.vicare.const import DEFAULT_CACHE_DURATION, DOMAIN
@@ -33,6 +34,7 @@ from homeassistant.helpers import (
     entity_registry as er,
     issue_registry as ir,
 )
+from homeassistant.util import dt as dt_util
 
 from . import MODULE, setup_integration
 from .conftest import Fixture, MockPyViCare
@@ -308,6 +310,98 @@ async def test_setup_entry_transient_error(
         await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_coordinator_backs_off_until_the_quota_resets(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a rate limited refresh defers the next one to the reset time."""
+    fixtures: list[Fixture] = [Fixture({"type:heatpump"}, "vicare/Vitocal250A.json")]
+    mock_vicare = MockPyViCare(fixtures)
+    service = mock_vicare.devices[0].service
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+        ),
+        patch(
+            f"{MODULE}._setup_vicare_api",
+            return_value=mock_vicare.as_vicare_data(),
+        ),
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data.devices[0].coordinator
+    assert coordinator is not None
+
+    service.fetch_all_features.side_effect = PyViCareRateLimitError(
+        {
+            "extendedPayload": {
+                "name": "development portal",
+                "requestCountLimit": 1450,
+                "limitReset": (dt_util.utcnow() + timedelta(hours=4)).timestamp()
+                * 1000,
+            }
+        }
+    )
+    await coordinator.async_refresh()
+
+    assert coordinator.last_update_success is False
+    assert coordinator.last_exception.retry_after == pytest.approx(4 * 3600, abs=5)
+
+    calls = service.fetch_all_features.call_count
+    freezer.tick(timedelta(seconds=DEFAULT_CACHE_DURATION * 2))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    # Asserting on retry_after alone would pass even if scheduling ignored it.
+    assert service.fetch_all_features.call_count == calls
+
+    freezer.tick(timedelta(hours=4))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert service.fetch_all_features.call_count > calls
+
+
+async def test_coordinator_backs_off_when_the_reset_has_passed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a reset time in the past still defers, instead of retrying at once."""
+    fixtures: list[Fixture] = [Fixture({"type:heatpump"}, "vicare/Vitocal250A.json")]
+    mock_vicare = MockPyViCare(fixtures)
+    service = mock_vicare.devices[0].service
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+        ),
+        patch(
+            f"{MODULE}._setup_vicare_api",
+            return_value=mock_vicare.as_vicare_data(),
+        ),
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data.devices[0].coordinator
+    assert coordinator is not None
+
+    service.fetch_all_features.side_effect = PyViCareRateLimitError(
+        {
+            "extendedPayload": {
+                "name": "development portal",
+                "requestCountLimit": 1450,
+                "limitReset": (dt_util.utcnow() - timedelta(hours=1)).timestamp()
+                * 1000,
+            }
+        }
+    )
+    await coordinator.async_refresh()
+
+    # A zero delay would make the coordinator reschedule immediately and hammer
+    # a quota that is still spent.
+    assert coordinator.last_exception.retry_after >= DEFAULT_CACHE_DURATION
 
 
 async def test_setup_entry_invalid_credentials(

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -34,12 +34,14 @@ from homeassistant.helpers import (
     entity_registry as er,
     issue_registry as ir,
 )
-from homeassistant.util import dt as dt_util
 
 from . import MODULE, setup_integration
 from .conftest import Fixture, MockPyViCare
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+# From a real rate limit response: 2026-09-09T00:00:04.144Z.
+QUOTA_RESET_MS = 1788912004144
 
 # 16-character zigbee IEEE address shared by the FHT fixtures.
 ZIGBEE_IEEE = "#" * 16
@@ -318,6 +320,7 @@ async def test_coordinator_backs_off_until_the_quota_resets(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test a rate limited refresh defers the next one to the reset time."""
+    freezer.move_to("2026-09-08 20:00:04+00:00")
     fixtures: list[Fixture] = [Fixture({"type:heatpump"}, "vicare/Vitocal250A.json")]
     mock_vicare = MockPyViCare(fixtures)
     service = mock_vicare.devices[0].service
@@ -341,8 +344,7 @@ async def test_coordinator_backs_off_until_the_quota_resets(
             "extendedPayload": {
                 "name": "development portal",
                 "requestCountLimit": 1450,
-                "limitReset": (dt_util.utcnow() + timedelta(hours=4)).timestamp()
-                * 1000,
+                "limitReset": QUOTA_RESET_MS,
             }
         }
     )
@@ -367,8 +369,10 @@ async def test_coordinator_backs_off_until_the_quota_resets(
 async def test_coordinator_backs_off_when_the_reset_has_passed(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test a reset time in the past still defers, instead of retrying at once."""
+    freezer.move_to("2026-09-09 01:00:04+00:00")
     fixtures: list[Fixture] = [Fixture({"type:heatpump"}, "vicare/Vitocal250A.json")]
     mock_vicare = MockPyViCare(fixtures)
     service = mock_vicare.devices[0].service
@@ -392,8 +396,7 @@ async def test_coordinator_backs_off_when_the_reset_has_passed(
             "extendedPayload": {
                 "name": "development portal",
                 "requestCountLimit": 1450,
-                "limitReset": (dt_util.utcnow() - timedelta(hours=1)).timestamp()
-                * 1000,
+                "limitReset": QUOTA_RESET_MS,
             }
         }
     )

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -401,7 +401,11 @@ async def test_coordinator_backs_off_when_the_reset_has_passed(
 
     # A zero delay would make the coordinator reschedule immediately and hammer
     # a quota that is still spent.
-    assert coordinator.last_exception.retry_after >= DEFAULT_CACHE_DURATION
+    assert coordinator.update_interval is not None
+    assert (
+        coordinator.last_exception.retry_after
+        >= coordinator.update_interval.total_seconds()
+    )
 
 
 async def test_setup_entry_invalid_credentials(

--- a/tests/components/vicare/test_utils.py
+++ b/tests/components/vicare/test_utils.py
@@ -1,8 +1,15 @@
 """Test ViCare utils."""
 
-import pytest
+from datetime import timedelta
 
-from homeassistant.components.vicare.utils import filter_state
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from PyViCare.PyViCareUtils import PyViCareRateLimitError
+
+from homeassistant.components.vicare.utils import filter_state, retry_after_from
+
+# From a real rate limit response: 2026-09-09T00:00:04.144Z.
+QUOTA_RESET_MS = 1788912004144
 
 
 @pytest.mark.parametrize(
@@ -21,3 +28,36 @@ async def test_filter_state(
     """Test filter_state."""
 
     assert filter_state(state) == expected_result
+
+
+@pytest.mark.parametrize(
+    ("now", "floor", "expected_result"),
+    [
+        ("2026-09-08 20:00:04+00:00", timedelta(seconds=60), 14400.144),
+        # A reset already passed must not retry at once.
+        ("2026-09-09 01:00:04+00:00", timedelta(seconds=60), 60),
+        # The floor is the caller's interval, not a fixed minute.
+        ("2026-09-09 01:00:04+00:00", timedelta(seconds=180), 180),
+        # Nothing waits longer than the quota window.
+        ("2026-09-06 00:00:04+00:00", timedelta(seconds=60), 86400),
+    ],
+)
+async def test_retry_after_from(
+    freezer: FrozenDateTimeFactory,
+    now: str,
+    floor: timedelta,
+    expected_result: float,
+) -> None:
+    """Test the rate limit backoff is clamped to the caller's interval and a day."""
+    freezer.move_to(now)
+    error = PyViCareRateLimitError(
+        {
+            "extendedPayload": {
+                "name": "development portal",
+                "requestCountLimit": 1450,
+                "limitReset": QUOTA_RESET_MS,
+            }
+        }
+    )
+
+    assert retry_after_from(error, floor) == expected_result


### PR DESCRIPTION
## Proposed change

A rate limit kept the coordinator polling at the normal interval for the rest of the blocked window. `PyViCareRateLimitError` carries the reset time, so the next refresh is deferred to it via `UpdateFailed.retry_after`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #181620
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
