### PR TITLE
Adjust lcn to not access DeviceEntry.config_entries

### DIFF
--- a/homeassistant/components/lcn/services.py
+++ b/homeassistant/components/lcn/services.py
@@ -21,7 +21,8 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.service import async_get_device_and_config_entry
 
 from .const import (
     CONF_KEYS,
@@ -69,28 +70,11 @@ class LcnServiceCall:
 
     def get_device_connection(self, service: ServiceCall) -> DeviceConnection:
         """Get address connection object."""
-        entries: list[LcnConfigEntry] = self.hass.config_entries.async_loaded_entries(
-            DOMAIN
+        entry: LcnConfigEntry
+        device, entry = async_get_device_and_config_entry(
+            self.hass, DOMAIN, service.data[CONF_DEVICE_ID]
         )
-        device_id = service.data[CONF_DEVICE_ID]
-        device_registry = dr.async_get(self.hass)
-        if not (device := device_registry.async_get(device_id)) or not (
-            entry := next(
-                (
-                    entry
-                    for entry in entries
-                    if entry.entry_id == device.primary_config_entry
-                ),
-                None,
-            )
-        ):
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="invalid_device_id",
-                translation_placeholders={"device_id": device_id},
-            )
-
-        return entry.runtime_data.device_connections[device_id]
+        return entry.runtime_data.device_connections[device.id]
 
     async def async_call_service(self, service: ServiceCall) -> ServiceResponse:
         """Execute service call."""

--- a/homeassistant/components/lcn/strings.json
+++ b/homeassistant/components/lcn/strings.json
@@ -76,9 +76,6 @@
     "cannot_connect": {
       "message": "Unable to connect to {config_entry_title}."
     },
-    "invalid_device_id": {
-      "message": "LCN device for given device ID {device_id} has not been configured."
-    },
     "invalid_domain": {
       "message": "Invalid domain {domain}."
     },

--- a/tests/components/lcn/test_services.py
+++ b/tests/components/lcn/test_services.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     CONF_STATE,
     CONF_UNIT_OF_MEASUREMENT,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.setup import async_setup_component
 
@@ -505,3 +505,49 @@ async def test_service_pck(
         )
 
     pck.assert_awaited_with("PIN4")
+
+
+async def test_service_unknown_device_id(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+) -> None:
+    """Test service call with an unknown device id raises."""
+    await async_setup_component(hass, "persistent_notification", {})
+    await init_integration(hass, entry)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            LcnService.PCK,
+            {
+                CONF_DEVICE_ID: "unknown_device_id",
+                CONF_PCK: "PIN4",
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert exc_info.value.translation_key == "service_device_not_found"
+
+
+async def test_service_unloaded_config_entry(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+) -> None:
+    """Test service call to a device of an unloaded config entry raises."""
+    await async_setup_component(hass, "persistent_notification", {})
+    await init_integration(hass, entry)
+    device_id = get_device(hass, entry, (0, 7, False)).id
+    assert await hass.config_entries.async_unload(entry.entry_id)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            LcnService.PCK,
+            {
+                CONF_DEVICE_ID: device_id,
+                CONF_PCK: "PIN4",
+            },
+            blocking=True,
+        )
+    assert exc_info.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert exc_info.value.translation_key == "service_config_entry_not_loaded"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust lcn to not access `DeviceEntry.config_entries`, instead use service helper `async_get_device_and_config_entry` to find the device and config entry

### Rationale:
`DeviceEntry.config_entries` is a remnant from the multi config entry device design. lcn devices are identified by ("lcn", <config_entry_id>), which means it's not realistic for an lcn device to be multi config entry

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
