### PR TITLE
Fix Z-Wave climate long floats

### DIFF
--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -480,6 +480,21 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
 
         await self._async_set_value(self._fan_mode, new_state)
 
+    def _round_setpoint(self, temp: float) -> float:
+        """Round to a resolution the device can encode.
+
+        Z-Wave derives the encoded precision from the float itself, so an
+        unrounded unit conversion becomes a 4-byte payload some nodes
+        mis-parse. Fahrenheit thermostats step in half degrees at best.
+        Clamp afterwards in case rounding pushed an already-validated value
+        outside the device's range.
+        """
+        if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
+            rounded = round(temp * 2) / 2
+        else:
+            rounded = round(temp, 1)
+        return min(max(rounded, self.min_temp), self.max_temp)
+
     @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
@@ -493,7 +508,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
             )
             target_temp: float | None = kwargs.get(ATTR_TEMPERATURE)
             if target_temp is not None:
-                await self._async_set_value(setpoint, target_temp)
+                await self._async_set_value(setpoint, self._round_setpoint(target_temp))
         elif len(self._current_mode_setpoint_enums) == 2:
             setpoint_low: ZwaveValue = self._setpoint_value_or_raise(
                 self._current_mode_setpoint_enums[0]
@@ -504,9 +519,13 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
             target_temp_low: float | None = kwargs.get(ATTR_TARGET_TEMP_LOW)
             target_temp_high: float | None = kwargs.get(ATTR_TARGET_TEMP_HIGH)
             if target_temp_low is not None:
-                await self._async_set_value(setpoint_low, target_temp_low)
+                await self._async_set_value(
+                    setpoint_low, self._round_setpoint(target_temp_low)
+                )
             if target_temp_high is not None:
-                await self._async_set_value(setpoint_high, target_temp_high)
+                await self._async_set_value(
+                    setpoint_high, self._round_setpoint(target_temp_high)
+                )
 
     @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:

--- a/tests/components/zwave_js/test_climate.py
+++ b/tests/components/zwave_js/test_climate.py
@@ -47,6 +47,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .common import (
     CLIMATE_DANFOSS_LC13_ENTITY,
@@ -391,6 +392,142 @@ async def test_thermostat_v2(
     )
     await hass.async_block_till_done()
     assert "Error while refreshing value" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("requested_temperature", "sent_temperature"),
+    [
+        pytest.param(23.3, 74.0, id="whole_fahrenheit_below"),
+        pytest.param(21.1, 70.0, id="whole_fahrenheit_above"),
+        pytest.param(23.9, 75.0, id="long_float"),
+        pytest.param(25, 77.0, id="exact"),
+    ],
+)
+async def test_setpoint_thermostat_fahrenheit_rounding(
+    hass: HomeAssistant,
+    client: MagicMock,
+    climate_radio_thermostat_ct100_plus: Node,
+    integration: MockConfigEntry,
+    requested_temperature: float,
+    sent_temperature: float,
+) -> None:
+    """Test setpoints are rounded to a resolution the Fahrenheit device can encode.
+
+    An unrounded unit conversion (e.g. 23.3 C -> 73.94 F) produces a Z-Wave
+    payload some nodes mis-parse, so it must be rounded to the nearest half
+    degree before being sent.
+    """
+    client.async_send_command.reset_mock()
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {
+            ATTR_ENTITY_ID: CLIMATE_RADIO_THERMOSTAT_ENTITY,
+            ATTR_TEMPERATURE: requested_temperature,
+        },
+        blocking=True,
+    )
+
+    args = client.async_send_command.call_args_list[0][0][0]
+    assert args["command"] == "node.set_value"
+    assert args["valueId"] == {
+        "commandClass": 67,
+        "endpoint": 1,
+        "property": "setpoint",
+        "propertyKey": 1,
+    }
+    assert args["value"] == sent_temperature
+
+
+async def test_setpoint_thermostat_fahrenheit_range_rounding(
+    hass: HomeAssistant,
+    client: MagicMock,
+    climate_radio_thermostat_ct100_plus: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test dual setpoints are rounded to a resolution the device can encode."""
+    node = climate_radio_thermostat_ct100_plus
+
+    # Switch the device into heat_cool mode so both setpoints are writable.
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": 13,
+            "args": {
+                "commandClassName": "Thermostat Mode",
+                "commandClass": 64,
+                "endpoint": 1,
+                "property": "mode",
+                "propertyName": "mode",
+                "newValue": 3,
+                "prevValue": 1,
+            },
+        },
+    )
+    node.receive_event(event)
+
+    client.async_send_command.reset_mock()
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {
+            ATTR_ENTITY_ID: CLIMATE_RADIO_THERMOSTAT_ENTITY,
+            ATTR_TARGET_TEMP_LOW: 23.3,
+            ATTR_TARGET_TEMP_HIGH: 25.9,
+        },
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 2
+    args = client.async_send_command.call_args_list[0][0][0]
+    assert args["command"] == "node.set_value"
+    assert args["valueId"] == {
+        "commandClass": 67,
+        "endpoint": 1,
+        "property": "setpoint",
+        "propertyKey": 1,
+    }
+    assert args["value"] == 74.0
+
+    args = client.async_send_command.call_args_list[1][0][0]
+    assert args["command"] == "node.set_value"
+    assert args["valueId"] == {
+        "commandClass": 67,
+        "endpoint": 1,
+        "property": "setpoint",
+        "propertyKey": 2,
+    }
+    assert args["value"] == 78.5
+
+
+async def test_setpoint_thermostat_celsius_rounding(
+    hass: HomeAssistant,
+    client: MagicMock,
+    climate_heatit_z_trm3: Node,
+    integration: MockConfigEntry,
+) -> None:
+    """Test setpoints on a Celsius device are rounded to a tenth of a degree."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    client.async_send_command.reset_mock()
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {
+            ATTR_ENTITY_ID: CLIMATE_FLOOR_THERMOSTAT_ENTITY,
+            ATTR_TEMPERATURE: 70,
+        },
+        blocking=True,
+    )
+
+    args = client.async_send_command.call_args_list[0][0][0]
+    assert args["command"] == "node.set_value"
+    assert args["valueId"]["commandClass"] == 67
+    assert args["value"] == 21.1
 
 
 async def test_thermostat_v2_turn_on_after_off(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix float handling in Z-Wave climate.

<details>
 <summary>Claude explanation</summary>

### Why the raw float breaks devices

zwave-js derives the encoded precision from the float itself — `getPrecision` in [`packages/core/src/values/Primitive.ts`](https://github.com/zwave-js/zwave-js/blob/master/packages/core/src/values/Primitive.ts) loops multiplying by 10 until the round trip is exact, capped at 7 by `encodeFloatWithScale`. So:

| value sent | encoded precision | scaled int | payload size |
|---|---|---|---|
| `75.02000000000001` | 7 (capped) | 750200000 | **4 bytes** |
| `73.94` | 2 | 7394 | 2 bytes |
| `75.0` | 1 | 750 | 2 bytes |

`75.02000000000001` serialises to `2C B7 24 C0`. The node in the issue thread reported back **44**, which is exactly `0x2C` — the first value byte. It ignored the size field and read one byte. That is a hard confirmation of the corruption mechanism.

### The symptom, reproduced

Walking whole-°F setpoints through the chain (`F → HomeKit 0.1 °C → back to °F → device floors onto its 0.5 grid`) reproduces the issue body exactly:

| User picks | HomeKit sends | HA sends today | Device lands on | Reported as |
|---|---|---|---|---|
| 74 °F | 23.3 °C | 73.9400 | 73.5 | **73 °F** |
| 70 °F | 21.1 °C | 69.9800 | 69.5 | **69 °F** |
| 73 °F | 22.8 °C | 73.0400 | 73.0 | 73 °F (ok) |

The 0.1 °C round trip lands either slightly above the intended degree (harmless — the device floors back onto it) or slightly below (broken — the device floors a full half-degree away). Half of all whole-°F setpoints land below, matching the reporter's "still can't use half the temperature setpoints".

</details>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #135639
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
