### PR TITLE
Migrate tests away from tts.async_get_media_source_audio

### DIFF
--- a/tests/components/picotts/test_tts.py
+++ b/tests/components/picotts/test_tts.py
@@ -23,6 +23,13 @@ from tests.components.tts.common import retrieve_media
 from tests.typing import ClientSessionGenerator
 
 
+async def get_tts_audio(hass: HomeAssistant) -> bytes:
+    """Get TTS audio from the Pico TTS entity."""
+    stream = tts.async_create_stream(hass, "tts.pico_tts_en_us", "en-US")
+    stream.async_set_message("Hello world")
+    return b"".join([chunk async for chunk in stream.async_stream_result()])
+
+
 def get_empty_wav() -> bytes:
     """Get bytes for empty WAV file."""
     with io.BytesIO() as wav_io:
@@ -142,12 +149,7 @@ async def test_get_tts_audio_subprocess_error(
         ),
         pytest.raises(HomeAssistantError) as exc_info,
     ):
-        await tts.async_get_media_source_audio(
-            hass,
-            tts.generate_media_source_id(
-                hass, "Hello world", "tts.pico_tts_en_us", "en-US"
-            ),
-        )
+        await get_tts_audio(hass)
 
     assert exc_info.value.translation_key == "returncode_error"
     assert exc_info.value.translation_placeholders == {"returncode": "1"}
@@ -165,12 +167,7 @@ async def test_get_tts_audio_timeout(
         ),
         pytest.raises(HomeAssistantError) as exc_info,
     ):
-        await tts.async_get_media_source_audio(
-            hass,
-            tts.generate_media_source_id(
-                hass, "Hello world", "tts.pico_tts_en_us", "en-US"
-            ),
-        )
+        await get_tts_audio(hass)
 
     assert exc_info.value.translation_key == "timeout_error"
 
@@ -190,11 +187,6 @@ async def test_get_tts_audio_file_read_error(
         ),
         pytest.raises(HomeAssistantError) as exc_info,
     ):
