### PR TITLE
Add intent aliases for smaller LLMs

### DIFF
--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -1,6 +1,7 @@
 """The Intent integration."""
 
 from collections.abc import Collection
+from enum import StrEnum
 import logging
 from typing import Any, Protocol, override
 
@@ -144,6 +145,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             device_classes=ONOFF_DEVICE_CLASSES,
         ),
     )
+    _async_register_onoff_aliases(hass)
     intent.async_register(
         hass,
         GetStateIntentHandler(),
@@ -276,6 +278,79 @@ class OnOffIntentHandler(intent.ServiceIntentHandler):
 
         # Fall back to homeassistant.turn_on/off
         await super().async_call_service(domain, service, intent_obj, state)
+
+
+def _async_register_onoff_aliases(hass: HomeAssistant) -> None:
+    """Register constrained aliases of turn on and turn off.
+
+    HassTurnOn and HassTurnOff already reach locks, covers, valves and buttons,
+    but for those domains on and off are not what the user says, and a caller
+    picking a tool by name can invert the mapping: asked to lock a door, an LLM
+    reaches for HassTurnOff. These aliases name the action instead, and pin the
+    domains they can target so the mapping cannot be inverted.
+
+    device_class is only offered where the constrained domains can carry one.
+    Locks never have a device class, so HassLock and HassUnlock do not accept
+    the slot at all rather than fail matching on a value that cannot apply.
+    """
+    aliases: tuple[tuple[str, str, set[str], set[type[StrEnum]] | None, str], ...] = (
+        (
+            intent.INTENT_LOCK,
+            SERVICE_TURN_ON,
+            {LOCK_DOMAIN},
+            None,
+            "Locks a lock. Use for requests like 'lock the front door'.",
+        ),
+        (
+            intent.INTENT_UNLOCK,
+            SERVICE_TURN_OFF,
+            {LOCK_DOMAIN},
+            None,
+            "Unlocks a lock. Use for requests like 'unlock the back door'.",
+        ),
+        (
+            intent.INTENT_OPEN,
+            SERVICE_TURN_ON,
+            {COVER_DOMAIN, VALVE_DOMAIN},
+            {CoverDeviceClass, ValveDeviceClass},
+            (
+                "Opens a cover or valve, such as a blind, curtain,"
+                " garage door or water valve."
+            ),
+        ),
+        (
+            intent.INTENT_CLOSE,
+            SERVICE_TURN_OFF,
+            {COVER_DOMAIN, VALVE_DOMAIN},
+            {CoverDeviceClass, ValveDeviceClass},
+            (
+                "Closes a cover or valve, such as a blind, curtain,"
+                " garage door or water valve."
+            ),
+        ),
+        (
+            intent.INTENT_PRESS,
+            SERVICE_TURN_ON,
+            {BUTTON_DOMAIN, INPUT_BUTTON_DOMAIN},
+            {ButtonDeviceClass},
+            "Presses a button. Use for requests like 'press the doorbell'.",
+        ),
+    )
+
+    for intent_type, service, domains, device_classes, description in aliases:
+        intent.async_register(
+            hass,
+            OnOffIntentHandler(
+                intent_type,
+                HOMEASSISTANT_DOMAIN,
+                service,
+                description=description,
+                required_domains=domains,
+                # Only offered when one of these domains is exposed.
+                platforms=domains,
+                device_classes=device_classes,
+            ),
+        )
 
 
 class GetStateIntentHandler(intent.IntentHandler):

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -283,15 +283,7 @@ class OnOffIntentHandler(intent.ServiceIntentHandler):
 def _async_register_onoff_aliases(hass: HomeAssistant) -> None:
     """Register constrained aliases of turn on and turn off.
 
-    HassTurnOn and HassTurnOff already reach locks, covers, valves and buttons,
-    but for those domains on and off are not what the user says, and a caller
-    picking a tool by name can invert the mapping: asked to lock a door, an LLM
-    reaches for HassTurnOff. These aliases name the action instead, and pin the
-    domains they can target so the mapping cannot be inverted.
-
-    device_class is only offered where the constrained domains can carry one.
-    Locks never have a device class, so HassLock and HassUnlock do not accept
-    the slot at all rather than fail matching on a value that cannot apply.
+    This lets smaller LLMs pick the right tools more effectively.
     """
     aliases: tuple[tuple[str, str, set[str], set[type[StrEnum]] | None, str], ...] = (
         (

--- a/homeassistant/components/intent/llm.py
+++ b/homeassistant/components/intent/llm.py
@@ -26,6 +26,13 @@ LLM_INTENTS = (
     intent.INTENT_CANCEL_ALL_TIMERS,
     intent.INTENT_SET_POSITION,
     intent.INTENT_STOP_MOVING,
+    # Named aliases of turn on and turn off, so a model does not have to work
+    # out that locking a door means turning it on.
+    intent.INTENT_LOCK,
+    intent.INTENT_UNLOCK,
+    intent.INTENT_OPEN,
+    intent.INTENT_CLOSE,
+    intent.INTENT_PRESS,
 )
 
 # Timer intents, only exposed for a device that supports timers.
@@ -41,7 +48,6 @@ TIMER_INTENTS = (
 
 DEVICE_CONTROL_TOOL_USAGE_PROMPT = (
     "When controlling Home Assistant always call the intent tools. "
-    "Use intent__HassTurnOn to lock and intent__HassTurnOff to unlock a lock. "
     "When controlling a device, prefer passing just name and domain. "
     "When controlling an area, prefer passing just area name and domain."
 )

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -39,9 +39,8 @@ INTENT_TURN_OFF = "HassTurnOff"
 INTENT_TURN_ON = "HassTurnOn"
 INTENT_TOGGLE = "HassToggle"
 
-# Constrained aliases of HassTurnOn and HassTurnOff, for the domains where on
-# and off do not read as what the user actually said. They exist so a caller
-# that has to pick a tool by name, such as an LLM, cannot invert the mapping.
+# Constrained aliases of HassTurnOn and HassTurnOff so smaller LLMs pick the
+# correct tools.
 INTENT_LOCK = "HassLock"
 INTENT_UNLOCK = "HassUnlock"
 INTENT_OPEN = "HassOpen"
@@ -1047,10 +1046,8 @@ class DynamicServiceIntentHandler(IntentHandler):
             domains = set(slots["domain"]["value"])
 
         if "device_class" in slots and self.device_classes:
-            # Slots allow extras, so a caller can send a device class to a
-            # handler that never offered the slot. Honouring it would filter on
-            # something the handler's domains cannot carry: a lock has no
-            # device class, so any value at all matches nothing.
+            # Only add constraint if the handler intentionally filters by device
+            # class. LLMs often pass this in wrong.
             device_classes = set(slots["device_class"]["value"])
 
         match_constraints = MatchTargetsConstraints(

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -38,6 +38,16 @@ type _IntentSlotsType = dict[
 INTENT_TURN_OFF = "HassTurnOff"
 INTENT_TURN_ON = "HassTurnOn"
 INTENT_TOGGLE = "HassToggle"
+
+# Constrained aliases of HassTurnOn and HassTurnOff, for the domains where on
+# and off do not read as what the user actually said. They exist so a caller
+# that has to pick a tool by name, such as an LLM, cannot invert the mapping.
+INTENT_LOCK = "HassLock"
+INTENT_UNLOCK = "HassUnlock"
+INTENT_OPEN = "HassOpen"
+INTENT_CLOSE = "HassClose"
+INTENT_PRESS = "HassPress"
+
 INTENT_GET_STATE = "HassGetState"
 INTENT_NEVERMIND = "HassNevermind"
 INTENT_SET_POSITION = "HassSetPosition"
@@ -1036,7 +1046,11 @@ class DynamicServiceIntentHandler(IntentHandler):
         if "domain" in slots:
             domains = set(slots["domain"]["value"])
 
-        if "device_class" in slots:
+        if "device_class" in slots and self.device_classes:
+            # Slots allow extras, so a caller can send a device class to a
+            # handler that never offered the slot. Honouring it would filter on
+            # something the handler's domains cannot carry: a lock has no
+            # device class, so any value at all matches nothing.
             device_classes = set(slots["device_class"]["value"])
 
         match_constraints = MatchTargetsConstraints(

--- a/tests/components/intent/test_init.py
+++ b/tests/components/intent/test_init.py
@@ -11,6 +11,7 @@ from homeassistant.components.cover import (
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
+    CoverDeviceClass,
     CoverState,
 )
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
@@ -803,3 +804,160 @@ async def test_stop_moving_intent_unsupported_domain(hass: HomeAssistant) -> Non
         await intent.async_handle(
             hass, "test", intent.INTENT_STOP_MOVING, {"name": {"value": "test light"}}
         )
+
+
+@pytest.mark.parametrize(
+    ("intent_type", "domain", "service", "entity_domain", "initial_state"),
+    [
+        pytest.param("HassLock", "lock", SERVICE_LOCK, "lock", "unlocked", id="lock"),
+        pytest.param(
+            "HassUnlock", "lock", SERVICE_UNLOCK, "lock", "locked", id="unlock"
+        ),
+        pytest.param(
+            "HassOpen",
+            COVER_DOMAIN,
+            SERVICE_OPEN_COVER,
+            "cover",
+            CoverState.CLOSED,
+            id="open_cover",
+        ),
+        pytest.param(
+            "HassClose",
+            COVER_DOMAIN,
+            SERVICE_CLOSE_COVER,
+            "cover",
+            CoverState.OPEN,
+            id="close_cover",
+        ),
+        pytest.param(
+            "HassOpen",
+            VALVE_DOMAIN,
+            SERVICE_OPEN_VALVE,
+            "valve",
+            ValveState.CLOSED,
+            id="open_valve",
+        ),
+        pytest.param(
+            "HassClose",
+            VALVE_DOMAIN,
+            SERVICE_CLOSE_VALVE,
+            "valve",
+            ValveState.OPEN,
+            id="close_valve",
+        ),
+        pytest.param(
+            "HassPress", "button", SERVICE_PRESS, "button", "unknown", id="press"
+        ),
+    ],
+)
+async def test_onoff_alias_intents(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    intent_type: str,
+    domain: str,
+    service: str,
+    entity_domain: str,
+    initial_state: str,
+) -> None:
+    """Test each alias calls the same service its turn on/off pair would."""
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    entry = entity_registry.async_get_or_create(entity_domain, "test", "alias_uid")
+    hass.states.async_set(entry.entity_id, initial_state)
+    calls = async_mock_service(hass, domain, service)
+
+    await intent.async_handle(
+        hass, "test", intent_type, {"name": {"value": entry.entity_id}}
+    )
+
+    assert len(calls) == 1
+    assert calls[0].domain == domain
+    assert calls[0].service == service
+    assert calls[0].data == {"entity_id": entry.entity_id}
+
+
+@pytest.mark.parametrize(
+    ("intent_type", "entity_domain"),
+    [
+        pytest.param("HassLock", "light", id="lock_a_light"),
+        pytest.param("HassOpen", "lock", id="open_a_lock"),
+        pytest.param("HassPress", "cover", id="press_a_cover"),
+    ],
+)
+async def test_onoff_alias_intents_are_domain_constrained(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    intent_type: str,
+    entity_domain: str,
+) -> None:
+    """Test an alias cannot reach a domain it was not meant for."""
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    entry = entity_registry.async_get_or_create(entity_domain, "test", "other_uid")
+    hass.states.async_set(entry.entity_id, "off")
+
+    with pytest.raises(intent.MatchFailedError) as err:
+        await intent.async_handle(
+            hass, "test", intent_type, {"name": {"value": entry.entity_id}}
+        )
+
+    assert err.value.result.no_match_reason == intent.MatchFailedReason.DOMAIN
+
+
+async def test_lock_alias_ignores_stray_device_class(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test a device class HassLock never offered does not break matching.
+
+    Locks have no device class, so honouring one would filter out every
+    candidate. Slots allow extras, so a caller can still send one.
+    """
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    lock = entity_registry.async_get_or_create("lock", "test", "lock_uid")
+    hass.states.async_set(lock.entity_id, "unlocked")
+    lock_calls = async_mock_service(hass, "lock", SERVICE_LOCK)
+
+    await intent.async_handle(
+        hass,
+        "test",
+        "HassLock",
+        {
+            "name": {"value": lock.entity_id},
+            "device_class": {"value": ["door"]},
+        },
+    )
+
+    assert len(lock_calls) == 1
+    assert lock_calls[0].data == {"entity_id": lock.entity_id}
+
+
+async def test_turn_on_still_honours_device_class(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test the handlers that do offer device_class are unaffected."""
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    garage = entity_registry.async_get_or_create(
+        "cover", "test", "garage_uid", original_name="Garage Door"
+    )
+    hass.states.async_set(
+        garage.entity_id,
+        CoverState.CLOSED,
+        {ATTR_DEVICE_CLASS: CoverDeviceClass.GARAGE, ATTR_FRIENDLY_NAME: "Garage Door"},
+    )
+    blind = entity_registry.async_get_or_create(
+        "cover", "test", "blind_uid", original_name="Blind"
+    )
+    hass.states.async_set(
+        blind.entity_id,
+        CoverState.CLOSED,
+        {ATTR_DEVICE_CLASS: CoverDeviceClass.BLIND, ATTR_FRIENDLY_NAME: "Blind"},
+    )
+    calls = async_mock_service(hass, COVER_DOMAIN, SERVICE_OPEN_COVER)
+
+    await intent.async_handle(
+        hass, "test", "HassTurnOn", {"device_class": {"value": ["garage"]}}
+    )
+
+    assert [call.data["entity_id"] for call in calls] == [garage.entity_id]

--- a/tests/components/intent/test_llm.py
+++ b/tests/components/intent/test_llm.py
@@ -98,3 +98,58 @@ async def test_no_prompt_without_exposed_entities(hass: HomeAssistant) -> None:
 async def test_no_tools_for_other_api(hass: HomeAssistant) -> None:
     """Test the platform returns None for an unsupported API."""
     assert intent_llm.async_get_tools(hass, _llm_context(), "other") is None
+
+
+ALIAS_TOOLS = {
+    "intent__HassLock",
+    "intent__HassUnlock",
+    "intent__HassOpen",
+    "intent__HassClose",
+    "intent__HassPress",
+}
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "expected"),
+    [
+        pytest.param(
+            "lock.front_door",
+            {"intent__HassLock", "intent__HassUnlock"},
+            id="lock",
+        ),
+        pytest.param(
+            "cover.blind",
+            {"intent__HassOpen", "intent__HassClose"},
+            id="cover",
+        ),
+        pytest.param(
+            "valve.water",
+            {"intent__HassOpen", "intent__HassClose"},
+            id="valve",
+        ),
+        pytest.param("button.doorbell", {"intent__HassPress"}, id="button"),
+        pytest.param("input_button.reset", {"intent__HassPress"}, id="input_button"),
+        pytest.param("light.kitchen", set(), id="light_offers_no_aliases"),
+    ],
+)
+async def test_onoff_aliases_require_a_relevant_exposed_entity(
+    hass: HomeAssistant, entity_id: str, expected: set[str]
+) -> None:
+    """Test each alias is only offered when one of its domains is exposed."""
+    # The fixture exposes a cover, which would offer the cover aliases.
+    async_expose_entity(hass, "conversation", COVER_ENTITY_ID, False)
+    hass.states.async_set(entity_id, "off")
+    async_expose_entity(hass, "conversation", entity_id, True)
+
+    names = await _tool_names(hass)
+
+    assert names & ALIAS_TOOLS == expected
+    # Turn on and off stay available for whatever else is exposed.
+    assert "intent__HassTurnOn" in names
+
+
+async def test_onoff_aliases_absent_when_nothing_exposed(hass: HomeAssistant) -> None:
+    """Test no aliases are offered when nothing at all is exposed."""
+    async_expose_entity(hass, "conversation", COVER_ENTITY_ID, False)
+
+    assert not await _tool_names(hass) & ALIAS_TOOLS

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -670,7 +670,6 @@ Static Context: An overview of the areas and the devices in this smart home:
 """
     first_part_prompt = (
         "When controlling Home Assistant always call the intent tools. "
-        "Use intent__HassTurnOn to lock and intent__HassTurnOff to unlock a lock. "
         "When controlling a device, prefer passing just name and domain. "
         "When controlling an area, prefer passing just area name and domain."
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Smaller LLMs in the sub 1B parameter range may fail to lock/unlock locks or open/close doors through the existing `HassTurnOn` and `HassTurnOff` tools because (1) they fail to pick the correct tool despite explicit instructions in the prompt, or (2) they add invalid constraints like "device_class: door" when targeting a lock.

The root of the problem is that `HassTurnOn` and `HassTurnOff` become generic tools with few constraints on their arguments. A simple fix is to add "alias" intents that **call the same code as the general intents** but have constrained slots (and therefore constrained tool arguments). These alias intents are not the same as older deprecated domain-specific HA intents (HassOpen, etc.), which lived in their respective integrations and had separate code. Alias intents are exposed to LLMs only for now, and not targeted by [sentence templates](https://github.com/OHF-Voice/intents).

This PR adds the following alias intents:

- HassLock
- HassUnlock
- HassOpen
- HassClose
- HassPress (suggested by Claude, but it could be removed)

With the alias intents in place, LLMs like Qwen2.5-0.5B-Instruct and Qwen3-0.6B are able to correctly select tools and arguments in most cases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
