### PR TITLE
Bump astral to 3.2

### DIFF
--- a/homeassistant/helpers/sun.py
+++ b/homeassistant/helpers/sun.py
@@ -144,7 +144,9 @@ def get_astral_event_date(
 
     event_func = cast(_AstralSunEventCallable, getattr(astral.sun, event))
     try:
-        return event_func(observer, date)
+        return dt_util.as_utc(
+            event_func(observer, date, tzinfo=dt_util.get_default_time_zone())
+        )
     except ValueError:
         # Event never occurs for specified date.
         return None

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -11,7 +11,7 @@ aiohttp_cors==0.8.1
 aiousbwatcher==1.1.2
 aiozoneinfo==0.2.3
 annotatedyaml==1.0.2
-astral==2.2
+astral==3.2
 async-interrupt==1.2.2
 async-upnp-client==0.48.1
 atomicwrites-homeassistant==1.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "aiohttp-asyncmdnsresolver==0.2.0",
   "aiozoneinfo==0.2.3",
   "annotatedyaml==1.0.2",
-  "astral==2.2",
+  "astral==3.2",
   "async-interrupt==1.2.2",
   "attrs==26.1.0",
   "atomicwrites-homeassistant==1.4.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ aiohttp==3.14.3
 aiohttp_cors==0.8.1
 aiozoneinfo==0.2.3
 annotatedyaml==1.0.2
-astral==2.2
+astral==3.2
 async-interrupt==1.2.2
 atomicwrites-homeassistant==1.4.1
 attrs==26.1.0

--- a/tests/components/sun/test_condition.py
+++ b/tests/components/sun/test_condition.py
@@ -123,7 +123,7 @@ async def test_if_action_before_sunrise_no_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-09-16T13:33:18.342542+00:00"},
+        {"result": False, "wanted_time_before": "2015-09-16T13:33:18.208658+00:00"},
     )
 
     # now = sunrise -> 'before sunrise' true
@@ -135,7 +135,7 @@ async def test_if_action_before_sunrise_no_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-09-16T13:33:18.342542+00:00"},
+        {"result": True, "wanted_time_before": "2015-09-16T13:33:18.208658+00:00"},
     )
 
     # now = local midnight -> 'before sunrise' true
@@ -147,7 +147,7 @@ async def test_if_action_before_sunrise_no_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-09-16T13:33:18.342542+00:00"},
+        {"result": True, "wanted_time_before": "2015-09-16T13:33:18.208658+00:00"},
     )
 
     # now = local midnight - 1s -> 'before sunrise' not true
@@ -159,7 +159,7 @@ async def test_if_action_before_sunrise_no_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-09-16T13:33:18.342542+00:00"},
+        {"result": False, "wanted_time_before": "2015-09-16T13:33:18.208658+00:00"},
     )
 
 
@@ -199,7 +199,7 @@ async def test_if_action_after_sunrise_no_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-09-16T13:33:18.342542+00:00"},
+        {"result": False, "wanted_time_after": "2015-09-16T13:33:18.208658+00:00"},
     )
 
     # now = sunrise + 1s -> 'after sunrise' true
@@ -211,7 +211,7 @@ async def test_if_action_after_sunrise_no_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-09-16T13:33:18.342542+00:00"},
+        {"result": True, "wanted_time_after": "2015-09-16T13:33:18.208658+00:00"},
     )
 
     # now = local midnight -> 'after sunrise' not true
@@ -223,7 +223,7 @@ async def test_if_action_after_sunrise_no_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-09-16T13:33:18.342542+00:00"},
+        {"result": False, "wanted_time_after": "2015-09-16T13:33:18.208658+00:00"},
     )
 
     # now = local midnight - 1s -> 'after sunrise' true
@@ -235,7 +235,7 @@ async def test_if_action_after_sunrise_no_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-09-16T13:33:18.342542+00:00"},
+        {"result": True, "wanted_time_after": "2015-09-16T13:33:18.208658+00:00"},
     )
 
 
@@ -278,7 +278,7 @@ async def test_if_action_before_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": False, "wanted_time_before": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = sunrise + 1h -> 'before sunrise' with offset +1h true
@@ -290,7 +290,7 @@ async def test_if_action_before_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": True, "wanted_time_before": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = UTC midnight -> 'before sunrise' with offset +1h not true
@@ -302,7 +302,7 @@ async def test_if_action_before_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": False, "wanted_time_before": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = UTC midnight - 1s -> 'before sunrise' with offset +1h not true
@@ -314,7 +314,7 @@ async def test_if_action_before_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": False, "wanted_time_before": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = local midnight -> 'before sunrise' with offset +1h true
@@ -326,7 +326,7 @@ async def test_if_action_before_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": True, "wanted_time_before": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = local midnight - 1s -> 'before sunrise' with offset +1h not true
@@ -338,7 +338,7 @@ async def test_if_action_before_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": False, "wanted_time_before": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = sunset -> 'before sunrise' with offset +1h not true
@@ -350,7 +350,7 @@ async def test_if_action_before_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": False, "wanted_time_before": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = sunset -1s -> 'before sunrise' with offset +1h not true
@@ -362,7 +362,7 @@ async def test_if_action_before_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": False, "wanted_time_before": "2015-09-16T14:33:18.208658+00:00"},
     )
 
 
