### PR TITLE
Honor rate limit retry hint in Tessie coordinators

### DIFF
--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 from http import HTTPStatus
 import logging
+import math
 from typing import TYPE_CHECKING, Any, override
 
 from aiohttp import ClientError, ClientResponseError
@@ -38,9 +39,12 @@ def _get_retry_after(err: RateLimited) -> float | None:
     """Return the Retry-After hint in seconds, if the server provided one."""
     if isinstance(err.data, dict) and (after := err.data.get("after")) is not None:
         try:
-            return float(after)
-        except TypeError, ValueError:
+            value = float(after)
+        except (TypeError, ValueError):
             return None
+        if math.isfinite(value) and value >= 0:
+            return value
+        return None
     return None
 
 

--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -7,7 +7,12 @@ from typing import TYPE_CHECKING, Any, override
 
 from aiohttp import ClientError, ClientResponseError
 from tesla_fleet_api.const import TeslaEnergyPeriod
-from tesla_fleet_api.exceptions import InvalidToken, MissingToken, TeslaFleetError
+from tesla_fleet_api.exceptions import (
+    InvalidToken,
+    MissingToken,
+    RateLimited,
+    TeslaFleetError,
+)
 from tesla_fleet_api.tessie import EnergySite, Vehicle
 
 from homeassistant.core import HomeAssistant
@@ -27,6 +32,16 @@ TESSIE_FLEET_API_SYNC_INTERVAL = timedelta(seconds=30)
 TESSIE_ENERGY_HISTORY_INTERVAL = timedelta(seconds=60)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _get_retry_after(err: RateLimited) -> float | None:
+    """Return the Retry-After hint in seconds, if the server provided one."""
+    if isinstance(err.data, dict) and (after := err.data.get("after")) is not None:
+        try:
+            return float(after)
+        except TypeError, ValueError:
+            return None
+    return None
 
 
 def flatten(data: dict[str, Any], parent: str | None = None) -> dict[str, Any]:
@@ -77,6 +92,12 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             vehicle = await self.api.state(use_cache=True)
         except (InvalidToken, MissingToken) as e:
             raise ConfigEntryAuthFailed from e
+        except RateLimited as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+                retry_after=_get_retry_after(e),
+            ) from e
         except TeslaFleetError as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -133,6 +154,12 @@ class TessieEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data = (await self.api.live_status())["response"]
         except (InvalidToken, MissingToken) as e:
             raise ConfigEntryAuthFailed from e
+        except RateLimited as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+                retry_after=_get_retry_after(e),
+            ) from e
         except TeslaFleetError as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -173,6 +200,12 @@ class TessieEnergySiteInfoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data = (await self.api.site_info())["response"]
         except (InvalidToken, MissingToken) as e:
             raise ConfigEntryAuthFailed from e
+        except RateLimited as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+                retry_after=_get_retry_after(e),
+            ) from e
         except TeslaFleetError as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -214,6 +247,12 @@ class TessieEnergyHistoryCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="auth_failed",
