### PR TITLE
Move RainMachine service registration to services.py

### DIFF
--- a/homeassistant/components/rainmachine/services.py
+++ b/homeassistant/components/rainmachine/services.py
@@ -68,8 +68,10 @@ SERVICE_NAME_PAUSE_WATERING = "pause_watering"
 SERVICE_NAME_PUSH_FLOW_METER_DATA = "push_flow_meter_data"
 SERVICE_NAME_PUSH_WEATHER_DATA = "push_weather_data"
 SERVICE_NAME_RESTRICT_WATERING = "restrict_watering"
+SERVICE_NAME_START_PROGRAM = "start_program"
 SERVICE_NAME_START_ZONE = "start_zone"
 SERVICE_NAME_STOP_ALL = "stop_all"
+SERVICE_NAME_STOP_PROGRAM = "stop_program"
 SERVICE_NAME_STOP_ZONE = "stop_zone"
 SERVICE_NAME_UNPAUSE_WATERING = "unpause_watering"
 SERVICE_NAME_UNRESTRICT_WATERING = "unrestrict_watering"
@@ -160,10 +162,26 @@ def async_setup_services(hass: HomeAssistant) -> None:
     service.async_register_platform_entity_service(
         hass,
         DOMAIN,
+        SERVICE_NAME_START_PROGRAM,
+        entity_domain=SWITCH_DOMAIN,
+        schema=None,
+        func="async_start_program",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
         SERVICE_NAME_START_ZONE,
         entity_domain=SWITCH_DOMAIN,
         schema=SERVICE_START_ZONE_SCHEMA,
         func="async_start_zone",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_NAME_STOP_PROGRAM,
+        entity_domain=SWITCH_DOMAIN,
+        schema=None,
+        func="async_stop_program",
     )
     service.async_register_platform_entity_service(
         hass,

--- a/homeassistant/components/rainmachine/services.py
+++ b/homeassistant/components/rainmachine/services.py
@@ -8,13 +8,22 @@ from regenmaschine.controller import Controller
 from regenmaschine.errors import RainMachineError
 import voluptuous as vol
 
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import CONF_CONDITION, CONF_DEVICE_ID, CONF_UNIT_OF_MEASUREMENT
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, service
+from homeassistant.helpers.typing import VolDictType
 from homeassistant.util.dt import as_timestamp, utcnow
 
-from .const import CONF_DURATION, DATA_PROGRAMS, DATA_ZONES, DOMAIN
+from .const import (
+    CONF_DEFAULT_ZONE_RUN_TIME,
+    CONF_DURATION,
+    DATA_PROGRAMS,
+    DATA_ZONES,
+    DEFAULT_ZONE_RUN,
+    DOMAIN,
+)
 
 if TYPE_CHECKING:
     from . import RainMachineConfigEntry
@@ -59,7 +68,9 @@ SERVICE_NAME_PAUSE_WATERING = "pause_watering"
 SERVICE_NAME_PUSH_FLOW_METER_DATA = "push_flow_meter_data"
 SERVICE_NAME_PUSH_WEATHER_DATA = "push_weather_data"
 SERVICE_NAME_RESTRICT_WATERING = "restrict_watering"
+SERVICE_NAME_START_ZONE = "start_zone"
 SERVICE_NAME_STOP_ALL = "stop_all"
+SERVICE_NAME_STOP_ZONE = "stop_zone"
 SERVICE_NAME_UNPAUSE_WATERING = "unpause_watering"
 SERVICE_NAME_UNRESTRICT_WATERING = "unrestrict_watering"
 
@@ -110,6 +121,11 @@ SERVICE_RESTRICT_WATERING_SCHEMA = SERVICE_SCHEMA.extend(
 )
 
 
+SERVICE_START_ZONE_SCHEMA: VolDictType = {
+    vol.Optional(CONF_DEFAULT_ZONE_RUN_TIME, default=DEFAULT_ZONE_RUN): cv.positive_int
+}
+
+
 async def async_update_programs_and_zones(
     hass: HomeAssistant, entry: RainMachineConfigEntry
 ) -> None:
@@ -140,6 +156,23 @@ def async_get_entry_for_service_call(
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Register services."""
+
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_NAME_START_ZONE,
+        entity_domain=SWITCH_DOMAIN,
+        schema=SERVICE_START_ZONE_SCHEMA,
+        func="async_start_zone",
+    )
+    service.async_register_platform_entity_service(
+        hass,
+        DOMAIN,
+        SERVICE_NAME_STOP_ZONE,
+        entity_domain=SWITCH_DOMAIN,
+        schema=None,
+        func="async_stop_zone",
+    )
 
     def call_with_controller(
         update_programs_and_zones: bool = True,

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -7,14 +7,13 @@ from datetime import datetime
 from typing import Any, Concatenate, override
 
 from regenmaschine.errors import RainMachineError
-import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ID, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import VolDictType
 
@@ -28,7 +27,6 @@ from .const import (
     DATA_PROVISION_SETTINGS,
     DATA_RESTRICTIONS_UNIVERSAL,
     DATA_ZONES,
-    DEFAULT_ZONE_RUN,
 )
 from .entity import RainMachineEntity, RainMachineEntityDescription
 from .services import async_update_programs_and_zones
@@ -180,17 +178,7 @@ async def async_setup_entry(
 
     services: tuple[tuple[str, VolDictType | None, str], ...] = (
         ("start_program", None, "async_start_program"),
-        (
-            "start_zone",
-            {
-                vol.Optional(
-                    CONF_DEFAULT_ZONE_RUN_TIME, default=DEFAULT_ZONE_RUN
-                ): cv.positive_int
-            },
-            "async_start_zone",
-        ),
         ("stop_program", None, "async_stop_program"),
-        ("stop_zone", None, "async_stop_zone"),
     )
     for service_name, schema, method in services:
         platform.async_register_entity_service(service_name, schema, method)

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -13,9 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ID, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.typing import VolDictType
 
 from . import RainMachineConfigEntry, RainMachineData
 from .const import (
@@ -174,15 +172,6 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up RainMachine switches based on a config entry."""
-    platform = entity_platform.async_get_current_platform()
-
-    services: tuple[tuple[str, VolDictType | None, str], ...] = (
-        ("start_program", None, "async_start_program"),
-        ("stop_program", None, "async_stop_program"),
-    )
-    for service_name, schema, method in services:
-        platform.async_register_entity_service(service_name, schema, method)
-
     data = entry.runtime_data
     entities: list[RainMachineBaseSwitch] = []
 

--- a/tests/components/rainmachine/test_switch.py
+++ b/tests/components/rainmachine/test_switch.py
@@ -6,13 +6,22 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.rainmachine.const import DOMAIN
-from homeassistant.const import Platform
+from homeassistant.components.rainmachine.const import (
+    CONF_DEFAULT_ZONE_RUN_TIME,
+    DOMAIN,
+)
+from homeassistant.components.rainmachine.services import (
+    SERVICE_NAME_START_ZONE,
+    SERVICE_NAME_STOP_ZONE,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, snapshot_platform
+
+ZONE_ENTITY_ID = "switch.12345_landscaping"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -32,3 +41,40 @@ async def test_switches(
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+async def test_zone_services(
+    hass: HomeAssistant,
+    config: dict[str, Any],
+    config_entry: MockConfigEntry,
+    client: AsyncMock,
+    controller: AsyncMock,
+) -> None:
+    """Test zone services continue to target zone switches."""
+    with (
+        patch("homeassistant.components.rainmachine.Client", return_value=client),
+        patch("homeassistant.components.rainmachine.PLATFORMS", [Platform.SWITCH]),
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_NAME_START_ZONE,
+        {
+            ATTR_ENTITY_ID: ZONE_ENTITY_ID,
+            CONF_DEFAULT_ZONE_RUN_TIME: 300,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    controller.zones.start.assert_awaited_once_with(1, 300)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_NAME_STOP_ZONE,
+        {ATTR_ENTITY_ID: ZONE_ENTITY_ID},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    controller.zones.stop.assert_awaited_once_with(1)

--- a/tests/components/rainmachine/test_switch.py
+++ b/tests/components/rainmachine/test_switch.py
@@ -11,7 +11,9 @@ from homeassistant.components.rainmachine.const import (
     DOMAIN,
 )
 from homeassistant.components.rainmachine.services import (
+    SERVICE_NAME_START_PROGRAM,
     SERVICE_NAME_START_ZONE,
+    SERVICE_NAME_STOP_PROGRAM,
     SERVICE_NAME_STOP_ZONE,
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
@@ -21,6 +23,7 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, snapshot_platform
 
+PROGRAM_ENTITY_ID = "switch.12345_morning"
 ZONE_ENTITY_ID = "switch.12345_landscaping"
 
 
@@ -43,20 +46,38 @@ async def test_switches(
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
-async def test_zone_services(
+async def test_activity_services(
     hass: HomeAssistant,
     config: dict[str, Any],
     config_entry: MockConfigEntry,
     client: AsyncMock,
     controller: AsyncMock,
 ) -> None:
-    """Test zone services continue to target zone switches."""
+    """Test program and zone services continue to target activity switches."""
     with (
         patch("homeassistant.components.rainmachine.Client", return_value=client),
         patch("homeassistant.components.rainmachine.PLATFORMS", [Platform.SWITCH]),
     ):
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_NAME_START_PROGRAM,
+        {ATTR_ENTITY_ID: PROGRAM_ENTITY_ID},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    controller.programs.start.assert_awaited_once_with(1)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_NAME_STOP_PROGRAM,
+        {ATTR_ENTITY_ID: PROGRAM_ENTITY_ID},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    controller.programs.stop.assert_awaited_once_with(1)
 
     await hass.services.async_call(
         DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Move the RainMachine `start_zone` and `stop_zone` entity service registration from the switch platform into the integration-level service setup.

This is a behavior-preserving refactor. The services continue to target RainMachine switch entities, keep the same schemas, and call the same `async_start_zone` and `async_stop_zone` entity methods.

This is a preliminary change requested during review of #181486 so the zone services can later be shared with the replacement valve entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Related pull request: #181486


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