@@ -402,7 +402,7 @@ async def test_if_action_before_sunset_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-09-17T02:53:44.723614+00:00"},
+        {"result": True, "wanted_time_before": "2015-09-17T02:53:44.441422+00:00"},
     )
 
     # now = sunset + 1s + 1h -> 'before sunset' with offset +1h not true
@@ -414,7 +414,7 @@ async def test_if_action_before_sunset_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-09-17T02:53:44.723614+00:00"},
+        {"result": False, "wanted_time_before": "2015-09-17T02:53:44.441422+00:00"},
     )
 
     # now = sunset + 1h -> 'before sunset' with offset +1h true
@@ -426,7 +426,7 @@ async def test_if_action_before_sunset_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-09-17T02:53:44.723614+00:00"},
+        {"result": True, "wanted_time_before": "2015-09-17T02:53:44.441422+00:00"},
     )
 
     # now = UTC midnight -> 'before sunset' with offset +1h true
@@ -438,7 +438,7 @@ async def test_if_action_before_sunset_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-09-17T02:53:44.723614+00:00"},
+        {"result": True, "wanted_time_before": "2015-09-17T02:53:44.441422+00:00"},
     )
 
     # now = UTC midnight - 1s -> 'before sunset' with offset +1h true
@@ -450,7 +450,7 @@ async def test_if_action_before_sunset_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-09-17T02:53:44.723614+00:00"},
+        {"result": True, "wanted_time_before": "2015-09-17T02:53:44.441422+00:00"},
     )
 
     # now = sunrise -> 'before sunset' with offset +1h true
@@ -462,7 +462,7 @@ async def test_if_action_before_sunset_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-09-17T02:53:44.723614+00:00"},
+        {"result": True, "wanted_time_before": "2015-09-17T02:53:44.441422+00:00"},
     )
 
     # now = sunrise -1s -> 'before sunset' with offset +1h true
@@ -474,7 +474,7 @@ async def test_if_action_before_sunset_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-09-17T02:53:44.723614+00:00"},
+        {"result": True, "wanted_time_before": "2015-09-17T02:53:44.441422+00:00"},
     )
 
     # now = local midnight-1s -> 'after sunrise' with offset +1h not true
@@ -486,7 +486,7 @@ async def test_if_action_before_sunset_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-09-17T02:53:44.723614+00:00"},
+        {"result": False, "wanted_time_before": "2015-09-17T02:53:44.441422+00:00"},
     )
 
 
@@ -526,7 +526,7 @@ async def test_if_action_after_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": False, "wanted_time_after": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = sunrise + 1h -> 'after sunrise' with offset +1h true
@@ -538,7 +538,7 @@ async def test_if_action_after_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": True, "wanted_time_after": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = UTC noon -> 'after sunrise' with offset +1h not true
@@ -550,7 +550,7 @@ async def test_if_action_after_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": False, "wanted_time_after": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = UTC noon - 1s -> 'after sunrise' with offset +1h not true
@@ -562,7 +562,7 @@ async def test_if_action_after_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": False, "wanted_time_after": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = local noon -> 'after sunrise' with offset +1h true
@@ -574,7 +574,7 @@ async def test_if_action_after_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": True, "wanted_time_after": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = local noon - 1s -> 'after sunrise' with offset +1h true
@@ -586,7 +586,7 @@ async def test_if_action_after_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": True, "wanted_time_after": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = sunset -> 'after sunrise' with offset +1h true
@@ -598,7 +598,7 @@ async def test_if_action_after_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": True, "wanted_time_after": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = sunset + 1s -> 'after sunrise' with offset +1h true
@@ -610,7 +610,7 @@ async def test_if_action_after_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": True, "wanted_time_after": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = local midnight-1s -> 'after sunrise' with offset +1h true
@@ -622,7 +622,7 @@ async def test_if_action_after_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-09-16T14:33:18.342542+00:00"},
+        {"result": True, "wanted_time_after": "2015-09-16T14:33:18.208658+00:00"},
     )
 
     # now = local midnight -> 'after sunrise' with offset +1h not true
@@ -634,7 +634,7 @@ async def test_if_action_after_sunrise_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-09-17T14:33:57.053037+00:00"},
+        {"result": False, "wanted_time_after": "2015-09-17T14:33:56.919025+00:00"},
     )
 
 
