### PR TITLE
Add Ecovacs water tank problem sensors

### DIFF
--- a/homeassistant/components/ecovacs/binary_sensor.py
+++ b/homeassistant/components/ecovacs/binary_sensor.py
@@ -46,14 +46,18 @@ ENTITY_DESCRIPTIONS: tuple[EcovacsBinarySensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     EcovacsBinarySensorEntityDescription[ErrorEvent](
-        capability_fn=lambda caps: caps.error,
+        capability_fn=lambda caps: (
+            caps.error if caps.station is not None and caps.water is not None else None
+        ),
         value_fn=lambda e: e.code == 322,
         key="clean_water_tank",
         translation_key="clean_water_tank",
         device_class=BinarySensorDeviceClass.PROBLEM,
     ),
     EcovacsBinarySensorEntityDescription[ErrorEvent](
-        capability_fn=lambda caps: caps.error,
+        capability_fn=lambda caps: (
+            caps.error if caps.station is not None and caps.water is not None else None
+        ),
         value_fn=lambda e: e.code == 323,
         key="dirty_water_tank",
         translation_key="dirty_water_tank",

--- a/homeassistant/components/ecovacs/binary_sensor.py
+++ b/homeassistant/components/ecovacs/binary_sensor.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import override
 
 from deebot_client.capabilities import CapabilityEvent
-from deebot_client.events import Event
+from deebot_client.events import ErrorEvent, Event
 from deebot_client.events.water_info import MopAttachedEvent
 from sucks import VacBot
 
@@ -44,6 +44,20 @@ ENTITY_DESCRIPTIONS: tuple[EcovacsBinarySensorEntityDescription, ...] = (
         key="water_mop_attached",
         translation_key="water_mop_attached",
         entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    EcovacsBinarySensorEntityDescription[ErrorEvent](
+        capability_fn=lambda caps: caps.error,
+        value_fn=lambda e: e.code == 322,
+        key="clean_water_tank",
+        translation_key="clean_water_tank",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    EcovacsBinarySensorEntityDescription[ErrorEvent](
+        capability_fn=lambda caps: caps.error,
+        value_fn=lambda e: e.code == 323,
+        key="dirty_water_tank",
+        translation_key="dirty_water_tank",
+        device_class=BinarySensorDeviceClass.PROBLEM,
     ),
 )
 

--- a/homeassistant/components/ecovacs/strings.json
+++ b/homeassistant/components/ecovacs/strings.json
@@ -51,6 +51,12 @@
   },
   "entity": {
     "binary_sensor": {
+      "clean_water_tank": {
+        "name": "Clean water tank"
+      },
+      "dirty_water_tank": {
+        "name": "Dirty water tank"
+      },
       "water_mop_attached": {
         "name": "Mop attached"
       }

--- a/tests/components/ecovacs/test_binary_sensor.py
+++ b/tests/components/ecovacs/test_binary_sensor.py
@@ -1,12 +1,13 @@
 """Tests for Ecovacs binary sensors."""
 
+from deebot_client.events import ErrorEvent
 from deebot_client.events.water_info import MopAttachedEvent
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.ecovacs.const import DOMAIN
 from homeassistant.components.ecovacs.controller import EcovacsController
-from homeassistant.const import STATE_OFF, STATE_UNKNOWN, Platform
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -52,3 +53,57 @@ async def test_mop_attached(
 
     assert (state := hass.states.get(state.entity_id))
     assert state.state == STATE_OFF
+
+
+async def test_water_tank_errors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    controller: EcovacsController,
+) -> None:
+    """Test water tank error binary sensors."""
+    clean_entry = next(
+        entry
+        for entry in entity_registry.entities.values()
+        if entry.translation_key == "clean_water_tank"
+    )
+    dirty_entry = next(
+        entry
+        for entry in entity_registry.entities.values()
+        if entry.translation_key == "dirty_water_tank"
+    )
+
+    assert (clean_state := hass.states.get(clean_entry.entity_id))
+    assert clean_state.state == STATE_UNKNOWN
+    assert (dirty_state := hass.states.get(dirty_entry.entity_id))
+    assert dirty_state.state == STATE_UNKNOWN
+
+    event_bus = controller.devices[0].events
+
+    await notify_and_wait(
+        hass,
+        event_bus,
+        ErrorEvent(322, "Clean water tank empty or not installed"),
+    )
+
+    assert (clean_state := hass.states.get(clean_entry.entity_id))
+    assert clean_state.state == STATE_ON
+    assert (dirty_state := hass.states.get(dirty_entry.entity_id))
+    assert dirty_state.state == STATE_OFF
+
+    await notify_and_wait(
+        hass,
+        event_bus,
+        ErrorEvent(323, "Dirty Water Tank is full not installed"),
+    )
+
+    assert (clean_state := hass.states.get(clean_entry.entity_id))
+    assert clean_state.state == STATE_OFF
+    assert (dirty_state := hass.states.get(dirty_entry.entity_id))
+    assert dirty_state.state == STATE_ON
+
+    await notify_and_wait(hass, event_bus, ErrorEvent(0, None))
+
+    assert (clean_state := hass.states.get(clean_entry.entity_id))
+    assert clean_state.state == STATE_OFF
+    assert (dirty_state := hass.states.get(dirty_entry.entity_id))
+    assert dirty_state.state == STATE_OFF

--- a/tests/components/ecovacs/test_binary_sensor.py
+++ b/tests/components/ecovacs/test_binary_sensor.py
@@ -55,6 +55,7 @@ async def test_mop_attached(
     assert state.state == STATE_OFF
 
 
+@pytest.mark.parametrize(("device_fixture"), ["9eamof"])
 async def test_water_tank_errors(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,


### PR DESCRIPTION
## Proposed change

Add two Ecovacs binary sensors for actionable dock water tank conditions:

- Clean water tank
- Dirty water tank

The Ecovacs client already decodes these conditions through `ErrorEvent`:

- Error code `322` indicates the clean water tank is empty or not installed.
- Error code `323` indicates the dirty water tank is full or not installed.

The new binary sensors use the `problem` device class:

- The clean water tank sensor turns on when error `322` is reported.
- The dirty water tank sensor turns on when error `323` is reported.
- Both return to off when the Ecovacs error code clears to `0`.

This exposes the already-decoded water tank conditions directly to Home Assistant users and automations without requiring users to enable the generic diagnostic error sensor and interpret numeric error codes.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #181665
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr