### PR TITLE
Bump habluetooth to 7.0.0

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -21,6 +21,6 @@
     "bluetooth-auto-recovery==1.6.4",
     "bluetooth-data-tools==1.29.24",
     "dbus-fast==5.0.22",
-    "habluetooth==6.26.11"
+    "habluetooth==7.0.0"
   ]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -36,7 +36,7 @@ fnv-hash-fast==2.0.3
 gazetteer-matcher==1.1.0
 go2rtc-client==0.4.0
 ha-ffmpeg==3.2.2
-habluetooth==6.26.11
+habluetooth==7.0.0
 hass-nabucasa==2.7.0
 hassil==3.12.0
 home-assistant-bluetooth==2.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1253,7 +1253,7 @@ ha-xthings-cloud==1.0.5
 habiticalib==0.4.7
 
 # homeassistant.components.bluetooth
-habluetooth==6.26.11
+habluetooth==7.0.0
 
 # homeassistant.components.hanna
 hanna-cloud==0.0.7


### PR DESCRIPTION
## Proposed change

Bump habluetooth from 6.26.11 to 7.0.0.

- Release notes / changelog: https://github.com/Bluetooth-Devices/habluetooth/blob/main/CHANGELOG.md#v700-2026-09-09
- Full diff: https://github.com/Bluetooth-Devices/habluetooth/compare/v6.26.11...v7.0.0

The release carries one functional change, [Bluetooth-Devices/habluetooth#613](https://github.com/Bluetooth-Devices/habluetooth/pull/613), plus dependency and pre-commit chores.

`async_clear_advertisement_history()` used to pop each scanner's `_previous_service_info` entry for the address. That mapping is both the merge / change-detection state *and* the discovered-device record that two of the three scanner implementations serve, so clearing the history also removed the only path a connection could resolve a backend through. The address stayed unconnectable until it advertised again:

```
Failed to connect after 10 attempt(s): No backend with an available connection slot
that can reach address 00:15:42:09:1A:1A was found: unknown (never seen by any scanner);
5 scanner(s) registered, 5 scanning, 5 connectable
```

The scanner now replaces that record with one that keeps the `BLEDevice`, rssi, time and tx_power but empties the advertisement data, so merging still resets from scratch on the next advertisement while the address stays reachable in the meantime. The retained record keeps its original timestamp and expires on the normal schedule, so clearing does not extend any record's lifetime, and the advertisement hot paths are unchanged.

habluetooth went to a major version because the observable contract of that public method changed: a caller that relied on the clear making a connect fail until the next advertisement now sees it succeed. Everything the method cleared before — manager history, name cache, smoothed RSSI, demoted sources, rescue state — is still cleared, so `bluetooth.async_ble_device_from_address()` and the dedup guard behave exactly as they did. `homeassistant/components/bluetooth` only re-exports the API; there are no in-tree callers, so nothing in core changes behaviour.

The fix was validated on the hardware it was reported from — an ISEO Argo BLE lock that encodes door state in mutually-exclusive service UUIDs, reached through a local adapter and four ESPHome proxies. With the history cleared on every advertisement, 7/7 connects succeeded on 7.0.0 against 0/5 on 6.26.11.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqUfoujs2tnVa1EhhgEhB7
