### PR TITLE
Cover the Sofar restored-total seeding guards

### DIFF
--- a/tests/components/sofar/test_init.py
+++ b/tests/components/sofar/test_init.py
@@ -16,8 +16,8 @@ from homeassistant.components.sofar.const import (
 )
 from homeassistant.components.sofar.coordinator import SofarRuntimeData
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE
-from homeassistant.core import HomeAssistant
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -31,7 +31,11 @@ from . import (
     seed_hybrid_inverter,
 )
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    mock_restore_cache_with_extra_data,
+)
 from tests.typing import WebSocketGenerator
 
 PV_POWER_REGISTER = 0x0586
@@ -108,6 +112,57 @@ async def test_setup_removes_the_stale_waiting_time_entity(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert entity_registry.async_get(entry.entity_id) is None
+
+
+@pytest.mark.parametrize(
+    ("extra_data", "restored_state"),
+    [
+        pytest.param(None, "120.0", id="no_extra_data"),
+        pytest.param(
+            {"native_value": None, "native_unit_of_measurement": "kWh"},
+            STATE_UNKNOWN,
+            id="no_value",
+        ),
+    ],
+)
+async def test_setup_skips_seeding_an_unusable_restored_total(
+    hass: HomeAssistant,
+    mock_connection: MockModbusConnection,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    extra_data: dict[str, str] | None,
+    restored_state: str,
+) -> None:
+    """Test a restored total without a usable number seeds no high-water mark."""
+    mock_config_entry.add_to_hass(hass)
+    entry = entity_registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        f"{MOCK_SERIAL}_load_consumption_total",
+        config_entry=mock_config_entry,
+    )
+    mock_restore_cache_with_extra_data(
+        hass, [(State(entry.entity_id, restored_state), extra_data)]
+    )
+
+    with (
+        patch(
+            "homeassistant.components.sofar.async_get_unit",
+            side_effect=lambda hass, entry, params, unit_id: mock_connection.for_unit(
+                unit_id
+            ),
+        ),
+        patch(
+            "sofar_modbus.model.TornReadCorrectedComponent.seed_high_water"
+        ) as mock_seed,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    # A seed attempt would raise on the unusable value, so setup surviving
+    # is half the assertion.
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    mock_seed.assert_not_called()
 
 
 async def test_setup_entry_unrecognized_inverter_raises_setup_error(

--- a/tests/components/sofar/test_init.py
+++ b/tests/components/sofar/test_init.py
@@ -1,7 +1,7 @@
 """Test the Sofar Inverter Modbus integration setup and unload."""
 
+from collections.abc import Callable
 from datetime import timedelta
-from typing import Any
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -35,6 +35,7 @@ from . import (
 from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
+    mock_restore_cache,
     mock_restore_cache_with_extra_data,
 )
 from tests.typing import WebSocketGenerator
@@ -115,15 +116,29 @@ async def test_setup_removes_the_stale_waiting_time_entity(
     assert entity_registry.async_get(entry.entity_id) is None
 
 
+def _seed_without_extra_data(hass: HomeAssistant, entity_id: str) -> None:
+    """Restore a total the way a non-sensor entity stores it: no extra data."""
+    mock_restore_cache(hass, [State(entity_id, "120.0")])
+
+
+def _seed_with_unusable_value(hass: HomeAssistant, entity_id: str) -> None:
+    """Restore a total that was unknown when it was written."""
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(entity_id, STATE_UNKNOWN),
+                {"native_value": None, "native_unit_of_measurement": "kWh"},
+            )
+        ],
+    )
+
+
 @pytest.mark.parametrize(
-    ("extra_data", "restored_state"),
+    "seed_restore_cache",
     [
-        pytest.param(None, "120.0", id="no_extra_data"),
-        pytest.param(
-            {"native_value": None, "native_unit_of_measurement": "kWh"},
-            STATE_UNKNOWN,
-            id="no_value",
-        ),
+        pytest.param(_seed_without_extra_data, id="no_extra_data"),
+        pytest.param(_seed_with_unusable_value, id="no_value"),
     ],
 )
 async def test_setup_skips_seeding_an_unusable_restored_total(
@@ -131,8 +146,7 @@ async def test_setup_skips_seeding_an_unusable_restored_total(
     mock_connection: MockModbusConnection,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
-    extra_data: dict[str, Any] | None,
-    restored_state: str,
+    seed_restore_cache: Callable[[HomeAssistant, str], None],
 ) -> None:
     """Test a restored total without a usable number seeds no high-water mark."""
     mock_config_entry.add_to_hass(hass)
@@ -142,9 +156,7 @@ async def test_setup_skips_seeding_an_unusable_restored_total(
         f"{MOCK_SERIAL}_load_consumption_total",
         config_entry=mock_config_entry,
     )
-    mock_restore_cache_with_extra_data(
-        hass, [(State(entry.entity_id, restored_state), extra_data)]
-    )
+    seed_restore_cache(hass, entry.entity_id)
 
     with (
         patch(

--- a/tests/components/sofar/test_init.py
+++ b/tests/components/sofar/test_init.py
@@ -1,6 +1,7 @@
 """Test the Sofar Inverter Modbus integration setup and unload."""
 
 from datetime import timedelta
+from typing import Any
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -130,7 +131,7 @@ async def test_setup_skips_seeding_an_unusable_restored_total(
     mock_connection: MockModbusConnection,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
-    extra_data: dict[str, str] | None,
+    extra_data: dict[str, Any] | None,
     restored_state: str,
 ) -> None:
     """Test a restored total without a usable number seeds no high-water mark."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Covers the two guards in the Sofar integration's _async_seed_high_water_marks that skip a restored total without a usable number.

Neither was tested deliberately. The missing-extra_data guard was not covered at all, and the non-numeric guard was reached only as a side effect of test_device_versions_need_a_reload_to_recover, which is about device version recovery and happened to restore a total with no value. Coverage that incidental moves whenever an unrelated test does, so this pins both branches with a parametrized test of their own and takes homeassistant/components/sofar/__init__.py to 100%.

Both cases were verified against an injected regression: removing either guard fails its own parametrized case and no other. The assertion pairs seed_high_water not being called with the entry still reaching LOADED, because a seed attempt on an unusable value raises before the mock is reached, which would otherwise let the test pass for the wrong reason.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
