### PR TITLE
Use library min/max kelvin in Tuya lights

### DIFF
--- a/homeassistant/components/tuya/light.py
+++ b/homeassistant/components/tuya/light.py
@@ -8,6 +8,7 @@ from tuya_device_handlers.definition.light import (
     LightDefinition,
     get_default_definition,
 )
+from tuya_device_handlers.device_wrapper.light import ColorTempWrapper
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.light import (
@@ -426,8 +427,8 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
 
     _white_color_mode = ColorMode.COLOR_TEMP
     _fixed_color_mode: ColorMode | None = None
-    _attr_min_color_temp_kelvin = 2000  # 500 Mireds
-    _attr_max_color_temp_kelvin = 6500  # 153 Mireds
+    _attr_min_color_temp_kelvin = ColorTempWrapper.MIN_KELVIN
+    _attr_max_color_temp_kelvin = ColorTempWrapper.MAX_KELVIN
 
     def __init__(
         self,
@@ -453,8 +454,12 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
             color_modes.add(ColorMode.HS)
 
         # Check if the light has color temperature
-        if definition.color_temp_wrapper:
+        if color_temp_wrapper := definition.color_temp_wrapper:
             color_modes.add(ColorMode.COLOR_TEMP)
+            # LightDefinition types the wrapper as a plain DeviceWrapper[int]
+            if isinstance(color_temp_wrapper, ColorTempWrapper):
+                self._attr_min_color_temp_kelvin = color_temp_wrapper.min_kelvin
+                self._attr_max_color_temp_kelvin = color_temp_wrapper.max_kelvin
         # If light has color but does not have color_temp, check if it has
         # work_mode "white"
         elif (

--- a/tests/components/tuya/test_light.py
+++ b/tests/components/tuya/test_light.py
@@ -5,12 +5,15 @@ from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tuya_device_handlers.device_wrapper.light import ColorTempWrapper
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP_KELVIN,
     ATTR_HS_COLOR,
+    ATTR_MAX_COLOR_TEMP_KELVIN,
+    ATTR_MIN_COLOR_TEMP_KELVIN,
     ATTR_WHITE,
     DOMAIN as LIGHT_DOMAIN,
     SERVICE_TURN_OFF,
@@ -167,3 +170,23 @@ async def test_action(
         mock_device.id,
         expected_commands,
     )
+
+
+@pytest.mark.parametrize("mock_device_code", ["dj_ilddqqih3tucdk68"])
+async def test_color_temp_range_override(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+) -> None:
+    """Test the entity reports the Kelvin range exposed by the wrapper."""
+    with (
+        patch.object(ColorTempWrapper, "min_kelvin", 1600),
+        patch.object(ColorTempWrapper, "max_kelvin", 4000),
+    ):
+        await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get("light.ieskas")
+    assert state is not None
+    assert state.attributes[ATTR_MIN_COLOR_TEMP_KELVIN] == 1600
+    assert state.attributes[ATTR_MAX_COLOR_TEMP_KELVIN] == 4000


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant-libs/tuya-device-handlers/releases/tag/v0.0.28 added the ability to set the color temperature range via a quirk (see https://github.com/home-assistant-libs/tuya-device-handlers/pull/519)

This maps the quirk values to the Home Assistant entity.

The default values are unchanged - but now come from the library.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
