### PR TITLE
Add number platform to Homevolt

### DIFF
--- a/homeassistant/components/homevolt/__init__.py
+++ b/homeassistant/components/homevolt/__init__.py
@@ -8,7 +8,12 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .coordinator import HomevoltConfigEntry, HomevoltDataUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.SELECT, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS: list[Platform] = [
+    Platform.NUMBER,
+    Platform.SELECT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: HomevoltConfigEntry) -> bool:

--- a/homeassistant/components/homevolt/number.py
+++ b/homeassistant/components/homevolt/number.py
@@ -106,5 +106,5 @@ class HomevoltNumberEntity(HomevoltEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set the value."""
         key = self.entity_description.key
-        await self.coordinator.client.set_battery_parameters(**{key: int(value)})
+        await self.coordinator.client.set_battery_parameters(**{key: value})
         self.coordinator.async_update_listeners()

--- a/homeassistant/components/homevolt/number.py
+++ b/homeassistant/components/homevolt/number.py
@@ -1,0 +1,110 @@
+"""Support for Homevolt number entities."""
+
+from typing import override
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+)
+from homeassistant.const import EntityCategory, UnitOfPower
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import HomevoltConfigEntry, HomevoltDataUpdateCoordinator
+from .entity import HomevoltEntity, homevolt_exception_handler
+
+PARALLEL_UPDATES = 0  # Coordinator-based updates
+
+MAX_CONTROL_POWER = 11000
+
+NUMBER_DESCRIPTIONS: tuple[NumberEntityDescription, ...] = (
+    NumberEntityDescription(
+        key="setpoint",
+        translation_key="setpoint",
+        native_min_value=0,
+        native_max_value=MAX_CONTROL_POWER,
+        native_step=100,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=NumberDeviceClass.POWER,
+        entity_category=EntityCategory.CONFIG,
+    ),
+    NumberEntityDescription(
+        key="grid_import_limit",
+        translation_key="grid_import_limit",
+        native_min_value=0,
+        native_max_value=MAX_CONTROL_POWER,
+        native_step=100,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=NumberDeviceClass.POWER,
+        entity_category=EntityCategory.CONFIG,
+    ),
+    NumberEntityDescription(
+        key="grid_export_limit",
+        translation_key="grid_export_limit",
+        native_min_value=0,
+        native_max_value=MAX_CONTROL_POWER,
+        native_step=100,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=NumberDeviceClass.POWER,
+        entity_category=EntityCategory.CONFIG,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: HomevoltConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Homevolt number entities."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        [
+            HomevoltNumberEntity(coordinator, description)
+            for description in NUMBER_DESCRIPTIONS
+        ]
+    )
+
+
+class HomevoltNumberEntity(HomevoltEntity, NumberEntity):
+    """Representation of a Homevolt number entity."""
+
+    entity_description: NumberEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: HomevoltDataUpdateCoordinator,
+        description: NumberEntityDescription,
+    ) -> None:
+        """Initialize the number entity."""
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.data.unique_id}_{description.key}"
+        device_id = coordinator.data.unique_id
+        super().__init__(coordinator, f"ems_{device_id}")
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return whether the current manual schedule supports parameter writes."""
+        return (
+            super().available
+            and self.entity_description.key
+            in self.coordinator.client.writable_battery_parameters
+        )
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return the current value."""
+        value = self.coordinator.client.schedule.get(self.entity_description.key)
+        return float(value) if value is not None else None
+
+    @homevolt_exception_handler
+    @override
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the value."""
+        key = self.entity_description.key
+        await self.coordinator.client.set_battery_parameters(**{key: int(value)})
+        self.coordinator.async_update_listeners()

--- a/homeassistant/components/homevolt/strings.json
+++ b/homeassistant/components/homevolt/strings.json
@@ -53,6 +53,17 @@
     }
   },
   "entity": {
+    "number": {
+      "grid_export_limit": {
+        "name": "Grid export limit"
+      },
+      "grid_import_limit": {
+        "name": "Grid import limit"
+      },
+      "setpoint": {
+        "name": "Power setpoint"
+      }
+    },
     "select": {
       "battery_mode": {
         "name": "Battery mode",

--- a/tests/components/homevolt/conftest.py
+++ b/tests/components/homevolt/conftest.py
@@ -81,12 +81,25 @@ def mock_homevolt_client() -> Generator[MagicMock]:
 
         # Load schedule data from fixture
         client.current_schedule = load_json_object_fixture("schedule.json", DOMAIN)
-        client.schedule = {"mode": client.current_schedule["schedule"][0]["type"]}
+        schedule_entry = client.current_schedule["schedule"][0]
+        schedule_params = schedule_entry["params"]
+        client.schedule = {
+            "mode": schedule_entry["type"],
+            "setpoint": schedule_params["setpoint"],
+            "max_charge": schedule_params["max_charge"],
+            "max_discharge": schedule_params["max_discharge"],
+            "min_soc": schedule_entry["min"],
+            "max_soc": schedule_entry["max"],
+            "grid_import_limit": schedule_params["import_limit"],
+            "grid_export_limit": schedule_params["export_limit"],
+        }
 
         # Switch (local mode) support
-        client.local_mode_enabled = False
+        client.local_mode_enabled = client.current_schedule["local_mode"]
+        client.writable_battery_parameters = frozenset()
         client.enable_local_mode = AsyncMock()
         client.disable_local_mode = AsyncMock()
+        client.set_battery_parameters = AsyncMock()
 
         yield client
 

--- a/tests/components/homevolt/fixtures/schedule.json
+++ b/tests/components/homevolt/fixtures/schedule.json
@@ -1,14 +1,17 @@
 {
-  "local_mode": true,
+  "local_mode": false,
+  "schedule_id": "Manual Schedule",
   "schedule": [
     {
       "type": 1,
+      "min": 10,
+      "max": 95,
       "params": {
         "setpoint": 0,
         "max_charge": 6028,
         "max_discharge": 6028,
-        "min_soc": 10,
-        "max_soc": 95
+        "import_limit": 10000,
+        "export_limit": 9000
       }
     }
   ]

--- a/tests/components/homevolt/snapshots/test_number.ambr
+++ b/tests/components/homevolt/snapshots/test_number.ambr
@@ -1,0 +1,184 @@
+# serializer version: 1
+# name: test_number_entities[number.homevolt_ems_grid_export_limit-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 11000,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 0,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 100,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.homevolt_ems_grid_export_limit',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Grid export limit',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Grid export limit',
+    'platform': 'homevolt',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'grid_export_limit',
+    'unique_id': '40580137858664_grid_export_limit',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_number_entities[number.homevolt_ems_grid_export_limit-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Homevolt EMS Grid export limit',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 11000,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 0,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 100,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.homevolt_ems_grid_export_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_number_entities[number.homevolt_ems_grid_import_limit-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 11000,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 0,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 100,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.homevolt_ems_grid_import_limit',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Grid import limit',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Grid import limit',
+    'platform': 'homevolt',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'grid_import_limit',
+    'unique_id': '40580137858664_grid_import_limit',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_number_entities[number.homevolt_ems_grid_import_limit-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Homevolt EMS Grid import limit',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 11000,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 0,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 100,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.homevolt_ems_grid_import_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_number_entities[number.homevolt_ems_power_setpoint-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 11000,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 0,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 100,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.homevolt_ems_power_setpoint',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Power setpoint',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.POWER: 'power'>,
+    'original_icon': None,
+    'original_name': 'Power setpoint',
+    'platform': 'homevolt',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'setpoint',
+    'unique_id': '40580137858664_setpoint',
+    'unit_of_measurement': <UnitOfPower.WATT: 'W'>,
+  })
+# ---
+# name: test_number_entities[number.homevolt_ems_power_setpoint-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'power',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Homevolt EMS Power setpoint',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 11000,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 0,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 100,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfPower.WATT: 'W'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.homevolt_ems_power_setpoint',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---

--- a/tests/components/homevolt/test_number.py
+++ b/tests/components/homevolt/test_number.py
@@ -3,11 +3,18 @@
 from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
-from homevolt import HomevoltConnectionError
+from homevolt import (
+    HomevoltAuthenticationError,
+    HomevoltCommandOutcomeUnknownError,
+    HomevoltCommandRejectedError,
+    HomevoltCommandVerificationError,
+    HomevoltConnectionError,
+    HomevoltError,
+)
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.homevolt.const import SCAN_INTERVAL
+from homeassistant.components.homevolt.const import DOMAIN, SCAN_INTERVAL
 from homeassistant.components.number import (
     ATTR_VALUE,
     DOMAIN as NUMBER_DOMAIN,
@@ -20,7 +27,11 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    HomeAssistantError,
+    ServiceValidationError,
+)
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
@@ -145,16 +156,79 @@ async def test_invalid_number_value(
 
 
 @pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    (
+        "error",
+        "expected_exception",
+        "translation_key",
+        "translation_placeholders",
+        "refresh_count",
+    ),
+    [
+        pytest.param(
+            HomevoltAuthenticationError("authentication failed"),
+            ConfigEntryAuthFailed,
+            "auth_failed",
+            None,
+            0,
+            id="authentication",
+        ),
+        pytest.param(
+            HomevoltCommandRejectedError("command rejected"),
+            HomeAssistantError,
+            "command_rejected",
+            None,
+            0,
+            id="command-rejected",
+        ),
+        pytest.param(
+            HomevoltCommandVerificationError("command verification failed"),
+            HomeAssistantError,
+            "command_verification_failed",
+            None,
+            1,
+            id="command-verification",
+        ),
+        pytest.param(
+            HomevoltCommandOutcomeUnknownError("command outcome unknown"),
+            HomeAssistantError,
+            "command_outcome_unknown",
+            None,
+            1,
+            id="command-outcome-unknown",
+        ),
+        pytest.param(
+            HomevoltConnectionError("connection failed"),
+            HomeAssistantError,
+            "communication_error",
+            {"error": "connection failed"},
+            0,
+            id="connection",
+        ),
+        pytest.param(
+            HomevoltError("unknown error"),
+            HomeAssistantError,
+            "unknown_error",
+            {"error": "unknown error"},
+            0,
+            id="unknown",
+        ),
+    ],
+)
 async def test_set_number_value_error(
     hass: HomeAssistant,
     mock_homevolt_client: MagicMock,
+    error: HomevoltError,
+    expected_exception: type[HomeAssistantError],
+    translation_key: str,
+    translation_placeholders: dict[str, str] | None,
+    refresh_count: int,
 ) -> None:
     """Test number actions use the shared translated error handler."""
-    mock_homevolt_client.set_battery_parameters.side_effect = HomevoltConnectionError(
-        "Connection failed"
-    )
+    mock_homevolt_client.set_battery_parameters.side_effect = error
+    mock_homevolt_client.update_info.reset_mock()
 
-    with pytest.raises(HomeAssistantError) as exc_info:
+    with pytest.raises(expected_exception) as exc_info:
         await hass.services.async_call(
             NUMBER_DOMAIN,
             SERVICE_SET_VALUE,
@@ -162,8 +236,11 @@ async def test_set_number_value_error(
             blocking=True,
         )
 
-    assert exc_info.value.translation_key == "communication_error"
-    assert exc_info.value.translation_placeholders == {"error": "Connection failed"}
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == translation_key
+    assert exc_info.value.translation_placeholders == translation_placeholders
+    assert exc_info.value.__cause__ is error
+    assert mock_homevolt_client.update_info.await_count == refresh_count
 
 
 async def test_commands_preserve_telemetry_polling(

--- a/tests/components/homevolt/test_number.py
+++ b/tests/components/homevolt/test_number.py
@@ -1,0 +1,202 @@
+"""Tests for the Homevolt number platform."""
+
+from unittest.mock import MagicMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+from homevolt import HomevoltConnectionError
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.homevolt.const import SCAN_INTERVAL
+from homeassistant.components.number import (
+    ATTR_VALUE,
+    DOMAIN as NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+SETPOINT_ENTITY_ID = "number.homevolt_ems_power_setpoint"
+IMPORT_LIMIT_ENTITY_ID = "number.homevolt_ems_grid_import_limit"
+EXPORT_LIMIT_ENTITY_ID = "number.homevolt_ems_grid_export_limit"
+
+
+@pytest.fixture
+def platforms(mock_homevolt_client: MagicMock) -> list[Platform]:
+    """Load the number platform with a writable manual schedule."""
+    mock_homevolt_client.local_mode_enabled = True
+    mock_homevolt_client.writable_battery_parameters = frozenset({"setpoint"})
+    return [Platform.NUMBER]
+
+
+async def test_number_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_integration: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test battery control number states and registry entries."""
+    await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("key", "entity_id", "value", "mode"),
+    [
+        pytest.param("setpoint", SETPOINT_ENTITY_ID, 1000, 1, id="setpoint"),
+        pytest.param(
+            "grid_import_limit", IMPORT_LIMIT_ENTITY_ID, 4000, 6, id="import-limit"
+        ),
+        pytest.param(
+            "grid_export_limit", EXPORT_LIMIT_ENTITY_ID, 5000, 6, id="export-limit"
+        ),
+    ],
+)
+async def test_set_number_value(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_homevolt_client: MagicMock,
+    key: str,
+    entity_id: str,
+    value: int,
+    mode: int,
+) -> None:
+    """Test each supported parameter publishes its verified value immediately."""
+    mock_homevolt_client.schedule["mode"] = mode
+    mock_homevolt_client.writable_battery_parameters = frozenset({key})
+    init_integration.runtime_data.async_update_listeners()
+
+    async def set_battery_parameters(**parameters: int) -> None:
+        mock_homevolt_client.schedule.update(parameters)
+
+    mock_homevolt_client.set_battery_parameters.side_effect = set_battery_parameters
+    mock_homevolt_client.update_info.reset_mock()
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_VALUE: value},
+        blocking=True,
+    )
+
+    mock_homevolt_client.set_battery_parameters.assert_awaited_once_with(**{key: value})
+    mock_homevolt_client.update_info.assert_not_awaited()
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == str(float(value))
+
+
+async def test_number_unknown_value(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_homevolt_client: MagicMock,
+) -> None:
+    """Test an absent manual parameter has an unknown state."""
+    mock_homevolt_client.schedule["setpoint"] = None
+    await init_integration.runtime_data.async_request_refresh()
+
+    state = hass.states.get(SETPOINT_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_numbers_unavailable_without_writable_manual_schedule(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_homevolt_client: MagicMock,
+) -> None:
+    """Test parameter writes are unavailable for non-manual schedules."""
+    mock_homevolt_client.writable_battery_parameters = frozenset()
+    await init_integration.runtime_data.async_request_refresh()
+
+    state = hass.states.get(SETPOINT_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.usefixtures("init_integration")
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param(-1, id="below-minimum"), pytest.param(11001, id="above-maximum")],
+)
+async def test_invalid_number_value(
+    hass: HomeAssistant,
+    mock_homevolt_client: MagicMock,
+    value: int,
+) -> None:
+    """Test out-of-range values never reach the client."""
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: SETPOINT_ENTITY_ID, ATTR_VALUE: value},
+            blocking=True,
+        )
+
+    mock_homevolt_client.set_battery_parameters.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_set_number_value_error(
+    hass: HomeAssistant,
+    mock_homevolt_client: MagicMock,
+) -> None:
+    """Test number actions use the shared translated error handler."""
+    mock_homevolt_client.set_battery_parameters.side_effect = HomevoltConnectionError(
+        "Connection failed"
+    )
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: SETPOINT_ENTITY_ID, ATTR_VALUE: 1000},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "communication_error"
+    assert exc_info.value.translation_placeholders == {"error": "Connection failed"}
+
+
+async def test_commands_preserve_telemetry_polling(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_homevolt_client: MagicMock,
+    platforms: list[Platform],
+) -> None:
+    """Test repeated schedule writes do not postpone the regular telemetry poll."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("homeassistant.components.homevolt.PLATFORMS", platforms):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    mock_homevolt_client.update_info.assert_awaited_once()
+    mock_homevolt_client.update_info.reset_mock()
+    command_interval = SCAN_INTERVAL / 3
+
+    for _ in range(2):
+        freezer.tick(command_interval)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {ATTR_ENTITY_ID: SETPOINT_ENTITY_ID, ATTR_VALUE: 1000},
+            blocking=True,
+        )
+        mock_homevolt_client.update_info.assert_not_awaited()
+
+    freezer.tick(command_interval.total_seconds() + 1)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    mock_homevolt_client.update_info.assert_awaited_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Homevolt number platform


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/48012
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
