### PR TITLE
Add a maximum volume sensor to Lyngdorf

### DIFF
--- a/homeassistant/components/lyngdorf/icons.json
+++ b/homeassistant/components/lyngdorf/icons.json
@@ -35,6 +35,9 @@
       "audio_input": {
         "default": "mdi:audio-input-stereo-minijack"
       },
+      "maximum_volume": {
+        "default": "mdi:volume-high"
+      },
       "streaming_source": {
         "default": "mdi:cast-audio"
       },

--- a/homeassistant/components/lyngdorf/quality_scale.yaml
+++ b/homeassistant/components/lyngdorf/quality_scale.yaml
@@ -69,8 +69,10 @@ rules:
   entity-disabled-by-default:
     status: done
     comment: >-
-      All entities are useful by default; the diagnostic sensors change only on
-      source or content changes.
+      The maximum volume sensor is disabled by default: most owners set no
+      ceiling and it would read the same value forever. Everything else is
+      useful by default; the diagnostic sensors change only on source or
+      content changes.
   entity-translations: done
   exception-translations: done
   icon-translations: done

--- a/homeassistant/components/lyngdorf/sensor.py
+++ b/homeassistant/components/lyngdorf/sensor.py
@@ -109,6 +109,9 @@ MAXIMUM_VOLUME_SENSOR = LyngdorfSensorEntityDescription(
         volume.maximum_volume if isinstance(volume := r.volume, VolumeControl) else None
     ),
     entity_category=EntityCategory.DIAGNOSTIC,
+    # Most owners never set a ceiling, and for them this reads the same value
+    # forever. It earns its place only once someone has one.
+    entity_registry_enabled_default=False,
 )
 
 

--- a/homeassistant/components/lyngdorf/sensor.py
+++ b/homeassistant/components/lyngdorf/sensor.py
@@ -4,14 +4,14 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, override
 
-from lyngdorf import LyngdorfReceiver
+from lyngdorf import LyngdorfReceiver, VolumeControl
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
 )
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, UnitOfSoundPressure
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -26,7 +26,7 @@ PARALLEL_UPDATES = 0
 class LyngdorfSensorEntityDescription(SensorEntityDescription):
     """Describe a Lyngdorf sensor entity."""
 
-    value_fn: Callable[[LyngdorfReceiver], str | None]
+    value_fn: Callable[[LyngdorfReceiver], str | float | None]
     options_fn: Callable[[LyngdorfReceiver], list[str]] | None = None
 
 
@@ -98,6 +98,20 @@ ZONE_B_SENSORS: tuple[LyngdorfSensorEntityDescription, ...] = (
 )
 
 
+# Only the models that report `!MAXVOL` carry a VolumeControl, so the ceiling
+# sensor is created from the control's type. Its value stays None until the
+# device first reports one, which never means the model has no ceiling.
+MAXIMUM_VOLUME_SENSOR = LyngdorfSensorEntityDescription(
+    key="maximum_volume",
+    translation_key="maximum_volume",
+    native_unit_of_measurement=UnitOfSoundPressure.DECIBEL,
+    value_fn=lambda r: (
+        volume.maximum_volume if isinstance(volume := r.volume, VolumeControl) else None
+    ),
+    entity_category=EntityCategory.DIAGNOSTIC,
+)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: LyngdorfConfigEntry,
@@ -112,6 +126,16 @@ async def async_setup_entry(
         )
         for description in MAIN_ZONE_SENSORS
     ]
+    if isinstance(runtime_data.receiver.volume, VolumeControl):
+        entities.append(
+            LyngdorfSensor(
+                runtime_data.receiver,
+                config_entry,
+                runtime_data.device_info,
+                MAXIMUM_VOLUME_SENSOR,
+            )
+        )
+
     # Zone B sensors stay on the main device so they read "Zone B audio input"
     # rather than repeating the zone in the Zone B device's own name.
     if runtime_data.zone_b_device_info is not None:
@@ -157,6 +181,6 @@ class LyngdorfSensor(LyngdorfEntity, SensorEntity):
 
     @override
     @property
-    def native_value(self) -> str | None:
+    def native_value(self) -> str | float | None:
         """Return the current sensor value."""
         return self.entity_description.value_fn(self._receiver)

--- a/homeassistant/components/lyngdorf/sensor.py
+++ b/homeassistant/components/lyngdorf/sensor.py
@@ -109,8 +109,7 @@ MAXIMUM_VOLUME_SENSOR = LyngdorfSensorEntityDescription(
         volume.maximum_volume if isinstance(volume := r.volume, VolumeControl) else None
     ),
     entity_category=EntityCategory.DIAGNOSTIC,
-    # Most owners never set a ceiling, and for them this reads the same value
-    # forever. It earns its place only once someone has one.
+    # Most owners set no ceiling, so this would read the same value forever.
     entity_registry_enabled_default=False,
 )
 

--- a/homeassistant/components/lyngdorf/strings.json
+++ b/homeassistant/components/lyngdorf/strings.json
@@ -89,6 +89,9 @@
       "audio_input": {
         "name": "Audio input"
       },
+      "maximum_volume": {
+        "name": "Maximum volume"
+      },
       "streaming_source": {
         "name": "Streaming source"
       },

--- a/tests/components/lyngdorf/conftest.py
+++ b/tests/components/lyngdorf/conftest.py
@@ -15,6 +15,7 @@ from lyngdorf import (
     RemoteKey,
     SteppableControl,
     Trim,
+    VolumeControl,
     ZoneB,
 )
 import pytest
@@ -68,6 +69,15 @@ def _steppable(value: float | None, value_range: NumericRange) -> MagicMock:
     control = MagicMock(spec=SteppableControl)
     control.value = value
     control.range = value_range
+    return control
+
+
+def _volume_control(value: float | None, value_range: NumericRange) -> MagicMock:
+    """Return a mocked volume control, as the MP and P models report."""
+    control = MagicMock(spec=VolumeControl)
+    control.value = value
+    control.range = value_range
+    control.maximum_volume = None
     return control
 
 
@@ -130,7 +140,7 @@ def mock_receiver(mock_create_receiver: MagicMock) -> MagicMock:
     receiver.zone_b_volume_range = NumericRange(-99.9, 24.0, 0.1)
 
     receiver.power_on = False
-    receiver.volume = _steppable(-40.0, NumericRange(-99.9, 24.0, 0.1))
+    receiver.volume = _volume_control(-40.0, NumericRange(-99.9, 24.0, 0.1))
     receiver.muted = False
     receiver.sources = []
     receiver.sound_modes = []
@@ -191,7 +201,7 @@ def mock_receiver(mock_create_receiver: MagicMock) -> MagicMock:
     receiver.zone_b = zone_b
     receiver.zone_b_streaming_source = "DLNA"
 
-    receiver.volume = _steppable(-40.0, NumericRange(-99.9, 24.0, 0.1))
+    receiver.volume = _volume_control(-40.0, NumericRange(-99.9, 24.0, 0.1))
     receiver.muted = False
     receiver.sources = []
     receiver.sound_modes = []

--- a/tests/components/lyngdorf/snapshots/test_sensor.ambr
+++ b/tests/components/lyngdorf/snapshots/test_sensor.ambr
@@ -109,6 +109,57 @@
     'state': 'optical',
   })
 # ---
+# name: test_entities[sensor.mock_lyngdorf_maximum_volume-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_lyngdorf_maximum_volume',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Maximum volume',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Maximum volume',
+    'platform': 'lyngdorf',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'maximum_volume',
+    'unique_id': '0050c27c76b2_maximum_volume',
+    'unit_of_measurement': <UnitOfSoundPressure.DECIBEL: 'dB'>,
+  })
+# ---
+# name: test_entities[sensor.mock_lyngdorf_maximum_volume-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Lyngdorf Maximum volume',
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfSoundPressure.DECIBEL: 'dB'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_lyngdorf_maximum_volume',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_entities[sensor.mock_lyngdorf_streaming_source-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/lyngdorf/test_sensor.py
+++ b/tests/components/lyngdorf/test_sensor.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+from lyngdorf import NumericRange
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -9,7 +10,7 @@ from homeassistant.const import STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .conftest import notify_receiver_update
+from .conftest import _steppable, notify_receiver_update
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -131,3 +132,42 @@ async def test_enum_options_follow_the_device(
 
     state = hass.states.get("sensor.mock_lyngdorf_audio_input")
     assert state.attributes["options"] == ["HDMI", "optical", "ARC"]
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_maximum_volume_follows_the_device(
+    hass: HomeAssistant,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test the ceiling sensor reports what the device says, and keeps up."""
+    assert hass.states.get("sensor.mock_lyngdorf_maximum_volume").state == STATE_UNKNOWN
+
+    mock_receiver.volume.maximum_volume = 0.0
+    notify_receiver_update(mock_receiver)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.mock_lyngdorf_maximum_volume").state == "0.0"
+
+    # The ceiling changes from the device's front panel, so it must not be
+    # read once and cached.
+    mock_receiver.volume.maximum_volume = -20.0
+    notify_receiver_update(mock_receiver)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.mock_lyngdorf_maximum_volume").state == "-20.0"
+
+
+async def test_no_maximum_volume_sensor_without_a_volume_control(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_receiver: MagicMock,
+) -> None:
+    """Test a model that reports no ceiling does not get the sensor."""
+    mock_config_entry.add_to_hass(hass)
+    mock_receiver.volume = _steppable(-40.0, NumericRange(-99.9, 24.0, 0.1))
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.mock_lyngdorf_maximum_volume") is None
+    assert hass.states.get("sensor.mock_lyngdorf_audio_information") is not None

--- a/tests/components/lyngdorf/test_sensor.py
+++ b/tests/components/lyngdorf/test_sensor.py
@@ -21,7 +21,7 @@ def platforms() -> list[Platform]:
     return [Platform.SENSOR]
 
 
-@pytest.mark.usefixtures("mock_receiver")
+@pytest.mark.usefixtures("mock_receiver", "entity_registry_enabled_by_default")
 async def test_entities(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
@@ -134,19 +134,34 @@ async def test_enum_options_follow_the_device(
     assert state.attributes["options"] == ["HDMI", "optical", "ARC"]
 
 
-@pytest.mark.usefixtures("init_integration")
+async def test_maximum_volume_is_disabled_by_default(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the ceiling sensor exists but is off by default."""
+    entry = entity_registry.async_get("sensor.mock_lyngdorf_maximum_volume")
+
+    assert entry is not None
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert hass.states.get("sensor.mock_lyngdorf_maximum_volume") is None
+
+
 async def test_maximum_volume_follows_the_device(
     hass: HomeAssistant,
+    init_integration: MockConfigEntry,
     mock_receiver: MagicMock,
+    entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test the ceiling sensor reports what the device says, and keeps up."""
-    assert hass.states.get("sensor.mock_lyngdorf_maximum_volume").state == STATE_UNKNOWN
-
+    """Test the ceiling sensor reports what the device says, once enabled."""
+    entity_id = "sensor.mock_lyngdorf_maximum_volume"
     mock_receiver.volume.maximum_volume = 0.0
-    notify_receiver_update(mock_receiver)
+
+    entity_registry.async_update_entity(entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(init_integration.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.mock_lyngdorf_maximum_volume").state == "0.0"
+    assert hass.states.get(entity_id).state == "0.0"
 
     # The ceiling changes from the device's front panel, so it must not be
     # read once and cached.
@@ -154,13 +169,14 @@ async def test_maximum_volume_follows_the_device(
     notify_receiver_update(mock_receiver)
     await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.mock_lyngdorf_maximum_volume").state == "-20.0"
+    assert hass.states.get(entity_id).state == "-20.0"
 
 
 async def test_no_maximum_volume_sensor_without_a_volume_control(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_receiver: MagicMock,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test a model that reports no ceiling does not get the sensor."""
     mock_config_entry.add_to_hass(hass)
@@ -169,5 +185,5 @@ async def test_no_maximum_volume_sensor_without_a_volume_control(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.mock_lyngdorf_maximum_volume") is None
+    assert entity_registry.async_get("sensor.mock_lyngdorf_maximum_volume") is None
     assert hass.states.get("sensor.mock_lyngdorf_audio_information") is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Lyngdorf processors have a user-settable volume ceiling, set in the device's own
setup menu, which silently clamps any volume written above it. Nothing in Home
Assistant showed it, so the top of the volume slider simply did nothing and gave
no reason why.

It is not a small part of the slider. On a receiver reporting a `0.0` dB ceiling
against its `-99.9` to `24.0` dB range, everything above 80.6% of the slider is
inert. That is the top fifth.

This adds a read-only diagnostic sensor reporting the ceiling in dB.

**Read-only deliberately.** The ceiling is a safety setting that the device
accepts only from its own menu: sending `!MAXVOL(300)` to a P200 was ignored and
it continued to answer `!MAXVOL(0)`. The library therefore offers no setter, and
this is a sensor rather than a number.

**Only the models that have a ceiling get the entity.** The capability question
is `isinstance(receiver.volume, VolumeControl)`, which the library answers from
the control's type at construction. It is deliberately not a check on the value:
`maximum_volume` is `None` until the device first reports one, and that never
means the model has no ceiling. The TDAI models carry a plain `SteppableControl`
and get no entity.

**Disabled by default.** Most owners set no ceiling, and for them this reads the
same value forever, so it ships disabled and can be enabled by anyone who has
one. The `entity-disabled-by-default` comment in `quality_scale.yaml` is updated
to name the exception rather than continuing to claim every entity is useful by
default.

Tested against real hardware, an MP-60, which reports a `0.0` dB ceiling.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/48047
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


