### PR TITLE
Do not fail esphome setup when Supervisor is not ready

### DIFF
--- a/homeassistant/components/esphome/dashboard.py
+++ b/homeassistant/components/esphome/dashboard.py
@@ -70,16 +70,16 @@ class ESPHomeDashboardManager:
                 addons = get_addons_info(self._hass)
             except HassioNotReadyError:
                 # Supervisor was unreachable during its own setup, so we cannot
-                # tell if the addon is installed. Supervisor discovery sets the
-                # dashboard up again once it recovers.
-                _LOGGER.debug("Supervisor is not ready, skipping dashboard restore")
-                return
-            if info["addon_slug"] not in addons:
-                # The addon is not installed anymore, but it make come back
-                # so we don't want to remove the dashboard, but for now
-                # we don't want to use it.
-                _LOGGER.debug("Addon %s is no longer installed", info["addon_slug"])
-                return
+                # tell if the addon is installed. Restore the dashboard anyway,
+                # a stale one only fails to refresh.
+                _LOGGER.debug("Supervisor is not ready, skipping addon check")
+            else:
+                if info["addon_slug"] not in addons:
+                    # The addon is not installed anymore, but it make come back
+                    # so we don't want to remove the dashboard, but for now
+                    # we don't want to use it.
+                    _LOGGER.debug("Addon %s is no longer installed", info["addon_slug"])
+                    return
 
         await self.async_set_dashboard_info(
             info["addon_slug"], info["host"], info["port"]

--- a/homeassistant/components/esphome/dashboard.py
+++ b/homeassistant/components/esphome/dashboard.py
@@ -61,15 +61,19 @@ class ESPHomeDashboardManager:
         if not (data := self._data) or not (info := data.get("info")):
             return
         if is_hassio(self._hass):
-            from homeassistant.components.hassio import get_addons_info  # noqa: PLC0415
+            from homeassistant.components.hassio import (  # noqa: PLC0415
+                HassioNotReadyError,
+                get_addons_info,
+            )
 
-            # This may raise HassioNotReadyError if Supervisor was unreachable
-            # during setup of the Supervisor integration. That will fail setup
-            # of this integration. However there is no better option at this time
-            # since we need to know if the addon is installed from Supervisor to
-            # correctly setup this integration and we can't raise ConfigEntryNotReady
-            # to trigger a retry from async_setup.
-            addons = get_addons_info(self._hass)
+            try:
+                addons = get_addons_info(self._hass)
+            except HassioNotReadyError:
+                # Supervisor was unreachable during its own setup, so we cannot
+                # tell if the addon is installed. Supervisor discovery sets the
+                # dashboard up again once it recovers.
+                _LOGGER.debug("Supervisor is not ready, skipping dashboard restore")
+                return
             if info["addon_slug"] not in addons:
                 # The addon is not installed anymore, but it make come back
                 # so we don't want to remove the dashboard, but for now

--- a/tests/components/esphome/test_dashboard.py
+++ b/tests/components/esphome/test_dashboard.py
@@ -112,11 +112,11 @@ async def test_restore_dashboard_storage_skipped_if_addon_uninstalled(
 
 
 @pytest.mark.usefixtures("hassio_stubs")
-async def test_restore_dashboard_storage_skipped_if_supervisor_not_ready(
+async def test_restore_dashboard_storage_if_supervisor_not_ready(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
 ) -> None:
-    """Restore is skipped, and setup succeeds, if Supervisor is not ready."""
+    """Restore the dashboard, without failing setup, if Supervisor is not ready."""
     hass_storage[dashboard.STORAGE_KEY] = {
         "version": dashboard.STORAGE_VERSION,
         "minor_version": dashboard.STORAGE_VERSION,
@@ -137,7 +137,7 @@ async def test_restore_dashboard_storage_skipped_if_supervisor_not_ready(
     ):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
-        assert not mock_dashboard_api.called
+        assert mock_dashboard_api.mock_calls[0][1][0] == "http://new-host:6052"
 
 
 async def test_setup_dashboard_fails(

--- a/tests/components/esphome/test_dashboard.py
+++ b/tests/components/esphome/test_dashboard.py
@@ -7,6 +7,7 @@ from aioesphomeapi import APIClient, DeviceInfo, InvalidEncryptionKeyAPIError
 import pytest
 
 from homeassistant.components.esphome import CONF_NOISE_PSK, DOMAIN, dashboard
+from homeassistant.components.hassio import HassioNotReadyError
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -107,6 +108,35 @@ async def test_restore_dashboard_storage_skipped_if_addon_uninstalled(
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
         assert "test-slug is no longer installed" in caplog.text
+        assert not mock_dashboard_api.called
+
+
+@pytest.mark.usefixtures("hassio_stubs")
+async def test_restore_dashboard_storage_skipped_if_supervisor_not_ready(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Restore is skipped, and setup succeeds, if Supervisor is not ready."""
+    hass_storage[dashboard.STORAGE_KEY] = {
+        "version": dashboard.STORAGE_VERSION,
+        "minor_version": dashboard.STORAGE_VERSION,
+        "key": dashboard.STORAGE_KEY,
+        "data": {"info": {"addon_slug": "test-slug", "host": "new-host", "port": 6052}},
+    }
+    with (
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI"
+        ) as mock_dashboard_api,
+        patch(
+            "homeassistant.components.esphome.dashboard.is_hassio", return_value=True
+        ),
+        patch(
+            "homeassistant.components.hassio.get_addons_info",
+            side_effect=HassioNotReadyError,
+        ),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
         assert not mock_dashboard_api.called
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


`ESPHomeDashboardManager.async_setup()` asks Supervisor for the addon list to check that the stored dashboard addon is still installed. Since 2026.6, `get_addons_info()` raises `HassioNotReadyError` when Supervisor was unreachable during its own setup. That exception propagates out of `async_setup()` and fails setup of the whole esphome component:

```
Error during setup of component esphome:
  File "homeassistant/components/esphome/dashboard.py", line 72, in async_setup
    addons = get_addons_info(self._hass)
  File "homeassistant/components/hassio/coordinator.py", line 1006, in get_addons_info
    raise HassioNotReadyError
homeassistant.components.hassio.exceptions.HassioNotReadyError
```

Catch the error, skip the addon check, and restore the dashboard from storage.

This was raised during review of #169586 and answered deliberately in [this comment](https://github.com/home-assistant/core/pull/169586#discussion_r3204291899). The reasoning there is correct on its own terms: esphome lists `hassio` in `after_dependencies`, a failed after-dependency raises `DependencyError`, so before #169586 an unreachable Supervisor failed `hassio` and esphome never set up at all. The old `is not None` check was unreachable in production, and failing setup here reproduces the old outcome on purpose.

I think the trade-off no longer holds, for three reasons.

The outcome is worse than it was before #169586, not equivalent. Back then `hassio` itself failed and the user saw one coherent story. Now `hassio` recovers on its next retry, but esphome does not: `async_setup` runs once, so every ESPHome device stays unavailable until Home Assistant is restarted.

The penalty is out of proportion to the missing information. The unknown is whether one optional addon is still installed. It gates the dashboard used for OTA updates and for reauth key retrieval. Taking the whole integration down for it also drops every device connection, none of which involve Supervisor.

Guessing wrong is cheap. If the addon really is gone, the coordinator's first refresh fails and the manager already keeps a failed dashboard on purpose, because the addon may come back.

The structural fix that both reviewers pointed to in [this thread](https://github.com/home-assistant/core/pull/169586#discussion_r3218645551), moving the Supervisor-dependent part behind something retryable, still stands. This change is the cheap interim that removes the user-visible harm in the meantime.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Introduced in 2026.6 by #169586 and present in 2026.9.1.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4vzZE22Fm6FjxazH4LMWh
