### PR TITLE
Retry sftp_storage setup when the SSH connection fails

### DIFF
--- a/homeassistant/components/sftp_storage/__init__.py
+++ b/homeassistant/components/sftp_storage/__init__.py
@@ -10,9 +10,9 @@ from homeassistant.components.backup import BackupAgentError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 
-from .client import BackupAgentClient
+from .client import BackupAgentClient, SFTPConnectionError
 from .const import (
     CONF_BACKUP_LOCATION,
     CONF_PRIVATE_KEY_FILE,
@@ -55,6 +55,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: SFTPConfigEntry) -> bool
     try:
         client = BackupAgentClient(entry, hass)
         await client.open()
+    except SFTPConnectionError as e:
+        raise ConfigEntryNotReady(str(e)) from e
     except BackupAgentError as e:
         raise ConfigEntryError from e
 

--- a/homeassistant/components/sftp_storage/client.py
+++ b/homeassistant/components/sftp_storage/client.py
@@ -13,7 +13,7 @@ from asyncssh import (
     SSHClientConnectionOptions,
     connect,
 )
-from asyncssh.misc import PermissionDenied
+from asyncssh.misc import Error as SSHError, PermissionDenied
 from asyncssh.sftp import SFTPNoSuchFile, SFTPPermissionDenied
 
 from homeassistant.components.backup import (
@@ -27,6 +27,10 @@ from .const import BUF_SIZE, LOGGER
 
 if TYPE_CHECKING:
     from . import SFTPConfigEntry, SFTPConfigEntryData
+
+
+class SFTPConnectionError(BackupAgentError):
+    """Error raised when the SSH connection could not be established."""
 
 
 def get_client_options(cfg: SFTPConfigEntryData) -> SSHClientConnectionOptions:
@@ -295,11 +299,16 @@ class BackupAgentClient:
                     get_client_options, self.cfg.runtime_data
                 ),
             )
-        except (OSError, PermissionDenied) as e:
+        except PermissionDenied as e:
             raise BackupAgentError(
                 "Failure while attempting to establish SSH"
                 " connection. Please check SSH credentials"
                 " and if changed, re-install the integration"
+            ) from e
+        except (OSError, SSHError) as e:
+            raise SFTPConnectionError(
+                f"Failed to establish SSH connection to"
+                f" {self.cfg.runtime_data.host}: {e}"
             ) from e
 
         # Configure SFTP Client Connection

--- a/homeassistant/components/sftp_storage/client.py
+++ b/homeassistant/components/sftp_storage/client.py
@@ -320,5 +320,9 @@ class BackupAgentClient:
                 "Failed to create SFTP client."
                 " Re-installing integration might be required"
             ) from e
+        except (OSError, SSHError) as e:
+            raise SFTPConnectionError(
+                f"Failed to open SFTP session on {self.cfg.runtime_data.host}: {e}"
+            ) from e
 
         return self

--- a/tests/components/sftp_storage/test_init.py
+++ b/tests/components/sftp_storage/test_init.py
@@ -3,8 +3,8 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from asyncssh.misc import ConnectionLost, PermissionDenied
-from asyncssh.sftp import SFTPPermissionDenied
+from asyncssh.misc import ChannelOpenError, ConnectionLost, PermissionDenied
+from asyncssh.sftp import SFTPConnectionLost, SFTPPermissionDenied
 import pytest
 
 from homeassistant.components.sftp_storage import SFTPConfigEntryData
@@ -96,6 +96,28 @@ async def test_setup_connection_error_is_retried(
     assert len(entries) == 1
     assert entries[0].state is ConfigEntryState.SETUP_RETRY
     assert "Failed to establish SSH connection to" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "sftp_error",
+    [ChannelOpenError(1, "Channel open failed"), SFTPConnectionLost("Connection lost")],
+    ids=["channel_open_error", "sftp_connection_lost"],
+)
+async def test_setup_sftp_session_error_is_retried(
+    mock_ssh_connection: SSHClientConnectionMock,
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    caplog: pytest.LogCaptureFixture,
+    sftp_error: Exception,
+) -> None:
+    """Test that losing the session after connecting is also retried."""
+    mock_ssh_connection._sftp._mock_chdir.side_effect = sftp_error
+    await setup_integration()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].state is ConfigEntryState.SETUP_RETRY
+    assert "Failed to open SFTP session on" in caplog.text
 
 
 async def test_setup_invalid_credentials(

--- a/tests/components/sftp_storage/test_init.py
+++ b/tests/components/sftp_storage/test_init.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
+from asyncssh.misc import ConnectionLost, PermissionDenied
 from asyncssh.sftp import SFTPPermissionDenied
 import pytest
 
@@ -73,15 +74,39 @@ async def test_setup_error(
     assert entries[0].state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_setup_unexpected_error(
+@pytest.mark.parametrize(
+    "connect_error",
+    [OSError("Error message"), ConnectionLost("Connection lost")],
+    ids=["oserror", "connection_lost"],
+)
+async def test_setup_connection_error_is_retried(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    caplog: pytest.LogCaptureFixture,
+    connect_error: Exception,
+) -> None:
+    """Test that a connection failure leaves the entry in a retrying state."""
+    with patch(
+        "homeassistant.components.sftp_storage.client.connect",
+        side_effect=connect_error,
+    ):
+        await setup_integration()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].state is ConfigEntryState.SETUP_RETRY
+    assert "Failed to establish SSH connection to" in caplog.text
+
+
+async def test_setup_invalid_credentials(
     hass: HomeAssistant,
     setup_integration: ComponentSetup,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test setup error."""
+    """Test that rejected credentials are not retried."""
     with patch(
         "homeassistant.components.sftp_storage.client.connect",
-        side_effect=OSError("Error message"),
+        side_effect=PermissionDenied("Permission denied"),
     ):
         await setup_integration()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`asyncssh.ConnectionLost` inherits from `asyncssh.Error`, not `OSError`, so it escaped the `except` around `connect()` and left the entry in a permanent error state. Since the backup agent is only offered while the entry is loaded, one dropped connection during startup removed the backup target until the entry was reloaded by hand, and scheduled backups silently continued to the remaining agents.

Connection failures now raise `ConfigEntryNotReady`. Rejected credentials and a missing backup directory stay `ConfigEntryError`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #160630
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
