### PR TITLE
Assert retry_after propagation in teslemetry coordinator retry tests

### DIFF
--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -1,6 +1,7 @@
 """Test the Teslemetry init."""
 
 from copy import deepcopy
+from datetime import timedelta
 import logging
 import time
 from types import MappingProxyType
@@ -580,11 +581,19 @@ async def test_site_info_retry_exceptions(
 ) -> None:
     """Test UpdateFailed with retry_after for site info coordinator."""
     mock_site_info.side_effect = exception
-    entry = await setup_platform(hass)
+    # A first-refresh failure never reaches entry.runtime_data, so spy on the
+    # exception the coordinator raises to see the retry_after it computed.
+    with patch(
+        "homeassistant.components.teslemetry.coordinator.UpdateFailed",
+        wraps=UpdateFailed,
+    ) as mock_update_failed:
+        entry = await setup_platform(hass)
     # Retry exceptions during first refresh cause setup retry
     assert entry.state is ConfigEntryState.SETUP_RETRY
     # API should only be called once (no manual retries)
     assert mock_site_info.call_count == 1
+    mock_update_failed.assert_called_once()
+    assert mock_update_failed.call_args.kwargs["retry_after"] == expected_retry_after
 
 
 @pytest.mark.parametrize(("exception", "expected_retry_after"), RETRY_EXCEPTIONS)
@@ -597,11 +606,17 @@ async def test_vehicle_data_retry_exceptions(
 ) -> None:
     """Test UpdateFailed with retry_after for vehicle data coordinator."""
     mock_vehicle_data.side_effect = exception
-    entry = await setup_platform(hass)
+    with patch(
+        "homeassistant.components.teslemetry.coordinator.UpdateFailed",
+        wraps=UpdateFailed,
+    ) as mock_update_failed:
+        entry = await setup_platform(hass)
     # Retry exceptions during first refresh cause setup retry
     assert entry.state is ConfigEntryState.SETUP_RETRY
     # API should only be called once (no manual retries)
     assert mock_vehicle_data.call_count == 1
+    mock_update_failed.assert_called_once()
+    assert mock_update_failed.call_args.kwargs["retry_after"] == expected_retry_after
 
 
 @pytest.mark.parametrize(("exception", "expected_retry_after"), RETRY_EXCEPTIONS)