+            ) from e
+        except RateLimited as e:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+                retry_after=_get_retry_after(e),
             ) from e
         except TeslaFleetError as e:
             raise UpdateFailed(

--- a/tests/components/tessie/test_coordinator.py
+++ b/tests/components/tessie/test_coordinator.py
@@ -2,6 +2,7 @@
 
 from copy import deepcopy
 from datetime import timedelta
+from unittest.mock import AsyncMock
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -104,7 +105,7 @@ async def test_coordinator_connection(
 
 
 async def test_coordinator_state_rate_limited(
-    hass: HomeAssistant, mock_get_state, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant, mock_get_state: AsyncMock, freezer: FrozenDateTimeFactory
 ) -> None:
     """Tests that a 429 with Retry-After backs off the state coordinator."""
 
@@ -175,7 +176,7 @@ async def test_coordinator_live_error(
 
 
 async def test_coordinator_live_rate_limited(
-    hass: HomeAssistant, mock_live_status, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant, mock_live_status: AsyncMock, freezer: FrozenDateTimeFactory
 ) -> None:
     """Tests that a 429 with Retry-After backs off the energy live coordinator."""
 

--- a/tests/components/tessie/test_coordinator.py
+++ b/tests/components/tessie/test_coordinator.py
@@ -18,6 +18,7 @@ from homeassistant.components.tessie.coordinator import (
     TESSIE_ENERGY_HISTORY_INTERVAL,
     TESSIE_FLEET_API_SYNC_INTERVAL,
     TESSIE_SYNC_INTERVAL,
+    _get_retry_after,
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
@@ -132,6 +133,24 @@ async def test_coordinator_state_rate_limited(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert mock_get_state.call_count == 2
+
+
+@pytest.mark.parametrize(
+    ("after", "expected"),
+    [
+        ("30", 30.0),
+        ("-5", None),
+        ("nan", None),
+        ("inf", None),
+        ("-inf", None),
+        ("not-a-number", None),
+    ],
+    ids=["valid", "negative", "nan", "inf", "neg-inf", "unparsable"],
+)
+def test_get_retry_after(after: str, expected: float | None) -> None:
+    """Tests that _get_retry_after rejects negative and non-finite values."""
+
+    assert _get_retry_after(RateLimited({"after": after})) == expected
 
 
 async def test_coordinator_live_error(

--- a/tests/components/tessie/test_coordinator.py
+++ b/tests/components/tessie/test_coordinator.py
@@ -5,7 +5,12 @@ from datetime import timedelta
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
-from tesla_fleet_api.exceptions import Forbidden, InvalidToken, MissingToken
+from tesla_fleet_api.exceptions import (
+    Forbidden,
+    InvalidToken,
+    MissingToken,
+    RateLimited,
+)
 
 from homeassistant.components.tessie import PLATFORMS
 from homeassistant.components.tessie.const import DOMAIN
@@ -97,6 +102,38 @@ async def test_coordinator_connection(
     assert coordinator.last_exception.translation_key == "cannot_connect"
 
 
+async def test_coordinator_state_rate_limited(
+    hass: HomeAssistant, mock_get_state, freezer: FrozenDateTimeFactory
+) -> None:
+    """Tests that a 429 with Retry-After backs off the state coordinator."""
+
+    entry = await setup_platform(hass, [Platform.BINARY_SENSOR])
+    coordinator = entry.runtime_data.vehicles[0].data_coordinator
+
+    mock_get_state.reset_mock()
+    mock_get_state.side_effect = RateLimited({"after": "30"})
+    freezer.tick(WAIT)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    mock_get_state.assert_called_once()
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.last_exception.retry_after == 30
+
+    # The normal sync interval has not yet elapsed since the rate limit hit,
+    # so the coordinator should still be waiting on the Retry-After backoff.
+    mock_get_state.side_effect = None
+    freezer.tick(WAIT)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    mock_get_state.assert_called_once()
+
+    # Once the Retry-After window elapses, the coordinator refreshes again.
+    freezer.tick(timedelta(seconds=30) - WAIT)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert mock_get_state.call_count == 2
+
+
 async def test_coordinator_live_error(
     hass: HomeAssistant, mock_live_status, freezer: FrozenDateTimeFactory
 ) -> None:
@@ -116,6 +153,39 @@ async def test_coordinator_live_error(
     assert isinstance(coordinator.last_exception, UpdateFailed)
     assert coordinator.last_exception.translation_domain == DOMAIN
     assert coordinator.last_exception.translation_key == "cannot_connect"
+
+
+async def test_coordinator_live_rate_limited(
+    hass: HomeAssistant, mock_live_status, freezer: FrozenDateTimeFactory
+) -> None:
+    """Tests that a 429 with Retry-After backs off the energy live coordinator."""
+
+    entry = await setup_platform(hass, [Platform.SENSOR])
+    coordinator = entry.runtime_data.energysites[0].live_coordinator
+    assert coordinator is not None
+
+    mock_live_status.reset_mock()
+    mock_live_status.side_effect = RateLimited({"after": "45"})
+    freezer.tick(TESSIE_FLEET_API_SYNC_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    mock_live_status.assert_called_once()
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.last_exception.retry_after == 45
+
+    # The normal sync interval has not yet elapsed since the rate limit hit,
+    # so the coordinator should still be waiting on the Retry-After backoff.
+    mock_live_status.side_effect = None
+    freezer.tick(TESSIE_FLEET_API_SYNC_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    mock_live_status.assert_called_once()
+
+    # Once the Retry-After window elapses, the coordinator refreshes again.
+    freezer.tick(timedelta(seconds=45) - TESSIE_FLEET_API_SYNC_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert mock_live_status.call_count == 2
 
 
 async def test_coordinator_info_error(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The four Tessie coordinators (state, energy live, energy info, energy history) caught every `TeslaFleetError`, including a 429 `RateLimited` response, and raised a bare `UpdateFailed`.

That meant the coordinator kept polling on its normal interval after a rate-limit, which prolongs the rate-limit instead of clearing it.

This mirrors the Tesla Fleet integration's existing handling of the `RateLimited` exception's `Retry-After` hint, but passes it through `UpdateFailed`'s `retry_after` argument so the coordinator's own scheduler handles the backoff instead of the integration mutating `update_interval` directly.

Tessie subclasses the same `tesla_fleet_api` transport as Tesla Fleet, so a 429 surfaces the same way: a `RateLimited` exception whose `.data` dict carries an `after` value taken from the `Retry-After` header.

When that value is missing or not parseable as a number, the coordinator falls back to its normal `update_interval` rather than guessing a backoff.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
