### PR TITLE
Add ScorpionTrack diagnostics

### DIFF
--- a/homeassistant/components/scorpiontrack/diagnostics.py
+++ b/homeassistant/components/scorpiontrack/diagnostics.py
@@ -1,0 +1,40 @@
+"""Diagnostics support for ScorpionTrack."""
+
+from dataclasses import asdict
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_SHARE_TOKEN
+from .coordinator import ScorpionTrackConfigEntry
+
+TO_REDACT = {
+    CONF_SHARE_TOKEN,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    "address",
+    "id",
+    "name",
+    "owner_name",
+    "registration",
+    "title",
+    "token",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ScorpionTrackConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = entry.runtime_data
+    data = asdict(coordinator.data)
+    # The redactor traverses lists, but not tuples.
+    data["vehicles"] = list(data["vehicles"])
+
+    return {
+        "entry_data": async_redact_data(entry.data, TO_REDACT),
+        "last_update_success": coordinator.last_update_success,
+        "data": async_redact_data(data, TO_REDACT),
+    }

--- a/homeassistant/components/scorpiontrack/quality_scale.yaml
+++ b/homeassistant/components/scorpiontrack/quality_scale.yaml
@@ -50,7 +50,7 @@ rules:
   test-coverage: done
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery:
     status: exempt
     comment: |

--- a/tests/components/scorpiontrack/snapshots/test_diagnostics.ambr
+++ b/tests/components/scorpiontrack/snapshots/test_diagnostics.ambr
@@ -1,0 +1,143 @@
+# serializer version: 1
+# name: test_diagnostics[failed_update]
+  dict({
+    'data': dict({
+      'created_at': '2026-09-04T12:00:00+00:00',
+      'distance_units': 'miles',
+      'expires_at': '2026-10-05T12:00:00+00:00',
+      'id': '**REDACTED**',
+      'owner_name': '**REDACTED**',
+      'title': '**REDACTED**',
+      'token': '**REDACTED**',
+      'vehicles': list([
+        dict({
+          'id': '**REDACTED**',
+          'make': 'Volkswagen',
+          'model': 'Golf R',
+          'name': '**REDACTED**',
+          'position': dict({
+            'address': '**REDACTED**',
+            'bearing': 182.0,
+            'ignition': True,
+            'latitude': '**REDACTED**',
+            'longitude': '**REDACTED**',
+            'speed_kmh': 48.3,
+            'timestamp': '2026-09-05T12:00:00+00:00',
+          }),
+          'registration': '**REDACTED**',
+          'status': 'Moving',
+        }),
+        dict({
+          'id': '**REDACTED**',
+          'make': 'Volkswagen',
+          'model': 'Golf R',
+          'name': '**REDACTED**',
+          'position': dict({
+            'address': '**REDACTED**',
+            'bearing': 182.0,
+            'ignition': True,
+            'latitude': '**REDACTED**',
+            'longitude': '**REDACTED**',
+            'speed_kmh': 48.3,
+            'timestamp': '2026-09-05T12:00:00+00:00',
+          }),
+          'registration': '**REDACTED**',
+          'status': 'Moving',
+        }),
+      ]),
+    }),
+    'entry_data': dict({
+      'share_token': '**REDACTED**',
+    }),
+    'last_update_success': False,
+  })
+# ---
+# name: test_diagnostics[successful_update]
+  dict({
+    'data': dict({
+      'created_at': '2026-09-04T12:00:00+00:00',
+      'distance_units': 'miles',
+      'expires_at': '2026-10-05T12:00:00+00:00',
+      'id': '**REDACTED**',
+      'owner_name': '**REDACTED**',
+      'title': '**REDACTED**',
+      'token': '**REDACTED**',
+      'vehicles': list([
+        dict({
+          'id': '**REDACTED**',
+          'make': 'Volkswagen',
+          'model': 'Golf R',
+          'name': '**REDACTED**',
+          'position': dict({
+            'address': '**REDACTED**',
+            'bearing': 182.0,
+            'ignition': True,
+            'latitude': '**REDACTED**',
+            'longitude': '**REDACTED**',
+            'speed_kmh': 48.3,
+            'timestamp': '2026-09-05T12:00:00+00:00',
+          }),
+          'registration': '**REDACTED**',
+          'status': 'Moving',
+        }),
+        dict({
+          'id': '**REDACTED**',
+          'make': 'Volkswagen',
+          'model': 'Golf R',
+          'name': '**REDACTED**',
+          'position': dict({
+            'address': '**REDACTED**',
+            'bearing': 182.0,
+            'ignition': True,
+            'latitude': '**REDACTED**',
+            'longitude': '**REDACTED**',
+            'speed_kmh': 48.3,
+            'timestamp': '2026-09-05T12:00:00+00:00',
+          }),
+          'registration': '**REDACTED**',
+          'status': 'Moving',
+        }),
+      ]),
+    }),
+    'entry_data': dict({
+      'share_token': '**REDACTED**',
+    }),
+    'last_update_success': True,
+  })
+# ---
+# name: test_diagnostics_missing_position
+  dict({
+    'data': dict({
+      'created_at': '2026-09-04T12:00:00+00:00',
+      'distance_units': 'miles',
+      'expires_at': '2026-10-05T12:00:00+00:00',
+      'id': '**REDACTED**',
+      'owner_name': '**REDACTED**',
+      'title': '**REDACTED**',
+      'token': '**REDACTED**',
+      'vehicles': list([
+        dict({
+          'id': '**REDACTED**',
+          'make': 'Volkswagen',
+          'model': 'Golf R',
+          'name': '**REDACTED**',
+          'position': dict({
+            'address': None,
+            'bearing': None,
+            'ignition': None,
+            'latitude': None,
+            'longitude': None,
+            'speed_kmh': None,
+            'timestamp': None,
+          }),
+          'registration': '**REDACTED**',
+          'status': 'unknown',
+        }),
+      ]),
+    }),
+    'entry_data': dict({
+      'share_token': '**REDACTED**',
+    }),
+    'last_update_success': True,
+  })
+# ---

--- a/tests/components/scorpiontrack/test_diagnostics.py
+++ b/tests/components/scorpiontrack/test_diagnostics.py
@@ -1,0 +1,97 @@
+"""Test ScorpionTrack diagnostics."""
+
+from dataclasses import replace
+from unittest.mock import AsyncMock
+
+from pyscorpiontrack import ScorpionTrackConnectionError, ScorpionTrackShare
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.scorpiontrack.const import CONF_SHARE_TOKEN
+from homeassistant.core import HomeAssistant
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+pytestmark = pytest.mark.freeze_time("2026-09-07T12:00:00Z")
+
+
+@pytest.mark.parametrize(
+    "update_error",
+    [
+        pytest.param(None, id="successful_update"),
+        pytest.param(
+            ScorpionTrackConnectionError("Failed request for canonical-token"),
+            id="failed_update",
+        ),
+    ],
+)
+async def test_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_scorpiontrack_client: AsyncMock,
+    mock_share: ScorpionTrackShare,
+    snapshot: SnapshotAssertion,
+    update_error: ScorpionTrackConnectionError | None,
+) -> None:
+    """Test redaction for every vehicle without fetching or changing cached data."""
+    vehicle = mock_share.vehicles[0]
+    share = replace(
+        mock_share,
+        vehicles=(vehicle, replace(vehicle, id=2, registration="EF34 GHI")),
+    )
+    mock_scorpiontrack_client.async_get_share.return_value = share
+    await setup_integration(hass, mock_config_entry)
+    mock_scorpiontrack_client.async_get_share.side_effect = update_error
+    await mock_config_entry.runtime_data.async_refresh()
+    mock_scorpiontrack_client.async_get_share.reset_mock()
+
+    result = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    assert result == snapshot
+    mock_scorpiontrack_client.async_get_share.assert_not_awaited()
+    assert mock_config_entry.runtime_data.data == share
+    assert mock_config_entry.data[CONF_SHARE_TOKEN] == "canonical-token"
+
+
+async def test_diagnostics_missing_position(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_scorpiontrack_client: AsyncMock,
+    mock_share: ScorpionTrackShare,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics when a vehicle has no position data."""
+    vehicle = mock_share.vehicles[0]
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share,
+        vehicles=(
+            replace(
+                vehicle,
+                position=replace(
+                    vehicle.position,
+                    latitude=None,
+                    longitude=None,
+                    timestamp=None,
+                    speed_kmh=None,
+                    ignition=None,
+                    bearing=None,
+                    address=None,
+                ),
+                status="unknown",
+            ),
+        ),
+    )
+    await setup_integration(hass, mock_config_entry)
+
+    assert (
+        await get_diagnostics_for_config_entry(hass, hass_client, mock_config_entry)
+        == snapshot
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I am adding downloadable diagnostics for ScorpionTrack to help troubleshoot shared vehicles. It uses the data already held by the integration and makes no additional API requests. Share tokens, vehicle identifiers, names and location details are redacted.

I ran the ScorpionTrack Core tests to check redaction, missing position data and diagnostics after a failed update.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/48014
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
