### PR TITLE
Add a reconfigure flow to KACO Modbus

### DIFF
--- a/homeassistant/components/kaco_modbus/config_flow.py
+++ b/homeassistant/components/kaco_modbus/config_flow.py
@@ -1,15 +1,21 @@
-"""Adding an inverter by address."""
+"""Adding an inverter by address, and pointing one at a new address."""
 
 import logging
 from typing import Any, override
 
-from kaco_modbus import KacoError, KacoInverter, NotAKacoInverterError
+from kaco_modbus import (
+    DeviceInfo as KacoDeviceInfo,
+    KacoError,
+    KacoInverter,
+    NotAKacoInverterError,
+)
 from modbus_connection import ModbusError, ModbusTcpParams
 import voluptuous as vol
 
 from homeassistant.components.modbus import async_get_temporary_unit
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import (
     NumberSelector,
@@ -41,10 +47,39 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 )
 
 
+async def _async_probe(hass: HomeAssistant, user_input: dict[str, Any]) -> KacoInverter:
+    """Read the inverter answering at an address, or raise."""
+    params = ModbusTcpParams(host=user_input[CONF_HOST], port=user_input[CONF_PORT])
+    async with async_get_temporary_unit(hass, params, user_input[CONF_UNIT_ID]) as unit:
+        device = KacoInverter(unit)
+        await device.async_update_readings()
+    return device
+
+
 class KacoModbusConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for KACO Modbus."""
 
     VERSION = 1
+
+    async def _async_identify(
+        self, user_input: dict[str, Any]
+    ) -> tuple[KacoDeviceInfo | None, dict[str, str]]:
+        """Return what answers at an address, or the errors to show instead."""
+        try:
+            device = await _async_probe(self.hass, user_input)
+        except NotAKacoInverterError:
+            return None, {"base": "not_a_kaco_inverter"}
+        except KacoError:
+            return None, {"base": "not_a_sunspec_inverter"}
+        except ModbusError, HomeAssistantError:
+            return None, {"base": "cannot_connect"}
+        except Exception:
+            _LOGGER.exception("Unexpected exception")
+            return None, {"base": "unknown"}
+
+        info = device.info
+        assert info is not None
+        return info, {}
 
     @override
     async def async_step_user(
@@ -54,27 +89,8 @@ class KacoModbusConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            params = ModbusTcpParams(
-                host=user_input[CONF_HOST], port=user_input[CONF_PORT]
-            )
-            try:
-                async with async_get_temporary_unit(
-                    self.hass, params, user_input[CONF_UNIT_ID]
-                ) as unit:
-                    device = KacoInverter(unit)
-                    await device.async_update_readings()
-            except NotAKacoInverterError:
-                errors["base"] = "not_a_kaco_inverter"
-            except KacoError:
-                errors["base"] = "not_a_sunspec_inverter"
-            except ModbusError, HomeAssistantError:
-                errors["base"] = "cannot_connect"
-            except Exception:
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
-            else:
-                info = device.info
-                assert info is not None
+            info, errors = await self._async_identify(user_input)
+            if info is not None:
                 # Stable across address changes, which a host or port is not.
                 await self.async_set_unique_id(info.serial_number)
                 self._abort_if_unique_id_configured()
@@ -83,5 +99,30 @@ class KacoModbusConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Point an existing entry at the address the inverter moved to."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            info, errors = await self._async_identify(user_input)
+            if info is not None:
+                await self.async_set_unique_id(info.serial_number)
+                # Another serial is a different inverter, not a moved one.
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry, data_updates=user_input
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA, user_input or reconfigure_entry.data
+            ),
             errors=errors,
         )

--- a/homeassistant/components/kaco_modbus/quality_scale.yaml
+++ b/homeassistant/components/kaco_modbus/quality_scale.yaml
@@ -84,7 +84,7 @@ rules:
   icon-translations:
     status: exempt
     comment: Entities use device_class-derived icons; no custom icons are needed.
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues: todo
   stale-devices:
     status: exempt

--- a/homeassistant/components/kaco_modbus/strings.json
+++ b/homeassistant/components/kaco_modbus/strings.json
@@ -1,7 +1,9 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "unique_id_mismatch": "Another inverter answers at that address. Reconfigure the one this entry was set up for."
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -10,6 +12,19 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "unit_id": "[%key:component::kaco_modbus::config::step::user::data::unit_id%]"
+        },
+        "data_description": {
+          "host": "[%key:component::kaco_modbus::config::step::user::data_description::host%]",
+          "port": "[%key:component::kaco_modbus::config::step::user::data_description::port%]",
+          "unit_id": "[%key:component::kaco_modbus::config::step::user::data_description::unit_id%]"
+        },
+        "description": "Update the address Home Assistant reaches this inverter at."
+      },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",

--- a/tests/components/kaco_modbus/test_config_flow.py
+++ b/tests/components/kaco_modbus/test_config_flow.py
@@ -11,6 +11,7 @@ import pytest
 
 from homeassistant.components.kaco_modbus.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import HomeAssistantError
@@ -129,3 +130,79 @@ async def test_user_step_aborts_when_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures("mock_temporary_unit", "mock_get_unit")
+async def test_reconfigure_moves_the_entry_to_a_new_address(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test an inverter that changed address keeps its entry and history."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {**MOCK_USER_INPUT, CONF_HOST: "192.168.1.101"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.101"
+    # Still the inverter it was set up for, so its entities keep their ids.
+    assert mock_config_entry.unique_id == MOCK_SERIAL
+
+
+@pytest.mark.usefixtures("mock_temporary_unit")
+async def test_reconfigure_rejects_a_different_inverter(hass: HomeAssistant) -> None:
+    """Test an address answering as another inverter is refused.
+
+    Accepting it would hand this entry's entities, and their history, to a
+    device that never produced any of it.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="8.6TL99999999",
+        data=MOCK_USER_INPUT,
+        title=MOCK_MODEL,
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], MOCK_USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unique_id_mismatch"
+
+
+@pytest.mark.usefixtures("mock_temporary_unit", "mock_get_unit")
+async def test_reconfigure_errors_then_recovers(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test a failure shows on the reconfigure form, which still completes.
+
+    Both steps map failures through the same helper, so the error matrix is
+    covered by the user step; this checks the reconfigure form is wired to it.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    with _raising(ModbusTimeoutError("no answer")):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], MOCK_USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {**MOCK_USER_INPUT, CONF_HOST: "192.168.1.101"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data[CONF_HOST] == "192.168.1.101"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds the reconfiguration flow to KACO Modbus, allowing for IP, port and unit id to be changed

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/48039
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
