### PR TITLE
Share Duco coordinator update test helper

### DIFF
--- a/tests/components/duco/__init__.py
+++ b/tests/components/duco/__init__.py
@@ -3,10 +3,22 @@
 from collections.abc import Sequence
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.components.duco.const import SCAN_INTERVAL
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def async_fire_coordinator_update(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Trigger a scheduled coordinator update."""
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
 
 async def setup_integration(

--- a/tests/components/duco/test_binary_sensor.py
+++ b/tests/components/duco/test_binary_sensor.py
@@ -14,7 +14,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
-from homeassistant.components.duco.const import BOX_NODE_ID, SCAN_INTERVAL
+from homeassistant.components.duco.const import BOX_NODE_ID
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     STATE_OFF,
@@ -26,9 +26,9 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import setup_platform_integration
+from . import async_fire_coordinator_update, setup_platform_integration
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry
 
 VENTILATION_PROBLEM_ENTITY_ID = "binary_sensor.living_ventilation"
 
@@ -36,13 +36,6 @@ DIAGNOSTIC_ERROR_TYPES = [
     pytest.param(DucoConnectionError, id="connection_error"),
     pytest.param(DucoError, id="duco_error"),
 ]
-
-
-async def _async_refresh(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
-    """Trigger a coordinator refresh."""
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
 
 
 async def test_diagnostic_binary_sensor_entity_registry_defaults(
@@ -144,7 +137,7 @@ async def test_diagnostic_binary_sensors_added_after_initial_empty_response(
         diagnostic_subsystems=(DiagComponent(component="Ventilation", status="Error"),)
     )
 
-    await _async_refresh(hass, freezer)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert hass.states.is_state(VENTILATION_PROBLEM_ENTITY_ID, STATE_ON)
 
@@ -155,7 +148,7 @@ async def test_diagnostic_binary_sensors_added_after_initial_empty_response(
         )
     )
 
-    await _async_refresh(hass, freezer)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert hass.states.is_state("binary_sensor.living_filter", STATE_OFF)
 
@@ -178,7 +171,7 @@ async def test_diagnostic_binary_sensors_wait_for_box_node(
     assert hass.states.get(VENTILATION_PROBLEM_ENTITY_ID) is None
 
     mock_duco_client.async_get_nodes.return_value = mock_sensor_nodes
-    await _async_refresh(hass, freezer)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert hass.states.is_state(VENTILATION_PROBLEM_ENTITY_ID, STATE_OFF)
 
@@ -209,7 +202,7 @@ async def test_diagnostic_binary_sensor_becomes_unknown_without_known_status(
         diagnostic_subsystems=diagnostic_subsystems
     )
 
-    await _async_refresh(hass, freezer)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert hass.states.is_state(VENTILATION_PROBLEM_ENTITY_ID, STATE_UNKNOWN)
 
@@ -233,13 +226,13 @@ async def test_diagnostics_refresh_failure_is_isolated_and_recovers(
 
     mock_duco_client.async_get_diagnostics_info.side_effect = exception_type("error")
 
-    await _async_refresh(hass, freezer)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert hass.states.is_state(VENTILATION_PROBLEM_ENTITY_ID, STATE_UNAVAILABLE)
     assert hass.states.is_state("sensor.office_co2_carbon_dioxide", "405")
 
     mock_duco_client.async_get_diagnostics_info.side_effect = None
-    await _async_refresh(hass, freezer)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert hass.states.is_state(VENTILATION_PROBLEM_ENTITY_ID, STATE_OFF)
 
@@ -266,7 +259,7 @@ async def test_initial_diagnostics_failure_is_isolated_and_recovers(
     assert hass.states.is_state("sensor.office_co2_carbon_dioxide", "405")
 
     mock_duco_client.async_get_diagnostics_info.side_effect = None
-    await _async_refresh(hass, freezer)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert hass.states.is_state(VENTILATION_PROBLEM_ENTITY_ID, STATE_OFF)
 
@@ -283,11 +276,11 @@ async def test_diagnostics_availability_transitions_logged(
     mock_duco_client.async_get_diagnostics_info.side_effect = DucoError("error")
 
     await setup_platform_integration(hass, mock_config_entry, [Platform.BINARY_SENSOR])
-    await _async_refresh(hass, freezer)
+    await async_fire_coordinator_update(hass, freezer)
 
     mock_duco_client.async_get_diagnostics_info.side_effect = None
-    await _async_refresh(hass, freezer)
-    await _async_refresh(hass, freezer)
+    await async_fire_coordinator_update(hass, freezer)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert [
         record.message

--- a/tests/components/duco/test_fan.py
+++ b/tests/components/duco/test_fan.py
@@ -8,7 +8,6 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.duco.const import SCAN_INTERVAL
 from homeassistant.components.fan import (
     ATTR_PERCENTAGE,
     ATTR_PRESET_MODE,
@@ -21,9 +20,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from . import setup_platform_integration
+from . import async_fire_coordinator_update, setup_platform_integration
 
-from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+from tests.common import MockConfigEntry, snapshot_platform
 
 _FAN_ENTITY = "fan.living"
 
@@ -145,9 +144,7 @@ async def test_coordinator_update_marks_unavailable(
         side_effect=DucoConnectionError("offline")
     )
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get(_FAN_ENTITY)
     assert state is not None

--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -21,13 +21,13 @@ from duco_connectivity import (
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.duco.const import BOX_NODE_ID, DOMAIN, SCAN_INTERVAL
+from homeassistant.components.duco.const import BOX_NODE_ID, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from . import setup_platform_integration
+from . import async_fire_coordinator_update, setup_platform_integration
 from .conftest import (
     TEST_HOST,
     TEST_MAC,
@@ -223,9 +223,7 @@ async def test_setup_entry_recovers_from_optional_temperature_capability_failure
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert hass.states.get("sensor.living_outdoor_air_temperature") is None
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get("sensor.living_outdoor_air_temperature")
     assert state is not None
@@ -289,9 +287,7 @@ async def test_empty_bypass_temperature_targets_are_retried(
     assert hass.states.get("number.living_bypass_target_2") is None
     mock_duco_client.async_get_bypass_supply_temperature_targets.assert_awaited_once_with()
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert mock_duco_client.async_get_bypass_supply_temperature_targets.await_count == 2
     assert hass.states.get("number.living_bypass_target_1") is not None
@@ -321,9 +317,7 @@ async def test_missing_bypass_temperature_targets_are_retried(
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert hass.states.get("number.living_bypass_target_1") is None
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get("number.living_bypass_target_1")
     assert state is not None

--- a/tests/components/duco/test_number.py
+++ b/tests/components/duco/test_number.py
@@ -13,7 +13,6 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.duco.const import SCAN_INTERVAL
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, SERVICE_SET_VALUE
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
@@ -21,9 +20,9 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
-from . import setup_platform_integration
+from . import async_fire_coordinator_update, setup_platform_integration
 
-from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+from tests.common import MockConfigEntry, snapshot_platform
 
 _ZONE_1_ENTITY_ID = "number.living_bypass_target_1"
 _ZONE_2_ENTITY_ID = "number.living_bypass_target_2"
@@ -298,18 +297,14 @@ async def test_bypass_supply_temperature_target_becomes_unavailable_when_missing
     assert state.state == "20.0"
 
     updated_target = replace(mock_bypass_supply_temperature_targets.pop(1), value=20.5)
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get(_ZONE_1_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
     mock_bypass_supply_temperature_targets[1] = updated_target
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get(_ZONE_1_ENTITY_ID)
     assert state is not None
@@ -334,17 +329,13 @@ async def test_bypass_supply_temperature_target_recovers_from_refresh_error(
         DucoError("Temporary bypass target failure"),
         mock_bypass_supply_temperature_targets.copy(),
     ]
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get(_ZONE_1_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get(_ZONE_1_ENTITY_ID)
     assert state is not None

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -95,11 +95,22 @@ async def test_ventilation_related_sensors_created_for_supported_node_types(
     assert hass.states.get("sensor.office_co2_state_end_time") is None
 
 
+@pytest.mark.parametrize(
+    ("ventilation_state", "expected_state_end"),
+    [
+        pytest.param(VentilationState.MAN1, "2023-11-14T22:20:59+00:00", id="timed"),
+        pytest.param(VentilationState.CNT1, STATE_UNKNOWN, id="continuous-1"),
+        pytest.param(VentilationState.CNT2, STATE_UNKNOWN, id="continuous-2"),
+        pytest.param(VentilationState.CNT3, STATE_UNKNOWN, id="continuous-3"),
+    ],
+)
 async def test_ventilation_related_sensors_created_for_box_node(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
     mock_sensor_nodes: list[Node],
+    ventilation_state: VentilationState,
+    expected_state_end: str,
 ) -> None:
     """Test ventilation-related sensors are created for the box node.
 
@@ -111,6 +122,7 @@ async def test_ventilation_related_sensors_created_for_box_node(
         mock_sensor_nodes[0],
         ventilation=replace(
             mock_sensor_nodes[0].ventilation,
+            state=ventilation_state,
             flow_lvl_tgt=42,
             time_state_end=1700000459,
         ),
@@ -124,7 +136,7 @@ async def test_ventilation_related_sensors_created_for_box_node(
 
     state = hass.states.get("sensor.living_ventilation_state")
     assert state is not None
-    assert state.state == "auto"
+    assert state.state == ventilation_state.lower()
 
     state = hass.states.get("sensor.living_target_flow_level")
     assert state is not None
@@ -132,7 +144,7 @@ async def test_ventilation_related_sensors_created_for_box_node(
 
     state = hass.states.get("sensor.living_state_end_time")
     assert state is not None
-    assert state.state == "2023-11-14T22:20:59+00:00"
+    assert state.state == expected_state_end
 
     assert hass.states.get("sensor.office_co2_ventilation_state") is None
     assert hass.states.get("sensor.office_co2_target_flow_level") is None

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -19,14 +19,14 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.duco.const import BOX_NODE_ID, DOMAIN, SCAN_INTERVAL
+from homeassistant.components.duco.const import BOX_NODE_ID, DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from . import setup_platform_integration
+from . import async_fire_coordinator_update, setup_platform_integration
 
-from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+from tests.common import MockConfigEntry, snapshot_platform
 
 FILTER_REMAINING_ENTITY_ID = "sensor.living_filter_remaining"
 VENTILATION_TEMPERATURE_ENTITY_IDS = (
@@ -95,22 +95,11 @@ async def test_ventilation_related_sensors_created_for_supported_node_types(
     assert hass.states.get("sensor.office_co2_state_end_time") is None
 
 
-@pytest.mark.parametrize(
-    ("ventilation_state", "expected_state_end"),
-    [
-        pytest.param(VentilationState.MAN1, "2023-11-14T22:20:59+00:00", id="timed"),
-        pytest.param(VentilationState.CNT1, STATE_UNKNOWN, id="continuous-1"),
-        pytest.param(VentilationState.CNT2, STATE_UNKNOWN, id="continuous-2"),
-        pytest.param(VentilationState.CNT3, STATE_UNKNOWN, id="continuous-3"),
-    ],
-)
 async def test_ventilation_related_sensors_created_for_box_node(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
     mock_sensor_nodes: list[Node],
-    ventilation_state: VentilationState,
-    expected_state_end: str,
 ) -> None:
     """Test ventilation-related sensors are created for the box node.
 
@@ -122,7 +111,6 @@ async def test_ventilation_related_sensors_created_for_box_node(
         mock_sensor_nodes[0],
         ventilation=replace(
             mock_sensor_nodes[0].ventilation,
-            state=ventilation_state,
             flow_lvl_tgt=42,
             time_state_end=1700000459,
         ),
@@ -136,7 +124,7 @@ async def test_ventilation_related_sensors_created_for_box_node(
 
     state = hass.states.get("sensor.living_ventilation_state")
     assert state is not None
-    assert state.state == ventilation_state.lower()
+    assert state.state == "auto"
 
     state = hass.states.get("sensor.living_target_flow_level")
     assert state is not None
@@ -144,7 +132,7 @@ async def test_ventilation_related_sensors_created_for_box_node(
 
     state = hass.states.get("sensor.living_state_end_time")
     assert state is not None
-    assert state.state == expected_state_end
+    assert state.state == "2023-11-14T22:20:59+00:00"
 
     assert hass.states.get("sensor.office_co2_ventilation_state") is None
     assert hass.states.get("sensor.office_co2_target_flow_level") is None
@@ -195,14 +183,15 @@ async def test_iaq_sensor_entities_disabled_by_default(
 
 
 @pytest.mark.usefixtures("init_integration")
-async def test_rssi_sensor_disabled_by_default(
+async def test_diagnostic_sensor_entities_disabled_by_default(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test that the RSSI sensor is disabled by default."""
-    entry = entity_registry.async_get("sensor.living_signal_strength")
-    assert entry is not None
-    assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+    """Test that diagnostic sensor entities are disabled by default."""
+    for entity_id in ("sensor.living_signal_strength",):
+        entry = entity_registry.async_get(entity_id)
+        assert entry is not None
+        assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
 
 
 @pytest.mark.usefixtures("init_integration")
@@ -223,9 +212,7 @@ async def test_coordinator_update_failure_marks_unavailable(
     """Test sensor entities become unavailable when the coordinator update fails."""
     mock_duco_client.async_get_nodes.side_effect = exception_type(exception_message)
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get("sensor.office_co2_carbon_dioxide")
     assert state is not None
@@ -249,9 +236,7 @@ async def test_lan_info_failures_keep_node_entities_available(
     """Test node entities stay available when LAN info retrieval fails."""
     mock_duco_client.async_get_lan_info = AsyncMock(side_effect=exception)
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get("sensor.office_co2_carbon_dioxide")
     assert state is not None
@@ -280,9 +265,7 @@ async def test_time_filter_remaining_missing_is_retried(
 
     assert hass.states.get(FILTER_REMAINING_ENTITY_ID) is None
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert mock_duco_client.async_get_time_filter_remaining.await_count == 2
     state = hass.states.get(FILTER_REMAINING_ENTITY_ID)
@@ -307,9 +290,7 @@ async def test_empty_ventilation_temperatures_are_retried(
     for entity_id in VENTILATION_TEMPERATURE_ENTITY_IDS:
         assert hass.states.get(entity_id) is None
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert mock_duco_client.async_get_ventilation_temperature_info.await_count == 2
     state = hass.states.get("sensor.living_outdoor_air_temperature")
@@ -358,9 +339,7 @@ async def test_time_filter_remaining_transient_failure_recovers_sensor_creation(
 
     assert hass.states.get(FILTER_REMAINING_ENTITY_ID) is None
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get(FILTER_REMAINING_ENTITY_ID)
     assert state is not None
@@ -414,9 +393,7 @@ async def test_new_node_added_dynamically(
     new_node = dynamic_sensor_nodes[node_id]
     mock_duco_client.async_get_nodes.return_value = [*mock_sensor_nodes, new_node]
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get(expected_entity_id)
     assert state is not None
@@ -448,9 +425,7 @@ async def test_deregistered_node_removes_device(
         node for node in mock_sensor_nodes if node.node_id != 2
     ]
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     # The device should be removed from the device registry.
     device = device_registry.async_get_device_by_identifier(
@@ -485,9 +460,7 @@ async def test_box_node_not_removed_on_transient_incomplete_node_list(
         node for node in mock_sensor_nodes if node.node_id != BOX_NODE_ID
     ]
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert (
         device_registry.async_get_device_by_identifier(
@@ -502,9 +475,7 @@ async def test_box_node_not_removed_on_transient_incomplete_node_list(
 
     mock_duco_client.async_get_nodes.return_value = mock_sensor_nodes
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get("fan.living")
     assert state is not None
@@ -538,9 +509,7 @@ async def test_unknown_node_type_logs_warning_and_creates_no_entities(
     )
 
     mock_duco_client.async_get_nodes.return_value = [*mock_sensor_nodes, unknown_node]
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert "99" in caplog.text
     assert "unsupported" in caplog.text.lower()
@@ -589,9 +558,7 @@ async def test_previously_unknown_node_gets_entities_after_type_becomes_known(
         *mock_sensor_nodes,
         _make_node(NodeType.UNKNOWN),
     ]
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     assert hass.states.get("sensor.future_sensor_humidity") is None
 
@@ -600,9 +567,7 @@ async def test_previously_unknown_node_gets_entities_after_type_becomes_known(
         *mock_sensor_nodes,
         _make_node("BSRH"),
     ]
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get("sensor.future_sensor_humidity")
     assert state is not None
@@ -642,16 +607,12 @@ async def test_unknown_node_logged_at_debug(
     mock_duco_client.async_get_nodes.return_value = [*mock_sensor_nodes, unknown_node]
 
     with caplog.at_level(logging.WARNING, logger="homeassistant.components.duco"):
-        freezer.tick(SCAN_INTERVAL)
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done(wait_background_tasks=True)
+        await async_fire_coordinator_update(hass, freezer)
 
     assert "has an unsupported device type" not in caplog.text
 
     with caplog.at_level(logging.DEBUG, logger="homeassistant.components.duco"):
-        freezer.tick(SCAN_INTERVAL)
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done(wait_background_tasks=True)
+        await async_fire_coordinator_update(hass, freezer)
 
     assert "has an unsupported device type" in caplog.text
 
@@ -684,9 +645,7 @@ async def test_ventilation_state_unknown_returns_state_unknown(
     ]
     mock_duco_client.async_get_nodes.return_value = updated_nodes
 
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await async_fire_coordinator_update(hass, freezer)
 
     state = hass.states.get("sensor.living_ventilation_state")
     assert state is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a test-only refactor that centralizes Duco's repeated scheduled coordinator update sequence.

Several Duco platform tests need to verify behavior after the normal polling interval elapses. Each of those tests previously repeated the same three operations:

- Advance frozen time by `SCAN_INTERVAL`.
- Fire Home Assistant's time-changed event.
- Wait for background tasks so the scheduled coordinator update has completed.

The sequence is now represented by `async_fire_coordinator_update()` in the shared Duco test module. The helper deliberately uses the real integration polling interval and waits for background tasks, so each caller continues to exercise the same public, time-driven coordinator path as before.

The helper replaces only literal copies of that complete sequence in binary sensor, fan, setup, number, and sensor tests. The surrounding setup, mocked client responses, state assertions, error handling, and recovery assertions are unchanged. This keeps the test scenarios independently readable while making the shared transition explicit and reducing the chance that one future test changes the polling trigger incompletely.

The diff touches six files because that polling transition was duplicated across those platform suites, not because the integration behavior or its coverage is changing. All existing Duco test cases remain collected and passing.

The following tests intentionally retain their inline timing and event choreography:

- Select tests that use half an update interval to prove targeted readback does not postpone the scheduled poll.
- Select concurrency tests that wait for a poll or readback at precise points; their ordering is the behavior under test.
- The setup test that advances a full day to show node names update on reload rather than periodic polling.

No production code, configuration flow behavior, manifests, dependencies, snapshots, or integration functionality changes in this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr