### PR TITLE
Add scene_target_states helper to homeassistant scene

### DIFF
--- a/homeassistant/components/homeassistant/scene.py
+++ b/homeassistant/components/homeassistant/scene.py
@@ -163,6 +163,20 @@ def entities_in_scene(hass: HomeAssistant, entity_id: str) -> list[str]:
     return list(cast(HomeAssistantScene, entity).scene_config.states)
 
 
+@callback
+def scene_target_states(hass: HomeAssistant, entity_id: str) -> dict[str, State]:
+    """Return the target state per entity in a scene."""
+    if DATA_PLATFORM not in hass.data:
+        return {}
+
+    platform: EntityPlatform = hass.data[DATA_PLATFORM]
+
+    if (entity := platform.entities.get(entity_id)) is None:
+        return {}
+
+    return dict(cast(HomeAssistantScene, entity).scene_config.states)
+
+
 async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,

--- a/tests/components/homeassistant/snapshots/test_scene.ambr
+++ b/tests/components/homeassistant/snapshots/test_scene.ambr
@@ -1,0 +1,40 @@
+# serializer version: 1
+# name: test_scene_target_states[one_entity]
+  dict({
+    'light.kitchen': StateSnapshot({
+      'attributes': ReadOnlyDict({
+      }),
+      'context': <ANY>,
+      'entity_id': 'light.kitchen',
+      'last_changed': <ANY>,
+      'last_reported': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'on',
+    }),
+  })
+# ---
+# name: test_scene_target_states[two_entities]
+  dict({
+    'light.kitchen': StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'brightness': 100,
+      }),
+      'context': <ANY>,
+      'entity_id': 'light.kitchen',
+      'last_changed': <ANY>,
+      'last_reported': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'on',
+    }),
+    'light.living_room': StateSnapshot({
+      'attributes': ReadOnlyDict({
+      }),
+      'context': <ANY>,
+      'entity_id': 'light.living_room',
+      'last_changed': <ANY>,
+      'last_reported': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'off',
+    }),
+  })
+# ---

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+from syrupy.assertion import SnapshotAssertion
 import voluptuous as vol
 import yaml
 
@@ -385,6 +386,67 @@ async def test_entities_in_scene(hass: HomeAssistant) -> None:
         ("scene.scene_3", ["light.kitchen", "light.living_room"]),
     ):
         assert ha_scene.entities_in_scene(hass, scene_id) == entities
+
+
+@pytest.mark.parametrize(
+    "scene_id",
+    [
+        pytest.param("scene.scene_1", id="one_entity"),
+        pytest.param("scene.scene_3", id="two_entities"),
+    ],
+)
+async def test_scene_target_states(
+    hass: HomeAssistant, snapshot: SnapshotAssertion, scene_id: str
+) -> None:
+    """Test reading the target states of a scene."""
+    assert await async_setup_component(
+        hass,
+        "scene",
+        {
+            "scene": [
+                {"name": "scene_1", "entities": {"light.kitchen": "on"}},
+                {"name": "scene_2", "entities": {"light.living_room": "off"}},
+                {
+                    "name": "scene_3",
+                    "entities": {
+                        "light.kitchen": {"state": "on", "brightness": 100},
+                        "light.living_room": "off",
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert ha_scene.scene_target_states(hass, scene_id) == snapshot
+
+
+async def test_scene_target_states_missing(hass: HomeAssistant) -> None:
+    """Test an unloaded platform and an unknown scene return no states."""
+    assert ha_scene.scene_target_states(hass, "scene.scene_1") == {}
+
+    assert await async_setup_component(
+        hass,
+        "scene",
+        {"scene": [{"name": "scene_1", "entities": {"light.kitchen": "on"}}]},
+    )
+    await hass.async_block_till_done()
+
+    assert ha_scene.scene_target_states(hass, "scene.unknown") == {}
+
+
+async def test_scene_target_states_returns_copy(hass: HomeAssistant) -> None:
+    """Test that changing the returned dict does not change the scene."""
+    assert await async_setup_component(
+        hass,
+        "scene",
+        {"scene": [{"name": "scene_1", "entities": {"light.kitchen": "on"}}]},
+    )
+    await hass.async_block_till_done()
+
+    ha_scene.scene_target_states(hass, "scene.scene_1").clear()
+
+    assert ha_scene.entities_in_scene(hass, "scene.scene_1") == ["light.kitchen"]
 
 
 async def test_config(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a public `scene_target_states` callback to `homeassistant.components.homeassistant.scene`, next to `scenes_with_entity` and `entities_in_scene`. It returns the target `State` per entity in a scene.

The scene platform stores a target `State` per entity for every scene. The two existing callbacks read that data. `scenes_with_entity` returns the scenes that reference an entity, and `entities_in_scene` returns the entity ids in a scene. Neither returns the target states.

An integration that wants to know whether a scene is active needs the target state and attributes of every member. Today the only way to get them is to read `hass.data["homeassistant_scene"]`, look up the scene entity on that platform, and read `HomeAssistantScene.scene_config.states`. Those are internals of the scene platform, so any integration that reads them breaks when they change. My use case is [scene_state](https://github.com/pszypowicz/scene_state), a custom integration that shows whether each scene is active by comparing member states with the scene targets. Its [`scene_source.py`](https://github.com/pszypowicz/scene_state/blob/main/custom_components/scene_state/scene_source.py) carries that platform lookup today.

The new callback runs the same lookup as `entities_in_scene` and returns the full mapping. An empty dict for a missing platform or an unknown scene matches how the existing helpers report those cases. The returned dict is a copy, so callers cannot change the scene config. Existing callers see no behavior change.

Tests cover a scene with one entity, a scene with two entities and an attribute, an unloaded platform, an unknown scene, and that the returned dict is a copy.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
