### PR TITLE
Bump py-madvr2 to 1.9.1

### DIFF
--- a/homeassistant/components/madvr/__init__.py
+++ b/homeassistant/components/madvr/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from madvr.madvr import Madvr
+from pymadvr.madvr import Madvr
 
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant
@@ -18,7 +18,6 @@ async def async_handle_unload(coordinator: MadVRCoordinator) -> None:
     """Handle unload."""
     _LOGGER.debug("Integration unloading")
     coordinator.client.stop()
-    await coordinator.client.async_cancel_tasks()
     _LOGGER.debug("Integration closing connection")
     await coordinator.client.close_connection()
     _LOGGER.debug("Unloaded")

--- a/homeassistant/components/madvr/config_flow.py
+++ b/homeassistant/components/madvr/config_flow.py
@@ -4,8 +4,7 @@ import asyncio
 import logging
 from typing import Any, override
 
-import aiohttp
-from madvr.madvr import HeartBeatError, Madvr
+from pymadvr.madvr import Madvr
 import voluptuous as vol
 
 from homeassistant.config_entries import (
@@ -105,18 +104,13 @@ async def test_connection(hass: HomeAssistant, host: str, port: int) -> str:
     # try to connect
     try:
         await asyncio.wait_for(madvr_client.open_connection(), timeout=15)
-    # connection can raise HeartBeatError if the device is not
-    # available or connection does not work
-    except (TimeoutError, aiohttp.ClientError, OSError, HeartBeatError) as err:
+    except (TimeoutError, OSError) as err:
         _LOGGER.error("Error connecting to madVR: %s", err)
         raise CannotConnect from err
 
     # check if we are connected
     if not madvr_client.connected:
         raise CannotConnect("Connection failed")
-
-    # background tasks needed to capture realtime info
-    await madvr_client.async_add_tasks()
 
     # wait for client to capture device info
     retry_time = 15
@@ -137,5 +131,4 @@ async def close_test_connection(madvr_client: Madvr) -> None:
     """Close the test connection."""
     _LOGGER.debug("Closing test connection")
     madvr_client.stop()
-    await madvr_client.async_cancel_tasks()
     await madvr_client.close_connection()

--- a/homeassistant/components/madvr/config_flow.py
+++ b/homeassistant/components/madvr/config_flow.py
@@ -101,30 +101,32 @@ async def test_connection(hass: HomeAssistant, host: str, port: int) -> str:
     """Test if we can connect to the device and grab the mac."""
     madvr_client = Madvr(host=host, port=port, loop=hass.loop)
     _LOGGER.debug("Testing connection to madVR at %s:%s", host, port)
-    # try to connect
     try:
-        await asyncio.wait_for(madvr_client.open_connection(), timeout=15)
-    except (TimeoutError, OSError) as err:
-        _LOGGER.error("Error connecting to madVR: %s", err)
-        raise CannotConnect from err
+        # try to connect
+        try:
+            await asyncio.wait_for(madvr_client.open_connection(), timeout=15)
+        except (TimeoutError, OSError) as err:
+            _LOGGER.error("Error connecting to madVR: %s", err)
+            raise CannotConnect from err
 
-    # check if we are connected
-    if not madvr_client.connected:
-        raise CannotConnect("Connection failed")
+        # check if we are connected
+        if not madvr_client.connected:
+            raise CannotConnect("Connection failed")
 
-    # wait for client to capture device info
-    retry_time = 15
-    while not madvr_client.mac_address and retry_time > 0:
-        await asyncio.sleep(RETRY_INTERVAL)
-        retry_time -= 1
+        # wait for client to capture device info
+        retry_time = 15
+        while not madvr_client.mac_address and retry_time > 0:
+            await asyncio.sleep(RETRY_INTERVAL)
+            retry_time -= 1
 
-    mac_address = madvr_client.mac_address
-    if mac_address:
-        _LOGGER.debug("Connected to madVR with MAC: %s", mac_address)
-    # close this connection because this client object will not be reused
-    await close_test_connection(madvr_client)
-    _LOGGER.debug("Connection test successful")
-    return mac_address
+        mac_address = madvr_client.mac_address
+        if mac_address:
+            _LOGGER.debug("Connected to madVR with MAC: %s", mac_address)
+        _LOGGER.debug("Connection test successful")
+        return mac_address
+    finally:
+        # close this connection because this client object will not be reused
+        await close_test_connection(madvr_client)
 
 
 async def close_test_connection(madvr_client: Madvr) -> None:

--- a/homeassistant/components/madvr/coordinator.py
+++ b/homeassistant/components/madvr/coordinator.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from madvr.madvr import Madvr
+from pymadvr.madvr import Madvr
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -49,4 +49,4 @@ class MadVRCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         _LOGGER.debug("Using loop: %s", self.client.loop)
         # tell the library to start background tasks
         await self.client.async_add_tasks()
-        _LOGGER.debug("Added %s tasks to client", len(self.client.tasks))
+        _LOGGER.debug("Added background tasks to client")

--- a/homeassistant/components/madvr/manifest.json
+++ b/homeassistant/components/madvr/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/madvr",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["py-madvr2==1.6.40"]
+  "requirements": ["py-madvr2==1.9.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1984,7 +1984,7 @@ py-dormakaba-dkey==1.0.6
 py-improv-ble-client==2.0.1
 
 # homeassistant.components.madvr
-py-madvr2==1.6.40
+py-madvr2==1.9.1
 
 # homeassistant.components.melissa
 py-melissa-climate==3.0.3

--- a/tests/components/madvr/conftest.py
+++ b/tests/components/madvr/conftest.py
@@ -39,7 +39,6 @@ def mock_madvr_client() -> Generator[AsyncMock]:
         client.connected.return_value = True
         client.is_device_connectable.return_value = True
         client.loop = AsyncMock()
-        client.tasks = AsyncMock()
         client.set_update_callback = MagicMock()
 
         # mock the property to be off on startup (which it is)

--- a/tests/components/madvr/test_config_flow.py
+++ b/tests/components/madvr/test_config_flow.py
@@ -44,8 +44,9 @@ async def test_full_flow(hass: HomeAssistant, mock_madvr_client: AsyncMock) -> N
     }
     assert result["result"].unique_id == MOCK_MAC
     mock_madvr_client.open_connection.assert_called_once()
-    mock_madvr_client.async_add_tasks.assert_called_once()
-    mock_madvr_client.async_cancel_tasks.assert_called_once()
+    mock_madvr_client.async_add_tasks.assert_not_called()
+    mock_madvr_client.async_cancel_tasks.assert_not_called()
+    mock_madvr_client.close_connection.assert_called_once()
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
@@ -98,9 +99,9 @@ async def test_flow_errors(hass: HomeAssistant, mock_madvr_client: AsyncMock) ->
 
     # Verify method calls
     assert mock_madvr_client.open_connection.call_count == 4
-    assert mock_madvr_client.async_add_tasks.call_count == 2
-    # the first call will not call this due to timeout as expected
-    assert mock_madvr_client.async_cancel_tasks.call_count == 2
+    assert mock_madvr_client.async_add_tasks.call_count == 0
+    assert mock_madvr_client.async_cancel_tasks.call_count == 0
+    assert mock_madvr_client.close_connection.call_count == 2
 
 
 async def test_duplicate(
@@ -155,8 +156,9 @@ async def test_reconfigure_flow(
 
     # Verify that the connection was tested
     mock_madvr_client.open_connection.assert_called()
-    mock_madvr_client.async_add_tasks.assert_called()
-    mock_madvr_client.async_cancel_tasks.assert_called()
+    mock_madvr_client.async_add_tasks.assert_not_called()
+    mock_madvr_client.async_cancel_tasks.assert_not_called()
+    mock_madvr_client.close_connection.assert_called()
 
 
 async def test_reconfigure_new_device(

--- a/tests/components/madvr/test_config_flow.py
+++ b/tests/components/madvr/test_config_flow.py
@@ -101,7 +101,7 @@ async def test_flow_errors(hass: HomeAssistant, mock_madvr_client: AsyncMock) ->
     assert mock_madvr_client.open_connection.call_count == 4
     assert mock_madvr_client.async_add_tasks.call_count == 0
     assert mock_madvr_client.async_cancel_tasks.call_count == 0
-    assert mock_madvr_client.close_connection.call_count == 2
+    assert mock_madvr_client.close_connection.call_count == 4
 
 
 async def test_duplicate(
@@ -127,6 +127,7 @@ async def test_reconfigure_flow(
     hass: HomeAssistant,
     mock_madvr_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
 ) -> None:
     """Test reconfigure flow."""
     mock_config_entry.add_to_hass(hass)
@@ -145,6 +146,7 @@ async def test_reconfigure_flow(
         result["flow_id"],
         {CONF_HOST: new_host, CONF_PORT: new_port},
     )
+    await hass.async_block_till_done()
 
     # should get the abort with success result
     assert result["type"] is FlowResultType.ABORT
@@ -159,6 +161,7 @@ async def test_reconfigure_flow(
     mock_madvr_client.async_add_tasks.assert_not_called()
     mock_madvr_client.async_cancel_tasks.assert_not_called()
     mock_madvr_client.close_connection.assert_called()
+    mock_setup_entry.assert_awaited_once()
 
 
 async def test_reconfigure_new_device(
@@ -193,6 +196,7 @@ async def test_reconfigure_flow_errors(
     hass: HomeAssistant,
     mock_madvr_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
 ) -> None:
     """Test error handling in reconfigure flow."""
     mock_config_entry.add_to_hass(hass)
@@ -228,5 +232,11 @@ async def test_reconfigure_flow_errors(
         result["flow_id"],
         {CONF_HOST: "192.168.1.100", CONF_PORT: 44077},
     )
+    await hass.async_block_till_done()
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
+    assert mock_madvr_client.open_connection.call_count == 3
+    assert mock_madvr_client.async_add_tasks.call_count == 0
+    assert mock_madvr_client.async_cancel_tasks.call_count == 0
+    assert mock_madvr_client.close_connection.call_count == 3
+    mock_setup_entry.assert_awaited_once()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump `py-madvr2` from 1.6.40 to 1.9.1 for the madVR Envy integration.

The new release renames the import namespace from `madvr` to `pymadvr` and updates the connection task lifecycle. This updates the integration imports, avoids starting or cancelling the config-flow client's background tasks twice, and removes the coordinator's dependency on the removed `tasks` list.

- PyPI release: https://pypi.org/project/py-madvr2/1.9.1/
- Changelog: https://github.com/iloveicedgreentea/py-madvr/releases/tag/v1.9.1
- Comparison diff: https://github.com/iloveicedgreentea/py-madvr/compare/v1.6.40...v1.9.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
