### PR TITLE
Stream usage prediction events instead of loading them into memory

### DIFF
--- a/homeassistant/components/usage_prediction/common_control.py
+++ b/homeassistant/components/usage_prediction/common_control.py
@@ -1,15 +1,12 @@
 """Code to generate common control usage patterns."""
 
 from collections import Counter
-from collections.abc import Callable, Sequence
 from datetime import datetime, timedelta
 from functools import cache
 import logging
 from typing import Any, Literal, cast
 
 from sqlalchemy import select
-from sqlalchemy.engine.row import Row
-from sqlalchemy.orm import Session
 
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.db_schema import EventData, Events, EventTypes
@@ -29,6 +26,9 @@ _LOGGER = logging.getLogger(__name__)
 TIME_CATEGORIES = ["morning", "afternoon", "evening", "night"]
 
 RESULTS_TO_INCLUDE = 8
+
+# Rows fetched per round trip while streaming the events query
+QUERY_YIELD_PER = 4096
 
 # List of domains for which we want to track usage
 ALLOWED_DOMAINS = {
@@ -94,83 +94,16 @@ async def async_predict_common_control(
     recorder = get_instance(hass)
     ent_reg = er.async_get(hass)
 
-    # Execute the database operation in the recorder's executor
-    data = await recorder.async_add_executor_job(
-        _fetch_with_session, hass, _fetch_and_process_data, ent_reg, user_id
-    )
-    # Prepare a dictionary to track results
-    results: dict[str, Counter[str]] = {
-        time_cat: Counter() for time_cat in TIME_CATEGORIES
+    allowed_entities = {
+        entity_id
+        for entity_id in hass.states.async_entity_ids(ALLOWED_DOMAINS)
+        if not ((entry := ent_reg.async_get(entity_id)) and entry.hidden)
     }
 
-    allowed_entities = set(hass.states.async_entity_ids(ALLOWED_DOMAINS))
-    hidden_entities: set[str] = set()
-
-    # Keep track of contexts that we processed so that we will only process
-    # the first service call in a context, and not subsequent calls.
-    context_processed: set[bytes] = set()
-    # Execute the query
-    context_id: bytes
-    time_fired_ts: float
-    shared_data: str | None
-    local_time_zone = dt_util.get_default_time_zone()
-    for context_id, time_fired_ts, shared_data in data:
-        # Skip if we have already processed an event that was part of this context
-        if context_id in context_processed:
-            continue
-
-        # Mark this context as processed
-        context_processed.add(context_id)
-
-        # Parse the event data
-        if not time_fired_ts or not shared_data:
-            continue
-
-        try:
-            event_data = json_loads_object(shared_data)
-        except (ValueError, TypeError) as err:
-            _LOGGER.debug("Failed to parse event data: %s", err)
-            continue
-
-        # Empty event data, skipping
-        if not event_data:
-            continue
-
-        service_data = cast(dict[str, Any] | None, event_data.get("service_data"))
-
-        # No service data found, skipping
-        if not service_data:
-            continue
-
-        entity_ids: str | list[str] | None = service_data.get("entity_id")
-
-        # No entity IDs found, skip this event
-        if entity_ids is None:
-            continue
-
-        if not isinstance(entity_ids, list):
-            entity_ids = [entity_ids]
-
-        # Convert to local time for time category determination
-        period = time_category(
-            datetime.fromtimestamp(time_fired_ts, local_time_zone).hour
-        )
-        period_results = results[period]
-
-        # Count entity usage
-        for entity_id in entity_ids:
-            if entity_id not in allowed_entities or entity_id in hidden_entities:
-                continue
-
-            if (
-                entity_id not in period_results
-                and (entry := ent_reg.async_get(entity_id))
-                and entry.hidden
-            ):
-                hidden_entities.add(entity_id)
-                continue
-
-            period_results[entity_id] += 1
+    # Execute the database operation in the recorder's executor
+    results = await recorder.async_add_executor_job(
+        _fetch_and_process_data, hass, user_id, allowed_entities
+    )
 
     return EntityUsagePredictions(
         morning=[
@@ -190,9 +123,13 @@ async def async_predict_common_control(
 
 
 def _fetch_and_process_data(
-    session: Session, ent_reg: er.EntityRegistry, user_id: str
-) -> Sequence[Row[tuple[bytes | None, float | None, str | None]]]:
-    """Fetch and process service call events from the database."""
+    hass: HomeAssistant, user_id: str, allowed_entities: set[str]
+) -> dict[str, Counter[str]]:
+    """Count service call events per entity and time category.
+
+    Rows are streamed and reduced here so only the counters cross the
+    executor boundary; a busy user can have millions of matching events.
+    """
     thirty_days_ago_ts = (dt_util.utcnow() - timedelta(days=30)).timestamp()
     user_id_bytes = uuid_hex_to_bytes_or_none(user_id)
     if not user_id_bytes:
@@ -213,16 +150,69 @@ def _fetch_and_process_data(
         .where(EventTypes.event_type == "call_service")
         .order_by(Events.time_fired_ts)
     )
-    return session.connection().execute(query).all()
 
+    # Prepare a dictionary to track results
+    results: dict[str, Counter[str]] = {
+        time_cat: Counter() for time_cat in TIME_CATEGORIES
+    }
 
-def _fetch_with_session(
-    hass: HomeAssistant,
-    fetch_func: Callable[
-        [Session], Sequence[Row[tuple[bytes | None, float | None, str | None]]]
-    ],
-    *args: object,
-) -> Sequence[Row[tuple[bytes | None, float | None, str | None]]]:
-    """Execute a fetch function with a database session."""
+    # Keep track of contexts that we processed so that we will only process
+    # the first service call in a context, and not subsequent calls.
+    context_processed: set[bytes] = set()
+    local_time_zone = dt_util.get_default_time_zone()
+
+    context_id: bytes
+    time_fired_ts: float
+    shared_data: str | None
     with session_scope(hass=hass, read_only=True) as session:
-        return fetch_func(session, *args)
+        rows = session.connection().execute(query).yield_per(QUERY_YIELD_PER)
+        for context_id, time_fired_ts, shared_data in rows:
+            # Skip if we have already processed an event that was part of this context
+            if context_id in context_processed:
+                continue
+
+            # Mark this context as processed
+            context_processed.add(context_id)
+
+            # Parse the event data
+            if not time_fired_ts or not shared_data:
+                continue
+
+            try:
+                event_data = json_loads_object(shared_data)
+            except (ValueError, TypeError) as err:
+                _LOGGER.debug("Failed to parse event data: %s", err)
+                continue
+
+            # Empty event data, skipping
+            if not event_data:
+                continue
+
+            service_data = cast(dict[str, Any] | None, event_data.get("service_data"))
+
+            # No service data found, skipping
+            if not service_data:
+                continue
+
+            entity_ids: str | list[str] | None = service_data.get("entity_id")
+
+            # No entity IDs found, skip this event
+            if entity_ids is None:
+                continue
+
+            if not isinstance(entity_ids, list):
+                entity_ids = [entity_ids]
+
+            # Convert to local time for time category determination
+            period_results = results[
+                time_category(
+                    datetime.fromtimestamp(time_fired_ts, local_time_zone).hour
+                )
+            ]
+
+            # Count entity usage
+            for entity_id in entity_ids:
+                if entity_id in allowed_entities:
+                    period_results[entity_id] += 1
+
+    return results

--- a/tests/components/usage_prediction/test_common_control.py
+++ b/tests/components/usage_prediction/test_common_control.py
@@ -1,5 +1,6 @@
 """Test the common control usage prediction."""
 
+from typing import Any
 from unittest.mock import patch
 import uuid
 
@@ -409,3 +410,83 @@ async def test_different_users_separated(hass: HomeAssistant) -> None:
         evening=[],
         night=["light.user2_light"],
     )
+
+
+@pytest.mark.usefixtures("recorder_mock")
+@pytest.mark.parametrize(
+    "event_data",
+    [
+        pytest.param({}, id="no_event_data"),
+        pytest.param({"domain": "light", "service": "turn_on"}, id="no_service_data"),
+        pytest.param(
+            {
+                "domain": "light",
+                "service": "turn_on",
+                "service_data": {"brightness": 255},
+            },
+            id="no_entity_id",
+        ),
+    ],
+)
+async def test_events_without_entity_ids_ignored(
+    hass: HomeAssistant, event_data: dict[str, Any]
+) -> None:
+    """Test that service call events without entity IDs are skipped."""
+    user_id = str(uuid.uuid4())
+
+    hass.states.async_set("light.kitchen", "off")
+
+    with freeze_time("2023-07-01 10:00:00"):
+        hass.bus.async_fire(
+            EVENT_CALL_SERVICE, event_data, context=Context(user_id=user_id)
+        )
+        await hass.async_block_till_done()
+
+    await async_wait_recording_done(hass)
+
+    with freeze_time("2023-07-02 10:00:00"):
+        results = await async_predict_common_control(hass, user_id)
+
+    assert results == EntityUsagePredictions()
+
+
+@pytest.mark.usefixtures("recorder_mock")
+@pytest.mark.parametrize(
+    "json_loads_kwargs",
+    [
+        pytest.param({"side_effect": ValueError("bad json")}, id="invalid_json"),
+        pytest.param({"return_value": {}}, id="empty_object"),
+    ],
+)
+async def test_unusable_event_data_ignored(
+    hass: HomeAssistant, json_loads_kwargs: dict[str, Any]
+) -> None:
+    """Test that events whose stored data cannot be used are skipped."""
+    user_id = str(uuid.uuid4())
+
+    hass.states.async_set("light.kitchen", "off")
+
+    with freeze_time("2023-07-01 10:00:00"):
+        hass.bus.async_fire(
+            EVENT_CALL_SERVICE,
+            {
+                "domain": "light",
+                "service": "turn_on",
+                "service_data": {"entity_id": "light.kitchen"},
+            },
+            context=Context(user_id=user_id),
+        )
+        await hass.async_block_till_done()
+
+    await async_wait_recording_done(hass)
+
+    with (
+        freeze_time("2023-07-02 10:00:00"),
+        patch(
+            "homeassistant.components.usage_prediction.common_control.json_loads_object",
+            **json_loads_kwargs,
+        ),
+    ):
+        results = await async_predict_common_control(hass, user_id)
+
+    assert results == EntityUsagePredictions()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `usage_prediction/common_control` websocket command, which the home dashboard's suggested entities section calls, loaded every `call_service` event row for the user from the last 30 days into Python with `.all()` before counting them. Each row carries the full `shared_data` JSON, so on an instance where the user's token generates many service calls (external automation tools, MCP servers, scripts) this allocates gigabytes and gets Core OOM-killed the moment the home dashboard opens. The result is cached for 24 hours, but Core never survives long enough to fill the cache, so every reload starts cold.

This change moves the counting into the recorder executor and streams the rows with `yield_per`, so only the four per-period counters cross back to the event loop. Memory now scales with the number of distinct contexts rather than the number of rows and their JSON payloads. The allowed entity set (with hidden registry entries removed) is computed once on the event loop and passed in, so the executor no longer touches the entity registry.

Tests cover the branches that skip events without data, with unparsable or empty data, without service data, and without entity IDs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181670
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8GjdchUsEGrDLKo2st4mT