### PR TITLE
Expand the Openhome test coverage

### DIFF
--- a/tests/components/openhome/conftest.py
+++ b/tests/components/openhome/conftest.py
@@ -1,0 +1,89 @@
+"""Fixtures for the Openhome integration tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from openhomedevice.device import Device
+import pytest
+
+from homeassistant.components.openhome.const import DOMAIN
+from homeassistant.const import CONF_HOST
+
+from tests.common import MockConfigEntry
+
+HOST = "http://localhost"
+
+TRACK_INFO = {
+    "albumArtwork": "http://localhost/album.jpg",
+    "albumTitle": "album_title",
+    "artist": ["artist"],
+    "title": "title",
+    "uri": "http://localhost/track.flac",
+}
+
+SOURCES = [
+    {"index": 0, "name": "Playlist", "type": "Playlist"},
+    {"index": 1, "name": "Radio", "type": "Radio"},
+]
+
+# The device coroutines the actions drive, referenced from the library so a
+# rename upstream fails the tests rather than leaving an action uncovered.
+ACTION_METHODS = (
+    Device.set_standby,
+    Device.play,
+    Device.pause,
+    Device.stop,
+    Device.skip,
+    Device.increase_volume,
+    Device.decrease_volume,
+    Device.set_volume,
+    Device.set_mute,
+    Device.set_source,
+    Device.play_media,
+    Device.invoke_pin,
+)
+
+
+@pytest.fixture(autouse=True)
+def media_proxy_token() -> Generator[None]:
+    """Freeze the media proxy token, which otherwise varies per run."""
+    with patch("secrets.token_hex", return_value="mock_token"):
+        yield
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mocked config entry."""
+    return MockConfigEntry(domain=DOMAIN, data={CONF_HOST: HOST}, unique_id="uuid")
+
+
+@pytest.fixture
+def mock_device_class() -> Generator[MagicMock]:
+    """Return the patched Openhome Device class."""
+    with patch("homeassistant.components.openhome.Device", MagicMock()) as mock_class:
+        device = mock_class.return_value
+        device.init = AsyncMock()
+        device.uuid = MagicMock(return_value="uuid")
+        device.manufacturer = MagicMock(return_value="manufacturer")
+        device.model_name = MagicMock(return_value="model_name")
+        device.friendly_name = MagicMock(return_value="friendly_name")
+        device.volume_enabled = True
+        device.pins_enabled = True
+        device.room = AsyncMock(return_value="room")
+        device.track_info = AsyncMock(return_value=TRACK_INFO)
+        device.volume = AsyncMock(return_value=50)
+        device.is_muted = AsyncMock(return_value=False)
+        device.sources = AsyncMock(return_value=SOURCES)
+        device.source = AsyncMock(return_value=SOURCES[0])
+        device.is_in_standby = AsyncMock(return_value=False)
+        device.transport_state = AsyncMock(return_value="Playing")
+        device.software_status = AsyncMock(return_value=None)
+        for method in ACTION_METHODS:
+            setattr(device, method.__name__, AsyncMock())
+        yield mock_class
+
+
+@pytest.fixture
+def mock_device(mock_device_class: MagicMock) -> MagicMock:
+    """Return a mocked Openhome device that polls successfully."""
+    return mock_device_class.return_value

--- a/tests/components/openhome/snapshots/test_media_player.ambr
+++ b/tests/components/openhome/snapshots/test_media_player.ambr
@@ -1,0 +1,70 @@
+# serializer version: 1
+# name: test_media_player[media_player.friendly_name-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <MediaPlayerEntityCapabilityAttribute.INPUT_SOURCE_LIST: 'source_list'>: list([
+        'Playlist',
+        'Radio',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'media_player',
+    'entity_category': None,
+    'entity_id': 'media_player.friendly_name',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'room',
+    'platform': 'openhome',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <MediaPlayerEntityFeature: 151485>,
+    'translation_key': None,
+    'unique_id': 'uuid',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_media_player[media_player.friendly_name-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/media_player_proxy/media_player.friendly_name?token=mock_token&cache=bf6152779af9031a',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'friendly_name room',
+      <MediaPlayerEntityStateAttribute.MEDIA_VOLUME_MUTED: 'is_volume_muted'>: False,
+      <MediaPlayerEntityStateAttribute.MEDIA_ALBUM_NAME: 'media_album_name'>: 'album_title',
+      <MediaPlayerEntityStateAttribute.MEDIA_ARTIST: 'media_artist'>: 'artist',
+      <MediaPlayerEntityStateAttribute.MEDIA_CONTENT_ID: 'media_content_id'>: 'http://localhost/track.flac',
+      <MediaPlayerEntityStateAttribute.MEDIA_CONTENT_TYPE: 'media_content_type'>: <MediaType.MUSIC: 'music'>,
+      <MediaPlayerEntityStateAttribute.MEDIA_TITLE: 'media_title'>: 'title',
+      <MediaPlayerEntityStateAttribute.INPUT_SOURCE: 'source'>: 'Playlist',
+      <MediaPlayerEntityCapabilityAttribute.INPUT_SOURCE_LIST: 'source_list'>: list([
+        'Playlist',
+        'Radio',
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <MediaPlayerEntityFeature: 151485>,
+      <MediaPlayerEntityStateAttribute.MEDIA_VOLUME_LEVEL: 'volume_level'>: 0.5,
+    }),
+    'context': <ANY>,
+    'entity_id': 'media_player.friendly_name',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'playing',
+  })
+# ---

--- a/tests/components/openhome/test_init.py
+++ b/tests/components/openhome/test_init.py
@@ -1,32 +1,65 @@
 """Tests for the Openhome integration setup."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
-from homeassistant.components.openhome.const import DOMAIN
+from openhomedevice.exceptions import OpenhomeConnectionError
+import pytest
+
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .conftest import HOST
+
 from tests.common import MockConfigEntry
 
-HOST = "http://localhost"
 
+async def setup_integration(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Set up the config entry without loading any platform."""
+    mock_config_entry.add_to_hass(hass)
 
