### PR TITLE
Bump pyschlage to 2026.9.0

### DIFF
--- a/homeassistant/components/schlage/manifest.json
+++ b/homeassistant/components/schlage/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/schlage",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "requirements": ["pyschlage==2026.7.0"]
+  "requirements": ["pyschlage==2026.9.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2591,7 +2591,7 @@ pysaj==0.0.16
 pysaunum==0.7.0
 
 # homeassistant.components.schlage
-pyschlage==2026.7.0
+pyschlage==2026.9.0
 
 # homeassistant.components.scorpiontrack
 pyscorpiontrack==0.1.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Bumps the `pyschlage` library used by the Schlage integration from 2026.7.0 to 2026.9.0.

- PyPI: https://pypi.org/project/pyschlage/2026.9.0/
- Release notes: https://github.com/dknowles2/pyschlage/releases/tag/2026.9.0
- Full diff: https://github.com/dknowles2/pyschlage/compare/2026.7.0...2026.9.0

### Most relevant change for Home Assistant

[dknowles2/pyschlage#444](https://github.com/dknowles2/pyschlage/pull/444) — *Fix: redact nested identifiers in `lockStateMetadata` diagnostics*

`Lock.get_diagnostics()` allow-listed `attributes.lockStateMetadata` with no child paths. `redact()` treats a bare entry as a wildcard over the whole subtree, so the nested `UUID`, `clientId` and `name` fields were emitted verbatim — these can carry real device identifiers (serial numbers) even though the top-level `serialNumber` is redacted. The allow-list entry is now narrowed to `attributes.lockStateMetadata.actionType`, and the other three render as `<REDACTED>`.

This was reported during review of #178337. Downloaded Schlage diagnostics from Home Assistant will no longer leak those identifiers once this bump lands.

No Home Assistant test changes are needed: `tests/components/schlage/test_diagnostics.py` mocks `Lock.get_diagnostics()` wholesale, so the redaction behaviour is covered by the library's own tests rather than an HA fixture.

### Other changes

**2026.9.0**
- Release drafter and dev dependency updates

**2026.8.0**
- `LockLog` now returns timezone-aware UTC datetimes (breaking change in the library). The Schlage integration only passes `LockLog` objects to `Lock.keypad_disabled()` and never reads their timestamps, so there is no user-visible change in Home Assistant.
- CI/docs/typing cleanups and dev dependency updates

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
