### PR TITLE
Discover newly shared ScorpionTrack vehicles

### DIFF
--- a/homeassistant/components/scorpiontrack/binary_sensor.py
+++ b/homeassistant/components/scorpiontrack/binary_sensor.py
@@ -4,10 +4,8 @@ from typing import override
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .coordinator import ScorpionTrackConfigEntry, ScorpionTrackCoordinator
 from .entity import ScorpionTrackEntity
 
@@ -21,21 +19,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up ScorpionTrack ignition binary sensors."""
     coordinator = entry.runtime_data
-    entity_registry = er.async_get(hass)
     known_vehicles: set[int] = set()
 
     @callback
     def async_add_new_vehicles() -> None:
         """Add ignition sensors for vehicles newly included in the share."""
-        new_vehicles = {
-            vehicle_id
-            for vehicle_id in coordinator.vehicles_by_id
-            if vehicle_id not in known_vehicles
-            or entity_registry.async_get_entity_id(
-                "binary_sensor", DOMAIN, f"{coordinator.data.id}_{vehicle_id}_ignition"
-            )
-            is None
-        }
+        new_vehicles = coordinator.vehicles_by_id.keys() - known_vehicles
         if not new_vehicles:
             return
         known_vehicles.update(new_vehicles)

--- a/homeassistant/components/scorpiontrack/binary_sensor.py
+++ b/homeassistant/components/scorpiontrack/binary_sensor.py
@@ -3,9 +3,11 @@
 from typing import override
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DOMAIN
 from .coordinator import ScorpionTrackConfigEntry, ScorpionTrackCoordinator
 from .entity import ScorpionTrackEntity
 
@@ -19,10 +21,31 @@ async def async_setup_entry(
 ) -> None:
     """Set up ScorpionTrack ignition binary sensors."""
     coordinator = entry.runtime_data
-    async_add_entities(
-        ScorpionTrackIgnitionBinarySensor(coordinator, vehicle.id)
-        for vehicle in coordinator.data.vehicles
-    )
+    entity_registry = er.async_get(hass)
+    known_vehicles: set[int] = set()
+
+    @callback
+    def async_add_new_vehicles() -> None:
+        """Add ignition sensors for vehicles newly included in the share."""
+        new_vehicles = {
+            vehicle_id
+            for vehicle_id in coordinator.vehicles_by_id
+            if vehicle_id not in known_vehicles
+            or entity_registry.async_get_entity_id(
+                "binary_sensor", DOMAIN, f"{coordinator.data.id}_{vehicle_id}_ignition"
+            )
+            is None
+        }
+        if not new_vehicles:
+            return
+        known_vehicles.update(new_vehicles)
+        async_add_entities(
+            ScorpionTrackIgnitionBinarySensor(coordinator, vehicle_id)
+            for vehicle_id in new_vehicles
+        )
+
+    async_add_new_vehicles()
+    entry.async_on_unload(coordinator.async_add_listener(async_add_new_vehicles))
 
 
 class ScorpionTrackIgnitionBinarySensor(ScorpionTrackEntity, BinarySensorEntity):

--- a/homeassistant/components/scorpiontrack/device_tracker.py
+++ b/homeassistant/components/scorpiontrack/device_tracker.py
@@ -5,9 +5,11 @@ from typing import override
 from pyscorpiontrack import ScorpionTrackVehicle
 
 from homeassistant.components.device_tracker import TrackerEntity
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DOMAIN
 from .coordinator import ScorpionTrackConfigEntry, ScorpionTrackCoordinator
 from .entity import ScorpionTrackEntity
 
@@ -21,10 +23,31 @@ async def async_setup_entry(
 ) -> None:
     """Set up ScorpionTrack tracker entities."""
     coordinator = entry.runtime_data
-    async_add_entities(
-        ScorpionTrackTrackerEntity(coordinator, vehicle.id)
-        for vehicle in coordinator.data.vehicles
-    )
+    entity_registry = er.async_get(hass)
+    known_vehicles: set[int] = set()
+
+    @callback
+    def async_add_new_vehicles() -> None:
+        """Add trackers for vehicles newly included in the share."""
+        new_vehicles = {
+            vehicle_id
+            for vehicle_id in coordinator.vehicles_by_id
+            if vehicle_id not in known_vehicles
+            or entity_registry.async_get_entity_id(
+                "device_tracker", DOMAIN, f"{coordinator.data.id}_{vehicle_id}"
+            )
+            is None
+        }
+        if not new_vehicles:
+            return
+        known_vehicles.update(new_vehicles)
+        async_add_entities(
+            ScorpionTrackTrackerEntity(coordinator, vehicle_id)
+            for vehicle_id in new_vehicles
+        )
+
+    async_add_new_vehicles()
+    entry.async_on_unload(coordinator.async_add_listener(async_add_new_vehicles))
 
 
 class ScorpionTrackTrackerEntity(ScorpionTrackEntity, TrackerEntity):

--- a/homeassistant/components/scorpiontrack/device_tracker.py
+++ b/homeassistant/components/scorpiontrack/device_tracker.py
@@ -6,10 +6,8 @@ from pyscorpiontrack import ScorpionTrackVehicle
 
 from homeassistant.components.device_tracker import TrackerEntity
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .coordinator import ScorpionTrackConfigEntry, ScorpionTrackCoordinator
 from .entity import ScorpionTrackEntity
 
@@ -23,21 +21,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up ScorpionTrack tracker entities."""
     coordinator = entry.runtime_data