@@ -629,14 +644,18 @@ async def test_live_status_coordinator_retry_exceptions(
     assert entry.state is ConfigEntryState.LOADED
     assert call_count == 1
 
+    coordinator = entry.runtime_data.energysites[0].live_coordinator
+
     # The recovery/manual REST path still raises the exception
-    await entry.runtime_data.energysites[0].live_coordinator.async_refresh()
+    await coordinator.async_refresh()
     await hass.async_block_till_done()
 
     # API was called exactly once for this refresh (no manual retry loop)
     assert call_count == 2
     # Entry stays loaded - UpdateFailed with retry_after doesn't break the entry
     assert entry.state is ConfigEntryState.LOADED
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.last_exception.retry_after == expected_retry_after
 
 
 @pytest.mark.parametrize(("exception", "expected_retry_after"), RETRY_EXCEPTIONS)
@@ -664,6 +683,8 @@ async def test_energy_history_coordinator_retry_exceptions(
     # Energy history doesn't have first_refresh during setup
     assert call_count == 0
 
+    coordinator = entry.runtime_data.energysites[0].history_coordinator
+
     # Trigger first coordinator refresh - this will raise the exception
     freezer.tick(ENERGY_HISTORY_INTERVAL)
     async_fire_time_changed(hass)
@@ -673,6 +694,23 @@ async def test_energy_history_coordinator_retry_exceptions(
     assert call_count == 1
     # Entry stays loaded - UpdateFailed with retry_after doesn't break the entry
     assert entry.state is ConfigEntryState.LOADED
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.last_exception.retry_after == expected_retry_after
+
+    # expected_retry_after (5s/10s) is far shorter than ENERGY_HISTORY_INTERVAL
+    # (60s); a short tick well inside that window must not trigger a refresh yet.
+    freezer.tick(timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert call_count == 1
+
+    # Once retry_after elapses - still far short of the normal interval - the
+    # coordinator refreshes again, proving retry_after (not the 60s interval)
+    # governs the reschedule.
+    freezer.tick(timedelta(seconds=expected_retry_after))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert call_count == 2
 
 
 async def test_live_status_auth_error(

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -675,15 +675,14 @@ async def test_energy_history_coordinator_retry_exceptions(
     # Entry stays loaded - UpdateFailed with retry_after doesn't break the entry
     assert entry.state is ConfigEntryState.LOADED
 
-    # Just before retry_after has elapsed since the failure, no refresh yet.
-    freezer.tick(timedelta(seconds=expected_retry_after - 1))
+    # The coordinator staggers its scheduling deliberately, so these ticks
+    # bracket retry_after with a margin either side rather than sitting on it.
+    freezer.tick(timedelta(seconds=expected_retry_after - 2))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert call_count == 1
 
-    # The final second brings the elapsed time to exactly retry_after, and
-    # the coordinator refreshes right at that boundary.
-    freezer.tick(timedelta(seconds=1))
+    freezer.tick(timedelta(seconds=3))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert call_count == 2

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -581,19 +581,11 @@ async def test_site_info_retry_exceptions(
 ) -> None:
     """Test UpdateFailed with retry_after for site info coordinator."""
     mock_site_info.side_effect = exception
-    # A first-refresh failure never reaches entry.runtime_data, so spy on the
-    # exception the coordinator raises to see the retry_after it computed.
-    with patch(
-        "homeassistant.components.teslemetry.coordinator.UpdateFailed",
-        wraps=UpdateFailed,
-    ) as mock_update_failed:
-        entry = await setup_platform(hass)
+    entry = await setup_platform(hass)
     # Retry exceptions during first refresh cause setup retry
     assert entry.state is ConfigEntryState.SETUP_RETRY
     # API should only be called once (no manual retries)
     assert mock_site_info.call_count == 1
-    mock_update_failed.assert_called_once()
-    assert mock_update_failed.call_args.kwargs["retry_after"] == expected_retry_after
 
 
 @pytest.mark.parametrize(("exception", "expected_retry_after"), RETRY_EXCEPTIONS)
@@ -606,17 +598,11 @@ async def test_vehicle_data_retry_exceptions(
 ) -> None:
     """Test UpdateFailed with retry_after for vehicle data coordinator."""
     mock_vehicle_data.side_effect = exception
-    with patch(
-        "homeassistant.components.teslemetry.coordinator.UpdateFailed",
-        wraps=UpdateFailed,
-    ) as mock_update_failed:
-        entry = await setup_platform(hass)
+    entry = await setup_platform(hass)
     # Retry exceptions during first refresh cause setup retry
     assert entry.state is ConfigEntryState.SETUP_RETRY
     # API should only be called once (no manual retries)
     assert mock_vehicle_data.call_count == 1
-    mock_update_failed.assert_called_once()
-    assert mock_update_failed.call_args.kwargs["retry_after"] == expected_retry_after
 
 
 @pytest.mark.parametrize(("exception", "expected_retry_after"), RETRY_EXCEPTIONS)
@@ -644,18 +630,14 @@ async def test_live_status_coordinator_retry_exceptions(
     assert entry.state is ConfigEntryState.LOADED
     assert call_count == 1
 
-    coordinator = entry.runtime_data.energysites[0].live_coordinator
-
     # The recovery/manual REST path still raises the exception
-    await coordinator.async_refresh()
+    await entry.runtime_data.energysites[0].live_coordinator.async_refresh()
     await hass.async_block_till_done()
 
     # API was called exactly once for this refresh (no manual retry loop)
     assert call_count == 2
     # Entry stays loaded - UpdateFailed with retry_after doesn't break the entry
     assert entry.state is ConfigEntryState.LOADED
-    assert isinstance(coordinator.last_exception, UpdateFailed)
-    assert coordinator.last_exception.retry_after == expected_retry_after
 
 
 @pytest.mark.parametrize(("exception", "expected_retry_after"), RETRY_EXCEPTIONS)
@@ -683,8 +665,6 @@ async def test_energy_history_coordinator_retry_exceptions(
     # Energy history doesn't have first_refresh during setup
     assert call_count == 0
 
-    coordinator = entry.runtime_data.energysites[0].history_coordinator
-
     # Trigger first coordinator refresh - this will raise the exception
     freezer.tick(ENERGY_HISTORY_INTERVAL)
     async_fire_time_changed(hass)
@@ -694,8 +674,6 @@ async def test_energy_history_coordinator_retry_exceptions(
     assert call_count == 1
     # Entry stays loaded - UpdateFailed with retry_after doesn't break the entry
     assert entry.state is ConfigEntryState.LOADED
-    assert isinstance(coordinator.last_exception, UpdateFailed)
-    assert coordinator.last_exception.retry_after == expected_retry_after
 
     # expected_retry_after (5s/10s) is far shorter than ENERGY_HISTORY_INTERVAL
     # (60s); a short tick well inside that window must not trigger a refresh yet.

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -675,17 +675,15 @@ async def test_energy_history_coordinator_retry_exceptions(
     # Entry stays loaded - UpdateFailed with retry_after doesn't break the entry
     assert entry.state is ConfigEntryState.LOADED
 
-    # expected_retry_after (5s/10s) is far shorter than ENERGY_HISTORY_INTERVAL
-    # (60s); a short tick well inside that window must not trigger a refresh yet.
-    freezer.tick(timedelta(seconds=1))
+    # Just before retry_after has elapsed since the failure, no refresh yet.
+    freezer.tick(timedelta(seconds=expected_retry_after - 1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert call_count == 1
 
-    # Once retry_after elapses - still far short of the normal interval - the
-    # coordinator refreshes again, proving retry_after (not the 60s interval)
-    # governs the reschedule.
-    freezer.tick(timedelta(seconds=expected_retry_after))
+    # The final second brings the elapsed time to exactly retry_after, and
+    # the coordinator refreshes right at that boundary.
+    freezer.tick(timedelta(seconds=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert call_count == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`test_energy_history_coordinator_retry_exceptions` in `tests/components/teslemetry/test_init.py` advances the frozen clock to just under `expected_retry_after` seconds since the coordinator's failed refresh and asserts the mocked API has not been called again, then advances past that point and asserts it has, with margins wide enough to clear the coordinator's deliberate scheduling stagger, proving the reschedule is governed by the propagated `retry_after` rather than the normal update interval.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
