### PR TITLE
Add property is_composite_device to DeviceEntry base class

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -251,7 +251,13 @@ async def async_get_device_automations(
         combined_results[device_id] = []
         if (device := device_registry.async_get(device_id)) is None:
             raise DeviceNotFound
-        for entry_id in device.config_entries:
+        if device.is_composite_device:
+            # A restored composite has no single owning config entry; the union
+            # of the split devices' config entries covers every owning domain.
+            entry_ids = device.config_entries
+        else:
+            entry_ids = {device.config_entry_id}
+        for entry_id in entry_ids:
             if config_entry := hass.config_entries.async_get_entry(entry_id):
                 domain_devices.setdefault(config_entry.domain, set()).add(device_id)
         for domain in device_entities_domains.get(device_id, []):

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -427,6 +427,16 @@ class BaseDeviceEntry:
         return self.config_entry_id
 
     @property
+    def is_composite_device(self) -> bool:
+        """Return if this entry is a restored composite device.
+
+        A restored composite is synthesized by async_get for a pre-migration
+        composite device id and never stored; a plain main or child device is
+        never a composite.
+        """
+        return False
+
+    @property
     def disabled(self) -> bool:
         """Return if entry is disabled."""
         return self.disabled_by is not None
@@ -525,6 +535,16 @@ class DeviceEntry(BaseDeviceEntry):
                 for entry_id, subentries in self._composite_subentries.items()
             }
         return {self.config_entry_id: {self.config_subentry_id}}
+
+    @property
+    @override
+    def is_composite_device(self) -> bool:
+        """Return if this entry is a restored composite device.
+
+        A restored composite is synthesized by async_get for a pre-migration
+        composite device id and never stored.
+        """
+        return self._composite_subentries is not None
 
     @property
     @override

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -1889,3 +1889,96 @@ async def test_validate_config_rewrites_composite_device_id(
         DeviceAutomationType.TRIGGER,
     )
     assert validated["device_id"] == device_fake.id
+
+
+def _mock_device_trigger_platform(hass: HomeAssistant, domain: str) -> None:
+    """Mock a device_trigger platform returning one trigger for the queried device."""
+
+    async def _async_get_triggers(
+        hass: HomeAssistant, device_id: str
+    ) -> list[dict[str, str]]:
+        """List device triggers."""
+        return [
+            {
+                "platform": "device",
+                "domain": domain,
+                "type": "changed_states",
+                "device_id": device_id,
+            }
+        ]
+
+    mock_platform(
+        hass,
+        f"{domain}.device_trigger",
+        Mock(async_get_triggers=_async_get_triggers, spec=["async_get_triggers"]),
+    )
+
+
+async def test_async_get_device_automations_composite_device(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test a composite id is queried for the domains of all its splits' config entries.
+
+    A split device is queried only for the domain of its own config entry.
+    """
+    await async_setup_component(hass, DOMAIN, {})
+    entry_a = MockConfigEntry(domain="domain_a")
+    entry_a.add_to_hass(hass)
+    entry_b = MockConfigEntry(domain="domain_b")
+    entry_b.add_to_hass(hass)
+    _mock_device_trigger_platform(hass, "domain_a")
+    _mock_device_trigger_platform(hass, "domain_b")
+
+    device_a = device_registry.async_get_or_create(
+        config_entry_id=entry_a.entry_id, identifiers={("domain_a", "1")}
+    )
+    device_b = device_registry.async_get_or_create(
+        config_entry_id=entry_b.entry_id, identifiers={("domain_b", "1")}
+    )
+    # Simulate a migration split: both devices carry the pre-migration composite id
+    device_registry._devices[device_a.id] = attr.evolve(
+        device_a, composite_device_id=COMPOSITE_ID
+    )
+    device_registry._devices[device_b.id] = attr.evolve(
+        device_b, composite_device_id=COMPOSITE_ID
+    )
+    assert device_registry.async_get(COMPOSITE_ID).is_composite_device is True
+    assert device_registry.async_get(device_a.id).is_composite_device is False
+
+    result = await device_automation.async_get_device_automations(
+        hass,
+        device_automation.DeviceAutomationType.TRIGGER,
+        [COMPOSITE_ID, device_a.id],
+    )
+
+    # Results are keyed by the requested ids, the composite id included
+    assert set(result) == {COMPOSITE_ID, device_a.id}
+    # The composite is queried for both of its splits' config entry domains
+    assert result[COMPOSITE_ID] == unordered(
+        [
+            {
+                "platform": "device",
+                "domain": "domain_a",
+                "type": "changed_states",
+                "device_id": COMPOSITE_ID,
+                "metadata": {},
+            },
+            {
+                "platform": "device",
+                "domain": "domain_b",
+                "type": "changed_states",
+                "device_id": COMPOSITE_ID,
+                "metadata": {},
+            },
+        ]
+    )
+    # A split is queried for its own config entry domain only
+    assert result[device_a.id] == [
+        {
+            "platform": "device",
+            "domain": "domain_a",
+            "type": "changed_states",
+            "device_id": device_a.id,
+            "metadata": {},
+        }
+    ]

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -10007,6 +10007,44 @@ async def test_async_get_returns_restored_composite(
     )
 
 
+async def test_is_composite_device_main_and_child(
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A plain main device and a child device are not composites."""
+    parent, child_device = _create_parent_and_child(
+        device_registry, mock_config_entry.entry_id
+    )
+
+    assert parent.is_composite_device is False
+    assert child_device.is_composite_device is False
+
+
+@pytest.mark.parametrize("load_registries", [False])
+async def test_is_composite_device_restored_composite(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """A restored composite reports is_composite_device True."""
+    entry_a = MockConfigEntry(domain="domain_a")
+    entry_a.add_to_hass(hass)
+    entry_b = MockConfigEntry(domain="domain_b")
+    entry_b.add_to_hass(hass)
+    hass_storage[dr.STORAGE_KEY] = _composite_device_storage(entry_a, entry_b)
+
+    dr.async_setup(hass)
+    await dr.async_load(hass)
+    device_registry = dr.async_get(hass)
+
+    composite = device_registry.async_get(COMPOSITE_ID)
+    assert composite is not None
+    assert composite.is_composite_device is True
+    # The split devices the composite was restored from are not composites
+    split_a = _get_device_for_config_entry(
+        device_registry, entry_a.entry_id, identifiers={("domain_a", "1")}
+    )
+    assert split_a.is_composite_device is False
+
+
 @pytest.mark.parametrize("load_registries", [False])
 async def test_restored_composite_preserves_primary_config_entry(
     hass: HomeAssistant, hass_storage: dict[str, Any]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add property `is_composite_device` to `BaseDeviceEntry`

The new property returns `True` if the device is a synthetic device representing a multi config entry device split in several devices.
The new property is intended to be used by integrations which genuinely need to access a composite device' `config_entries`, `config_entries_subentries` or `primary_config_entry` attributes, which will allow us to deprecate those attributes on non composite device entries.

The `device_automation` integration is updated to make use of the new property to illustrate the concept.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