-async def test_device_uses_shared_session(hass: HomeAssistant) -> None:
-    """Test the device is given Home Assistant's shared aiohttp session."""
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: HOST}, unique_id="uuid")
-    entry.add_to_hass(hass)
-
-    with (
-        patch("homeassistant.components.openhome.PLATFORMS", []),
-        patch("homeassistant.components.openhome.Device", MagicMock()) as mock_device,
-    ):
-        mock_device.return_value.init = AsyncMock()
-        mock_device.return_value.uuid = MagicMock(return_value="uuid")
-
-        await hass.config_entries.async_setup(entry.entry_id)
+    with patch("homeassistant.components.openhome.PLATFORMS", []):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is ConfigEntryState.LOADED
-    mock_device.assert_called_once_with(HOST, session=async_get_clientsession(hass))
+
+async def test_device_uses_shared_session(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_device_class: MagicMock,
+) -> None:
+    """Test the device is given Home Assistant's shared aiohttp session."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    mock_device_class.assert_called_once_with(
+        HOST, session=async_get_clientsession(hass)
+    )
+
+
+async def test_setup_retries_when_device_unreachable(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_device: MagicMock
+) -> None:
+    """Test setup is retried when the device cannot be reached."""
+    mock_device.init.side_effect = OpenhomeConnectionError("device unreachable")
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.usefixtures("mock_device")
+async def test_unload_entry(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test the config entry unloads cleanly."""
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/openhome/test_media_player.py
+++ b/tests/components/openhome/test_media_player.py
@@ -1,6 +1,6 @@
 """Tests for the Openhome media player platform."""
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable
 from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from openhomedevice.device import Device
 from openhomedevice.exceptions import OpenhomeConnectionError
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.media_player import (
     ATTR_INPUT_SOURCE,
@@ -27,7 +28,6 @@ from homeassistant.components.openhome.services import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    CONF_HOST,
     SERVICE_MEDIA_NEXT_TRACK,
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
@@ -39,37 +39,21 @@ from homeassistant.const import (
     SERVICE_VOLUME_MUTE,
     SERVICE_VOLUME_SET,
     SERVICE_VOLUME_UP,
+    STATE_IDLE,
+    STATE_OFF,
+    STATE_PAUSED,
+    STATE_PLAYING,
+    STATE_UNAVAILABLE,
     Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 ENTITY_ID = "media_player.friendly_name"
-
-SOURCES = [
-    {"index": 0, "name": "Playlist", "type": "Playlist"},
-    {"index": 1, "name": "Radio", "type": "Radio"},
-]
-
-# The device coroutines the actions drive, referenced from the library so a
-# rename upstream fails the test rather than silently skipping an action.
-ACTION_METHODS = (
-    Device.set_standby,
-    Device.play,
-    Device.pause,
-    Device.stop,
-    Device.skip,
-    Device.increase_volume,
-    Device.decrease_volume,
-    Device.set_volume,
-    Device.set_mute,
-    Device.set_source,
-    Device.play_media,
-    Device.invoke_pin,
-)
 
 # Each action, the coroutine it drives, and a source type that exposes the
 # supported feature it is gated behind.
@@ -181,60 +165,104 @@ ACTIONS = [
         "Playlist",
         id="play_media",
     ),
-    pytest.param(
-        DOMAIN,
-        SERVICE_INVOKE_PIN,
-        {ATTR_PIN_INDEX: 1},
-        Device.invoke_pin,
-        "Playlist",
-        id="invoke_pin",
-    ),
 ]
 
 
-@pytest.fixture
-def mock_device() -> Generator[MagicMock]:
-    """Return a mocked Openhome device that polls successfully."""
-    with patch("homeassistant.components.openhome.Device", MagicMock()) as mock_class:
-        device = mock_class.return_value
-        device.init = AsyncMock()
-        device.uuid = MagicMock(return_value="uuid")
-        device.manufacturer = MagicMock(return_value="manufacturer")
-        device.model_name = MagicMock(return_value="model_name")
-        device.friendly_name = MagicMock(return_value="friendly_name")
-        device.volume_enabled = True
-        device.pins_enabled = True
-        device.room = AsyncMock(return_value="room")
-        device.track_info = AsyncMock(return_value={})
-        device.volume = AsyncMock(return_value=50)
-        device.is_muted = AsyncMock(return_value=False)
-        device.sources = AsyncMock(return_value=SOURCES)
-        device.is_in_standby = AsyncMock(return_value=False)
-        device.transport_state = AsyncMock(return_value="Playing")
-        for method in ACTION_METHODS:
-            setattr(device, method.__name__, AsyncMock())
-        yield device
+async def async_poll(hass: HomeAssistant) -> None:
+    """Trigger a poll of the media player platform."""
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
+    await hass.async_block_till_done()
 
 
 async def setup_platform(
-    hass: HomeAssistant, mock_device: MagicMock, source_type: str
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_device: MagicMock,
+    source_type: str = "Playlist",
 ) -> None:
     """Load the media player platform and poll once to populate features."""
     mock_device.source = AsyncMock(
         return_value={"index": 0, "name": source_type, "type": source_type}
     )
-    entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "http://localhost"}, unique_id="uuid"
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
     with patch("homeassistant.components.openhome.PLATFORMS", [Platform.MEDIA_PLAYER]):
-        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
     # Supported features are only set once the device has been polled.
