### PR TITLE
Improve error handling in Airly integration

### DIFF
--- a/homeassistant/components/airly/config_flow.py
+++ b/homeassistant/components/airly/config_flow.py
@@ -15,7 +15,13 @@ from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_USE_NEAREST, DEFAULT_NAME, DOMAIN, NO_AIRLY_SENSORS
+from .const import (
+    CONF_USE_NEAREST,
+    DEFAULT_NAME,
+    DEFAULT_TIMEOUT,
+    DOMAIN,
+    NO_AIRLY_SENSORS,
+)
 
 DESCRIPTION_PLACEHOLDERS = {
     "developer_registration_url": "https://developer.airly.eu/register",
@@ -115,7 +121,7 @@ async def check_location(
         measurements = airly.create_measurements_session_point(
             latitude=latitude, longitude=longitude
         )
-    async with timeout(10):
+    async with timeout(DEFAULT_TIMEOUT):
         await measurements.update()
 
     current = measurements.current

--- a/homeassistant/components/airly/config_flow.py
+++ b/homeassistant/components/airly/config_flow.py
@@ -2,9 +2,10 @@
 
 from asyncio import timeout
 from http import HTTPStatus
+import logging
 from typing import Any, override
 
-from aiohttp import ClientSession
+from aiohttp import ClientConnectorError, ClientSession
 from airly import Airly
 from airly.exceptions import AirlyError
 import voluptuous as vol
@@ -19,6 +20,7 @@ from .const import CONF_USE_NEAREST, DEFAULT_NAME, DOMAIN, NO_AIRLY_SENSORS
 DESCRIPTION_PLACEHOLDERS = {
     "developer_registration_url": "https://developer.airly.eu/register",
 }
+_LOGGER = logging.getLogger(__name__)
 
 
 class AirlyFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -59,8 +61,15 @@ class AirlyFlowHandler(ConfigFlow, domain=DOMAIN):
             except AirlyError as err:
                 if err.status_code == HTTPStatus.UNAUTHORIZED:
                     errors["base"] = "invalid_api_key"
-                if err.status_code == HTTPStatus.NOT_FOUND:
+                elif err.status_code == HTTPStatus.NOT_FOUND:
                     errors["base"] = "wrong_location"
+                else:
+                    errors["base"] = "unknown"
+            except ClientConnectorError, TimeoutError:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
             else:
                 if not location_point_valid:
                     if not location_nearest_valid:

--- a/homeassistant/components/airly/const.py
+++ b/homeassistant/components/airly/const.py
@@ -37,3 +37,4 @@ NO_AIRLY_SENSORS: Final = "There are no Airly sensors in this area yet."
 URL = "https://airly.org/map/#{latitude},{longitude}"
 
 DEFAULT_NAME: Final = "Airly"
+DEFAULT_TIMEOUT = 10

--- a/homeassistant/components/airly/coordinator.py
+++ b/homeassistant/components/airly/coordinator.py
@@ -21,6 +21,7 @@ from .const import (
     ATTR_API_CAQI,
     ATTR_API_CAQI_DESCRIPTION,
     ATTR_API_CAQI_LEVEL,
+    DEFAULT_TIMEOUT,
     DOMAIN,
     MAX_UPDATE_INTERVAL,
     MIN_UPDATE_INTERVAL,
@@ -104,7 +105,7 @@ class AirlyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, str | float | i
                 self.latitude, self.longitude
             )
         try:
-            async with timeout(20):
+            async with timeout(DEFAULT_TIMEOUT):
                 await measurements.update()
         except (AirlyError, ClientConnectorError, TimeoutError) as error:
             raise UpdateFailed(

--- a/homeassistant/components/airly/coordinator.py
+++ b/homeassistant/components/airly/coordinator.py
@@ -103,18 +103,18 @@ class AirlyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, str | float | i
             measurements = self.airly.create_measurements_session_point(
                 self.latitude, self.longitude
             )
-        async with timeout(20):
-            try:
+        try:
+            async with timeout(20):
                 await measurements.update()
-            except (AirlyError, ClientConnectorError) as error:
-                raise UpdateFailed(
-                    translation_domain=DOMAIN,
-                    translation_key="update_error",
-                    translation_placeholders={
-                        "entry": self.config_entry.title,
-                        "error": repr(error),
-                    },
-                ) from error
+        except (AirlyError, ClientConnectorError, TimeoutError) as error:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="update_error",
+                translation_placeholders={
+                    "entry": self.config_entry.title,
+                    "error": repr(error),
+                },
+            ) from error
 
         _LOGGER.debug(
             "Requests remaining: %s/%s",

--- a/homeassistant/components/airly/strings.json
+++ b/homeassistant/components/airly/strings.json
@@ -5,7 +5,9 @@
       "wrong_location": "[%key:component::airly::config::error::wrong_location%]"
     },
     "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_api_key": "[%key:common::config_flow::error::invalid_api_key%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
       "wrong_location": "No Airly measuring stations in this area."
     },
     "step": {

--- a/tests/components/airly/test_config_flow.py
+++ b/tests/components/airly/test_config_flow.py
@@ -2,8 +2,9 @@
 
 from collections.abc import Generator
 from http import HTTPStatus
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from aiohttp import ClientConnectorError
 from airly.exceptions import AirlyError
 import pytest
 
@@ -15,7 +16,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from . import API_NEAREST_URL, API_POINT_URL
 
-from tests.common import MockConfigEntry, async_load_fixture, patch
+from tests.common import MockConfigEntry, async_load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 CONFIG = {
@@ -228,3 +229,90 @@ async def test_create_entry_with_nearest_method(
     assert result["data"][CONF_LONGITUDE] == CONFIG[CONF_LONGITUDE]
     assert result["data"][CONF_API_KEY] == CONFIG[CONF_API_KEY]
     assert result["data"][CONF_USE_NEAREST] is True
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (TimeoutError(), "cannot_connect"),
+        (ClientConnectorError(MagicMock(), OSError("test")), "cannot_connect"),
+    ],
+)
+async def test_cannot_connect(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test that cannot_connect error is shown when connection fails."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch("airly.measurements.MeasurementsSession.update", side_effect=exception):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=CONFIG
+        )
+
+    assert result["errors"] == {"base": error}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.get(
+        API_POINT_URL, text=await async_load_fixture(hass, "valid_station.json", DOMAIN)
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=CONFIG
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+@pytest.mark.parametrize(
+    ("exception", "error"),
+    [
+        (Exception("unexpected"), "unknown"),
+        (
+            AirlyError(HTTPStatus.INTERNAL_SERVER_ERROR, {"message": "Server error"}),
+            "unknown",
+        ),
+    ],
+)
+async def test_unknown_error(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    exception: Exception,
+    error: str,
+) -> None:
+    """Test that unknown error is shown for unexpected exceptions."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with patch("airly.measurements.MeasurementsSession.update", side_effect=exception):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=CONFIG
+        )
+
+    assert result["errors"] == {"base": error}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.get(
+        API_POINT_URL, text=await async_load_fixture(hass, "valid_station.json", DOMAIN)
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=CONFIG
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY

--- a/tests/components/airly/test_config_flow.py
+++ b/tests/components/airly/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Generator
 from http import HTTPStatus
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp import ClientConnectorError
 from airly.exceptions import AirlyError
@@ -235,7 +235,7 @@ async def test_create_entry_with_nearest_method(
     ("exception", "error"),
     [
         (TimeoutError(), "cannot_connect"),
-        (ClientConnectorError(MagicMock(), OSError("test")), "cannot_connect"),
+        (ClientConnectorError(Mock(), OSError("test")), "cannot_connect"),
     ],
 )
 async def test_cannot_connect(

--- a/tests/components/airly/test_sensor.py
+++ b/tests/components/airly/test_sensor.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 from unittest.mock import patch
 
 from airly.exceptions import AirlyError
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.airly.const import DOMAIN
@@ -43,8 +44,17 @@ async def test_sensor(
         assert state == snapshot(name=f"{entity_entry.entity_id}-state")
 
 
+@pytest.mark.parametrize(
+    "exception",
+    [
+        AirlyError(HTTPStatus.NOT_FOUND, {"message": "Not found"}),
+        TimeoutError(),
+    ],
+)
 async def test_availability(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    exception: Exception,
 ) -> None:
     """Ensure that we mark the entities unavailable correctly.
 
@@ -58,9 +68,7 @@ async def test_availability(
     assert state.state == "68.35"
 
     aioclient_mock.clear_requests()
-    aioclient_mock.get(
-        API_POINT_URL, exc=AirlyError(HTTPStatus.NOT_FOUND, {"message": "Not found"})
-    )
+    aioclient_mock.get(API_POINT_URL, exc=exception)
     future = utcnow() + timedelta(minutes=60)
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR addresses Copilot's comment https://github.com/home-assistant/core/pull/181024#discussion_r3944941422

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
