### PR TITLE
Bump waterfurnace to 1.9.0

### DIFF
--- a/homeassistant/components/waterfurnace/manifest.json
+++ b/homeassistant/components/waterfurnace/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["waterfurnace"],
   "quality_scale": "bronze",
-  "requirements": ["waterfurnace==1.7.1"]
+  "requirements": ["waterfurnace==1.9.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3431,7 +3431,7 @@ wallbox==0.9.0
 watchdog==6.0.0
 
 # homeassistant.components.waterfurnace
-waterfurnace==1.7.1
+waterfurnace==1.9.0
 
 # homeassistant.components.watergate
 watergate-local-api==2026.2.2


### PR DESCRIPTION
## Proposed change

Bump the `waterfurnace` library from 1.7.1 to 1.9.0.

The main driver for this release is a fix for a broken login flow: WaterFurnace added Laravel CSRF protection to their login form, which had been silently breaking authentication for all users. The library now fetches the login page first to extract a CSRF token before posting credentials.

The energy data endpoint also moved server-side (`/api.php/v2/gateway/{gwid}/energy` -> `/api/v2/gateway/{gwid}/energy`); this is handled internally and the public `get_energy_data()` signature and return type are unchanged, so no changes are needed in the integration itself.

- PyPI: https://pypi.org/project/waterfurnace/1.9.0/
- Changelog: https://github.com/sdague/waterfurnace/releases/tag/v1.9.0
- Diff: https://github.com/sdague/waterfurnace/compare/v1.7.1...v1.9.0

Fixes #181689 

## Type of change

- [x] Dependency upgrade
- [x] Bugfix for #181689 
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #181689 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
