### PR TITLE
Fix iCloud device tracker stale location by requesting an active locate on each poll

### DIFF
--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -175,6 +175,11 @@ class IcloudAccount:
         api_devices = {}
         try:
             api_devices = self.api.devices
+            # Since pyicloud 2.3.0 device reads are cache-only and the library
+            # requests an active locate from Apple only at service creation, so
+            # explicitly refresh with locate=True to get a fresh GPS fix on
+            # every poll instead of Apple's cached location.
+            api_devices.refresh(locate=True)
         except Exception as err:  # noqa: BLE001
             _LOGGER.error("Unknown iCloud error: %s", err)
             self._fetch_interval = 2

--- a/tests/components/icloud/test_account.py
+++ b/tests/components/icloud/test_account.py
@@ -99,6 +99,11 @@ class MockDevicesContainer:
         """Initialize with userinfo and list of device objects."""
         self.user_info = userinfo
         self._devices = devices
+        self.refresh_calls: list[bool] = []
+
+    def refresh(self, locate: bool = False) -> None:
+        """Record refresh calls made by the account."""
+        self.refresh_calls.append(locate)
 
     def __iter__(self):
         """Iterate returns device objects (each must have .status(...))."""
@@ -165,3 +170,7 @@ async def test_setup_success_with_devices(
     assert account.owner_fullname == "user name"
     assert "johntravolta" in account.family_members_fullname
     assert account.family_members_fullname["johntravolta"] == "John TRAVOLTA"
+    # An active locate must be requested on every poll (pyicloud >= 2.3.0
+    # only locates at service creation, so the account has to ask for it)
+    assert mock_icloud_service.devices.refresh_calls == [True]
+    assert "device1" in account.devices


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since the bump to pyicloud 2.3.0 (#161164, shipped in 2026.2), the iCloud `device_tracker` entities never receive a fresh GPS location after startup: coordinates stay frozen for hours/days while the battery sensors keep updating on every poll.

Cause: before pyicloud 2.3.0, `AppleDevice.status()` implicitly called `refresh_client()`, which always sent `"shouldLocate": true` — so every `IcloudAccount.update_devices()` poll actively located the devices. pyicloud PR timlaing/pyicloud#175 (released in 2.3.0) made device reads cache-only and moved refreshing to a background thread that refreshes with `locate=False`; the only active locate now happens once, when the service manager is constructed. Apple then keeps serving its cached location payload — battery stays fresh (devices push status to Apple on their own), GPS never updates. The failure is completely silent (no errors, nothing in logs). Reported upstream as timlaing/pyicloud#360.

This PR restores the pre-2.3.0 behavior by explicitly calling the public `refresh(locate=True)` on the Find My service manager in `update_devices()` before reading device status. Locate frequency thereby follows the integration's existing dynamic fetch interval (`_determine_interval`), exactly as it did with pyicloud ≤ 2.2.x.

Verified on a production install (2026.8.3 and 2026.9.1, account with `with_family: true`, 9 devices): before the change, a phone's tracker kept bit-for-bit identical lat/lon/`gps_accuracy` for ~10 hours across two real-world trips; with the change, the very next poll returned a fresh fix (device correctly moved into its actual zone) and every subsequent poll produces fresh accuracy readings.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181730
- This PR is related to issue: timlaing/pyicloud#360
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