-    entity_registry = er.async_get(hass)
     known_vehicles: set[int] = set()
 
     @callback
     def async_add_new_vehicles() -> None:
         """Add trackers for vehicles newly included in the share."""
-        new_vehicles = {
-            vehicle_id
-            for vehicle_id in coordinator.vehicles_by_id
-            if vehicle_id not in known_vehicles
-            or entity_registry.async_get_entity_id(
-                "device_tracker", DOMAIN, f"{coordinator.data.id}_{vehicle_id}"
-            )
-            is None
-        }
+        new_vehicles = coordinator.vehicles_by_id.keys() - known_vehicles
         if not new_vehicles:
             return
         known_vehicles.update(new_vehicles)

--- a/homeassistant/components/scorpiontrack/quality_scale.yaml
+++ b/homeassistant/components/scorpiontrack/quality_scale.yaml
@@ -74,7 +74,7 @@ rules:
   docs-supported-functions: done
   docs-troubleshooting: done
   docs-use-cases: todo
-  dynamic-devices: todo
+  dynamic-devices: done
   entity-category: done
   entity-device-class: done
   entity-disabled-by-default: done

--- a/homeassistant/components/scorpiontrack/sensor.py
+++ b/homeassistant/components/scorpiontrack/sensor.py
@@ -15,11 +15,9 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import DEGREE, EntityCategory, UnitOfSpeed
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .const import DOMAIN
 from .coordinator import ScorpionTrackConfigEntry, ScorpionTrackCoordinator
 from .entity import ScorpionTrackEntity
 
@@ -76,25 +74,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up ScorpionTrack sensors."""
     coordinator = entry.runtime_data
-    entity_registry = er.async_get(hass)
     known_vehicles: set[int] = set()
 
     @callback
     def async_add_new_vehicles() -> None:
         """Add sensors for vehicles newly included in the share."""
-        new_vehicles = {
-            vehicle_id
-            for vehicle_id in coordinator.vehicles_by_id
-            if vehicle_id not in known_vehicles
-            or not any(
-                entity_registry.async_get_entity_id(
-                    "sensor",
-                    DOMAIN,
-                    f"{coordinator.data.id}_{vehicle_id}_{description.key}",
-                )
-                for description in SENSORS
-            )
-        }
+        new_vehicles = coordinator.vehicles_by_id.keys() - known_vehicles
         if not new_vehicles:
             return
         known_vehicles.update(new_vehicles)

--- a/homeassistant/components/scorpiontrack/sensor.py
+++ b/homeassistant/components/scorpiontrack/sensor.py
@@ -14,10 +14,12 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import DEGREE, EntityCategory, UnitOfSpeed
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
+from .const import DOMAIN
 from .coordinator import ScorpionTrackConfigEntry, ScorpionTrackCoordinator
 from .entity import ScorpionTrackEntity
 
@@ -74,11 +76,36 @@ async def async_setup_entry(
 ) -> None:
     """Set up ScorpionTrack sensors."""
     coordinator = entry.runtime_data
-    async_add_entities(
-        ScorpionTrackSensor(coordinator, vehicle.id, entity_description)
-        for vehicle in coordinator.data.vehicles
-        for entity_description in SENSORS
-    )
+    entity_registry = er.async_get(hass)
+    known_vehicles: set[int] = set()
+
+    @callback
+    def async_add_new_vehicles() -> None:
+        """Add sensors for vehicles newly included in the share."""
+        new_vehicles = {
+            vehicle_id
+            for vehicle_id in coordinator.vehicles_by_id
+            if vehicle_id not in known_vehicles
+            or not any(
+                entity_registry.async_get_entity_id(
+                    "sensor",
+                    DOMAIN,
+                    f"{coordinator.data.id}_{vehicle_id}_{description.key}",
+                )
+                for description in SENSORS
+            )
+        }
+        if not new_vehicles:
+            return
+        known_vehicles.update(new_vehicles)
+        async_add_entities(
+            ScorpionTrackSensor(coordinator, vehicle_id, entity_description)
+            for vehicle_id in new_vehicles
+            for entity_description in SENSORS
+        )
+
+    async_add_new_vehicles()
+    entry.async_on_unload(coordinator.async_add_listener(async_add_new_vehicles))
 
 
 class ScorpionTrackSensor(ScorpionTrackEntity, SensorEntity):

--- a/tests/components/scorpiontrack/test_device_tracker.py
+++ b/tests/components/scorpiontrack/test_device_tracker.py
@@ -5,10 +5,11 @@ from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from pyscorpiontrack import ScorpionTrackConnectionError, ScorpionTrackShare
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.scorpiontrack.const import DEFAULT_SCAN_INTERVAL
-from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.const import STATE_NOT_HOME, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -75,14 +76,20 @@ async def test_connection_error_makes_tracker_unavailable(
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_new_vehicles_after_setup_do_not_add_tracker_entities(
+@pytest.mark.parametrize(
+    ("latitude", "expected_state"),
+    [(51.5074, STATE_NOT_HOME), (None, STATE_UNAVAILABLE)],
+)
+async def test_new_vehicle_tracker_availability(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
     mock_share: ScorpionTrackShare,
     mock_scorpiontrack_client: AsyncMock,
+    latitude: float | None,
+    expected_state: str,
 ) -> None:
-    """Vehicles that appear later should wait for a future dynamic-device PR."""
+    """Test a newly discovered tracker still requires coordinates."""
     await setup_integration(hass, mock_config_entry)
 
     new_vehicle = replace(
@@ -91,6 +98,7 @@ async def test_new_vehicles_after_setup_do_not_add_tracker_entities(
         name="Tiguan",
         registration="EF34 ABC",
         model="Tiguan",
+        position=replace(mock_share.vehicles[0].position, latitude=latitude),
     )
     mock_scorpiontrack_client.async_get_share.return_value = replace(
         mock_share, vehicles=(*mock_share.vehicles, new_vehicle)
@@ -99,4 +107,6 @@ async def test_new_vehicles_after_setup_do_not_add_tracker_entities(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert hass.states.get("device_tracker.ef34_abc") is None
+    state = hass.states.get("device_tracker.ef34_abc")
+    assert state is not None
+    assert state.state == expected_state

--- a/tests/components/scorpiontrack/test_init.py
+++ b/tests/components/scorpiontrack/test_init.py
@@ -100,7 +100,7 @@ async def test_vehicle_added_after_setup(
     device_registry: dr.DeviceRegistry,
     entity_id: str,
 ) -> None:
-    """Test discovery, repeat updates, and a vehicle returning to the share."""
+    """Test discovery, repeat updates, returning vehicles, and reload."""
     await setup_integration(hass, mock_config_entry)
     assert hass.states.get(entity_id) is None
     initial_entities = len(
@@ -131,7 +131,8 @@ async def test_vehicle_added_after_setup(
     assert hass.states.get(heading.entity_id) is None
     assert mock_scorpiontrack_client.async_get_share.await_count == 2
 
-    await mock_config_entry.runtime_data.async_refresh()
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert (
         len(
@@ -143,12 +144,14 @@ async def test_vehicle_added_after_setup(
     )
 
     mock_scorpiontrack_client.async_get_share.return_value = mock_share
-    await mock_config_entry.runtime_data.async_refresh()
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     mock_scorpiontrack_client.async_get_share.return_value = updated_share
-    await mock_config_entry.runtime_data.async_refresh()
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == state.state
     assert entity_registry.async_get(entity_id).id == registry_entry.id
@@ -161,11 +164,18 @@ async def test_vehicle_added_after_setup(
         == initial_entities * 2
     )
 
+    assert await hass.config_entries.async_reload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == state.state
+    assert entity_registry.async_get(entity_id).id == registry_entry.id
+
 
 async def test_discovery_stops_on_unload(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
     mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test unloading removes the discovery listeners."""
@@ -173,58 +183,17 @@ async def test_discovery_stops_on_unload(
     initial_entities = len(
         er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id)
     )
-    coordinator = mock_config_entry.runtime_data
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     added_vehicle = replace(mock_share.vehicles[0], id=2, registration="XY34 ABC")
-    coordinator.vehicles_by_id[added_vehicle.id] = added_vehicle
-    coordinator.async_set_updated_data(
-        replace(mock_share, vehicles=(*mock_share.vehicles, added_vehicle))
-    )
-    await hass.async_block_till_done()
-    assert (
-        len(
-            er.async_entries_for_config_entry(
-                entity_registry, mock_config_entry.entry_id
-            )
-        )
-        == initial_entities
-    )
-
-
-async def test_deleted_vehicle_can_return(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_share: ScorpionTrackShare,
-    mock_scorpiontrack_client: AsyncMock,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Test discovery recreates a previously deleted vehicle device."""
-    await setup_integration(hass, mock_config_entry)
-    initial_entities = len(
-        er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id)
-    )
-    device = device_registry.async_get_device_by_identifier(
-        ("scorpiontrack", "101_1"), mock_config_entry.entry_id
-    )
-    assert device is not None
-
     mock_scorpiontrack_client.async_get_share.return_value = replace(
-        mock_share, vehicles=()
+        mock_share, vehicles=(*mock_share.vehicles, added_vehicle)
     )
-    await mock_config_entry.runtime_data.async_refresh()
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    device_registry.async_remove_device(device.id)
-    await hass.async_block_till_done()
-    assert not er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
-    )
-
-    mock_scorpiontrack_client.async_get_share.return_value = mock_share
-    await mock_config_entry.runtime_data.async_refresh()
-    await hass.async_block_till_done()
+    mock_scorpiontrack_client.async_get_share.assert_awaited_once_with()
     assert (
         len(
             er.async_entries_for_config_entry(
@@ -233,4 +202,3 @@ async def test_deleted_vehicle_can_return(
         )
         == initial_entities
     )
-    assert hass.states.get("device_tracker.ab12_cde").state != STATE_UNAVAILABLE

--- a/tests/components/scorpiontrack/test_init.py
+++ b/tests/components/scorpiontrack/test_init.py
@@ -1,21 +1,26 @@
 """Test ScorpionTrack integration setup."""
 
+from dataclasses import replace
 from unittest.mock import AsyncMock
 
+from freezegun.api import FrozenDateTimeFactory
 from pyscorpiontrack import (
     ScorpionTrackConnectionError,
     ScorpionTrackInvalidTokenError,
+    ScorpionTrackShare,
     ScorpionTrackShareUnavailableError,
 )
 import pytest
 
+from homeassistant.components.scorpiontrack.const import DEFAULT_SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_setup_entry(
@@ -74,3 +79,158 @@ async def test_setup_entry_errors(
 
     await setup_integration(hass, mock_config_entry)
     assert mock_config_entry.state is expected_state
+
+
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        "device_tracker.xy34_abc",
+        "sensor.xy34_abc_speed",
+        "sensor.xy34_abc_last_reported",
+        "binary_sensor.xy34_abc_ignition",
+    ],
+)
+async def test_vehicle_added_after_setup(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    entity_id: str,
+) -> None:
+    """Test discovery, repeat updates, and a vehicle returning to the share."""
+    await setup_integration(hass, mock_config_entry)
+    assert hass.states.get(entity_id) is None
+    initial_entities = len(
+        er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id)
+    )
+
+    added_vehicle = replace(mock_share.vehicles[0], id=2, registration="XY34 ABC")
+    updated_share = replace(mock_share, vehicles=(*mock_share.vehicles, added_vehicle))
+    mock_scorpiontrack_client.async_get_share.return_value = updated_share
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    registry_entry = entity_registry.async_get(entity_id)
+    assert registry_entry is not None
+    device = device_registry.async_get_device_by_identifier(
+        ("scorpiontrack", "101_2"), mock_config_entry.entry_id
+    )
+    assert device is not None
+    assert registry_entry.device_id == device.id
+    heading = entity_registry.async_get("sensor.xy34_abc_heading")
+    assert heading is not None
+    assert heading.device_id == device.id
+    assert heading.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert hass.states.get(heading.entity_id) is None
+    assert mock_scorpiontrack_client.async_get_share.await_count == 2
+
+    await mock_config_entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+    assert (
+        len(
+            er.async_entries_for_config_entry(
+                entity_registry, mock_config_entry.entry_id
+            )
+        )
+        == initial_entities * 2
+    )
+
+    mock_scorpiontrack_client.async_get_share.return_value = mock_share
+    await mock_config_entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+    mock_scorpiontrack_client.async_get_share.return_value = updated_share
+    await mock_config_entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == state.state
+    assert entity_registry.async_get(entity_id).id == registry_entry.id
+    assert (
+        len(
+            er.async_entries_for_config_entry(
+                entity_registry, mock_config_entry.entry_id
+            )
+        )
+        == initial_entities * 2
+    )
+
+
+async def test_discovery_stops_on_unload(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test unloading removes the discovery listeners."""
+    await setup_integration(hass, mock_config_entry)
+    initial_entities = len(
+        er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id)
+    )
+    coordinator = mock_config_entry.runtime_data
+    await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    added_vehicle = replace(mock_share.vehicles[0], id=2, registration="XY34 ABC")
+    coordinator.vehicles_by_id[added_vehicle.id] = added_vehicle
+    coordinator.async_set_updated_data(
+        replace(mock_share, vehicles=(*mock_share.vehicles, added_vehicle))
+    )
+    await hass.async_block_till_done()
+    assert (
+        len(
+            er.async_entries_for_config_entry(
+                entity_registry, mock_config_entry.entry_id
+            )
+        )
+        == initial_entities
+    )
+
+
+async def test_deleted_vehicle_can_return(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test discovery recreates a previously deleted vehicle device."""
+    await setup_integration(hass, mock_config_entry)
+    initial_entities = len(
+        er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id)
+    )
+    device = device_registry.async_get_device_by_identifier(
+        ("scorpiontrack", "101_1"), mock_config_entry.entry_id
+    )
+    assert device is not None
+
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, vehicles=()
+    )
+    await mock_config_entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+    device_registry.async_remove_device(device.id)
+    await hass.async_block_till_done()
+    assert not er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+
+    mock_scorpiontrack_client.async_get_share.return_value = mock_share
+    await mock_config_entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+    assert (
+        len(
+            er.async_entries_for_config_entry(
+                entity_registry, mock_config_entry.entry_id
+            )
+        )
+        == initial_entities
+    )
+    assert hass.states.get("device_tracker.ab12_cde").state != STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I am adding automatic discovery for vehicles added to an existing ScorpionTrack share. Their entities are created during the normal update, without reloading the integration. Each poll still makes one request for the whole share.

Existing entities keep their IDs. A vehicle that leaves the share becomes unavailable and becomes available again when it returns.

I ran the ScorpionTrack tests to check discovery, repeated updates, vehicles leaving and returning, reload and unloading.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/48015
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr