### PR TITLE
Adjust unifiprotect to not access DeviceEntry.config_entries

### DIFF
--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -834,23 +834,6 @@ class ProtectData:
 
 
 @callback
-def async_ufp_instance_for_config_entry_ids(
-    hass: HomeAssistant, config_entry_ids: set[str]
-) -> ProtectApiClient | None:
-    """Find the UFP instance for the config entry ids."""
-    return next(
-        iter(
-            entry.runtime_data.api
-            for entry_id in config_entry_ids
-            if (entry := hass.config_entries.async_get_entry(entry_id))
-            and entry.domain == DOMAIN
-            and hasattr(entry, "runtime_data")
-        ),
-        None,
-    )
-
-
-@callback
 def async_get_ufp_entries(hass: HomeAssistant) -> list[UFPConfigEntry]:
     """Get all the UFP entries."""
     return cast(

--- a/homeassistant/components/unifiprotect/services.py
+++ b/homeassistant/components/unifiprotect/services.py
@@ -25,6 +25,7 @@ from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
     entity_registry as er,
+    service,
 )
 from homeassistant.helpers.target import (
     TargetSelection,
@@ -43,7 +44,7 @@ from .const import (
     KEYRINGS_USER_FULL_NAME,
     KEYRINGS_USER_STATUS,
 )
-from .data import async_ufp_instance_for_config_entry_ids
+from .data import UFPConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -104,35 +105,24 @@ PTZ_GOTO_PRESET_SCHEMA = vol.Schema(
 @callback
 def _async_get_ufp_instance(hass: HomeAssistant, device_id: str) -> ProtectApiClient:
     device_registry = dr.async_get(hass)
-    if not (device_entry := device_registry.async_get(device_id)):
-        raise HomeAssistantError(
-            translation_domain=DOMAIN,
-            translation_key="device_not_found",
-            translation_placeholders={"device_id": device_id},
-        )
+    device_entry = device_registry.async_get(device_id)
 
     if isinstance(device_entry, dr.ChildDeviceEntry):
         return _async_get_ufp_instance(hass, device_entry.parent_device_id)
 
-    if device_entry.via_device_id is not None:
+    if device_entry is not None and device_entry.via_device_id is not None:
         return _async_get_ufp_instance(hass, device_entry.via_device_id)
 
-    config_entry_ids = device_entry.config_entries
-    if ufp_instance := async_ufp_instance_for_config_entry_ids(hass, config_entry_ids):
-        if ufp_instance.is_public_only:
-            # Actions read/write through the private bootstrap, which an
-            # API-key-only entry never initializes.
-            raise HomeAssistantError(
-                translation_domain=DOMAIN,
-                translation_key="public_only_no_actions",
-            )
-        return ufp_instance
-
-    raise HomeAssistantError(
-        translation_domain=DOMAIN,
-        translation_key="device_not_found",
-        translation_placeholders={"device_id": device_id},
-    )
+    _, config_entry = service.async_get_device_and_config_entry(hass, DOMAIN, device_id)
+    ufp_instance = cast(UFPConfigEntry, config_entry).runtime_data.api
+    if ufp_instance.is_public_only:
+        # Actions read/write through the private bootstrap, which an
+        # API-key-only entry never initializes.
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="public_only_no_actions",
+        )
+    return ufp_instance
 
 
 @callback

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -841,9 +841,6 @@
     "command_error": {
       "message": "Error communicating with UniFi Protect while sending command: {error}"
     },
-    "device_not_found": {
-      "message": "No device found for device id: {device_id}"
-    },
     "entry_auth_failed": {
       "message": "Authentication failed, please reauthenticate"
     },

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -25,10 +25,7 @@ from homeassistant.components.unifiprotect.const import (
     PLATFORMS,
     PUBLIC_ONLY_PLATFORMS,
 )
-from homeassistant.components.unifiprotect.data import (
-    ProtectData,
-    async_ufp_instance_for_config_entry_ids,
-)
+from homeassistant.components.unifiprotect.data import ProtectData
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_API_KEY, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
@@ -472,61 +469,6 @@ async def test_remove_config_entry_device_rejects_child_device(
         == "Failed to remove device entry, rejected by integration"
     )
     assert device_registry.async_get(child_device.id)
-
-
-@pytest.mark.parametrize(
-    ("mock_entries", "expected_result"),
-    [
-        pytest.param(
-            [
-                MockConfigEntry(
-                    domain=DOMAIN,
-                    entry_id="1",
-                    data={},
-                ),
-                MockConfigEntry(
-                    domain="other_domain",
-                    entry_id="2",
-                    data={},
-                ),
-            ],
-            "mock_api_instance_1",
-            id="one_matching_domain",
-        ),
-        pytest.param(
-            [
-                MockConfigEntry(
-                    domain="other_domain",
-                    entry_id="1",
-                    data={},
-                ),
-                MockConfigEntry(
-                    domain="other_domain",
-                    entry_id="2",
-                    data={},
-                ),
-            ],
-            None,
-            id="no_matching_domain",
-        ),
-    ],
-)
-async def test_async_ufp_instance_for_config_entry_ids(
-    hass: HomeAssistant,
-    mock_entries: list[MockConfigEntry],
-    expected_result: str | None,
-) -> None:
-    """Test async_ufp_instance_for_config_entry_ids with various configs."""
-
-    for index, entry in enumerate(mock_entries):
-        entry.add_to_hass(hass)
-        entry.runtime_data = Mock(api=f"mock_api_instance_{index + 1}")
-
-    entry_ids = {entry.entry_id for entry in mock_entries}
-
-    result = async_ufp_instance_for_config_entry_ids(hass, entry_ids)
-
-    assert result == expected_result
 
 
 @pytest.mark.parametrize("mock_user_can_write_nvr", [True], indirect=True)

--- a/tests/components/unifiprotect/test_services.py
+++ b/tests/components/unifiprotect/test_services.py
@@ -30,13 +30,15 @@ from homeassistant.components.unifiprotect.services import (
 )
 from homeassistant.config_entries import ConfigEntryDisabler
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID, ATTR_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import patch_ufp_method
 from .conftest import UNIFI_MAC
 from .utils import MockUFPFixture, init_entry
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="device")
@@ -69,12 +71,13 @@ async def test_global_service_bad_device(
 ) -> None:
     """Test global service, invalid device ID."""
 
+    await init_entry(hass, ufp, [])
     nvr = ufp.api.bootstrap.nvr
 
     with patch_ufp_method(
         nvr, "add_custom_doorbell_message", new_callable=AsyncMock
     ) as mock_method:
-        with pytest.raises(HomeAssistantError):
+        with pytest.raises(ServiceValidationError) as error:
             await hass.services.async_call(
                 DOMAIN,
                 SERVICE_ADD_DOORBELL_TEXT,
@@ -82,6 +85,37 @@ async def test_global_service_bad_device(
                 blocking=True,
             )
         assert not mock_method.called
+
+    assert error.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert error.value.translation_key == "service_device_not_found"
+
+
+async def test_global_service_device_from_other_integration(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    ufp: MockUFPFixture,
+) -> None:
+    """Test a device not owned by a UniFi Protect config entry is rejected."""
+
+    await init_entry(hass, ufp, [])
+    other_entry = MockConfigEntry(domain="other")
+    other_entry.add_to_hass(hass)
+    other_device = device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id,
+        identifiers={("other", "other-device")},
+        name="Other device",
+    )
+
+    with pytest.raises(ServiceValidationError) as error:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_DOORBELL_TEXT,
+            {ATTR_DEVICE_ID: other_device.id, ATTR_MESSAGE: "Test Message"},
+            blocking=True,
+        )
+
+    assert error.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert error.value.translation_key == "service_device_wrong_domain"
 
 
 async def test_global_service_exception(
@@ -159,7 +193,7 @@ async def test_add_doorbell_text_disabled_config_entry(
     with patch_ufp_method(
         nvr, "add_custom_doorbell_message", new_callable=AsyncMock
     ) as mock_method:
-        with pytest.raises(HomeAssistantError):
+        with pytest.raises(ServiceValidationError) as error:
             await hass.services.async_call(
                 DOMAIN,
                 SERVICE_ADD_DOORBELL_TEXT,
@@ -167,6 +201,9 @@ async def test_add_doorbell_text_disabled_config_entry(
                 blocking=True,
             )
         assert not mock_method.called
+
+    assert error.value.translation_domain == HOMEASSISTANT_DOMAIN
+    assert error.value.translation_key == "service_config_entry_not_loaded"
 
 
 async def test_set_chime_paired_doorbells(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust unifiprotect to not access `DeviceEntry.config_entries`, instead use service helper `async_get_device_and_config_entry`

### Rationale:
`DeviceEntry.config_entries` is a remnant from the multi config entry device design.
Although devices linked to multiple unifiprotect config entries are plausible (caused by a camera being moved between NVRs), the NVR device is what's used to look up the unifiprotect config entry, and those devices won't have more than a single config entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