-        await tts.async_get_media_source_audio(
-            hass,
-            tts.generate_media_source_id(
-                hass, "Hello world", "tts.pico_tts_en_us", "en-US"
-            ),
-        )
+        await get_tts_audio(hass)
 
     assert exc_info.value.translation_key == "file_read_error"

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1450,7 +1450,7 @@ async def test_legacy_fetching_in_async(
         stream.async_set_message(message)
         return stream
 
-    # Each stream fetches the same message independently
+    # Streams for the same message share a single fetch
     stream = create_stream("test message")
     stream2 = create_stream("test message")
     stream3 = create_stream("test message")
@@ -1508,7 +1508,7 @@ async def test_fetching_in_async(
         stream.async_set_message(message)
         return stream
 
-    # Each stream fetches the same message independently
+    # Streams for the same message share a single fetch
     stream = create_stream("test message")
     stream2 = create_stream("test message")
     stream3 = create_stream("test message")

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -50,6 +50,11 @@ from tests.typing import ClientSessionGenerator, WebSocketGenerator
 ORIG_WRITE_TAGS = tts.SpeechManager.write_tags
 
 
+async def get_stream_data(stream: tts.ResultStream) -> bytes:
+    """Get all data of a result stream."""
+    return b"".join([chunk async for chunk in stream.async_stream_result()])
+
+
 async def test_config_entry_unload(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -835,11 +840,10 @@ async def test_service_receive_voice(
     assert req.status == HTTPStatus.OK
     assert await req.read() == tts_data
 
-    extension, data = await tts.async_get_media_source_audio(
-        hass, calls[0].data[ATTR_MEDIA_CONTENT_ID]
-    )
-    assert extension == "mp3"
-    assert tts_data == data
+    stream = tts.async_get_stream(hass, url.rsplit("/", 1)[-1])
+    assert stream is not None
+    assert stream.extension == "mp3"
+    assert tts_data == b"".join([chunk async for chunk in stream.async_stream_result()])
 
 
 @pytest.mark.parametrize(
@@ -1441,25 +1445,21 @@ async def test_legacy_fetching_in_async(
 
     await mock_setup(hass, ProviderWithAsyncFetching(DEFAULT_LANG))
 
-    # Test async_get_media_source_audio
-    media_source_id = tts.generate_media_source_id(
-        hass,
-        "test message",
-        "test",
-        "en_US",
-        cache=None,
-    )
+    def create_stream(message: str) -> tts.ResultStream:
+        stream = tts.async_create_stream(hass, "test", "en_US")
+        stream.async_set_message(message)
+        return stream
 
-    task = hass.async_create_task(
-        tts.async_get_media_source_audio(hass, media_source_id)
-    )
-    task2 = hass.async_create_task(
-        tts.async_get_media_source_audio(hass, media_source_id)
-    )
+    # Each stream fetches the same message independently
+    stream = create_stream("test message")
+    stream2 = create_stream("test message")
+    stream3 = create_stream("test message")
 
-    url = await get_media_source_url(hass, media_source_id)
+    task = hass.async_create_task(get_stream_data(stream))
+    task2 = hass.async_create_task(get_stream_data(stream2))
+
     client = await hass_client()
-    client_get_task = hass.async_create_task(client.get(url))
+    client_get_task = hass.async_create_task(client.get(stream3.url))
 
     # Make sure that tasks are waiting for our future to resolve
     done, pending = await asyncio.wait((task, task2, client_get_task), timeout=0.1)
@@ -1468,28 +1468,23 @@ async def test_legacy_fetching_in_async(
 
     tts_audio.set_result(b"test")
 
-    assert await task == ("mp3", b"test")
-    assert await task2 == ("mp3", b"test")
+    assert stream.extension == "mp3"
+    assert await task == b"test"
+    assert await task2 == b"test"
 
     req = await client_get_task
     assert req.status == HTTPStatus.OK
     assert await req.read() == b"test"
 
     # Test error is not cached
-    media_source_id = tts.generate_media_source_id(
-        hass, "test message 2", "test", "en_US", None, None
-    )
     tts_audio = asyncio.Future()
     tts_audio.set_exception(HomeAssistantError("test error"))
     with pytest.raises(HomeAssistantError):
-        assert await tts.async_get_media_source_audio(hass, media_source_id)
+        await get_stream_data(create_stream("test message 2"))
 
     tts_audio = asyncio.Future()
     tts_audio.set_result(b"test 2")
-    assert await tts.async_get_media_source_audio(hass, media_source_id) == (
-        "mp3",
-        b"test 2",
-    )
+    assert await get_stream_data(create_stream("test message 2")) == b"test 2"
 
 
 async def test_fetching_in_async(
@@ -1508,25 +1503,21 @@ async def test_fetching_in_async(
 
     await mock_config_entry_setup(hass, EntityWithAsyncFetching(DEFAULT_LANG))
 
-    # Test async_get_media_source_audio
-    media_source_id = tts.generate_media_source_id(
-        hass,
-        "test message",
-        "tts.test",
-        "en_US",
-        cache=None,
-    )
+    def create_stream(message: str) -> tts.ResultStream:
+        stream = tts.async_create_stream(hass, "tts.test", "en_US")
+        stream.async_set_message(message)
+        return stream
 
-    task = hass.async_create_task(
-        tts.async_get_media_source_audio(hass, media_source_id)
-    )
-    task2 = hass.async_create_task(
-        tts.async_get_media_source_audio(hass, media_source_id)
-    )
+    # Each stream fetches the same message independently
+    stream = create_stream("test message")
+    stream2 = create_stream("test message")
+    stream3 = create_stream("test message")
 
-    url = await get_media_source_url(hass, media_source_id)
+    task = hass.async_create_task(get_stream_data(stream))
+    task2 = hass.async_create_task(get_stream_data(stream2))
+
     client = await hass_client()
-    client_get_task = hass.async_create_task(client.get(url))
+    client_get_task = hass.async_create_task(client.get(stream3.url))
 
     # Make sure that tasks are waiting for our future to resolve
     done, pending = await asyncio.wait((task, task2, client_get_task), timeout=0.1)
@@ -1535,28 +1526,23 @@ async def test_fetching_in_async(
 
     tts_audio.set_result(b"test")
 
-    assert await task == ("mp3", b"test")
-    assert await task2 == ("mp3", b"test")
+    assert stream.extension == "mp3"
+    assert await task == b"test"
+    assert await task2 == b"test"
 
     req = await client_get_task
     assert req.status == HTTPStatus.OK
     assert await req.read() == b"test"
 
     # Test error is not cached
-    media_source_id = tts.generate_media_source_id(
-        hass, "test message 2", "tts.test", "en_US", None, None
-    )
     tts_audio = asyncio.Future()
     tts_audio.set_exception(HomeAssistantError("test error"))
     with pytest.raises(HomeAssistantError):
-        assert await tts.async_get_media_source_audio(hass, media_source_id)
+        await get_stream_data(create_stream("test message 2"))
 
     tts_audio = asyncio.Future()
     tts_audio.set_result(b"test 2")
-    assert await tts.async_get_media_source_audio(hass, media_source_id) == (
-        "mp3",
-        b"test 2",
-    )
+    assert await get_stream_data(create_stream("test message 2")) == b"test 2"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -132,18 +132,13 @@ async def test_get_tts_audio(
         "homeassistant.components.wyoming.tts.AsyncTcpClient",
         MockAsyncTcpClient(audio_events),
     ) as mock_client:
-        extension, data = await tts.async_get_media_source_audio(
-            hass,
-            tts.generate_media_source_id(
-                hass,
-                "Hello world",
-                "tts.test_tts",
-                "en-US",
-                options={tts.ATTR_PREFERRED_FORMAT: "wav"},
-            ),
+        stream = tts.async_create_stream(
+            hass, "tts.test_tts", "en-US", options={tts.ATTR_PREFERRED_FORMAT: "wav"}
         )
+        stream.async_set_message("Hello world")
+        data = b"".join([chunk async for chunk in stream.async_stream_result()])
 
-    assert extension == "wav"
+    assert stream.extension == "wav"
     assert data is not None
     with io.BytesIO(data) as wav_io, wave.open(wav_io, "rb") as wav_file:
         assert wav_file.getframerate() == 16000
@@ -173,22 +168,20 @@ async def test_get_tts_audio_different_formats(
         "homeassistant.components.wyoming.tts.AsyncTcpClient",
         MockAsyncTcpClient(audio_events),
     ) as mock_client:
-        extension, data = await tts.async_get_media_source_audio(
+        stream = tts.async_create_stream(
             hass,
-            tts.generate_media_source_id(
-                hass,
-                "Hello world",
-                "tts.test_tts",
-                "en-US",
-                options={
-                    tts.ATTR_PREFERRED_FORMAT: "wav",
-                    tts.ATTR_PREFERRED_SAMPLE_RATE: 48000,
-                    tts.ATTR_PREFERRED_SAMPLE_CHANNELS: 2,
-                },
-            ),
+            "tts.test_tts",
+            "en-US",
+            options={
+                tts.ATTR_PREFERRED_FORMAT: "wav",
+                tts.ATTR_PREFERRED_SAMPLE_RATE: 48000,
+                tts.ATTR_PREFERRED_SAMPLE_CHANNELS: 2,
+            },
         )
+        stream.async_set_message("Hello world")
+        data = b"".join([chunk async for chunk in stream.async_stream_result()])
 
-    assert extension == "wav"
+    assert stream.extension == "wav"
     assert data is not None
     with io.BytesIO(data) as wav_io, wave.open(wav_io, "rb") as wav_file:
         assert wav_file.getframerate() == 48000
@@ -208,17 +201,11 @@ async def test_get_tts_audio_different_formats(
         "homeassistant.components.wyoming.tts.AsyncTcpClient",
         MockAsyncTcpClient(audio_events),
     ) as mock_client:
-        extension, data = await tts.async_get_media_source_audio(
-            hass,
-            tts.generate_media_source_id(
-                hass,
-                "Hello world",
-                "tts.test_tts",
-                "en-US",
-            ),
-        )
+        stream = tts.async_create_stream(hass, "tts.test_tts", "en-US")
+        stream.async_set_message("Hello world")
+        data = b"".join([chunk async for chunk in stream.async_stream_result()])
 
-    assert extension == "mp3"
+    assert stream.extension == "mp3"
     assert b"ID3" in data
     assert mock_client.written == snapshot
 
@@ -251,22 +238,18 @@ async def test_get_tts_audio_audio_oserror(
 
     mock_client = MockAsyncTcpClient(audio_events)
 
+    stream = tts.async_create_stream(hass, "tts.test_tts", "en-US")
     with (
         patch(
             "homeassistant.components.wyoming.tts.AsyncTcpClient",
             mock_client,
         ),
         patch.object(mock_client, "read_event", side_effect=OSError("Boom!")),
-        pytest.raises(
-            HomeAssistantError,
-        ),
     ):
-        await tts.async_get_media_source_audio(
-            hass,
-            tts.generate_media_source_id(
-                hass, "Hello world", "tts.test_tts", hass.config.language
-            ),
-        )
+        stream.async_set_message("Hello world")
+        with pytest.raises(HomeAssistantError):
+            async for _chunk in stream.async_stream_result():
+                pass
 
 
 @pytest.mark.usefixtures("init_wyoming_tts")
@@ -285,17 +268,15 @@ async def test_get_tts_audio_error_event(
     hass: HomeAssistant, error_code: str | None, expected_message: str
 ) -> None:
     """Test that an error event from the service is reported."""
-    with (
-        patch(
-            "homeassistant.components.wyoming.tts.AsyncTcpClient",
-            MockAsyncTcpClient([Error(text="Boom!", code=error_code).event()]),
-        ),
-        pytest.raises(HomeAssistantError, match=re.escape(expected_message)),
+    stream = tts.async_create_stream(hass, "tts.test_tts", "en-US")
+    with patch(
+        "homeassistant.components.wyoming.tts.AsyncTcpClient",
+        MockAsyncTcpClient([Error(text="Boom!", code=error_code).event()]),
     ):
-        await tts.async_get_media_source_audio(
-            hass,
-            tts.generate_media_source_id(hass, "Hello world", "tts.test_tts", "en-US"),
-        )
+        stream.async_set_message("Hello world")
+        with pytest.raises(HomeAssistantError, match=re.escape(expected_message)):
+            async for _chunk in stream.async_stream_result():
+                pass
 
 
 @pytest.mark.usefixtures("init_wyoming_streaming_tts")
@@ -339,16 +320,16 @@ async def test_voice_speaker(
         "homeassistant.components.wyoming.tts.AsyncTcpClient",
         MockAsyncTcpClient(audio_events),
     ) as mock_client:
-        await tts.async_get_media_source_audio(
+        stream = tts.async_create_stream(
             hass,
-            tts.generate_media_source_id(
-                hass,
-                "Hello world",
-                "tts.test_tts",
-                "en-US",
-                options={tts.ATTR_VOICE: "voice1", wyoming.ATTR_SPEAKER: "speaker1"},
-            ),
+            "tts.test_tts",
+            "en-US",
+            options={tts.ATTR_VOICE: "voice1", wyoming.ATTR_SPEAKER: "speaker1"},
         )
+        stream.async_set_message("Hello world")
+        async for _chunk in stream.async_stream_result():
+            pass
+
         assert mock_client.written == snapshot
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Preparation for deprecating `tts.async_get_media_source_audio`. The tests that used it as a convenient way to fetch TTS audio now use `tts.async_create_stream` plus `ResultStream.async_stream_result`, which is the API that also works for streaming TTS providers.

Covered: `picotts`, `wyoming`, and the incidental uses in the `tts` tests. The wyoming snapshots are unchanged, so the requests sent to the service are identical.

One test changes meaning: `test_get_tts_audio_audio_oserror` asked for `hass.config.language` (`en`), which the wyoming entity does not support. It passed on that language error, not on the `OSError` it is named after. It now asks for `en-US` and exercises the `OSError` path.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZmAzyAzH2e8oVRNTtCmSD