@@ -674,7 +674,7 @@ async def test_if_action_after_sunset_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-09-17T02:53:44.723614+00:00"},
+        {"result": False, "wanted_time_after": "2015-09-17T02:53:44.441422+00:00"},
     )
 
     # now = sunset + 1h -> 'after sunset' with offset +1h true
@@ -686,7 +686,7 @@ async def test_if_action_after_sunset_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-09-17T02:53:44.723614+00:00"},
+        {"result": True, "wanted_time_after": "2015-09-17T02:53:44.441422+00:00"},
     )
 
     # now = midnight-1s -> 'after sunset' with offset +1h true
@@ -698,7 +698,7 @@ async def test_if_action_after_sunset_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-09-16T02:55:06.099767+00:00"},
+        {"result": True, "wanted_time_after": "2015-09-16T02:55:05.817758+00:00"},
     )
 
     # now = midnight -> 'after sunset' with offset +1h not true
@@ -710,7 +710,7 @@ async def test_if_action_after_sunset_with_offset(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-09-17T02:53:44.723614+00:00"},
+        {"result": False, "wanted_time_after": "2015-09-17T02:53:44.441422+00:00"},
     )
 
 
@@ -752,8 +752,8 @@ async def test_if_action_after_and_before_during(
         "sun",
         {
             "result": False,
-            "wanted_time_before": "2015-09-17T01:53:44.723614+00:00",
-            "wanted_time_after": "2015-09-16T13:33:18.342542+00:00",
+            "wanted_time_before": "2015-09-17T01:53:44.441422+00:00",
+            "wanted_time_after": "2015-09-16T13:33:18.208658+00:00",
         },
     )
 
@@ -766,7 +766,7 @@ async def test_if_action_after_and_before_during(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-09-17T01:53:44.723614+00:00"},
+        {"result": False, "wanted_time_before": "2015-09-17T01:53:44.441422+00:00"},
     )
 
     # now = sunrise + 1s -> 'after sunrise' + 'before sunset' true
@@ -780,8 +780,8 @@ async def test_if_action_after_and_before_during(
         "sun",
         {
             "result": True,
-            "wanted_time_before": "2015-09-17T01:53:44.723614+00:00",
-            "wanted_time_after": "2015-09-16T13:33:18.342542+00:00",
+            "wanted_time_before": "2015-09-17T01:53:44.441422+00:00",
+            "wanted_time_after": "2015-09-16T13:33:18.208658+00:00",
         },
     )
 
@@ -796,8 +796,8 @@ async def test_if_action_after_and_before_during(
         "sun",
         {
             "result": True,
-            "wanted_time_before": "2015-09-17T01:53:44.723614+00:00",
-            "wanted_time_after": "2015-09-16T13:33:18.342542+00:00",
+            "wanted_time_before": "2015-09-17T01:53:44.441422+00:00",
+            "wanted_time_after": "2015-09-16T13:33:18.208658+00:00",
         },
     )
 
@@ -812,8 +812,8 @@ async def test_if_action_after_and_before_during(
         "sun",
         {
             "result": True,
-            "wanted_time_before": "2015-09-17T01:53:44.723614+00:00",
-            "wanted_time_after": "2015-09-16T13:33:18.342542+00:00",
+            "wanted_time_before": "2015-09-17T01:53:44.441422+00:00",
+            "wanted_time_after": "2015-09-16T13:33:18.208658+00:00",
         },
     )
 
@@ -856,8 +856,8 @@ async def test_if_action_before_or_after_during(
         "sun",
         {
             "result": True,
-            "wanted_time_after": "2015-09-17T01:53:44.723614+00:00",
-            "wanted_time_before": "2015-09-16T13:33:18.342542+00:00",
+            "wanted_time_after": "2015-09-17T01:53:44.441422+00:00",
+            "wanted_time_before": "2015-09-16T13:33:18.208658+00:00",
         },
     )
 
@@ -872,8 +872,8 @@ async def test_if_action_before_or_after_during(
         "sun",
         {
             "result": True,
-            "wanted_time_after": "2015-09-17T01:53:44.723614+00:00",
-            "wanted_time_before": "2015-09-16T13:33:18.342542+00:00",
+            "wanted_time_after": "2015-09-17T01:53:44.441422+00:00",
+            "wanted_time_before": "2015-09-16T13:33:18.208658+00:00",
         },
     )
 
@@ -888,8 +888,8 @@ async def test_if_action_before_or_after_during(
         "sun",
         {
             "result": False,
-            "wanted_time_after": "2015-09-17T01:53:44.723614+00:00",
-            "wanted_time_before": "2015-09-16T13:33:18.342542+00:00",
+            "wanted_time_after": "2015-09-17T01:53:44.441422+00:00",
+            "wanted_time_before": "2015-09-16T13:33:18.208658+00:00",
         },
     )
 
