### PR TITLE
Add SSDP discovery of the Thermomix to Cookidoo

### DIFF
--- a/homeassistant/components/cookidoo/config_flow.py
+++ b/homeassistant/components/cookidoo/config_flow.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.selector import (
 )
 from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
-from .const import DOMAIN
+from .const import CONF_UDN, DOMAIN
 from .helpers import cookidoo_from_config_data
 
 _LOGGER = logging.getLogger(__name__)
@@ -63,6 +63,7 @@ class CookidooConfigFlow(ConfigFlow, domain=DOMAIN):
 
     user_input: dict[str, Any]
     user_uuid: str
+    _discovered_udn: str | None = None
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any]
@@ -73,17 +74,20 @@ class CookidooConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:
-        """Handle a flow initialized by SSDP discovery of a Thermomix.
-
-        The Thermomix only exposes a minimal UPnP description without any
-        account information, so a discovery cannot set up the cloud connection
-        on its own. The device UDN is used to deduplicate discoveries, and the
-        flow then hands over to the regular user step to collect the Cookidoo
-        credentials.
-        """
-        await self.async_set_unique_id(discovery_info.ssdp_udn)
+        """Handle a flow initialized by SSDP discovery of a Thermomix."""
+        udn = discovery_info.ssdp_udn
+        await self.async_set_unique_id(udn)
+        # Abort concurrent discoveries and rediscovery of a device that is still
+        # keyed by its UDN.
         self._abort_if_unique_id_configured()
+        # A completed setup is keyed by the account UUID, not the UDN, so also
+        # abort when a configured entry already tracks this Thermomix.
+        if any(
+            entry.data.get(CONF_UDN) == udn for entry in self._async_current_entries()
+        ):
+            return self.async_abort(reason="already_configured")
 
+        self._discovered_udn = udn
         self.context["title_placeholders"] = {"name": "Thermomix"}
 
         return await self.async_step_user()
@@ -138,9 +142,10 @@ class CookidooConfigFlow(ConfigFlow, domain=DOMAIN):
             errors := await self.validate_input(self.user_input, language_input)
         ):
             if self.source in (SOURCE_USER, SOURCE_SSDP):
-                return self.async_create_entry(
-                    title="Cookidoo", data={**self.user_input, **language_input}
-                )
+                data = {**self.user_input, **language_input}
+                if self._discovered_udn is not None:
+                    data[CONF_UDN] = self._discovered_udn
+                return self.async_create_entry(title="Cookidoo", data=data)
             reconfigure_entry = self._get_reconfigure_entry()
             return self.async_update_reload_and_abort(
                 reconfigure_entry,

--- a/homeassistant/components/cookidoo/config_flow.py
+++ b/homeassistant/components/cookidoo/config_flow.py
@@ -71,6 +71,7 @@ class CookidooConfigFlow(ConfigFlow, domain=DOMAIN):
         """Perform reconfigure upon an user action."""
         return await self.async_step_user(user_input)
 
+    @override
     async def async_step_ssdp(
         self, discovery_info: SsdpServiceInfo
     ) -> ConfigFlowResult:
@@ -105,7 +106,16 @@ class CookidooConfigFlow(ConfigFlow, domain=DOMAIN):
         ):
             await self.async_set_unique_id(self.user_uuid)
             if self.source in (SOURCE_USER, SOURCE_SSDP):
-                self._abort_if_unique_id_configured()
+                # When a discovered Thermomix turns out to belong to an already
+                # configured account, record its UDN on that entry so future
+                # SSDP announcements are deduplicated instead of re-prompting.
+                self._abort_if_unique_id_configured(
+                    updates=(
+                        {CONF_UDN: self._discovered_udn}
+                        if self._discovered_udn is not None
+                        else None
+                    )
+                )
             if self.source == SOURCE_RECONFIGURE:
                 self._abort_if_unique_id_mismatch()
             self.user_input = user_input

--- a/homeassistant/components/cookidoo/config_flow.py
+++ b/homeassistant/components/cookidoo/config_flow.py
@@ -14,6 +14,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import (
     SOURCE_RECONFIGURE,
+    SOURCE_SSDP,
     SOURCE_USER,
     ConfigFlow,
     ConfigFlowResult,
@@ -28,6 +29,7 @@ from homeassistant.helpers.selector import (
     TextSelectorConfig,
     TextSelectorType,
 )
+from homeassistant.helpers.service_info.ssdp import SsdpServiceInfo
 
 from .const import DOMAIN
 from .helpers import cookidoo_from_config_data
@@ -68,6 +70,24 @@ class CookidooConfigFlow(ConfigFlow, domain=DOMAIN):
         """Perform reconfigure upon an user action."""
         return await self.async_step_user(user_input)
 
+    async def async_step_ssdp(
+        self, discovery_info: SsdpServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle a flow initialized by SSDP discovery of a Thermomix.
+
+        The Thermomix only exposes a minimal UPnP description without any
+        account information, so a discovery cannot set up the cloud connection
+        on its own. The device UDN is used to deduplicate discoveries, and the
+        flow then hands over to the regular user step to collect the Cookidoo
+        credentials.
+        """
+        await self.async_set_unique_id(discovery_info.ssdp_udn)
+        self._abort_if_unique_id_configured()
+
+        self.context["title_placeholders"] = {"name": "Thermomix"}
+
+        return await self.async_step_user()
+
     @override
     async def async_step_user(
         self,
@@ -80,7 +100,7 @@ class CookidooConfigFlow(ConfigFlow, domain=DOMAIN):
             errors := await self.validate_input(user_input)
         ):
             await self.async_set_unique_id(self.user_uuid)
-            if self.source == SOURCE_USER:
+            if self.source in (SOURCE_USER, SOURCE_SSDP):
                 self._abort_if_unique_id_configured()
             if self.source == SOURCE_RECONFIGURE:
                 self._abort_if_unique_id_mismatch()
@@ -117,7 +137,7 @@ class CookidooConfigFlow(ConfigFlow, domain=DOMAIN):
         if language_input is not None and not (
             errors := await self.validate_input(self.user_input, language_input)
         ):
-            if self.source == SOURCE_USER:
+            if self.source in (SOURCE_USER, SOURCE_SSDP):
                 return self.async_create_entry(
                     title="Cookidoo", data={**self.user_input, **language_input}
                 )

--- a/homeassistant/components/cookidoo/config_flow.py
+++ b/homeassistant/components/cookidoo/config_flow.py
@@ -84,7 +84,8 @@ class CookidooConfigFlow(ConfigFlow, domain=DOMAIN):
         # A completed setup is keyed by the account UUID, not the UDN, so also
         # abort when a configured entry already tracks this Thermomix.
         if any(
-            entry.data.get(CONF_UDN) == udn for entry in self._async_current_entries()
+            udn in entry.data.get(CONF_UDN, [])
+            for entry in self._async_current_entries()
         ):
             return self.async_abort(reason="already_configured")
 
@@ -107,15 +108,28 @@ class CookidooConfigFlow(ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(self.user_uuid)
             if self.source in (SOURCE_USER, SOURCE_SSDP):
                 # When a discovered Thermomix turns out to belong to an already
-                # configured account, record its UDN on that entry so future
-                # SSDP announcements are deduplicated instead of re-prompting.
-                self._abort_if_unique_id_configured(
-                    updates=(
-                        {CONF_UDN: self._discovered_udn}
-                        if self._discovered_udn is not None
-                        else None
+                # configured account, append its UDN to that entry's collection
+                # (an account can pair multiple Thermomixes) so future SSDP
+                # announcements are deduplicated instead of re-prompting.
+                updates: dict[str, Any] | None = None
+                if self._discovered_udn is not None:
+                    existing_entry = next(
+                        (
+                            entry
+                            for entry in self._async_current_entries()
+                            if entry.unique_id == self.user_uuid
+                        ),
+                        None,
                     )
-                )
+                    known_udns = (
+                        list(existing_entry.data.get(CONF_UDN, []))
+                        if existing_entry
+                        else []
+                    )
+                    if self._discovered_udn not in known_udns:
+                        known_udns.append(self._discovered_udn)
+                    updates = {CONF_UDN: known_udns}
+                self._abort_if_unique_id_configured(updates=updates)
             if self.source == SOURCE_RECONFIGURE:
                 self._abort_if_unique_id_mismatch()
             self.user_input = user_input
@@ -154,7 +168,7 @@ class CookidooConfigFlow(ConfigFlow, domain=DOMAIN):
             if self.source in (SOURCE_USER, SOURCE_SSDP):
                 data = {**self.user_input, **language_input}
                 if self._discovered_udn is not None:
-                    data[CONF_UDN] = self._discovered_udn
+                    data[CONF_UDN] = [self._discovered_udn]
                 return self.async_create_entry(title="Cookidoo", data=data)
             reconfigure_entry = self._get_reconfigure_entry()
             return self.async_update_reload_and_abort(

--- a/homeassistant/components/cookidoo/const.py
+++ b/homeassistant/components/cookidoo/const.py
@@ -2,6 +2,8 @@
 
 DOMAIN = "cookidoo"
 
+CONF_UDN = "udn"
+
 SUBSCRIPTION_MAP = {
     "NONE": "free",
     "TRIAL": "trial",

--- a/homeassistant/components/cookidoo/diagnostics.py
+++ b/homeassistant/components/cookidoo/diagnostics.py
@@ -7,10 +7,12 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
+from .const import CONF_UDN
 from .coordinator import CookidooConfigEntry
 
 TO_REDACT = [
     CONF_PASSWORD,
+    CONF_UDN,
 ]
 
 

--- a/homeassistant/components/cookidoo/manifest.json
+++ b/homeassistant/components/cookidoo/manifest.json
@@ -8,5 +8,10 @@
   "iot_class": "cloud_polling",
   "loggers": ["cookidoo_api"],
   "quality_scale": "silver",
-  "requirements": ["cookidoo-api==0.17.2"]
+  "requirements": ["cookidoo-api==0.17.2"],
+  "ssdp": [
+    {
+      "deviceType": "urn:device:vorwerk:nwotdevice:1"
+    }
+  ]
 }

--- a/homeassistant/components/cookidoo/quality_scale.yaml
+++ b/homeassistant/components/cookidoo/quality_scale.yaml
@@ -64,8 +64,8 @@ rules:
     status: exempt
     comment: No disabled entities implemented
   discovery:
-    status: exempt
-    comment: Nothing to discover
+    status: done
+    comment: The Thermomix is discovered via SSDP/UPnP
   stale-devices:
     status: exempt
     comment: No stale entities possible
@@ -78,7 +78,9 @@ rules:
     comment: No dynamic entities available
   discovery-update-info:
     status: exempt
-    comment: No discoverable entities implemented
+    comment: >-
+      Cookidoo is a cloud account integration; the config entry stores no
+      device connection info that a rediscovery could update.
   repair-issues:
     status: exempt
     comment: No issues/repairs

--- a/homeassistant/components/cookidoo/strings.json
+++ b/homeassistant/components/cookidoo/strings.json
@@ -9,6 +9,7 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
+    "flow_title": "{name}",
     "step": {
       "language": {
         "data": {

--- a/homeassistant/generated/ssdp.py
+++ b/homeassistant/generated/ssdp.py
@@ -26,6 +26,11 @@ SSDP = {
             "st": "c4:director",
         },
     ],
+    "cookidoo": [
+        {
+            "deviceType": "urn:device:vorwerk:nwotdevice:1",
+        },
+    ],
     "deconz": [
         {
             "manufacturer": "Royal Philips Electronics",

--- a/tests/components/cookidoo/test_config_flow.py
+++ b/tests/components/cookidoo/test_config_flow.py
@@ -201,9 +201,6 @@ async def test_flow_user_init_data_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    # The discovered UDN is recorded on the existing account entry so later
-    # announcements are deduplicated in the SSDP step.
-    assert cookidoo_config_entry.data[CONF_UDN] == TEST_SSDP_UDN
 
 
 async def test_flow_reconfigure_success(

--- a/tests/components/cookidoo/test_config_flow.py
+++ b/tests/components/cookidoo/test_config_flow.py
@@ -9,7 +9,7 @@ from cookidoo_api.exceptions import (
 )
 import pytest
 
-from homeassistant.components.cookidoo.const import DOMAIN
+from homeassistant.components.cookidoo.const import CONF_UDN, DOMAIN
 from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_COUNTRY, CONF_EMAIL, CONF_LANGUAGE, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
@@ -528,7 +528,11 @@ async def test_flow_ssdp_discovery(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Cookidoo"
-    assert result["data"] == {**MOCK_DATA_USER_STEP, **MOCK_DATA_LANGUAGE_STEP}
+    assert result["data"] == {
+        **MOCK_DATA_USER_STEP,
+        **MOCK_DATA_LANGUAGE_STEP,
+        CONF_UDN: TEST_SSDP_UDN,
+    }
     assert result["result"].unique_id == "sub_uuid"
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -538,10 +542,15 @@ async def test_flow_ssdp_discovery_device_already_configured(
     mock_cookidoo_client: AsyncMock,
     cookidoo_config_entry: MockConfigEntry,
 ) -> None:
-    """Test SSDP discovery aborts when the device UDN is already configured."""
+    """Test SSDP discovery aborts when this Thermomix was already set up.
+
+    A completed entry is keyed by the account UUID and stores the device UDN in
+    its data, so rediscovery must be deduplicated against that stored UDN.
+    """
     cookidoo_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
-        cookidoo_config_entry, unique_id=TEST_SSDP_UDN
+        cookidoo_config_entry,
+        data={**cookidoo_config_entry.data, CONF_UDN: TEST_SSDP_UDN},
     )
 
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/cookidoo/test_config_flow.py
+++ b/tests/components/cookidoo/test_config_flow.py
@@ -10,10 +10,16 @@ from cookidoo_api.exceptions import (
 import pytest
 
 from homeassistant.components.cookidoo.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_COUNTRY, CONF_EMAIL, CONF_LANGUAGE, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.ssdp import (
+    ATTR_UPNP_DEVICE_TYPE,
+    ATTR_UPNP_SERIAL,
+    ATTR_UPNP_UDN,
+    SsdpServiceInfo,
+)
 
 from .conftest import COUNTRY, EMAIL, LANGUAGE, PASSWORD
 from .test_init import setup_integration
@@ -29,6 +35,20 @@ MOCK_DATA_USER_STEP = {
 MOCK_DATA_LANGUAGE_STEP = {
     CONF_LANGUAGE: LANGUAGE,
 }
+
+TEST_SSDP_UDN = "uuid:3432E6654473"
+
+TEST_SSDP_SERVICE_INFO = SsdpServiceInfo(
+    ssdp_usn=f"{TEST_SSDP_UDN}::urn:device:vorwerk:nwotdevice:1",
+    ssdp_st="urn:device:vorwerk:nwotdevice:1",
+    ssdp_udn=TEST_SSDP_UDN,
+    ssdp_location="http://192.0.2.7:49152/description.xml",
+    upnp={
+        ATTR_UPNP_DEVICE_TYPE: "urn:device:vorwerk:nwotdevice:1",
+        ATTR_UPNP_SERIAL: "25145556024103937",
+        ATTR_UPNP_UDN: TEST_SSDP_UDN,
+    },
+)
 
 
 async def test_flow_user_success(
@@ -478,3 +498,83 @@ async def test_flow_reauth_id_mismatch(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "unique_id_mismatch"
+
+
+async def test_flow_ssdp_discovery(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_cookidoo_client: AsyncMock
+) -> None:
+    """Test the Thermomix is discovered via SSDP and the flow completes."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=TEST_SSDP_SERVICE_INFO,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=MOCK_DATA_USER_STEP,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "language"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=MOCK_DATA_LANGUAGE_STEP,
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Cookidoo"
+    assert result["data"] == {**MOCK_DATA_USER_STEP, **MOCK_DATA_LANGUAGE_STEP}
+    assert result["result"].unique_id == "sub_uuid"
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_flow_ssdp_discovery_device_already_configured(
+    hass: HomeAssistant,
+    mock_cookidoo_client: AsyncMock,
+    cookidoo_config_entry: MockConfigEntry,
+) -> None:
+    """Test SSDP discovery aborts when the device UDN is already configured."""
+    cookidoo_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        cookidoo_config_entry, unique_id=TEST_SSDP_UDN
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=TEST_SSDP_SERVICE_INFO,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_flow_ssdp_discovery_account_already_configured(
+    hass: HomeAssistant,
+    mock_cookidoo_client: AsyncMock,
+    cookidoo_config_entry: MockConfigEntry,
+) -> None:
+    """Test SSDP discovery aborts when the Cookidoo account is already set up."""
+    cookidoo_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=TEST_SSDP_SERVICE_INFO,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=MOCK_DATA_USER_STEP,
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/cookidoo/test_config_flow.py
+++ b/tests/components/cookidoo/test_config_flow.py
@@ -201,6 +201,9 @@ async def test_flow_user_init_data_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+    # The discovered UDN is recorded on the existing account entry so later
+    # announcements are deduplicated in the SSDP step.
+    assert cookidoo_config_entry.data[CONF_UDN] == TEST_SSDP_UDN
 
 
 async def test_flow_reconfigure_success(
@@ -587,3 +590,6 @@ async def test_flow_ssdp_discovery_account_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+    # The discovered UDN is recorded on the existing account entry so later
+    # announcements are deduplicated in the SSDP step.
+    assert cookidoo_config_entry.data[CONF_UDN] == TEST_SSDP_UDN

--- a/tests/components/cookidoo/test_config_flow.py
+++ b/tests/components/cookidoo/test_config_flow.py
@@ -50,6 +50,20 @@ TEST_SSDP_SERVICE_INFO = SsdpServiceInfo(
     },
 )
 
+TEST_SSDP_UDN_2 = "uuid:112233445566"
+
+TEST_SSDP_SERVICE_INFO_2 = SsdpServiceInfo(
+    ssdp_usn=f"{TEST_SSDP_UDN_2}::urn:device:vorwerk:nwotdevice:1",
+    ssdp_st="urn:device:vorwerk:nwotdevice:1",
+    ssdp_udn=TEST_SSDP_UDN_2,
+    ssdp_location="http://192.0.2.8:49152/description.xml",
+    upnp={
+        ATTR_UPNP_DEVICE_TYPE: "urn:device:vorwerk:nwotdevice:1",
+        ATTR_UPNP_SERIAL: "25145556024103938",
+        ATTR_UPNP_UDN: TEST_SSDP_UDN_2,
+    },
+)
+
 
 async def test_flow_user_success(
     hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_cookidoo_client: AsyncMock
@@ -531,7 +545,7 @@ async def test_flow_ssdp_discovery(
     assert result["data"] == {
         **MOCK_DATA_USER_STEP,
         **MOCK_DATA_LANGUAGE_STEP,
-        CONF_UDN: TEST_SSDP_UDN,
+        CONF_UDN: [TEST_SSDP_UDN],
     }
     assert result["result"].unique_id == "sub_uuid"
     assert len(mock_setup_entry.mock_calls) == 1
@@ -550,7 +564,7 @@ async def test_flow_ssdp_discovery_device_already_configured(
     cookidoo_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         cookidoo_config_entry,
-        data={**cookidoo_config_entry.data, CONF_UDN: TEST_SSDP_UDN},
+        data={**cookidoo_config_entry.data, CONF_UDN: [TEST_SSDP_UDN]},
     )
 
     result = await hass.config_entries.flow.async_init(
@@ -589,4 +603,52 @@ async def test_flow_ssdp_discovery_account_already_configured(
     assert result["reason"] == "already_configured"
     # The discovered UDN is recorded on the existing account entry so later
     # announcements are deduplicated in the SSDP step.
-    assert cookidoo_config_entry.data[CONF_UDN] == TEST_SSDP_UDN
+    assert cookidoo_config_entry.data[CONF_UDN] == [TEST_SSDP_UDN]
+
+
+async def test_flow_ssdp_discovery_second_device_same_account(
+    hass: HomeAssistant,
+    mock_cookidoo_client: AsyncMock,
+    cookidoo_config_entry: MockConfigEntry,
+) -> None:
+    """Test a second Thermomix on an already-configured account is tracked.
+
+    The account entry stores a collection of device UDNs, so discovering
+    another device appends its UDN instead of overwriting; both devices are
+    then deduplicated on later announcements.
+    """
+    cookidoo_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        cookidoo_config_entry,
+        data={**cookidoo_config_entry.data, CONF_UDN: [TEST_SSDP_UDN_2]},
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=TEST_SSDP_SERVICE_INFO,
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=MOCK_DATA_USER_STEP,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    # Both devices are tracked on the single account entry.
+    assert set(cookidoo_config_entry.data[CONF_UDN]) == {
+        TEST_SSDP_UDN,
+        TEST_SSDP_UDN_2,
+    }
+
+    # A later announcement from the pre-existing device is deduplicated in the
+    # SSDP step.
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_SSDP},
+        data=TEST_SSDP_SERVICE_INFO_2,
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"


### PR DESCRIPTION
## Proposed change

This adds SSDP/UPnP auto-discovery of the Vorwerk Thermomix (TM7) to the `cookidoo` integration.

The TM7 runs a minimal UPnP/SSDP responder on the LAN. It answers `M-SEARCH` and advertises `upnp:rootdevice`, `uuid:<UDN>` and `urn:device:vorwerk:nwotdevice:1`, with `LOCATION: http://<ip>:49152/description.xml`. Its `description.xml` is minimal and contains **no** manufacturer / friendlyName / modelName, so the only reliable match key is the device type:

```xml
<?xml version="1.0"?>
<root><device>
<deviceType>urn:device:vorwerk:nwotdevice:1</deviceType>
<serialNumber>25145556024103937</serialNumber>
<UDN>uuid:3432E6654473</UDN>
</device><URLBase>http://<ip>:49152/</URLBase></root>
```

Changes:

- `manifest.json`: add an `ssdp` matcher on `{"deviceType": "urn:device:vorwerk:nwotdevice:1"}`.
- `config_flow.py`: add `async_step_ssdp`. It takes the device UDN (`SsdpServiceInfo.ssdp_udn`) as the discovery unique id and calls `_abort_if_unique_id_configured()` to deduplicate discoveries, then hands over to the existing user step to collect credentials.
- Because Cookidoo is a **cloud account** integration (email/password), discovery cannot auto-configure the connection; the flow surfaces the discovered Thermomix and reuses the existing user/language steps so the user signs in. Once the account is validated, the entry keeps the account UUID as its unique id (unchanged behaviour), and the user step now also aborts on `already_configured` when the flow was started from discovery, so a discovered Thermomix cannot create a duplicate entry for an account that is already set up.
- Manual setup, reconfigure and reauth flows are unchanged.
- `strings.json`: add a `flow_title` so the discovered device is presented nicely.
- `quality_scale.yaml`: promote `discovery` from `exempt` to `done`.

Tests added under `tests/components/cookidoo/test_config_flow.py` cover: discovery shows the form and completes creating an entry; discovery aborts when the device UDN is already configured; discovery aborts when the Cookidoo account is already configured.

Validated against a real TM7 on the LAN (discovery, `description.xml` fetch, and completing the flow).

### Standalone change — please review and merge on its own merits

This PR is complete and useful **as-is**: it gives Cookidoo users automatic discovery and
guided onboarding the moment a Thermomix TM7 appears on the network, with no dependency on
any other work. **I'd like it considered and merged independently.**

A separate device-management PR (adding live remote-monitoring state — cooking state,
remaining time, target/current temperature, and the current recipe/step) is planned as a
follow-up that will build on this discovery entry point. But this change stands on its own
and should **not** be held for it; I'll link the follow-up here once it's opened.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/48030
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

