### PR TITLE
Log device availability transitions in Midea

### DIFF
--- a/homeassistant/components/midea/__init__.py
+++ b/homeassistant/components/midea/__init__.py
@@ -127,6 +127,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: MideaConfigEntry) -> boo
                 translation_placeholders={"device_id": str(device_id)},
             )
 
+    unavailable_logged = False
+
+    def _log_availability(_status: Mapping[str, Any]) -> None:
+        """Log once when the device goes offline and once when it is back."""
+        nonlocal unavailable_logged
+        if not device.available and not unavailable_logged:
+            LOGGER.info("Device %s is unavailable", device_id)
+            unavailable_logged = True
+        elif device.available and unavailable_logged:
+            LOGGER.info("Device %s is back online", device_id)
+            unavailable_logged = False
+
+    device.register_update(_log_availability)
+    entry.async_on_unload(partial(device.unregister_update, _log_availability))
+
     # The library's reconnect loop keeps retrying with a growing backoff
     # (up to 600s) without checking for a stop request while sleeping, so
     # device.close() alone cannot guarantee the background thread exits

--- a/homeassistant/components/midea/quality_scale.yaml
+++ b/homeassistant/components/midea/quality_scale.yaml
@@ -36,7 +36,7 @@ rules:
   docs-installation-parameters: done
   entity-unavailable: todo
   integration-owner: done
-  log-when-unavailable: todo
+  log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: todo
   test-coverage: done

--- a/tests/components/midea/test_init.py
+++ b/tests/components/midea/test_init.py
@@ -1,8 +1,10 @@
 """Tests for midea __init__.py."""
 
+import logging
 from unittest.mock import patch
 
 from midealocal.const import DeviceType, ProtocolVersion
+import pytest
 
 from homeassistant.components.midea.const import CONF_SN, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -54,6 +56,36 @@ async def test_unload_entry(hass: HomeAssistant, config_entry: MockConfigEntry) 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     assert config_entry.state is ConfigEntryState.NOT_LOADED
     assert ("close",) in device.calls
+
+
+async def test_logs_once_when_device_unavailable_and_back(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the device is logged once when it goes offline and once when it recovers."""
+    config_entry.add_to_hass(hass)
+    device = DummyDevice(DeviceType.AC)
+    with patch(
+        "homeassistant.components.midea.device_selector",
+        return_value=device,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    unavailable_msg = f"Device {TEST_DEVICE_ID} is unavailable"
+    back_online_msg = f"Device {TEST_DEVICE_ID} is back online"
+
+    with caplog.at_level(logging.INFO, logger="homeassistant.components.midea"):
+        device.available = False
+        device.notify_update({"available": False})
+        device.notify_update({"available": False})
+        assert caplog.text.count(unavailable_msg) == 1
+
+        device.available = True
+        device.notify_update({"available": True})
+        device.notify_update({"available": True})
+        assert caplog.text.count(back_online_msg) == 1
 
 
 async def test_async_setup_entry_paths(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Log device availability transitions in Midea

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