@@ -904,8 +904,8 @@ async def test_if_action_before_or_after_during(
         "sun",
         {
             "result": False,
-            "wanted_time_after": "2015-09-17T01:53:44.723614+00:00",
-            "wanted_time_before": "2015-09-16T13:33:18.342542+00:00",
+            "wanted_time_after": "2015-09-17T01:53:44.441422+00:00",
+            "wanted_time_before": "2015-09-16T13:33:18.208658+00:00",
         },
     )
 
@@ -920,8 +920,8 @@ async def test_if_action_before_or_after_during(
         "sun",
         {
             "result": True,
-            "wanted_time_after": "2015-09-17T01:53:44.723614+00:00",
-            "wanted_time_before": "2015-09-16T13:33:18.342542+00:00",
+            "wanted_time_after": "2015-09-17T01:53:44.441422+00:00",
+            "wanted_time_before": "2015-09-16T13:33:18.208658+00:00",
         },
     )
 
@@ -936,8 +936,8 @@ async def test_if_action_before_or_after_during(
         "sun",
         {
             "result": True,
-            "wanted_time_after": "2015-09-17T01:53:44.723614+00:00",
-            "wanted_time_before": "2015-09-16T13:33:18.342542+00:00",
+            "wanted_time_after": "2015-09-17T01:53:44.441422+00:00",
+            "wanted_time_before": "2015-09-16T13:33:18.208658+00:00",
         },
     )
 
@@ -973,9 +973,9 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
         },
     )
 
-    # sunrise: 2015-07-24 04:48:24 local = 2015-07-24 12:48:24 UTC
+    # sunrise: 2015-07-24 04:48:19 local = 2015-07-24 12:48:19 UTC
     # now = sunrise + 1s -> 'before sunrise' not true
-    now = datetime(2015, 7, 24, 12, 48, 25, tzinfo=dt_util.UTC)
+    now = datetime(2015, 7, 24, 12, 48, 20, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -983,11 +983,11 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-07-24T12:48:24.249497+00:00"},
+        {"result": False, "wanted_time_before": "2015-07-24T12:48:19.714989+00:00"},
     )
 
     # now = sunrise - 1h -> 'before sunrise' true
-    now = datetime(2015, 7, 24, 11, 48, 24, tzinfo=dt_util.UTC)
+    now = datetime(2015, 7, 24, 11, 48, 19, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -995,7 +995,7 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-07-24T12:48:24.249497+00:00"},
+        {"result": True, "wanted_time_before": "2015-07-24T12:48:19.714989+00:00"},
     )
 
     # now = local midnight -> 'before sunrise' true
@@ -1007,7 +1007,7 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-07-24T12:48:24.249497+00:00"},
+        {"result": True, "wanted_time_before": "2015-07-24T12:48:19.714989+00:00"},
     )
 
     # now = local midnight - 1s -> 'before sunrise' not true
@@ -1019,7 +1019,7 @@ async def test_if_action_before_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-07-23T12:43:32.413351+00:00"},
+        {"result": False, "wanted_time_before": "2015-07-23T12:43:27.624760+00:00"},
     )
 
 
@@ -1054,9 +1054,9 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
         },
     )
 
-    # sunrise: 2015-07-24 04:48:24 local = 2015-07-24 12:48:24 UTC
+    # sunrise: 2015-07-24 04:48:19 local = 2015-07-24 12:48:19 UTC
     # now = sunrise + 1s -> 'after sunrise' true
-    now = datetime(2015, 7, 24, 12, 48, 25, tzinfo=dt_util.UTC)
+    now = datetime(2015, 7, 24, 12, 48, 20, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -1064,11 +1064,11 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-07-24T12:48:24.249497+00:00"},
+        {"result": True, "wanted_time_after": "2015-07-24T12:48:19.714989+00:00"},
     )
 
     # now = sunrise - 1h -> 'after sunrise' not true
-    now = datetime(2015, 7, 24, 11, 48, 24, tzinfo=dt_util.UTC)
+    now = datetime(2015, 7, 24, 11, 48, 19, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -1076,7 +1076,7 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-07-24T12:48:24.249497+00:00"},
+        {"result": False, "wanted_time_after": "2015-07-24T12:48:19.714989+00:00"},
     )
 
     # now = local midnight -> 'after sunrise' not true
@@ -1088,7 +1088,7 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-07-24T12:48:24.249497+00:00"},
+        {"result": False, "wanted_time_after": "2015-07-24T12:48:19.714989+00:00"},
     )
 
     # now = local midnight - 1s -> 'after sunrise' true
@@ -1100,7 +1100,7 @@ async def test_if_action_after_sunrise_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-07-23T12:43:32.413351+00:00"},
+        {"result": True, "wanted_time_after": "2015-07-23T12:43:27.624760+00:00"},
     )
 
 
@@ -1136,7 +1136,7 @@ async def test_if_action_before_sunset_no_offset_kotzebue(
         },
     )
 
-    # 2015-08-07 local has two sunsets: 00:03 (08:03 UTC) and 23:59 (08-08 07:59 UTC)
+    # 2015-08-07 local has two sunsets: 00:03 (08:03 UTC) and 23:59 (08-08 07:59:23 UTC)
     # now = local midnight -> 'before sunset' true
     now = datetime(2015, 8, 7, 8, 0, 0, tzinfo=dt_util.UTC)
     with freeze_time(now):
@@ -1146,7 +1146,7 @@ async def test_if_action_before_sunset_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-08-08T07:59:25.982224+00:00"},
+        {"result": True, "wanted_time_before": "2015-08-08T07:59:23.170221+00:00"},
     )
 
     # now = first (early) sunset + 1s -> still 'before sunset' (tracks the late one)
@@ -1158,11 +1158,11 @@ async def test_if_action_before_sunset_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-08-08T07:59:25.982224+00:00"},
+        {"result": True, "wanted_time_before": "2015-08-08T07:59:23.170221+00:00"},
     )
 
     # now = late sunset - 1h -> 'before sunset' true
-    now = datetime(2015, 8, 8, 6, 59, 25, tzinfo=dt_util.UTC)
+    now = datetime(2015, 8, 8, 6, 59, 23, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -1170,11 +1170,11 @@ async def test_if_action_before_sunset_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_before": "2015-08-08T07:59:25.982224+00:00"},
+        {"result": True, "wanted_time_before": "2015-08-08T07:59:23.170221+00:00"},
     )
 
     # now = late sunset + 1s -> 'before sunset' not true
-    now = datetime(2015, 8, 8, 7, 59, 26, tzinfo=dt_util.UTC)
+    now = datetime(2015, 8, 8, 7, 59, 24, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -1182,7 +1182,7 @@ async def test_if_action_before_sunset_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_before": "2015-08-08T07:59:25.982224+00:00"},
+        {"result": False, "wanted_time_before": "2015-08-08T07:59:23.170221+00:00"},
     )
 
 
@@ -1218,7 +1218,7 @@ async def test_if_action_after_sunset_no_offset_kotzebue(
         },
     )
 
-    # 2015-08-07 local has two sunsets: 00:03 (08:03 UTC) and 23:59 (08-08 07:59 UTC)
+    # 2015-08-07 local has two sunsets: 00:03 (08:03 UTC) and 23:59 (08-08 07:59:23 UTC)
     # now = first (early) sunset + 1s -> 'after sunset' not true (tracks the late one)
     now = datetime(2015, 8, 7, 8, 4, 0, tzinfo=dt_util.UTC)
     with freeze_time(now):
@@ -1228,11 +1228,11 @@ async def test_if_action_after_sunset_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-08-08T07:59:25.982224+00:00"},
+        {"result": False, "wanted_time_after": "2015-08-08T07:59:23.170221+00:00"},
     )
 
     # now = late sunset - 1s -> 'after sunset' not true
-    now = datetime(2015, 8, 8, 7, 59, 25, tzinfo=dt_util.UTC)
+    now = datetime(2015, 8, 8, 7, 59, 23, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -1240,11 +1240,11 @@ async def test_if_action_after_sunset_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-08-08T07:59:25.982224+00:00"},
+        {"result": False, "wanted_time_after": "2015-08-08T07:59:23.170221+00:00"},
     )
 
     # now = late sunset + 1s -> 'after sunset' true
-    now = datetime(2015, 8, 8, 7, 59, 27, tzinfo=dt_util.UTC)
+    now = datetime(2015, 8, 8, 7, 59, 24, tzinfo=dt_util.UTC)
     with freeze_time(now):
         hass.bus.async_fire("test_event")
         await hass.async_block_till_done()
@@ -1252,7 +1252,7 @@ async def test_if_action_after_sunset_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": True, "wanted_time_after": "2015-08-08T07:59:25.982224+00:00"},
+        {"result": True, "wanted_time_after": "2015-08-08T07:59:23.170221+00:00"},
     )
 
     # now = local midnight (next day) -> 'after sunset' not true
@@ -1264,7 +1264,7 @@ async def test_if_action_after_sunset_no_offset_kotzebue(
     await assert_automation_condition_trace(
         hass_ws_client,
         "sun",
-        {"result": False, "wanted_time_after": "2015-08-09T07:55:10.646523+00:00"},
+        {"result": False, "wanted_time_after": "2015-08-09T07:55:07.897003+00:00"},
     )
 
 
@@ -1845,14 +1845,14 @@ async def test_midnight_sun_polar_night_condition(
         # Midnight sun starts at this solar midnight (elevation crosses above).
         (
             "sun.is_midnight_sun",
-            datetime(2015, 4, 18, 22, 56, 36, tzinfo=dt_util.UTC),
+            datetime(2015, 4, 18, 22, 56, 30, tzinfo=dt_util.UTC),
             False,
             True,
         ),
         # Midnight sun ends at this solar midnight (crosses below).
         (
             "sun.is_midnight_sun",
-            datetime(2015, 8, 25, 22, 59, 19, tzinfo=dt_util.UTC),
+            datetime(2015, 8, 25, 22, 59, 11, tzinfo=dt_util.UTC),
             True,
             False,
         ),

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -174,10 +174,10 @@ async def test_norway_in_june(hass: HomeAssistant) -> None:
 
     assert dt_util.parse_datetime(
         state.attributes[entity.STATE_ATTR_NEXT_RISING]
-    ) == datetime(2016, 7, 24, 22, 59, 45, 689645, tzinfo=dt_util.UTC)
+    ) == datetime(2016, 7, 25, 23, 26, 30, 480352, tzinfo=dt_util.UTC)
     assert dt_util.parse_datetime(
         state.attributes[entity.STATE_ATTR_NEXT_SETTING]
-    ) == datetime(2016, 7, 25, 22, 17, 13, 503932, tzinfo=dt_util.UTC)
+    ) == datetime(2016, 7, 25, 22, 16, 21, 829089, tzinfo=dt_util.UTC)
 
     assert state.state == sun.STATE_ABOVE_HORIZON
 

--- a/tests/components/sun/test_trigger.py
+++ b/tests/components/sun/test_trigger.py
@@ -39,15 +39,15 @@ _SUN_ENTITY_ID = "sun.sun"
 # Next dawn/dusk after _TEST_DATETIME at the default test location (San Diego),
 # precomputed to serve as an independent oracle for the trigger's scheduler.
 _DAWN_DUSK = {
-    ("dawn", "civil"): datetime(2015, 9, 15, 13, 7, 26, 84892, tzinfo=dt_util.UTC),
-    ("dawn", "nautical"): datetime(2015, 9, 15, 12, 38, 34, 55317, tzinfo=dt_util.UTC),
+    ("dawn", "civil"): datetime(2015, 9, 15, 13, 7, 26, 70280, tzinfo=dt_util.UTC),
+    ("dawn", "nautical"): datetime(2015, 9, 15, 12, 38, 34, 47559, tzinfo=dt_util.UTC),
     ("dawn", "astronomical"): datetime(
-        2015, 9, 15, 12, 9, 9, 742065, tzinfo=dt_util.UTC
+        2015, 9, 15, 12, 9, 9, 736437, tzinfo=dt_util.UTC
     ),
-    ("dusk", "civil"): datetime(2015, 9, 15, 2, 21, 39, 56429, tzinfo=dt_util.UTC),
-    ("dusk", "nautical"): datetime(2015, 9, 15, 2, 50, 29, 596023, tzinfo=dt_util.UTC),
+    ("dusk", "civil"): datetime(2015, 9, 15, 2, 21, 39, 26129, tzinfo=dt_util.UTC),
+    ("dusk", "nautical"): datetime(2015, 9, 15, 2, 50, 29, 580392, tzinfo=dt_util.UTC),
     ("dusk", "astronomical"): datetime(
-        2015, 9, 15, 3, 19, 52, 663966, tzinfo=dt_util.UTC
+        2015, 9, 15, 3, 19, 52, 653071, tzinfo=dt_util.UTC
     ),
 }
 
@@ -518,7 +518,7 @@ async def test_two_sunsets_on_one_day_at_kotzebue(
     await hass.config.async_set_time_zone(time_zone)
     await hass.config.async_update(latitude=latitude, longitude=longitude, elevation=0)
 
-    # 2015-08-07 08:03:42 UTC (00:03 local) and 2015-08-08 07:59:25 UTC (23:59 local)
+    # 2015-08-07 08:03:39 UTC (00:03 local) and 2015-08-08 07:59:23 UTC (23:59 local)
     now = datetime(2015, 8, 7, 7, tzinfo=dt_util.UTC)
     with freeze_time(now) as freezer:
         await _arm_automation(hass, {"platform": "sun.sunset"}, {})
@@ -553,7 +553,7 @@ async def test_two_sunrises_on_one_day(
     await hass.config.async_set_time_zone(time_zone)
     await hass.config.async_update(latitude=latitude, longitude=longitude, elevation=0)
 
-    # 2015-03-07 09:02:36 UTC (00:02 local) and 2015-03-08 08:58:43 UTC (23:58 local)
+    # 2015-03-07 09:02:38 UTC (00:02 local) and 2015-03-08 08:58:45 UTC (23:58 local)
     now = datetime(2015, 3, 7, 9, tzinfo=dt_util.UTC)
     with freeze_time(now) as freezer:
         await _arm_automation(hass, {"platform": "sun.sunrise"}, {})
@@ -784,12 +784,12 @@ _POLAR_TRIGGER_CASES = [
     (
         "sun.midnight_sun_started",
         datetime(2015, 4, 1, 12, tzinfo=dt_util.UTC),
-        datetime(2015, 4, 18, 22, 56, 36, tzinfo=dt_util.UTC),
+        datetime(2015, 4, 18, 22, 56, 30, tzinfo=dt_util.UTC),
     ),
     (
         "sun.midnight_sun_ended",
         datetime(2015, 8, 1, 12, tzinfo=dt_util.UTC),
-        datetime(2015, 8, 25, 22, 59, 19, tzinfo=dt_util.UTC),
+        datetime(2015, 8, 25, 22, 59, 11, tzinfo=dt_util.UTC),
     ),
     (
         "sun.polar_night_started",
@@ -860,7 +860,7 @@ async def test_midnight_sun_trigger_offset_catches_pending_crossing(
     # Midnight sun starts at the 2015-04-18 22:56 solar midnight; a 3-day "after"
     # offset pushes the fire time to 2015-04-21. now sits between the two.
     now = datetime(2015, 4, 20, 12, tzinfo=dt_util.UTC)
-    expected = datetime(2015, 4, 21, 22, 56, 36, tzinfo=dt_util.UTC)
+    expected = datetime(2015, 4, 21, 22, 56, 30, tzinfo=dt_util.UTC)
     with freeze_time(now):
         await _arm_automation(
             hass,
@@ -912,8 +912,8 @@ def test_next_polar_transition_large_before_offset() -> None:
     observer = astral.Observer(*_SVALBARD[:2], 0)
     now = datetime(2015, 2, 27, 12, tzinfo=dt_util.UTC)
     # The 2015-04-18 crossing's fire (60 days earlier) is already past, so the
-    # next fire derives from the 2016-04-17 22:56:39 solar-midnight crossing.
-    expected = datetime(2016, 2, 17, 22, 56, 39, tzinfo=dt_util.UTC)
+    # next fire derives from the 2016-04-17 22:56:33 solar-midnight crossing.
+    expected = datetime(2016, 2, 17, 22, 56, 33, tzinfo=dt_util.UTC)
     result = _next_polar_transition(
         observer, "midnight", now, target_above=True, offset=timedelta(days=-60)
     )

--- a/tests/components/tod/test_binary_sensor.py
+++ b/tests/components/tod/test_binary_sensor.py
@@ -205,9 +205,7 @@ async def test_from_sunrise_to_sunset(
     sunrise = dt_util.as_local(
         get_astral_event_date(hass, "sunrise", dt_util.as_utc(test_time))
     )
-    sunset = dt_util.as_local(
-        get_astral_event_date(hass, "sunset", dt_util.as_utc(test_time))
-    )
+    sunset = dt_util.as_local(get_astral_event_next(hass, "sunset", sunrise))
     config = {
         "binary_sensor": [
             {
@@ -544,12 +542,11 @@ async def test_sun_offset(
 ) -> None:
     """Test sun event with offset."""
     test_time = datetime(2019, 1, 12, tzinfo=hass_tz_info)
-    sunrise = dt_util.as_local(
-        get_astral_event_date(hass, "sunrise", dt_util.as_utc(test_time))
-        + timedelta(hours=-1, minutes=-30)
-    )
+    sunrise_event = get_astral_event_date(hass, "sunrise", dt_util.as_utc(test_time))
+    assert sunrise_event is not None
+    sunrise = dt_util.as_local(sunrise_event + timedelta(hours=-1, minutes=-30))
     sunset = dt_util.as_local(
-        get_astral_event_date(hass, "sunset", dt_util.as_utc(test_time))
+        get_astral_event_next(hass, "sunset", sunrise_event)
         + timedelta(hours=1, minutes=30)
     )
     config = {

--- a/tests/helpers/test_sun.py
+++ b/tests/helpers/test_sun.py
@@ -96,13 +96,14 @@ def test_date_events(hass: HomeAssistant) -> None:
     location = LocationInfo(
         latitude=hass.config.latitude, longitude=hass.config.longitude
     )
+    time_zone = dt_util.get_default_time_zone()
 
-    dawn = astral.sun.dawn(location.observer, utc_today)
-    dusk = astral.sun.dusk(location.observer, utc_today)
-    midnight = astral.sun.midnight(location.observer, utc_today)
-    noon = astral.sun.noon(location.observer, utc_today)
-    sunrise = astral.sun.sunrise(location.observer, utc_today)
-    sunset = astral.sun.sunset(location.observer, utc_today)
+    dawn = astral.sun.dawn(location.observer, utc_today, tzinfo=time_zone)
+    dusk = astral.sun.dusk(location.observer, utc_today, tzinfo=time_zone)
+    midnight = astral.sun.midnight(location.observer, utc_today, tzinfo=time_zone)
+    noon = astral.sun.noon(location.observer, utc_today, tzinfo=time_zone)
+    sunrise = astral.sun.sunrise(location.observer, utc_today, tzinfo=time_zone)
+    sunset = astral.sun.sunset(location.observer, utc_today, tzinfo=time_zone)
 
     assert dawn == sun.get_astral_event_date(hass, "dawn", utc_today)
     assert dusk == sun.get_astral_event_date(hass, "dusk", utc_today)
@@ -121,13 +122,14 @@ def test_date_events_default_date(hass: HomeAssistant) -> None:
     location = LocationInfo(
         latitude=hass.config.latitude, longitude=hass.config.longitude
     )
+    time_zone = dt_util.get_default_time_zone()
 
-    dawn = astral.sun.dawn(location.observer, date=utc_today)
-    dusk = astral.sun.dusk(location.observer, date=utc_today)
-    midnight = astral.sun.midnight(location.observer, date=utc_today)
-    noon = astral.sun.noon(location.observer, date=utc_today)
-    sunrise = astral.sun.sunrise(location.observer, date=utc_today)
-    sunset = astral.sun.sunset(location.observer, date=utc_today)
+    dawn = astral.sun.dawn(location.observer, date=utc_today, tzinfo=time_zone)
+    dusk = astral.sun.dusk(location.observer, date=utc_today, tzinfo=time_zone)
+    midnight = astral.sun.midnight(location.observer, date=utc_today, tzinfo=time_zone)
+    noon = astral.sun.noon(location.observer, date=utc_today, tzinfo=time_zone)
+    sunrise = astral.sun.sunrise(location.observer, date=utc_today, tzinfo=time_zone)
+    sunset = astral.sun.sunset(location.observer, date=utc_today, tzinfo=time_zone)
 
     with freeze_time(utc_now):
         assert dawn == sun.get_astral_event_date(hass, "dawn", utc_today)
@@ -147,13 +149,14 @@ def test_date_events_accepts_datetime(hass: HomeAssistant) -> None:
     location = LocationInfo(
         latitude=hass.config.latitude, longitude=hass.config.longitude
     )
+    time_zone = dt_util.get_default_time_zone()
 
-    dawn = astral.sun.dawn(location.observer, date=utc_today)
-    dusk = astral.sun.dusk(location.observer, date=utc_today)
-    midnight = astral.sun.midnight(location.observer, date=utc_today)
-    noon = astral.sun.noon(location.observer, date=utc_today)
-    sunrise = astral.sun.sunrise(location.observer, date=utc_today)
-    sunset = astral.sun.sunset(location.observer, date=utc_today)
+    dawn = astral.sun.dawn(location.observer, date=utc_today, tzinfo=time_zone)
+    dusk = astral.sun.dusk(location.observer, date=utc_today, tzinfo=time_zone)
+    midnight = astral.sun.midnight(location.observer, date=utc_today, tzinfo=time_zone)
+    noon = astral.sun.noon(location.observer, date=utc_today, tzinfo=time_zone)
+    sunrise = astral.sun.sunrise(location.observer, date=utc_today, tzinfo=time_zone)
+    sunset = astral.sun.sunset(location.observer, date=utc_today, tzinfo=time_zone)
 
     assert dawn == sun.get_astral_event_date(hass, "dawn", utc_now)
     assert dusk == sun.get_astral_event_date(hass, "dusk", utc_now)
@@ -182,10 +185,10 @@ def test_norway_in_june(hass: HomeAssistant) -> None:
     june = datetime(2016, 6, 1, tzinfo=dt_util.UTC)
 
     assert sun.get_astral_event_next(hass, SUN_EVENT_SUNRISE, june) == datetime(
-        2016, 7, 24, 22, 59, 45, 689645, tzinfo=dt_util.UTC
+        2016, 7, 25, 23, 26, 30, 480352, tzinfo=dt_util.UTC
     )
     assert sun.get_astral_event_next(hass, SUN_EVENT_SUNSET, june) == datetime(
-        2016, 7, 25, 22, 17, 13, 503932, tzinfo=dt_util.UTC
+        2016, 7, 25, 22, 16, 21, 829089, tzinfo=dt_util.UTC
     )
     assert sun.get_astral_event_date(hass, SUN_EVENT_SUNRISE, june) is None
     assert sun.get_astral_event_date(hass, SUN_EVENT_SUNSET, june) is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Upgrade Astral from 2.2 to 3.2.

Astral 3.2 checks sunrise, sunset, dawn, and dusk against the requested local date. Date-specific calculations now pass Home Assistant's configured time zone before converting the result to UTC. The tests now use Astral 3.2's revised event times.

- PyPI: https://pypi.org/project/astral/3.2/
- Changelog: https://github.com/sffjunkie/astral/releases/tag/3.2
- Comparison: https://github.com/sffjunkie/astral/compare/2.2...3.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr