### PR TITLE
Adjust hassio to not access DeviceEntry.config_entries

### DIFF
--- a/homeassistant/components/hassio/services.py
+++ b/homeassistant/components/hassio/services.py
@@ -26,11 +26,13 @@ from homeassistant.core import (
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import (
     config_validation as cv,
-    device_registry as dr,
     issue_registry as ir,
     selector,
 )
-from homeassistant.helpers.service import async_register_admin_service
+from homeassistant.helpers.service import (
+    async_get_device_and_config_entry,
+    async_register_admin_service,
+)
 from homeassistant.util.dt import now
 
 from .const import (
@@ -47,10 +49,8 @@ from .const import (
     ATTR_SLUG,
     DOMAIN,
     ISSUE_KEY_LEGACY_HOMEASSISTANT_FOLDER,
-    MAIN_COORDINATOR,
     SupervisorEntityModel,
 )
-from .coordinator import HassioMainDataUpdateCoordinator
 from .handler import get_supervisor_client
 
 SERVICE_ADDON_START = "addon_start"
@@ -449,28 +449,14 @@ def async_register_network_storage_services(
     hass: HomeAssistant, supervisor_client: SupervisorClient
 ) -> None:
     """Register network storage (or mount) services."""
-    dev_reg = dr.async_get(hass)
 
     async def async_mount_reload(service: ServiceCall) -> None:
         """Handle service calls for Hass.io."""
-        coordinator: HassioMainDataUpdateCoordinator | None = None
+        device, _ = async_get_device_and_config_entry(
+            hass, DOMAIN, service.data[ATTR_DEVICE_ID]
+        )
 
-        if (
-            device := dev_reg.async_get(
-                service.data[ATTR_DEVICE_ID], include_child_devices=False
-            )
-        ) is None:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="mount_reload_unknown_device_id",
-            )
-
-        if (
-            device.name is None
-            or device.model != SupervisorEntityModel.MOUNT
-            or (coordinator := hass.data.get(MAIN_COORDINATOR)) is None
-            or coordinator.entry_id != device.config_entry_id
-        ):
+        if device.name is None or device.model != SupervisorEntityModel.MOUNT:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
                 translation_key="mount_reload_invalid_device",

--- a/homeassistant/components/hassio/services.py
+++ b/homeassistant/components/hassio/services.py
@@ -469,7 +469,7 @@ def async_register_network_storage_services(
             device.name is None
             or device.model != SupervisorEntityModel.MOUNT
             or (coordinator := hass.data.get(MAIN_COORDINATOR)) is None
-            or coordinator.entry_id not in device.config_entries
+            or coordinator.entry_id != device.config_entry_id
         ):
             raise ServiceValidationError(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/hassio/strings.json
+++ b/homeassistant/components/hassio/strings.json
@@ -50,9 +50,6 @@
     "mount_reload_invalid_device": {
       "message": "Device is not a supervisor mount point"
     },
-    "mount_reload_unknown_device_id": {
-      "message": "Device ID not found"
-    },
     "supervisor_not_connected": {
       "message": "Not connected with the supervisor / system too busy"
     },

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -1723,7 +1723,7 @@ async def test_mount_reload_unknown_device_id(
         await hass.services.async_call(
             DOMAIN, "mount_reload", {"device_id": "1234"}, blocking=True
         )
-    assert str(exc.value) == "Device ID not found"
+    assert str(exc.value) == "Device with ID 1234 was not found"
 
 
 async def test_mount_reload_no_name(
@@ -1775,7 +1775,7 @@ async def test_mount_reload_not_supervisor_device(
         await hass.services.async_call(
             DOMAIN, "mount_reload", {"device_id": device2.id}, blocking=True
         )
-    assert str(exc.value) == "Device is not a supervisor mount point"
+    assert str(exc.value) == "Device NAS does not belong to integration hassio"
 
 
 async def test_mount_reload_selector_matches_device_name(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Adjust hassio to not access `DeviceEntry.config_entries`, instead use service helper `async_get_device_and_config_entry`

### Rationale:
`DeviceEntry.config_entries` is a remnant from the multi config entry device design.
The code tests the model name of the hassio mount device which is identified by (hassio, mount_<mount.name>)
hassio is single config entry, and it's not realistic that the device is a multi config entry device

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
