### PR TITLE
Honor rate limit retry hint in Tesla Fleet vehicle coordinator

### DIFF
--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -166,11 +166,16 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except VehicleOffline:
             self.data["state"] = TeslaFleetState.ASLEEP
             return self.data
-        except RateLimited:
-            LOGGER.warning(
-                "%s rate limited, will skip refresh",
-                self.name,
-            )
+        except RateLimited as e:
+            if isinstance(e.data, dict) and "after" in e.data:
+                LOGGER.warning(
+                    "%s rate limited, will retry in %s seconds",
+                    self.name,
+                    e.data["after"],
+                )
+                self.update_interval = timedelta(seconds=int(e.data["after"]))
+            else:
+                LOGGER.warning("%s rate limited, will skip refresh", self.name)
             return self.data
         except (InvalidToken, OAuthExpired) as e:
             _invalidate_access_token(self.hass, self.config_entry)

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -374,24 +374,33 @@ async def test_vehicle_refresh_ratelimited(
     mock_vehicle_data: AsyncMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test coordinator refresh handles 429."""
+    """Test coordinator refresh handles 429 and backs off using the after hint."""
+
+    await setup_platform(hass, normal_config_entry)
 
     mock_vehicle_data.side_effect = RateLimited(
         {"after": VEHICLE_INTERVAL_SECONDS + 10}
     )
-    await setup_platform(hass, normal_config_entry)
+    freezer.tick(VEHICLE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
+    assert mock_vehicle_data.call_count == 2
     assert (state := hass.states.get("sensor.test_battery_level"))
-    assert state.state == "unknown"
-
-    mock_vehicle_data.reset_mock()
+    assert state.state != "unavailable"
 
     freezer.tick(VEHICLE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert (state := hass.states.get("sensor.test_battery_level"))
-    assert state.state == "unknown"
+    # Should not call for another 10 seconds
+    assert mock_vehicle_data.call_count == 2
+
+    freezer.tick(VEHICLE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert mock_vehicle_data.call_count == 3
 
 
 async def test_vehicle_refresh_ratelimited_no_after(

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -378,9 +378,8 @@ async def test_vehicle_refresh_ratelimited(
 
     await setup_platform(hass, normal_config_entry)
 
-    mock_vehicle_data.side_effect = RateLimited(
-        {"after": VEHICLE_INTERVAL_SECONDS + 10}
-    )
+    after_seconds = VEHICLE_INTERVAL_SECONDS + 10
+    mock_vehicle_data.side_effect = RateLimited({"after": after_seconds})
     freezer.tick(VEHICLE_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
@@ -393,13 +392,14 @@ async def test_vehicle_refresh_ratelimited(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    # Should not call for another 10 seconds
+    # Not yet past the after hint, must not call
     assert mock_vehicle_data.call_count == 2
 
-    freezer.tick(VEHICLE_INTERVAL)
+    freezer.tick(timedelta(seconds=after_seconds - VEHICLE_INTERVAL_SECONDS))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
+    # Exactly past the after hint, must call
     assert mock_vehicle_data.call_count == 3
 
 

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -387,7 +387,7 @@ async def test_vehicle_refresh_ratelimited(
 
     assert mock_vehicle_data.call_count == 2
     assert (state := hass.states.get("sensor.test_battery_level"))
-    assert state.state != "unavailable"
+    assert state.state == "77"
 
     freezer.tick(VEHICLE_INTERVAL)
     async_fire_time_changed(hass)
@@ -401,6 +401,22 @@ async def test_vehicle_refresh_ratelimited(
     await hass.async_block_till_done()
 
     assert mock_vehicle_data.call_count == 3
+
+
+async def test_vehicle_refresh_ratelimited_on_first_refresh(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+    mock_vehicle_data: AsyncMock,
+) -> None:
+    """Test coordinator handles 429 on the first refresh, before any data exists."""
+
+    mock_vehicle_data.side_effect = RateLimited(
+        {"after": VEHICLE_INTERVAL_SECONDS + 10}
+    )
+    await setup_platform(hass, normal_config_entry)
+
+    assert (state := hass.states.get("sensor.test_battery_level"))
+    assert state.state == "unknown"
 
 
 async def test_vehicle_refresh_ratelimited_no_after(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The three energy coordinators in `tesla_fleet/coordinator.py` already honour the `after` hint on a `RateLimited` response, backing off `update_interval` to the number of seconds the server asked us to wait. The vehicle coordinator caught `RateLimited` bare and ignored the hint, so it kept polling at its normal 10 minute interval straight through a rate limit, which just prolongs it.

This brings the vehicle coordinator's `RateLimited` handling in line with the energy coordinators so it also backs off when the server supplies an `after` value.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