-    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=30))
-    await hass.async_block_till_done()
+    await async_poll(hass)
+
+
+async def test_media_player(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_device: MagicMock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the media player is set up from the device state."""
+    await setup_platform(hass, mock_config_entry, mock_device)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_becomes_unavailable_and_recovers(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_device: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a failed poll logs once, marks the device unavailable and recovers."""
+    await setup_platform(hass, mock_config_entry, mock_device)
+
+    assert hass.states.get(ENTITY_ID).state == STATE_PLAYING
+
+    mock_device.room.side_effect = OpenhomeConnectionError("device unreachable")
+    await async_poll(hass)
+
+    assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
+    assert caplog.text.count("device unreachable") == 1
+
+    # A second consecutive failure must not log the same outage again.
+    await async_poll(hass)
+
+    assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
+    assert caplog.text.count("device unreachable") == 1
+
+    mock_device.room.side_effect = None
+    await async_poll(hass)
+
+    assert hass.states.get(ENTITY_ID).state == STATE_PLAYING
+
+
+@pytest.mark.parametrize(
+    ("in_standby", "transport_state", "expected_state"),
+    [
+        pytest.param(True, "Playing", STATE_OFF, id="standby"),
+        pytest.param(False, "Paused", STATE_PAUSED, id="paused"),
+        pytest.param(False, "Playing", STATE_PLAYING, id="playing"),
+        pytest.param(False, "Buffering", STATE_PLAYING, id="buffering"),
+        pytest.param(False, "Stopped", STATE_IDLE, id="stopped"),
+        # An external source with no transport controls still counts as playing.
+        pytest.param(False, "Unknown", STATE_PLAYING, id="external_source"),
+    ],
+)
+async def test_state_mapping(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_device: MagicMock,
+    in_standby: bool,
+    transport_state: str,
+    expected_state: str,
+) -> None:
+    """Test the device transport state maps onto the media player state."""
+    mock_device.is_in_standby = AsyncMock(return_value=in_standby)
+    mock_device.transport_state = AsyncMock(return_value=transport_state)
+
+    await setup_platform(hass, mock_config_entry, mock_device)
+
+    assert hass.states.get(ENTITY_ID).state == expected_state
 
 
 @pytest.mark.parametrize(
@@ -242,6 +270,7 @@ async def setup_platform(
 )
 async def test_action_error_is_raised(
     hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
     mock_device: MagicMock,
     domain: str,
     service: str,
@@ -250,7 +279,7 @@ async def test_action_error_is_raised(
     source_type: str,
 ) -> None:
     """Test every action raises when the device rejects the request."""
-    await setup_platform(hass, mock_device, source_type)
+    await setup_platform(hass, mock_config_entry, mock_device, source_type)
 
     mocked = getattr(mock_device, method.__name__)
     mocked.side_effect = OpenhomeConnectionError("no route to host")
@@ -266,12 +295,26 @@ async def test_action_error_is_raised(
     mocked.assert_awaited()
 
 
-async def test_invoke_pin_without_pin_support(
-    hass: HomeAssistant, mock_device: MagicMock
+@pytest.mark.parametrize(
+    ("pins_enabled", "translation_key", "await_count"),
+    [
+        pytest.param(True, SERVICE_INVOKE_PIN, 1, id="pins_supported"),
+        pytest.param(False, "pins_not_supported", 0, id="pins_not_supported"),
+    ],
+)
+async def test_invoke_pin(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_device: MagicMock,
+    pins_enabled: bool,
+    translation_key: str,
+    await_count: int,
 ) -> None:
-    """Test invoking a pin on a device without pin support raises."""
-    mock_device.pins_enabled = False
-    await setup_platform(hass, mock_device, "Playlist")
+    """Test invoking a pin on a device with and without pin support."""
+    mock_device.pins_enabled = pins_enabled
+    await setup_platform(hass, mock_config_entry, mock_device)
+    # Only reached when the device supports pins; the other case raises first.
+    mock_device.invoke_pin.side_effect = OpenhomeConnectionError("no route to host")
 
     with pytest.raises(HomeAssistantError) as err:
         await hass.services.async_call(
@@ -282,5 +325,5 @@ async def test_invoke_pin_without_pin_support(
         )
 
     assert err.value.translation_domain == DOMAIN
-    assert err.value.translation_key == "pins_not_supported"
-    mock_device.invoke_pin.assert_not_awaited()
+    assert err.value.translation_key == translation_key
+    assert mock_device.invoke_pin.await_count == await_count

--- a/tests/components/openhome/test_update.py
+++ b/tests/components/openhome/test_update.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from openhomedevice.exceptions import OpenhomeConnectionError
 import pytest
 
 from homeassistant.components.openhome.const import DOMAIN
@@ -156,6 +157,22 @@ async def test_update_available(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     update_firmware.assert_called_once()
+
+
+async def test_firmware_update_error(hass: HomeAssistant) -> None:
+    """Ensure a failed firmware install is raised to the user."""
+
+    update_firmware = AsyncMock(side_effect=OpenhomeConnectionError("no route to host"))
+    await setup_integration(hass, FIRMWARE_UPDATE_AVAILABLE, update_firmware)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {ATTR_ENTITY_ID: "update.friendly_name"},
+            blocking=True,
+        )
+    update_firmware.assert_awaited_once()
 
 
 async def test_firmware_update_not_required(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Nothing covered the polling failure that made players go unavailable, the setup retry, entry unloading, the transport state mapping or a failed firmware install. Add those, and a snapshot of the media player so its attributes are pinned.

Move the device mocking into conftest.py, which the three test files were each duplicating.

Cover invoke_pin with and without pin support in one parametrised test rather than a separate case for the unsupported device.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
