### PR TITLE
Give LLMs structured match errors

### DIFF
--- a/homeassistant/components/mcp_server/server.py
+++ b/homeassistant/components/mcp_server/server.py
@@ -150,7 +150,7 @@ async def create_server(
         return [_format_tool(tool, llm_api.custom_serializer) for tool in llm_api.tools]
 
     @server.call_tool()  # type: ignore[untyped-decorator]
-    async def call_tool(name: str, arguments: dict) -> Sequence[types.TextContent]:
+    async def call_tool(name: str, arguments: dict) -> types.CallToolResult:
         """Handle calling tools."""
         llm_api = await get_api_instance()
         tool_input = llm.ToolInput(tool_name=name, tool_args=arguments)
@@ -160,11 +160,16 @@ async def create_server(
             tool_response = await llm_api.async_call_tool(tool_input)
         except (HomeAssistantError, vol.Invalid) as e:
             raise HomeAssistantError(f"Error calling tool: {e}") from e
-        return [
-            types.TextContent(
-                type="text",
-                text=json.dumps(tool_response, ensure_ascii=False),
-            )
-        ]
+        return types.CallToolResult(
+            content=[
+                types.TextContent(
+                    type="text",
+                    text=json.dumps(tool_response, ensure_ascii=False),
+                )
+            ],
+            # A tool may describe its own failure rather than raising, so that
+            # the caller can correct the call. Report it as an error either way.
+            isError="error" in tool_response,
+        )
 
     return server

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -221,15 +221,9 @@ class API(ABC):
 
 
 def _match_failed_result(err: intent.MatchFailedError) -> JsonObjectType:
-    """Describe a failed target match so the model can correct its own call.
-
-    Structured rather than prose: the model has to work out which argument to
-    change, and it is told the response language separately, so a sentence here
-    would be both less reliable and in the wrong language.
-    """
+    """Describe a failed target match so the model can correct its own call."""
     constraints = err.constraints
-    # Keyed by slot name rather than by constraint field, so the model can tell
-    # which of its own arguments to drop or change.
+    # Keyed by actual slot name, so the model has a chance to repair the call.
     provided: dict[str, Any] = {}
     for slot, value in (
         ("name", constraints.name),

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -220,6 +220,39 @@ class API(ABC):
         raise NotImplementedError
 
 
+def _match_failed_result(err: intent.MatchFailedError) -> JsonObjectType:
+    """Describe a failed target match so the model can correct its own call.
+
+    Structured rather than prose: the model has to work out which argument to
+    change, and it is told the response language separately, so a sentence here
+    would be both less reliable and in the wrong language.
+    """
+    constraints = err.constraints
+    # Keyed by slot name rather than by constraint field, so the model can tell
+    # which of its own arguments to drop or change.
+    provided: dict[str, Any] = {}
+    for slot, value in (
+        ("name", constraints.name),
+        ("area", constraints.area_name),
+        ("floor", constraints.floor_name),
+        ("domain", constraints.domains),
+        ("device_class", constraints.device_classes),
+        ("state", constraints.states),
+    ):
+        if not value:
+            continue
+        provided[slot] = value if isinstance(value, str) else sorted(value)
+
+    result: JsonObjectType = {"error": "MatchFailedError", "constraints": provided}
+    if reason := err.result.no_match_reason:
+        # The members are auto(), so the name is the stable identifier.
+        result["reason"] = reason.name.lower()
+    if err.result.no_match_name:
+        result["no_match_name"] = err.result.no_match_name
+
+    return result
+
+
 class IntentTool(Tool):
     """LLM Tool representing an Intent."""
 
@@ -280,17 +313,23 @@ class IntentTool(Tool):
                 if slot_value and slot_name in self.extra_slots:
                     slots[slot_name] = {"value": slot_value}
 
-        intent_response = await intent.async_handle(
-            hass=hass,
-            platform=llm_context.platform,
-            intent_type=self.intent_type,
-            slots=slots,
-            text_input=None,
-            context=llm_context.context,
-            language=llm_context.language,
-            assistant=llm_context.assistant,
-            device_id=llm_context.device_id,
-        )
+        try:
+            intent_response = await intent.async_handle(
+                hass=hass,
+                platform=llm_context.platform,
+                intent_type=self.intent_type,
+                slots=slots,
+                text_input=None,
+                context=llm_context.context,
+                language=llm_context.language,
+                assistant=llm_context.assistant,
+                device_id=llm_context.device_id,
+            )
+        except intent.MatchFailedError as err:
+            # Returned rather than raised: an over-constrained call is something
+            # the model can fix on the next iteration, unlike an internal error.
+            return _match_failed_result(err)
+
         return IntentResponseDict(intent_response)
 
 

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -457,12 +457,38 @@ async def test_mcp_tool_call_failed(
     mcp_client: Any,
     hass_supervisor_access_token: str,
 ) -> None:
-    """Test the tool call endpoint with a failure."""
+    """Test a tool that describes its own failure is still reported as an error."""
 
     async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
         result = await session.call_tool(
             name="intent__HassTurnOn",
             arguments={"name": "backyard"},
+        )
+
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    # Described as data, so the caller can tell which argument to correct.
+    assert json.loads(result.content[0].text) == {
+        "error": "MatchFailedError",
+        "reason": "name",
+        "constraints": {"name": "backyard"},
+    }
+
+
+async def test_mcp_tool_call_raised(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test a tool that raises is reported as an error."""
+
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        result = await session.call_tool(
+            name="intent__NotATool",
+            arguments={"name": "kitchen"},
         )
 
     assert result.isError

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -1342,3 +1342,131 @@ async def test_deprecated_async_render_no_api_prompt(
         "The deprecated function async_render_no_api_prompt was called. It will be "
         "removed in HA Core 2027.2. Use an empty string instead"
     ) in caplog.text
+
+
+@pytest.fixture
+async def front_door_lock(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> str:
+    """Register an exposed lock, which never has a device class."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "intent", {})
+
+    entry = entity_registry.async_get_or_create(
+        "lock", "test", "front_door", original_name="Front Door"
+    )
+    hass.states.async_set(entry.entity_id, "locked", {"friendly_name": "Front Door"})
+    async_expose_entity(hass, "conversation", entry.entity_id, True)
+    return entry.entity_id
+
+
+def _turn_off_tool(hass: HomeAssistant) -> llm.IntentTool:
+    """Return an IntentTool wrapping the real HassTurnOff handler."""
+    handler = next(
+        handler
+        for handler in intent.async_get(hass)
+        if handler.intent_type == intent.INTENT_TURN_OFF
+    )
+    return llm.IntentTool(f"intent__{handler.intent_type}", handler)
+
+
+@pytest.mark.usefixtures("front_door_lock")
+async def test_intent_tool_match_failed_is_returned_not_raised(
+    hass: HomeAssistant,
+) -> None:
+    """Test an over-constrained call describes itself instead of erroring.
+
+    A model asked to lock a front door tends to add device_class "door", which
+    no lock entity can have. The result has to tell it which argument to drop.
+    """
+    llm_context = llm.LLMContext(
+        platform="test_platform",
+        context=Context(),
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+
+    result = await _turn_off_tool(hass).async_call(
+        hass,
+        llm.ToolInput(
+            "intent__HassTurnOff",
+            {"name": "Front Door", "domain": ["lock"], "device_class": ["door"]},
+        ),
+        llm_context,
+    )
+
+    assert result == {
+        "error": "MatchFailedError",
+        "reason": "device_class",
+        "constraints": {
+            "name": "Front Door",
+            "domain": ["lock"],
+            "device_class": ["door"],
+        },
+    }
+
+
+@pytest.mark.usefixtures("front_door_lock")
+async def test_intent_tool_match_failed_names_the_bad_value(
+    hass: HomeAssistant,
+) -> None:
+    """Test a constraint that does not exist at all is named in the result."""
+    llm_context = llm.LLMContext(
+        platform="test_platform",
+        context=Context(),
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+
+    result = await _turn_off_tool(hass).async_call(
+        hass,
+        llm.ToolInput("intent__HassTurnOff", {"area": "Nowhere"}),
+        llm_context,
+    )
+
+    assert result == {
+        "error": "MatchFailedError",
+        "reason": "invalid_area",
+        "constraints": {"area": "Nowhere"},
+        "no_match_name": "Nowhere",
+    }
+
+
+@pytest.mark.parametrize(
+    ("constraints", "expected"),
+    [
+        pytest.param(
+            intent.MatchTargetsConstraints(
+                floor_name="Upstairs", states={"on"}, assistant="conversation"
+            ),
+            {"floor": "Upstairs", "state": ["on"]},
+            id="floor_and_state_use_slot_names",
+        ),
+        pytest.param(
+            intent.MatchTargetsConstraints(
+                domains={"light", "cover"}, assistant="conversation"
+            ),
+            {"domain": ["cover", "light"]},
+            id="collections_are_sorted",
+        ),
+        pytest.param(
+            # assistant and single_target are internal, not model arguments.
+            intent.MatchTargetsConstraints(
+                assistant="conversation", single_target=True
+            ),
+            {},
+            id="internal_constraints_omitted",
+        ),
+    ],
+)
+def test_match_failed_result_constraints(
+    constraints: intent.MatchTargetsConstraints, expected: dict[str, object]
+) -> None:
+    """Test only the model's own arguments are echoed back, by slot name."""
+    err = intent.MatchFailedError(
+        intent.MatchTargetsResult(False, intent.MatchFailedReason.NAME), constraints
+    )
+
+    assert llm._match_failed_result(err)["constraints"] == expected


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Smaller LLMs may over-constrain tool calls, for example trying to unlock a lock with `HassTurnOff`:

```json
{
  "device_class": [
    "door"  <-- WRONG
  ],
  "domain": [
    "lock"
  ],
  "name": "Front Door"
}
```

This PR catches the resulting `intent.MatchFailedError` and returns it as a structured error to the LLM:

```json
{
  "error": "MatchFailedError",
  "constraints": {
    "name": "Front Door",
    "domain": [
      "lock"
    ],
    "device_class": [
      "door"
    ]
  },
  "reason": "device_class"
}
```

With thinking enabled or follow-up corrections, the LLM can use this information to correct its previous call. At the very least, this allows the LLM to emit a meaningful error message:

```
I'm sorry, I couldn't unlock the front door. There was an issue with the device class for the lock.
```

A small change in the MCP server was required because this is still an error but not raised as an exception anymore.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
