### PR TITLE
Nest climate: recompute supported_features from live device traits

### DIFF
--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -126,7 +126,6 @@ class ThermostatEntity(ClimateEntity):
     @override
     async def async_added_to_hass(self) -> None:
         """Run when entity is added to register update signal handler."""
-        self._attr_supported_features = self._get_supported_features()
         self.async_on_remove(
             self._device.add_update_listener(self.async_write_ha_state)
         )
@@ -263,6 +262,12 @@ class ThermostatEntity(ClimateEntity):
         ):
             return FAN_INV_MODES
         return []
+
+    @property
+    @override
+    def supported_features(self) -> ClimateEntityFeature:
+        """Return the bitmap of supported features, computed from current traits."""
+        return self._get_supported_features()
 
     def _get_supported_features(self) -> ClimateEntityFeature:
         """Compute the bitmap of supported features from the current state."""

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -1372,6 +1372,57 @@ async def test_thermostat_fan_empty(
     assert ATTR_FAN_MODES not in thermostat.attributes
 
 
+async def test_thermostat_fan_becomes_supported_after_update(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    create_device: CreateDevice,
+    create_event: CreateEvent,
+) -> None:
+    """Test that supported_features is recomputed once the fan trait reports a mode.
+
+    The fan trait can be present at startup without a timer_mode value yet
+    populated (e.g. before the initial full state has propagated). Regression
+    test for supported_features being frozen at entity setup rather than
+    reflecting the live device state.
+    """
+    create_device.create(
+        {
+            "sdm.devices.traits.Fan": {},
+            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
+                "mode": "OFF",
+            },
+        }
+    )
+    await setup_platform()
+
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert ATTR_FAN_MODE not in thermostat.attributes
+    assert ATTR_FAN_MODES not in thermostat.attributes
+    assert not (
+        thermostat.attributes[ATTR_SUPPORTED_FEATURES]
+        & ClimateEntityFeature.FAN_MODE
+    )
+
+    # The fan trait later reports a real timer_mode value
+    await create_event(
+        {
+            "sdm.devices.traits.Fan": {"timerMode": "OFF"},
+        }
+    )
+
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert (
+        thermostat.attributes[ATTR_SUPPORTED_FEATURES]
+        & ClimateEntityFeature.FAN_MODE
+    )
+    assert thermostat.attributes[ATTR_FAN_MODE] == FAN_OFF
+    assert thermostat.attributes[ATTR_FAN_MODES] == [FAN_ON, FAN_OFF]
+
+
 async def test_thermostat_invalid_fan_mode(
     hass: HomeAssistant,
     setup_platform: PlatformSetup,

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -1402,8 +1402,7 @@ async def test_thermostat_fan_becomes_supported_after_update(
     assert ATTR_FAN_MODE not in thermostat.attributes
     assert ATTR_FAN_MODES not in thermostat.attributes
     assert not (
-        thermostat.attributes[ATTR_SUPPORTED_FEATURES]
-        & ClimateEntityFeature.FAN_MODE
+        thermostat.attributes[ATTR_SUPPORTED_FEATURES] & ClimateEntityFeature.FAN_MODE
     )
 
     # The fan trait later reports a real timer_mode value
@@ -1416,8 +1415,7 @@ async def test_thermostat_fan_becomes_supported_after_update(
     thermostat = hass.states.get("climate.my_thermostat")
     assert thermostat is not None
     assert (
-        thermostat.attributes[ATTR_SUPPORTED_FEATURES]
-        & ClimateEntityFeature.FAN_MODE
+        thermostat.attributes[ATTR_SUPPORTED_FEATURES] & ClimateEntityFeature.FAN_MODE
     )
     assert thermostat.attributes[ATTR_FAN_MODE] == FAN_OFF
     assert thermostat.attributes[ATTR_FAN_MODES] == [FAN_ON, FAN_OFF]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`ThermostatEntity.supported_features` (nest/climate.py) was only computed once, in `async_added_to_hass`, and cached via `_attr_supported_features`. If a trait such as `ThermostatEco` (eco preset) or `Fan.timer_mode` (fan control) wasn't yet reflected on the `Device` object at the moment the entity was added to hass, the corresponding feature bit was permanently missing for the lifetime of the entity — even though `preset_mode`/`preset_modes`/`fan_mode`/`fan_modes` in the same class already read `self._device.traits` live on every access, and the underlying device data was otherwise current.

In practice this means the eco preset and/or fan control can silently never appear for an entity, with no error anywhere, until Home Assistant is restarted (which re-creates the entity and re-runs the once-only computation against whatever the device state happens to be at that new moment).

This changes `supported_features` to a `@property` that calls the existing `_get_supported_features()` helper on every read, matching the pattern already used by `preset_mode`, `preset_modes`, `fan_mode`, and `fan_modes` in this same file.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

This fix has been running against a real SDM Device Access project / real Nest Learning Thermostats (deployed as a `custom_components` override for testing purposes) and reliably resolves the eco preset and fan control never appearing. Added `test_thermostat_fan_becomes_supported_after_update` to `tests/components/nest/test_climate.py`, reproducing the scenario where the fan trait is present but empty at setup and only reports a `timer_mode` via a later pubsub update — this fails against the previous cache-once behavior and passes with this change.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
