### PR TITLE
Fix MikroTik switch discovery for wifi interfaces

### DIFF
--- a/homeassistant/components/mikrotik/switch.py
+++ b/homeassistant/components/mikrotik/switch.py
@@ -47,6 +47,7 @@ async def async_setup_entry(
         for switch_desc in SENSORS
         for interface in coordinator.api.interfaces
         if interface.get("type") == switch_desc.key
+        or (switch_desc.key == "wlan" and interface.get("type") == "wifi")
     ]
 
     async_add_entities(switch_list)

--- a/tests/components/mikrotik/snapshots/test_switch.ambr
+++ b/tests/components/mikrotik/snapshots/test_switch.ambr
@@ -50,6 +50,108 @@
     'state': 'on',
   })
 # ---
+# name: test_switch_entities_created[switch.wifi1_wlan-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.wifi1_wlan',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'WLAN',
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_icon': None,
+    'original_name': 'WLAN',
+    'platform': 'mikrotik',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wlan',
+    'unique_id': '02_00_00_00_00_04_wifi1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities_created[switch.wifi1_wlan-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'switch',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'wifi1 WLAN',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.wifi1_wlan',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_entities_created[switch.wifi2_wlan-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.wifi2_wlan',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'WLAN',
+    'options': dict({
+    }),
+    'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
+    'original_icon': None,
+    'original_name': 'WLAN',
+    'platform': 'mikrotik',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'wlan',
+    'unique_id': '02_00_00_00_00_05_wifi2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities_created[switch.wifi2_wlan-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'switch',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'wifi2 WLAN',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.wifi2_wlan',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_switch_entities_created[switch.wlan1_wlan-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/mikrotik/test_switch.py
+++ b/tests/components/mikrotik/test_switch.py
@@ -20,6 +20,23 @@ from .const import BRIDGE1_INTERFACE, ETHER1_INTERFACE, INTERFACE_DATA, WLAN1_IN
 
 from tests.common import snapshot_platform
 
+WIFI1_INTERFACE = {
+    ".id": "*4",
+    "name": "wifi1",
+    "type": "wifi",
+    "mac-address": "02:00:00:00:00:04",
+    "running": True,
+    "disabled": False,
+}
+WIFI2_INTERFACE = {
+    ".id": "*5",
+    "name": "wifi2",
+    "type": "wifi",
+    "mac-address": "02:00:00:00:00:05",
+    "running": False,
+    "disabled": True,
+}
+
 
 async def test_switch_entities_created(
     hass: HomeAssistant,
@@ -28,23 +45,44 @@ async def test_switch_entities_created(
 ) -> None:
     """Test Mikrotik switch entities are created with expected values."""
     with patch("homeassistant.components.mikrotik.PLATFORMS", [Platform.SWITCH]):
-        config_entry = await setup_mikrotik_entry(hass, interface_data=INTERFACE_DATA)
+        config_entry = await setup_mikrotik_entry(
+            hass, interface_data=[*INTERFACE_DATA, WIFI1_INTERFACE, WIFI2_INTERFACE]
+        )
+
+    assert sorted(hass.states.async_entity_ids(SWITCH_DOMAIN)) == [
+        "switch.ether1_ethernet",
+        "switch.wifi1_wlan",
+        "switch.wifi2_wlan",
+        "switch.wlan1_wlan",
+    ]
 
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
-async def test_switch_no_matching_interfaces(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize("interface_type", ["bridge", "vlan", "wireguard", None])
+async def test_switch_no_matching_interfaces(
+    hass: HomeAssistant, interface_type: str | None
+) -> None:
     """Test no switch entities are created for unsupported interface types."""
     with patch("homeassistant.components.mikrotik.PLATFORMS", [Platform.SWITCH]):
-        await setup_mikrotik_entry(hass, interface_data=[BRIDGE1_INTERFACE])
+        await setup_mikrotik_entry(
+            hass, interface_data=[{**BRIDGE1_INTERFACE, "type": interface_type}]
+        )
 
     assert hass.states.async_entity_ids(SWITCH_DOMAIN) == []
 
 
 @pytest.mark.parametrize(
+    ("interface", "entity_id"),
+    [
+        pytest.param(ETHER1_INTERFACE, "switch.ether1_ethernet", id="ether"),
+        pytest.param(WLAN1_INTERFACE, "switch.wlan1_wlan", id="wlan"),
+        pytest.param(WIFI1_INTERFACE, "switch.wifi1_wlan", id="wifi1"),
+        pytest.param(WIFI2_INTERFACE, "switch.wifi2_wlan", id="wifi2"),
+    ],
+)
+@pytest.mark.parametrize(
     (
-        "interface",
-        "entity_id",
         "initial_state",
         "service",
         "command",
@@ -52,8 +90,6 @@ async def test_switch_no_matching_interfaces(hass: HomeAssistant) -> None:
     ),
     [
         pytest.param(
-            ETHER1_INTERFACE,
-            "switch.ether1_ethernet",
             STATE_ON,
             SERVICE_TURN_OFF,
             "/interface/disable",
@@ -61,8 +97,6 @@ async def test_switch_no_matching_interfaces(hass: HomeAssistant) -> None:
             id="turn_off",
         ),
         pytest.param(
-            WLAN1_INTERFACE,
-            "switch.wlan1_wlan",
             STATE_OFF,
             SERVICE_TURN_ON,
             "/interface/enable",
@@ -83,13 +117,23 @@ async def test_switch_turn_on_off(
 ) -> None:
     """Test turning a Mikrotik switch on/off updates state via the coordinator."""
 
+    interfaces = {
+        item[".id"]: {**item, "disabled": initial_state == STATE_OFF}
+        for item in (
+            ETHER1_INTERFACE,
+            WLAN1_INTERFACE,
+            WIFI1_INTERFACE,
+            WIFI2_INTERFACE,
+        )
+    }
     with patch("homeassistant.components.mikrotik.PLATFORMS", [Platform.SWITCH]):
-        await setup_mikrotik_entry(hass, interface_data=[interface])
+        await setup_mikrotik_entry(hass, interface_data=list(interfaces.values()))
 
     assert (state := hass.states.get(entity_id))
     assert state.state == initial_state
 
-    mock_api.return_value = [{**interface, "disabled": final_state == STATE_OFF}]
+    interfaces[interface[".id"]]["disabled"] = final_state == STATE_OFF
+    mock_api.return_value = list(interfaces.values())
 
     await hass.services.async_call(
         SWITCH_DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


RouterOS reports interfaces managed by the newer Wi-Fi stack as `type="wifi"`. MikroTik switch discovery currently matches only `ether` and `wlan`, so these interfaces have connectivity sensors but no on/off switches. This was reproduced with Home Assistant 2026.9.1 and a hAP ax3 running RouterOS 7.22.3.

Match `wifi` interfaces to the existing `wlan` switch description. This retains the existing unique ID construction, WLAN translations and icons, and Ethernet behavior.

Extend the switch tests with synthetic `wifi1` and `wifi2` interfaces. Cover discovery alongside Ethernet and legacy WLAN without extra entities, exclusion of unsupported types, and both enable and disable commands targeting each interface's `.id`.

Validation: all 79 MikroTik tests and 47 snapshots pass, with 100% integration coverage. The new tests fail in five cases when the discovery fix is removed. All applicable pre-commit checks pass on the changed files, including Ruff, pylint, and mypy.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: #177245 (switch platform), #180636 (wireless device tracking); neither addresses discovery of `type="wifi"` switches.
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
