### PR TITLE
Migrate nexia unique identifiers to strings

### DIFF
--- a/homeassistant/components/nexia/__init__.py
+++ b/homeassistant/components/nexia/__init__.py
@@ -63,10 +63,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NexiaConfigEntry) -> boo
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
 
-    await er.async_migrate_entries(hass, entry.entry_id, _migrate_unique_id)
-    device_registry = dr.async_get(hass)
-    _migrate_device_identifiers(device_registry, entry.entry_id)
-    _preregister_devices(device_registry, entry, nexia_home)
+    _preregister_devices(hass, entry, nexia_home)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     if nexia_home.any_room_iq_monitors():
@@ -76,37 +73,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: NexiaConfigEntry) -> boo
     return True
 
 
-@callback
-def _migrate_unique_id(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
-    """Migrate int unique_ids to strings."""
-    if isinstance(entity_entry.unique_id, str):
-        return None
-    return {"new_unique_id": str(entity_entry.unique_id)}
-
-
-def _migrate_device_identifiers(
-    device_registry: dr.DeviceRegistry, entry_id: str
-) -> None:
-    """Migrate int device identifiers to strings."""
-    for device_entry in dr.async_entries_for_config_entry(device_registry, entry_id):
-        new_ids: set[tuple[str, str]] = set()
-        needs_update = False
-        for domain, identifier in device_entry.identifiers:
-            if domain == DOMAIN and not isinstance(identifier, str):
-                new_ids.add((domain, str(identifier)))
-                needs_update = True
-            else:
-                new_ids.add((domain, identifier))
-        if needs_update:
-            device_registry.async_update_device(
-                device_entry.id, new_identifiers=new_ids
-            )
-
-
 def _preregister_devices(
-    device_registry: dr.DeviceRegistry, entry: NexiaConfigEntry, nexia_home: NexiaHome
+    hass: HomeAssistant, entry: NexiaConfigEntry, nexia_home: NexiaHome
 ) -> None:
     """Register devices before forwarding platforms so sub-devices resolve via_device_id regardless of setup order."""
+    device_registry = dr.async_get(hass)
     for thermostat_id in nexia_home.get_thermostat_ids():
         thermostat = nexia_home.get_thermostat_by_id(thermostat_id)
         device_registry.async_get_or_create(
@@ -154,13 +125,45 @@ async def async_migrate_entry(hass: HomeAssistant, entry: NexiaConfigEntry) -> b
     _LOGGER.debug("Migrating from version %s", entry.version)
 
     if entry.version == 1:
-        # 1 -> 2: Unique ID from integer to string
+        # 1.1 -> 1.2: Unique ID from integer to string
         if entry.minor_version == 1:
-            minor_version = 2
             hass.config_entries.async_update_entry(
-                entry, unique_id=str(entry.unique_id), minor_version=minor_version
+                entry, unique_id=str(entry.unique_id)
             )
+
+        # 1.2 -> 2.1: Make nexia entity and device unique ids strings
+        await er.async_migrate_entries(hass, entry.entry_id, _migrate_unique_id)
+        _migrate_device_identifiers(dr.async_get(hass), entry.entry_id)
+
+        hass.config_entries.async_update_entry(entry, version=2, minor_version=1)
 
     _LOGGER.debug("Migration successful")
 
     return True
+
+
+@callback
+def _migrate_unique_id(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
+    """Migrate int entity unique_ids to strings."""
+    if isinstance(entity_entry.unique_id, str):
+        return None
+    return {"new_unique_id": str(entity_entry.unique_id)}
+
+
+def _migrate_device_identifiers(
+    device_registry: dr.DeviceRegistry, entry_id: str
+) -> None:
+    """Migrate int device identifiers to strings."""
+    for device_entry in dr.async_entries_for_config_entry(device_registry, entry_id):
+        new_ids: set[tuple[str, str]] = set()
+        needs_update = False
+        for domain, identifier in device_entry.identifiers:
+            if domain == DOMAIN and not isinstance(identifier, str):
+                new_ids.add((domain, str(identifier)))
+                needs_update = True
+            else:
+                new_ids.add((domain, identifier))
+        if needs_update:
+            device_registry.async_update_device(
+                device_entry.id, new_identifiers=new_ids
+            )

--- a/homeassistant/components/nexia/__init__.py
+++ b/homeassistant/components/nexia/__init__.py
@@ -9,9 +9,9 @@ from nexia.thermostat import NexiaThermostat
 from nexia.zone import NexiaThermostatZone
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_BRAND, DOMAIN, PLATFORMS
@@ -63,7 +63,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: NexiaConfigEntry) -> boo
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
 
-    _preregister_devices(hass, entry, nexia_home)
+    await er.async_migrate_entries(hass, entry.entry_id, _migrate_unique_id)
+    device_registry = dr.async_get(hass)
+    _migrate_device_identifiers(device_registry, entry.entry_id)
+    _preregister_devices(device_registry, entry, nexia_home)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     if nexia_home.any_room_iq_monitors():
@@ -73,22 +76,48 @@ async def async_setup_entry(hass: HomeAssistant, entry: NexiaConfigEntry) -> boo
     return True
 
 
+@callback
+def _migrate_unique_id(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
+    """Migrate int unique_ids to strings."""
+    if isinstance(entity_entry.unique_id, str):
+        return None
+    return {"new_unique_id": str(entity_entry.unique_id)}
+
+
+def _migrate_device_identifiers(
+    device_registry: dr.DeviceRegistry, entry_id: str
+) -> None:
+    """Migrate int device identifiers to strings."""
+    for device_entry in dr.async_entries_for_config_entry(device_registry, entry_id):
+        new_ids: set[tuple[str, str]] = set()
+        needs_update = False
+        for domain, identifier in device_entry.identifiers:
+            if domain == DOMAIN and not isinstance(identifier, str):
+                new_ids.add((domain, str(identifier)))
+                needs_update = True
+            else:
+                new_ids.add((domain, identifier))
+        if needs_update:
+            device_registry.async_update_device(
+                device_entry.id, new_identifiers=new_ids
+            )
+
+
 def _preregister_devices(
-    hass: HomeAssistant, entry: NexiaConfigEntry, nexia_home: NexiaHome
+    device_registry: dr.DeviceRegistry, entry: NexiaConfigEntry, nexia_home: NexiaHome
 ) -> None:
     """Register devices before forwarding platforms so sub-devices resolve via_device_id regardless of setup order."""
-    device_registry = dr.async_get(hass)
     for thermostat_id in nexia_home.get_thermostat_ids():
         thermostat = nexia_home.get_thermostat_by_id(thermostat_id)
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
-            identifiers={(DOMAIN, thermostat_id)},  # type: ignore[arg-type] # until fix issue #139773
+            identifiers={(DOMAIN, str(thermostat_id))},
         )
         for zone_id in thermostat.get_zone_ids():
             zone = thermostat.get_zone_by_id(zone_id)
             device_registry.async_get_or_create(
                 config_entry_id=entry.entry_id,
-                identifiers={(DOMAIN, zone_id)},  # type: ignore[arg-type] # until fix issue #139773
+                identifiers={(DOMAIN, str(zone_id))},
                 suggested_area=zone.get_name(),
             )
 
@@ -106,11 +135,11 @@ async def async_remove_config_entry_device(
     nexia_home = coordinator.nexia_home
     dev_ids = {dev_id[1] for dev_id in device_entry.identifiers if dev_id[0] == DOMAIN}
     for thermostat_id in nexia_home.get_thermostat_ids():
-        if thermostat_id in dev_ids:
+        if str(thermostat_id) in dev_ids:
             return False
         thermostat: NexiaThermostat = nexia_home.get_thermostat_by_id(thermostat_id)
         for zone_id in thermostat.get_zone_ids():
-            if zone_id in dev_ids:
+            if str(zone_id) in dev_ids:
                 return False
             zone: NexiaThermostatZone = thermostat.get_zone_by_id(zone_id)
             for room_iq_sensor in zone.get_sensors():

--- a/homeassistant/components/nexia/climate.py
+++ b/homeassistant/components/nexia/climate.py
@@ -165,7 +165,7 @@ class NexiaZone(NexiaThermostatZoneEntity, ClimateEntity):
         self, coordinator: NexiaDataUpdateCoordinator, zone: NexiaThermostatZone
     ) -> None:
         """Initialize the thermostat."""
-        super().__init__(coordinator, zone, zone.zone_id)  # type: ignore[arg-type] # until fix issue #139773
+        super().__init__(coordinator, zone, str(zone.zone_id))
         thermostat = self._thermostat
         unit = thermostat.get_unit()
         min_humidity, max_humidity = thermostat.get_humidity_setpoint_limits()

--- a/homeassistant/components/nexia/config_flow.py
+++ b/homeassistant/components/nexia/config_flow.py
@@ -80,8 +80,8 @@ async def validate_input(hass: HomeAssistant, data):
 class NexiaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Nexia."""
 
-    VERSION = 1
-    MINOR_VERSION = 2
+    VERSION = 2
+    MINOR_VERSION = 1
 
     @override
     async def async_step_user(

--- a/homeassistant/components/nexia/entity.py
+++ b/homeassistant/components/nexia/entity.py
@@ -54,7 +54,7 @@ class NexiaThermostatEntity(NexiaEntity):
         thermostat_id = thermostat.thermostat_id
         self._attr_device_info = DeviceInfo(
             configuration_url=self.coordinator.nexia_home.root_url,
-            identifiers={(DOMAIN, thermostat_id)},  # type: ignore[arg-type] # until fix issue #139773
+            identifiers={(DOMAIN, str(thermostat_id))},
             manufacturer=MANUFACTURER,
             model=thermostat.get_model(),
             name=thermostat.get_name(),
@@ -111,11 +111,11 @@ class NexiaThermostatZoneEntity(NexiaThermostatEntity):
             self._attr_device_info |= dev_info
         else:
             self._attr_device_info |= {
-                ATTR_IDENTIFIERS: {(DOMAIN, zone.zone_id)},  # type: ignore[arg-type] # until fix issue #139773
+                ATTR_IDENTIFIERS: {(DOMAIN, str(zone.zone_id))},
                 ATTR_NAME: zone.get_name(),
                 "via_device_id": dr.async_get_device_id_by_identifier(
                     self.coordinator.hass,
-                    (DOMAIN, zone.thermostat.thermostat_id),  # type: ignore[arg-type] # until fix issue #139773
+                    (DOMAIN, str(zone.thermostat.thermostat_id)),
                     config_entry_id=self.coordinator.config_entry.entry_id,
                 ),
             }
@@ -166,7 +166,7 @@ class NexiaRoomIQEntity(NexiaThermostatZoneEntity):
                 sw_version=None,  # not reported
                 via_device_id=dr.async_get_device_id_by_identifier(
                     coordinator.hass,
-                    (DOMAIN, zone.zone_id),  # type: ignore[arg-type] # until fix issue #139773
+                    (DOMAIN, str(zone.zone_id)),
                     config_entry_id=coordinator.config_entry.entry_id,
                 ),
             )

--- a/homeassistant/components/nexia/scene.py
+++ b/homeassistant/components/nexia/scene.py
@@ -42,7 +42,7 @@ class NexiaAutomationScene(NexiaEntity, Scene):
         self, coordinator: NexiaDataUpdateCoordinator, automation: NexiaAutomation
     ) -> None:
         """Initialize the automation scene."""
-        super().__init__(coordinator, automation.automation_id)  # type: ignore[arg-type] # until fix issue #139773
+        super().__init__(coordinator, str(automation.automation_id))
         self._attr_name = automation.name
         self._automation = automation
         self._attr_extra_state_attributes = {ATTR_DESCRIPTION: automation.description}

--- a/homeassistant/components/nexia/switch.py
+++ b/homeassistant/components/nexia/switch.py
@@ -68,8 +68,7 @@ class NexiaHoldSwitch(NexiaThermostatZoneEntity, SwitchEntity):
         self, coordinator: NexiaDataUpdateCoordinator, zone: NexiaThermostatZone
     ) -> None:
         """Initialize the hold mode switch."""
-        zone_id = zone.zone_id
-        super().__init__(coordinator, zone, zone_id)  # type: ignore[arg-type] # until fix issue #139773
+        super().__init__(coordinator, zone, str(zone.zone_id))
 
     @property
     @override

--- a/tests/components/nexia/conftest.py
+++ b/tests/components/nexia/conftest.py
@@ -10,6 +10,7 @@ from nexia.thermostat import NexiaThermostat
 from nexia.zone import NexiaThermostatZone
 import pytest
 
+from homeassistant.components.nexia.config_flow import NexiaConfigFlow
 from homeassistant.components.nexia.const import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -410,7 +411,8 @@ async def setup_integration(
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_USERNAME: "mock", CONF_PASSWORD: "mock"},
-        minor_version=2,
+        version=NexiaConfigFlow.VERSION,
+        minor_version=NexiaConfigFlow.MINOR_VERSION,
         unique_id=unique_id,
     )
     entry.add_to_hass(hass)

--- a/tests/components/nexia/test_init.py
+++ b/tests/components/nexia/test_init.py
@@ -1,12 +1,13 @@
 """The init tests for the nexia platform."""
 
-from unittest.mock import NonCallableMock, patch
+from unittest.mock import AsyncMock, NonCallableMock, patch
 
 import aiohttp
 from nexia.home import NexiaHome
 import pytest
 
 from homeassistant.components.nexia import _preregister_devices
+from homeassistant.components.nexia.config_flow import NexiaConfigFlow
 from homeassistant.components.nexia.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -68,7 +69,7 @@ async def test_device_remove_devices(
 
 
 async def test_migrate_entry_minor_version_1_2(hass: HomeAssistant) -> None:
-    """Test migrating a 1.1 config entry to 1.2."""
+    """Test migrating a 1.1 config entry."""
     with patch("homeassistant.components.nexia.async_setup_entry", return_value=True):
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -79,8 +80,9 @@ async def test_migrate_entry_minor_version_1_2(hass: HomeAssistant) -> None:
         )
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
-        assert entry.version == 1
-        assert entry.minor_version == 2
+        assert entry.state is ConfigEntryState.LOADED
+        assert entry.version == NexiaConfigFlow.VERSION
+        assert entry.minor_version == NexiaConfigFlow.MINOR_VERSION
         assert entry.unique_id == "123456"
 
 
@@ -90,7 +92,10 @@ async def test_migrate_entity_identifiers(
 ) -> None:
     """Test migrating config entity identifiers to string."""
     entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_USERNAME: "mock", CONF_PASSWORD: "mock"}
+        domain=DOMAIN,
+        data={CONF_USERNAME: "mock", CONF_PASSWORD: "mock"},
+        version=1,
+        minor_version=2,
     )
     entry.add_to_hass(hass)
 
@@ -108,7 +113,6 @@ async def test_migrate_entity_identifiers(
     )
     modified_before = str_entry.modified_at
     assert await hass.config_entries.async_setup(entry.entry_id) is True
-    await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.LOADED
 
     migrated_entry = entity_registry.async_get(int_entry.entity_id)
@@ -128,7 +132,10 @@ async def test_migrate_device_identifiers(
 ) -> None:
     """Test migrating config device identifiers to string."""
     entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_USERNAME: "mock", CONF_PASSWORD: "mock"}
+        domain=DOMAIN,
+        data={CONF_USERNAME: "mock", CONF_PASSWORD: "mock"},
+        version=1,
+        minor_version=2,
     )
     entry.add_to_hass(hass)
 
@@ -144,7 +151,6 @@ async def test_migrate_device_identifiers(
     )
     modified_before = str_device.modified_at
     assert await hass.config_entries.async_setup(entry.entry_id) is True
-    await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.LOADED
 
     migrated_device = device_registry.async_get(int_device.id)
@@ -161,7 +167,9 @@ async def test_migrate_device_identifiers(
     assert unchanged_device.modified_at == modified_before
 
 
+@patch("homeassistant.components.nexia.async_migrate_entry")
 async def test_string_identifiers(
+    mock_migrate_entry: AsyncMock,
     hass: HomeAssistant,
     patch_nexia_home: NexiaHome,
     entity_registry: er.EntityRegistry,
@@ -169,6 +177,9 @@ async def test_string_identifiers(
 ) -> None:
     """Test the identifiers are strings."""
     entry = await setup_integration(hass, patch_nexia_home)
+
+    # verify migration was not called
+    mock_migrate_entry.assert_not_awaited()
 
     entities = entity_registry.entities
     entity_entries = entities.get_entries_for_config_entry_id(entry.entry_id)
@@ -192,7 +203,7 @@ async def test_device_preregistration(
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
 
-    _preregister_devices(device_registry, entry, mock_nexia_home)
+    _preregister_devices(hass, entry, mock_nexia_home)
 
     thermostat_ids = mock_nexia_home.get_thermostat_ids()
     assert len(thermostat_ids) > 0

--- a/tests/components/nexia/test_init.py
+++ b/tests/components/nexia/test_init.py
@@ -4,6 +4,7 @@ from unittest.mock import NonCallableMock, patch
 
 import aiohttp
 from nexia.home import NexiaHome
+import pytest
 
 from homeassistant.components.nexia import _preregister_devices
 from homeassistant.components.nexia.const import DOMAIN
@@ -83,6 +84,107 @@ async def test_migrate_entry_minor_version_1_2(hass: HomeAssistant) -> None:
         assert entry.unique_id == "123456"
 
 
+@pytest.mark.usefixtures("patch_nexia_home")
+async def test_migrate_entity_identifiers(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test migrating config entity identifiers to string."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_USERNAME: "mock", CONF_PASSWORD: "mock"}
+    )
+    entry.add_to_hass(hass)
+
+    int_entry = entity_registry.async_get_or_create(
+        "climate",
+        DOMAIN,
+        85034552,
+        config_entry=entry,
+    )
+    str_entry = entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "already_a_string",
+        config_entry=entry,
+    )
+    modified_before = str_entry.modified_at
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
+
+    migrated_entry = entity_registry.async_get(int_entry.entity_id)
+    assert migrated_entry is not None
+    assert migrated_entry.unique_id == "85034552"
+    assert migrated_entry.entity_id == int_entry.entity_id
+
+    unchanged_entry = entity_registry.async_get(str_entry.entity_id)
+    assert unchanged_entry is not None
+    assert unchanged_entry.unique_id == "already_a_string"
+    assert unchanged_entry.modified_at == modified_before
+
+
+@pytest.mark.usefixtures("patch_nexia_home")
+async def test_migrate_device_identifiers(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test migrating config device identifiers to string."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_USERNAME: "mock", CONF_PASSWORD: "mock"}
+    )
+    entry.add_to_hass(hass)
+
+    int_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, 12345), ("other_domain", "not_touched")},
+        name="Center",
+    )
+    str_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "already_a_string")},
+        name="Center",
+    )
+    modified_before = str_device.modified_at
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
+
+    migrated_device = device_registry.async_get(int_device.id)
+    assert migrated_device is not None
+    assert migrated_device.identifiers == {
+        (DOMAIN, "12345"),
+        ("other_domain", "not_touched"),
+    }
+    assert migrated_device.id == int_device.id
+
+    unchanged_device = device_registry.async_get(str_device.id)
+    assert unchanged_device is not None
+    assert unchanged_device.identifiers == {(DOMAIN, "already_a_string")}
+    assert unchanged_device.modified_at == modified_before
+
+
+async def test_string_identifiers(
+    hass: HomeAssistant,
+    patch_nexia_home: NexiaHome,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the identifiers are strings."""
+    entry = await setup_integration(hass, patch_nexia_home)
+
+    entities = entity_registry.entities
+    entity_entries = entities.get_entries_for_config_entry_id(entry.entry_id)
+    assert len(entity_entries) > 0
+    for entity_entry in entity_entries:
+        assert isinstance(entity_entry.unique_id, str)
+
+    device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+    assert len(device_entries) > 0
+    for device_entry in device_entries:
+        for domain, ident in device_entry.identifiers:
+            assert isinstance(ident, str), (
+                f"Device [{device_entry.name}] has non-string identifier ({domain}, {ident})"
+            )
+
+
 async def test_device_preregistration(
     hass: HomeAssistant, mock_nexia_home: NexiaHome, device_registry: dr.DeviceRegistry
 ) -> None:
@@ -90,7 +192,7 @@ async def test_device_preregistration(
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
 
-    _preregister_devices(hass, entry, mock_nexia_home)
+    _preregister_devices(device_registry, entry, mock_nexia_home)
 
     thermostat_ids = mock_nexia_home.get_thermostat_ids()
     assert len(thermostat_ids) > 0
@@ -98,8 +200,7 @@ async def test_device_preregistration(
     for thermostat_id in thermostat_ids:
         thermostat = mock_nexia_home.get_thermostat_by_id(thermostat_id)
         device = device_registry.async_get_device_by_identifier(
-            (DOMAIN, thermostat.thermostat_id),  # type: ignore[arg-type] # until fix issue #139773
-            entry.entry_id,
+            (DOMAIN, str(thermostat.thermostat_id)), entry.entry_id
         )
         assert device is not None
 
@@ -109,8 +210,7 @@ async def test_device_preregistration(
         for zone_id in zone_ids:
             zone = thermostat.get_zone_by_id(zone_id)
             device = device_registry.async_get_device_by_identifier(
-                (DOMAIN, zone.zone_id),  # type: ignore[arg-type] # until fix issue #139773
-                entry.entry_id,
+                (DOMAIN, str(zone.zone_id)), entry.entry_id
             )
             assert device is not None
             assert device.area_id == slugify(zone.get_name())
@@ -125,22 +225,19 @@ async def test_device_via_device_links(
     config_entry = await setup_integration(hass, patch_nexia_home)
 
     thermostat_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, 2000004),  # type: ignore[arg-type] # until fix issue #139773
-        config_entry.entry_id,
+        (DOMAIN, "2000004"), config_entry.entry_id
     )
     assert thermostat_device is not None
 
     zone_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, 500),  # type: ignore[arg-type] # until fix issue #139773
-        config_entry.entry_id,
+        (DOMAIN, "500"), config_entry.entry_id
     )
     assert zone_device is not None
     assert zone_device.via_device_id == thermostat_device.id
     assert zone_device.area_id == "zone3"
 
     sensor_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, "502"),
-        config_entry.entry_id,
+        (DOMAIN, "502"), config_entry.entry_id
     )
     assert sensor_device is not None
     assert sensor_device.via_device_id == zone_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change the Nexia integration to use strings for its entity unique_ids and device identifiers.
Migrate any existing Nexia configuration data so this change won't affect existing users.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #139773
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
