### PR TITLE
Adjust renault to not access DeviceEntry.config_entries

### DIFF
--- a/homeassistant/components/renault/services.py
+++ b/homeassistant/components/renault/services.py
@@ -9,7 +9,8 @@ import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.service import async_get_device_and_config_entry
 
 from .const import DOMAIN
 from .renault_vehicle import RenaultVehicleProxy
@@ -177,25 +178,14 @@ async def ac_set_schedules(service_call: ServiceCall) -> None:
 
 def get_vehicle_proxy(service_call: ServiceCall) -> RenaultVehicleProxy:
     """Get vehicle from service_call data."""
-    device_registry = dr.async_get(service_call.hass)
-    device_id = service_call.data[RenaultServiceArgument.VEHICLE]
-    device_entry = device_registry.async_get(device_id)
-    if device_entry is None:
-        raise ServiceValidationError(
-            translation_domain=DOMAIN,
-            translation_key="invalid_device_id",
-            translation_placeholders={"device_id": device_id},
-        )
-
-    loaded_entries: list[RenaultConfigEntry] = [
-        entry
-        for entry in service_call.hass.config_entries.async_loaded_entries(DOMAIN)
-        if entry.entry_id in device_entry.config_entries
-    ]
-    for entry in loaded_entries:
-        for vin, vehicle in entry.runtime_data.vehicles.items():
-            if (DOMAIN, vin) in device_entry.identifiers:
-                return vehicle
+    device_id: str = service_call.data[RenaultServiceArgument.VEHICLE]
+    entry: RenaultConfigEntry
+    device_entry, entry = async_get_device_and_config_entry(
+        service_call.hass, DOMAIN, device_id
+    )
+    for vin, vehicle in entry.runtime_data.vehicles.items():
+        if (DOMAIN, vin) in device_entry.identifiers:
+            return vehicle
     raise ServiceValidationError(
         translation_domain=DOMAIN,
         translation_key="no_config_entry_for_device",

--- a/homeassistant/components/renault/strings.json
+++ b/homeassistant/components/renault/strings.json
@@ -213,9 +213,6 @@
     "battery_soc_unavailable": {
       "message": "Battery state of charge data is currently unavailable"
     },
-    "invalid_device_id": {
-      "message": "No device with ID {device_id} was found"
-    },
     "no_config_entry_for_device": {
       "message": "No loaded config entry was found for device with ID {device_id}"
     },

--- a/tests/components/renault/test_services.py
+++ b/tests/components/renault/test_services.py
@@ -14,7 +14,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.renault.const import DOMAIN
 from homeassistant.components.renault.services import RenaultServiceArgument
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 
@@ -412,7 +412,8 @@ async def test_service_invalid_device_id(
         await hass.services.async_call(
             DOMAIN, RenaultService.AC_CANCEL, service_data=data, blocking=True
         )
-    assert err.value.translation_key == "invalid_device_id"
+    assert err.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert err.value.translation_key == "service_device_not_found"
     assert err.value.translation_placeholders == {"device_id": "some_random_id"}
 
 
@@ -442,6 +443,24 @@ async def test_service_invalid_device_id2(
         )
     assert err.value.translation_key == "no_config_entry_for_device"
     assert err.value.translation_placeholders == {"device_id": "REG-NUMBER"}
+
+
+async def test_service_unloaded_config_entry(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
+    """Test that service fails if the config entry is not loaded."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    data = {RenaultServiceArgument.VEHICLE: get_device_id(hass)}
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN, RenaultService.AC_CANCEL, service_data=data, blocking=True
+        )
+    assert err.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert err.value.translation_key == "service_config_entry_not_loaded"
 
 
 async def test_service_exception(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust renault to not access `DeviceEntry.config_entries`, instead use service helper `async_get_device_and_config_entry` to find the device and config entry

### Rationale:
`DeviceEntry.config_entries` is a remnant from the multi config entry device design.
Renault devices are identified by ("renault", <VIN>), without a uniqueness check of the vehicle in the config flow. The config flow instead tests uniqueness of the Renault account. This means a device could potentially be tied to multiple renault config entries if it's possible for multiple Renault account to be associated with the same vehicle. However, this was not correctly handled by the old code, so I assume it's not a problem.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
