### PR TITLE
Adjust lg_netcast to not access DeviceEntry.config_entries

### DIFF
--- a/homeassistant/components/lg_netcast/device_trigger.py
+++ b/homeassistant/components/lg_netcast/device_trigger.py
@@ -8,15 +8,16 @@ from homeassistant.components.device_automation import (
     DEVICE_TRIGGER_BASE_SCHEMA,
     InvalidDeviceAutomationConfig,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_DEVICE_ID, CONF_PLATFORM, CONF_TYPE
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
 from . import trigger
 from .const import DOMAIN
-from .helpers import async_get_device_entry_by_device_id
 from .triggers.turn_on import (
     PLATFORM_TYPE as TURN_ON_PLATFORM_TYPE,
     async_get_turn_on_trigger,
@@ -40,15 +41,14 @@ async def async_validate_trigger_config(
     if config[CONF_TYPE] == TURN_ON_PLATFORM_TYPE:
         device_id = config[CONF_DEVICE_ID]
 
-        try:
-            device = async_get_device_entry_by_device_id(hass, device_id)
-        except ValueError as err:
-            raise InvalidDeviceAutomationConfig(err) from err
-
-        if not any(
-            entry.entry_id in device.config_entries
-            for entry in hass.config_entries.async_loaded_entries(DOMAIN)
-        ):
+        device, config_entry = dr.async_get_device_and_config_entry_for_domain(
+            hass, device_id, domain=DOMAIN
+        )
+        if device is None:
+            raise InvalidDeviceAutomationConfig(
+                f"Device {device_id} is not a valid {DOMAIN} device."
+            )
+        if config_entry is None or config_entry.state is not ConfigEntryState.LOADED:
             raise InvalidDeviceAutomationConfig(
                 f"Device {device.id} is not from an existing {DOMAIN} config entry"
             )

--- a/tests/components/lg_netcast/test_device_trigger.py
+++ b/tests/components/lg_netcast/test_device_trigger.py
@@ -161,4 +161,25 @@ async def test_failure_scenarios(
     with pytest.raises(InvalidDeviceAutomationConfig):
         await device_trigger.async_validate_trigger_config(hass, config)
 
+    not_loaded_entry = MockConfigEntry(
+        domain=DOMAIN, data={}, unique_id="not-loaded-unique-id"
+    )
+    not_loaded_entry.add_to_hass(hass)
+
+    not_loaded_device = device_registry.async_get_or_create(
+        config_entry_id=not_loaded_entry.entry_id,
+        identifiers={(DOMAIN, "not-loaded-unique-id")},
+    )
+
+    not_loaded_config = {
+        "platform": "device",
+        "domain": DOMAIN,
+        "device_id": not_loaded_device.id,
+        "type": "lg_netcast.turn_on",
+    }
+
+    # Test that a device from a not-loaded lg_netcast config entry raises exception
+    with pytest.raises(InvalidDeviceAutomationConfig, match="is not from an existing"):
+        await device_trigger.async_validate_trigger_config(hass, not_loaded_config)
+
     # Test that only valid triggers are attached


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust lg_netcast to not access `DeviceEntry.config_entries`, instead use helper `async_get_device_and_config_entry_for_domain` to find the device and config entry

### Rationale:
`DeviceEntry.config_entries` is a remnant from the multi config entry device design. lg_netcast devices are identified by ("lg_netcast", <TV UUID>) with a uniqueness check of the UUID in the config flow, which means it's not realistic for an lg_netcast device to be multi config entry


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
