### PR TITLE
Suppress repeated Splunk send-failure logs during sustained outages

### DIFF
--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -219,8 +219,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await event_collector.queue(json.dumps(payload, cls=JSONEncoder), send=False)
 
+    send_failing = False
+
     async def splunk_event_listener(event: Event[EventStateChangedData]) -> None:
         """Listen for new messages on the bus and sends them to Splunk."""
+        nonlocal send_failing
+
         state = event.data.get("new_state")
         if state is None or not entity_filter(state.entity_id):
             return
@@ -250,15 +254,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 # Trigger reauth flow
                 entry.async_start_reauth(hass)
             else:
-                _LOGGER.warning("Splunk payload error: %s", err)
+                if not send_failing:
+                    _LOGGER.warning("Splunk payload error: %s", err)
+                send_failing = True
         except ClientConnectionError as err:
-            _LOGGER.debug("Connection error sending to Splunk: %s", err)
+            if not send_failing:
+                _LOGGER.debug("Connection error sending to Splunk: %s", err)
+            send_failing = True
         except TimeoutError:
-            _LOGGER.debug("Timeout sending to Splunk at %s:%s", host, port)
+            if not send_failing:
+                _LOGGER.debug("Timeout sending to Splunk at %s:%s", host, port)
+            send_failing = True
         except ClientResponseError as err:
-            _LOGGER.warning("Splunk response error: %s", err.message)
+            if not send_failing:
+                _LOGGER.warning("Splunk response error: %s", err.message)
+            send_failing = True
         except Exception:
-            _LOGGER.exception("Unexpected error sending event to Splunk")
+            if not send_failing:
+                _LOGGER.exception("Unexpected error sending event to Splunk")
+            send_failing = True
+        else:
+            if send_failing:
+                _LOGGER.info("Sending events to Splunk has recovered")
+            send_failing = False
 
     # Store the event listener cancellation callback
     entry.async_on_unload(

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -220,10 +220,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await event_collector.queue(json.dumps(payload, cls=JSONEncoder), send=False)
 
     last_failure_category: str | None = None
+    last_failure_level = logging.INFO
 
     async def splunk_event_listener(event: Event[EventStateChangedData]) -> None:
         """Listen for new messages on the bus and sends them to Splunk."""
-        nonlocal last_failure_category
+        nonlocal last_failure_category, last_failure_level
 
         state = event.data.get("new_state")
         if state is None or not entity_filter(state.entity_id):
@@ -253,30 +254,38 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 if last_failure_category != "unauthorized":
                     _LOGGER.error("Splunk token unauthorized: %s", err)
                 last_failure_category = "unauthorized"
+                last_failure_level = logging.ERROR
                 entry.async_start_reauth(hass)
             else:
                 if last_failure_category != "payload_error":
                     _LOGGER.warning("Splunk payload error: %s", err)
                 last_failure_category = "payload_error"
+                last_failure_level = logging.WARNING
         except ClientConnectionError as err:
             if last_failure_category != "connection_error":
                 _LOGGER.debug("Connection error sending to Splunk: %s", err)
             last_failure_category = "connection_error"
+            last_failure_level = logging.DEBUG
         except TimeoutError:
             if last_failure_category != "timeout":
                 _LOGGER.debug("Timeout sending to Splunk at %s:%s", host, port)
             last_failure_category = "timeout"
+            last_failure_level = logging.DEBUG
         except ClientResponseError as err:
             if last_failure_category != "response_error":
                 _LOGGER.warning("Splunk response error: %s", err.message)
             last_failure_category = "response_error"
+            last_failure_level = logging.WARNING
         except Exception:
             if last_failure_category != "unexpected_error":
                 _LOGGER.exception("Unexpected error sending event to Splunk")
             last_failure_category = "unexpected_error"
+            last_failure_level = logging.ERROR
         else:
             if last_failure_category is not None:
-                _LOGGER.info("Sending events to Splunk has recovered")
+                _LOGGER.log(
+                    last_failure_level, "Sending events to Splunk has recovered"
+                )
             last_failure_category = None
 
     # Store the event listener cancellation callback

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -226,8 +226,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     last_failure_level = logging.NOTSET
 
     # Each firing runs as its own task, so a slower send can complete after a
-    # newer one. Sequence numbers taken at dispatch let a completion detect
-    # that it has been superseded and skip mutating the failure state.
+    # newer one. Sequence numbers taken at dispatch let a stale success detect
+    # that it has been superseded and skip clearing a newer failure. Failures
+    # always apply regardless of order, since a failure is a fact about a
+    # send that genuinely failed.
     next_sequence = 0
     last_applied_sequence = 0
 
@@ -291,37 +293,37 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             level = logging.WARNING
             log_message, log_args = "Splunk response error: %s", (err.message,)
         except Exception:
-            # Logged here, not after the gate below, so exc_info is captured
-            # while this exception is still the one being handled.
-            if sequence > last_applied_sequence:
-                last_applied_sequence = sequence
-                if last_failure_category != "unexpected_error":
-                    _LOGGER.exception("Unexpected error sending event to Splunk")
-                last_failure_category = "unexpected_error"
-                last_failure_level = max(last_failure_level, logging.ERROR)
+            # Logged here, not after the failure branch below, so exc_info is
+            # captured while this exception is still the one being handled.
+            if last_failure_category != "unexpected_error":
+                _LOGGER.exception("Unexpected error sending event to Splunk")
+            last_failure_category = "unexpected_error"
+            last_failure_level = max(last_failure_level, logging.ERROR)
+            last_applied_sequence = max(last_applied_sequence, sequence)
             return
         else:
             category = None
 
-        # A slower send can complete after a newer one has already updated
-        # the failure state; only the newest-dispatched completion may apply.
+        # A failure is a fact about this send regardless of dispatch order, so
+        # it is applied unconditionally. A stale success must never clear a
+        # newer failure, so only success is subject to the sequence gate
+        # below.
+        if category is not None:
+            if last_failure_category != category:
+                _LOGGER.log(level, log_message, *log_args)
+            last_failure_category = category
+            last_failure_level = max(last_failure_level, level)
+            last_applied_sequence = max(last_applied_sequence, sequence)
+            return
+
         if sequence <= last_applied_sequence:
             return
         last_applied_sequence = sequence
 
-        if category is None:
-            if last_failure_category is not None:
-                _LOGGER.log(
-                    last_failure_level, "Sending events to Splunk has recovered"
-                )
-            last_failure_category = None
-            last_failure_level = logging.NOTSET
-            return
-
-        if last_failure_category != category:
-            _LOGGER.log(level, log_message, *log_args)
-        last_failure_category = category
-        last_failure_level = max(last_failure_level, level)
+        if last_failure_category is not None:
+            _LOGGER.log(last_failure_level, "Sending events to Splunk has recovered")
+        last_failure_category = None
+        last_failure_level = logging.NOTSET
 
     # Store the event listener cancellation callback
     entry.async_on_unload(

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -219,11 +219,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await event_collector.queue(json.dumps(payload, cls=JSONEncoder), send=False)
 
-    send_failing = False
+    last_failure_category: str | None = None
 
     async def splunk_event_listener(event: Event[EventStateChangedData]) -> None:
         """Listen for new messages on the bus and sends them to Splunk."""
-        nonlocal send_failing
+        nonlocal last_failure_category
 
         state = event.data.get("new_state")
         if state is None or not entity_filter(state.entity_id):
@@ -250,34 +250,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await event_collector.queue(json.dumps(payload, cls=JSONEncoder), send=True)
         except SplunkPayloadError as err:
             if err.status == HTTPStatus.UNAUTHORIZED:
-                if not send_failing:
+                if last_failure_category != "unauthorized":
                     _LOGGER.error("Splunk token unauthorized: %s", err)
-                send_failing = True
+                last_failure_category = "unauthorized"
                 entry.async_start_reauth(hass)
             else:
-                if not send_failing:
+                if last_failure_category != "payload_error":
                     _LOGGER.warning("Splunk payload error: %s", err)
-                send_failing = True
+                last_failure_category = "payload_error"
         except ClientConnectionError as err:
-            if not send_failing:
+            if last_failure_category != "connection_error":
                 _LOGGER.debug("Connection error sending to Splunk: %s", err)
-            send_failing = True
+            last_failure_category = "connection_error"
         except TimeoutError:
-            if not send_failing:
+            if last_failure_category != "timeout":
                 _LOGGER.debug("Timeout sending to Splunk at %s:%s", host, port)
-            send_failing = True
+            last_failure_category = "timeout"
         except ClientResponseError as err:
-            if not send_failing:
+            if last_failure_category != "response_error":
                 _LOGGER.warning("Splunk response error: %s", err.message)
-            send_failing = True
+            last_failure_category = "response_error"
         except Exception:
-            if not send_failing:
+            if last_failure_category != "unexpected_error":
                 _LOGGER.exception("Unexpected error sending event to Splunk")
-            send_failing = True
+            last_failure_category = "unexpected_error"
         else:
-            if send_failing:
+            if last_failure_category is not None:
                 _LOGGER.info("Sending events to Splunk has recovered")
-            send_failing = False
+            last_failure_category = None
 
     # Store the event listener cancellation callback
     entry.async_on_unload(

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -225,13 +225,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     last_failure_category: str | None = None
     last_failure_level = logging.NOTSET
 
+    # Each firing runs as its own task, so a slower send can complete after a
+    # newer one. Sequence numbers taken at dispatch let a completion detect
+    # that it has been superseded and skip mutating the failure state.
+    next_sequence = 0
+    last_applied_sequence = 0
+
     async def splunk_event_listener(event: Event[EventStateChangedData]) -> None:
         """Listen for new messages on the bus and sends them to Splunk."""
         nonlocal last_failure_category, last_failure_level
+        nonlocal next_sequence, last_applied_sequence
 
         state = event.data.get("new_state")
         if state is None or not entity_filter(state.entity_id):
             return
+
+        next_sequence += 1
+        sequence = next_sequence
 
         _state: float | str
         try:
@@ -250,47 +260,68 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             },
         }
 
+        category: str | None
+        level = logging.NOTSET
+        log_message = ""
+        log_args: tuple[Any, ...] = ()
+
         try:
             await event_collector.queue(json.dumps(payload, cls=JSONEncoder), send=True)
         except SplunkPayloadError as err:
             if err.status == HTTPStatus.UNAUTHORIZED:
-                if last_failure_category != "unauthorized":
-                    _LOGGER.error("Splunk token unauthorized: %s", err)
-                last_failure_category = "unauthorized"
-                last_failure_level = max(last_failure_level, logging.ERROR)
                 entry.async_start_reauth(hass)
+                category = "unauthorized"
+                level = logging.ERROR
+                log_message, log_args = "Splunk token unauthorized: %s", (err,)
             else:
-                if last_failure_category != "payload_error":
-                    _LOGGER.warning("Splunk payload error: %s", err)
-                last_failure_category = "payload_error"
-                last_failure_level = max(last_failure_level, logging.WARNING)
+                category = "payload_error"
+                level = logging.WARNING
+                log_message, log_args = "Splunk payload error: %s", (err,)
         except ClientConnectionError as err:
-            if last_failure_category != "connection_error":
-                _LOGGER.debug("Connection error sending to Splunk: %s", err)
-            last_failure_category = "connection_error"
-            last_failure_level = max(last_failure_level, logging.DEBUG)
+            category = "connection_error"
+            level = logging.DEBUG
+            log_message, log_args = "Connection error sending to Splunk: %s", (err,)
         except TimeoutError:
-            if last_failure_category != "timeout":
-                _LOGGER.debug("Timeout sending to Splunk at %s:%s", host, port)
-            last_failure_category = "timeout"
-            last_failure_level = max(last_failure_level, logging.DEBUG)
+            category = "timeout"
+            level = logging.DEBUG
+            log_message = "Timeout sending to Splunk at %s:%s"
+            log_args = (host, port)
         except ClientResponseError as err:
-            if last_failure_category != "response_error":
-                _LOGGER.warning("Splunk response error: %s", err.message)
-            last_failure_category = "response_error"
-            last_failure_level = max(last_failure_level, logging.WARNING)
+            category = "response_error"
+            level = logging.WARNING
+            log_message, log_args = "Splunk response error: %s", (err.message,)
         except Exception:
-            if last_failure_category != "unexpected_error":
-                _LOGGER.exception("Unexpected error sending event to Splunk")
-            last_failure_category = "unexpected_error"
-            last_failure_level = max(last_failure_level, logging.ERROR)
+            # Logged here, not after the gate below, so exc_info is captured
+            # while this exception is still the one being handled.
+            if sequence > last_applied_sequence:
+                last_applied_sequence = sequence
+                if last_failure_category != "unexpected_error":
+                    _LOGGER.exception("Unexpected error sending event to Splunk")
+                last_failure_category = "unexpected_error"
+                last_failure_level = max(last_failure_level, logging.ERROR)
+            return
         else:
+            category = None
+
+        # A slower send can complete after a newer one has already updated
+        # the failure state; only the newest-dispatched completion may apply.
+        if sequence <= last_applied_sequence:
+            return
+        last_applied_sequence = sequence
+
+        if category is None:
             if last_failure_category is not None:
                 _LOGGER.log(
                     last_failure_level, "Sending events to Splunk has recovered"
                 )
             last_failure_category = None
             last_failure_level = logging.NOTSET
+            return
+
+        if last_failure_category != category:
+            _LOGGER.log(level, log_message, *log_args)
+        last_failure_category = category
+        last_failure_level = max(last_failure_level, level)
 
     # Store the event listener cancellation callback
     entry.async_on_unload(

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -219,31 +219,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await event_collector.queue(json.dumps(payload, cls=JSONEncoder), send=False)
 
-    # Repeats of the same failure category are suppressed, a category change
-    # logs again, and the recovery is logged at the highest severity reached
-    # during the run (not just the most recent failure).
-    last_failure_category: str | None = None
-    last_failure_level = logging.NOTSET
-
-    # Each firing runs as its own task, so a slower send can complete after a
-    # newer one. Sequence numbers taken at dispatch let a stale success detect
-    # that it has been superseded and skip clearing a newer failure. Failures
-    # always apply regardless of order, since a failure is a fact about a
-    # send that genuinely failed.
-    next_sequence = 0
-    last_applied_sequence = 0
+    # Only the first failure logs at its natural level; repeats log at debug
+    # until recovery, so a stuck connection doesn't flood the log.
+    is_send_failing = False
+    highest_failure_level = logging.NOTSET
 
     async def splunk_event_listener(event: Event[EventStateChangedData]) -> None:
         """Listen for new messages on the bus and sends them to Splunk."""
-        nonlocal last_failure_category, last_failure_level
-        nonlocal next_sequence, last_applied_sequence
+        nonlocal is_send_failing, highest_failure_level
 
         state = event.data.get("new_state")
         if state is None or not entity_filter(state.entity_id):
             return
-
-        next_sequence += 1
-        sequence = next_sequence
 
         _state: float | str
         try:
@@ -262,7 +249,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             },
         }
 
-        category: str | None
         level = logging.NOTSET
         log_message = ""
         log_args: tuple[Any, ...] = ()
@@ -272,58 +258,47 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except SplunkPayloadError as err:
             if err.status == HTTPStatus.UNAUTHORIZED:
                 entry.async_start_reauth(hass)
-                category = "unauthorized"
                 level = logging.ERROR
                 log_message, log_args = "Splunk token unauthorized: %s", (err,)
             else:
-                category = "payload_error"
                 level = logging.WARNING
                 log_message, log_args = "Splunk payload error: %s", (err,)
         except ClientConnectionError as err:
-            category = "connection_error"
             level = logging.DEBUG
             log_message, log_args = "Connection error sending to Splunk: %s", (err,)
         except TimeoutError:
-            category = "timeout"
             level = logging.DEBUG
             log_message = "Timeout sending to Splunk at %s:%s"
             log_args = (host, port)
         except ClientResponseError as err:
-            category = "response_error"
             level = logging.WARNING
             log_message, log_args = "Splunk response error: %s", (err.message,)
         except Exception:
-            # Logged here, not after the failure branch below, so exc_info is
-            # captured while this exception is still the one being handled.
-            if last_failure_category != "unexpected_error":
+            # Logged here, not after the block below, so exc_info is captured
+            # while this exception is still the one being handled.
+            if is_send_failing:
+                _LOGGER.debug("Unexpected error sending event to Splunk")
+            else:
                 _LOGGER.exception("Unexpected error sending event to Splunk")
-            last_failure_category = "unexpected_error"
-            last_failure_level = max(last_failure_level, logging.ERROR)
-            last_applied_sequence = max(last_applied_sequence, sequence)
-            return
-        else:
-            category = None
-
-        # A failure is a fact about this send regardless of dispatch order, so
-        # it is applied unconditionally. A stale success must never clear a
-        # newer failure, so only success is subject to the sequence gate
-        # below.
-        if category is not None:
-            if last_failure_category != category:
-                _LOGGER.log(level, log_message, *log_args)
-            last_failure_category = category
-            last_failure_level = max(last_failure_level, level)
-            last_applied_sequence = max(last_applied_sequence, sequence)
+            is_send_failing = True
+            highest_failure_level = max(highest_failure_level, logging.ERROR)
             return
 
-        if sequence <= last_applied_sequence:
+        if log_message:
+            _LOGGER.log(
+                logging.DEBUG if is_send_failing else level, log_message, *log_args
+            )
+            is_send_failing = True
+            highest_failure_level = max(highest_failure_level, level)
             return
-        last_applied_sequence = sequence
 
-        if last_failure_category is not None:
-            _LOGGER.log(last_failure_level, "Sending events to Splunk has recovered")
-        last_failure_category = None
-        last_failure_level = logging.NOTSET
+        if is_send_failing:
+            _LOGGER.log(
+                min(highest_failure_level, logging.WARNING),
+                "Sending events to Splunk has recovered",
+            )
+        is_send_failing = False
+        highest_failure_level = logging.NOTSET
 
     # Store the event listener cancellation callback
     entry.async_on_unload(

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -219,14 +219,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await event_collector.queue(json.dumps(payload, cls=JSONEncoder), send=False)
 
-    # Only the first failure logs at its natural level; repeats log at debug
-    # until recovery, so a stuck connection doesn't flood the log.
-    is_send_failing = False
+    # A failure logs at its natural level only the first time, or if it is
+    # more severe than anything seen so far in the outage; equal or lower
+    # repeats log at debug until recovery, so a stuck connection doesn't
+    # flood the log while an escalation stays visible.
     highest_failure_level = logging.NOTSET
 
     async def splunk_event_listener(event: Event[EventStateChangedData]) -> None:
         """Listen for new messages on the bus and sends them to Splunk."""
-        nonlocal is_send_failing, highest_failure_level
+        nonlocal highest_failure_level
 
         state = event.data.get("new_state")
         if state is None or not entity_filter(state.entity_id):
@@ -254,7 +255,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         log_args: tuple[Any, ...] = ()
 
         try:
-            await event_collector.queue(json.dumps(payload, cls=JSONEncoder), send=True)
+            sent = await event_collector.queue(
+                json.dumps(payload, cls=JSONEncoder), send=True
+            )
         except SplunkPayloadError as err:
             if err.status == HTTPStatus.UNAUTHORIZED:
                 entry.async_start_reauth(hass)
@@ -276,28 +279,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except Exception:
             # Logged here, not after the block below, so exc_info is captured
             # while this exception is still the one being handled.
-            if is_send_failing:
-                _LOGGER.debug("Unexpected error sending event to Splunk")
-            else:
+            if highest_failure_level < logging.ERROR:
                 _LOGGER.exception("Unexpected error sending event to Splunk")
-            is_send_failing = True
+            else:
+                _LOGGER.debug("Unexpected error sending event to Splunk")
             highest_failure_level = max(highest_failure_level, logging.ERROR)
             return
 
         if log_message:
             _LOGGER.log(
-                logging.DEBUG if is_send_failing else level, log_message, *log_args
+                level if level > highest_failure_level else logging.DEBUG,
+                log_message,
+                *log_args,
             )
-            is_send_failing = True
             highest_failure_level = max(highest_failure_level, level)
             return
 
-        if is_send_failing:
+        if not sent:
+            # Coalesced into an already in-flight send; not a fact about this
+            # send, so it must not be treated as a success or a recovery.
+            return
+
+        if highest_failure_level != logging.NOTSET:
             _LOGGER.log(
                 min(highest_failure_level, logging.WARNING),
                 "Sending events to Splunk has recovered",
             )
-        is_send_failing = False
         highest_failure_level = logging.NOTSET
 
     # Store the event listener cancellation callback

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -219,8 +219,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await event_collector.queue(json.dumps(payload, cls=JSONEncoder), send=False)
 
+    # Repeats of the same failure category are suppressed, a category change
+    # logs again, and the recovery is logged at the highest severity reached
+    # during the run (not just the most recent failure).
     last_failure_category: str | None = None
-    last_failure_level = logging.INFO
+    last_failure_level = logging.NOTSET
 
     async def splunk_event_listener(event: Event[EventStateChangedData]) -> None:
         """Listen for new messages on the bus and sends them to Splunk."""
@@ -254,39 +257,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 if last_failure_category != "unauthorized":
                     _LOGGER.error("Splunk token unauthorized: %s", err)
                 last_failure_category = "unauthorized"
-                last_failure_level = logging.ERROR
+                last_failure_level = max(last_failure_level, logging.ERROR)
                 entry.async_start_reauth(hass)
             else:
                 if last_failure_category != "payload_error":
                     _LOGGER.warning("Splunk payload error: %s", err)
                 last_failure_category = "payload_error"
-                last_failure_level = logging.WARNING
+                last_failure_level = max(last_failure_level, logging.WARNING)
         except ClientConnectionError as err:
             if last_failure_category != "connection_error":
                 _LOGGER.debug("Connection error sending to Splunk: %s", err)
             last_failure_category = "connection_error"
-            last_failure_level = logging.DEBUG
+            last_failure_level = max(last_failure_level, logging.DEBUG)
         except TimeoutError:
             if last_failure_category != "timeout":
                 _LOGGER.debug("Timeout sending to Splunk at %s:%s", host, port)
             last_failure_category = "timeout"
-            last_failure_level = logging.DEBUG
+            last_failure_level = max(last_failure_level, logging.DEBUG)
         except ClientResponseError as err:
             if last_failure_category != "response_error":
                 _LOGGER.warning("Splunk response error: %s", err.message)
             last_failure_category = "response_error"
-            last_failure_level = logging.WARNING
+            last_failure_level = max(last_failure_level, logging.WARNING)
         except Exception:
             if last_failure_category != "unexpected_error":
                 _LOGGER.exception("Unexpected error sending event to Splunk")
             last_failure_category = "unexpected_error"
-            last_failure_level = logging.ERROR
+            last_failure_level = max(last_failure_level, logging.ERROR)
         else:
             if last_failure_category is not None:
                 _LOGGER.log(
                     last_failure_level, "Sending events to Splunk has recovered"
                 )
             last_failure_category = None
+            last_failure_level = logging.NOTSET
 
     # Store the event listener cancellation callback
     entry.async_on_unload(

--- a/homeassistant/components/splunk/__init__.py
+++ b/homeassistant/components/splunk/__init__.py
@@ -250,8 +250,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await event_collector.queue(json.dumps(payload, cls=JSONEncoder), send=True)
         except SplunkPayloadError as err:
             if err.status == HTTPStatus.UNAUTHORIZED:
-                _LOGGER.error("Splunk token unauthorized: %s", err)
-                # Trigger reauth flow
+                if not send_failing:
+                    _LOGGER.error("Splunk token unauthorized: %s", err)
+                send_failing = True
                 entry.async_start_reauth(hass)
             else:
                 if not send_failing:

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -311,6 +311,117 @@ async def test_event_listener_error_handling(
     )
 
 
+@pytest.mark.parametrize(
+    ("error", "expected_log_level", "expected_message"),
+    [
+        (
+            ClientResponseError(
+                request_info=MagicMock(),
+                history=(),
+                status=500,
+                message="Internal Server Error",
+            ),
+            logging.WARNING,
+            "Splunk response error: Internal Server Error",
+        ),
+        (
+            ValueError("boom"),
+            logging.ERROR,
+            "Unexpected error sending event to Splunk",
+        ),
+    ],
+)
+async def test_event_listener_repeated_failures_log_once(
+    hass: HomeAssistant,
+    mock_hass_splunk: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+    error: Exception,
+    expected_log_level: int,
+    expected_message: str,
+) -> None:
+    """Test that a sustained run of send failures logs only the first one."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_hass_splunk.queue.side_effect = error
+
+    with caplog.at_level(logging.DEBUG):
+        for i in range(5):
+            hass.states.async_set("sensor.test", str(i))
+            await hass.async_block_till_done()
+
+    matching_records = [
+        record
+        for record in caplog.records
+        if record.levelno == expected_log_level and expected_message in record.message
+    ]
+    assert len(matching_records) == 1
+
+
+async def test_event_listener_recovery_logs_once(
+    hass: HomeAssistant,
+    mock_hass_splunk: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that recovery after failures logs exactly one recovery message."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_hass_splunk.queue.side_effect = ClientResponseError(
+        request_info=MagicMock(),
+        history=(),
+        status=500,
+        message="Internal Server Error",
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        for i in range(3):
+            hass.states.async_set("sensor.test", str(i))
+            await hass.async_block_till_done()
+
+        mock_hass_splunk.queue.side_effect = None
+
+        for i in range(3):
+            hass.states.async_set("sensor.test", f"recovered-{i}")
+            await hass.async_block_till_done()
+
+    recovery_records = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.INFO
+        and "Sending events to Splunk has recovered" in record.message
+    ]
+    assert len(recovery_records) == 1
+
+
+async def test_event_listener_no_recovery_message_without_prior_failure(
+    hass: HomeAssistant,
+    mock_hass_splunk: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a successful send without prior failures logs no recovery message."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    with caplog.at_level(logging.DEBUG):
+        hass.states.async_set("sensor.test", "123")
+        await hass.async_block_till_done()
+
+    assert not any(
+        "Sending events to Splunk has recovered" in record.message
+        for record in caplog.records
+    )
+
+
 async def test_yaml_filter_only_no_deprecation_issue(
     hass: HomeAssistant,
     issue_registry: ir.IssueRegistry,

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -661,6 +661,73 @@ async def test_event_listener_out_of_order_completion_preserves_failure(
     )
 
 
+async def test_event_listener_out_of_order_failure_after_success(
+    hass: HomeAssistant,
+    mock_hass_splunk: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a slow failure finishing after a fast success is not discarded.
+
+    An older send that fails slowly can complete after a newer send has
+    already succeeded. That success advances the sequence gate, but the
+    late failure must still be recorded and logged: it is a fact about a
+    send that genuinely failed, not stale good news that can be dropped.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    async def delayed_queue(data: str, send: bool = True) -> bool:
+        if "slow-failure" in data:
+            await asyncio.sleep(0.1)
+            raise SplunkPayloadError(0, "Bad request", HTTPStatus.BAD_REQUEST)
+        return True
+
+    mock_hass_splunk.queue.side_effect = delayed_queue
+
+    with caplog.at_level(logging.DEBUG):
+        # Dispatched first but resolves last.
+        hass.states.async_set("sensor.test", "slow-failure")
+        # Dispatched second but resolves first.
+        hass.states.async_set("sensor.test", "fast-success")
+        await hass.async_block_till_done()
+
+    # The late failure must still be logged even though a newer send already
+    # succeeded and advanced the sequence gate.
+    assert any("Splunk payload error" in record.message for record in caplog.records)
+
+    caplog.clear()
+    mock_hass_splunk.queue.side_effect = SplunkPayloadError(
+        0, "Bad request", HTTPStatus.BAD_REQUEST
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        hass.states.async_set("sensor.test", "still-failing")
+        await hass.async_block_till_done()
+
+    # The failure category recorded by the late-arriving failure must have
+    # survived, so a same-category failure is suppressed.
+    assert not any(
+        "Splunk payload error" in record.message for record in caplog.records
+    )
+
+    caplog.clear()
+    mock_hass_splunk.queue.side_effect = None
+
+    with caplog.at_level(logging.DEBUG):
+        hass.states.async_set("sensor.test", "recovered")
+        await hass.async_block_till_done()
+
+    recovery_records = [
+        record
+        for record in caplog.records
+        if "Sending events to Splunk has recovered" in record.message
+    ]
+    assert len(recovery_records) == 1
+
+
 async def test_yaml_filter_only_no_deprecation_issue(
     hass: HomeAssistant,
     issue_registry: ir.IssueRegistry,

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -304,6 +304,55 @@ async def test_event_listener_unauthorized_repeated_failures_log_once(
     assert len(recovery_records) == 1
 
 
+async def test_event_listener_category_change_logs_again(
+    hass: HomeAssistant,
+    mock_hass_splunk: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test switching from one failure category to another logs the new one too."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_hass_splunk.queue.side_effect = ClientConnectionError("Connection failed")
+
+    with caplog.at_level(logging.DEBUG):
+        for i in range(3):
+            hass.states.async_set("sensor.test", str(i))
+            await hass.async_block_till_done()
+
+        mock_hass_splunk.queue.side_effect = SplunkPayloadError(
+            0, "Unauthorized", HTTPStatus.UNAUTHORIZED
+        )
+
+        for i in range(3):
+            hass.states.async_set("sensor.test", f"unauthorized-{i}")
+            await hass.async_block_till_done()
+
+    connection_records = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.DEBUG
+        and "Connection error sending to Splunk" in record.message
+    ]
+    assert len(connection_records) == 1
+
+    unauthorized_records = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.ERROR
+        and "Splunk token unauthorized" in record.message
+    ]
+    assert len(unauthorized_records) == 1
+
+    # Reauth still fires on every failure regardless of log suppression.
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == "reauth"
+
+
 @pytest.mark.parametrize(
     ("error", "expected_log_level", "expected_message"),
     [

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -1,6 +1,5 @@
 """Test the Splunk integration init."""
 
-import asyncio
 from http import HTTPStatus
 import logging
 from unittest.mock import AsyncMock, MagicMock
@@ -296,24 +295,23 @@ async def test_event_listener_unauthorized_repeated_failures_log_once(
         hass.states.async_set("sensor.test", "recovered")
         await hass.async_block_till_done()
 
-    # Unauthorized failures are user-visible at ERROR, so the recovery that
-    # closes them out must be equally visible, not silently downgraded.
+    # Recovery never logs higher than warning, even after an ERROR failure.
     recovery_records = [
         record
         for record in caplog.records
-        if record.levelno == logging.ERROR
+        if record.levelno == logging.WARNING
         and "Sending events to Splunk has recovered" in record.message
     ]
     assert len(recovery_records) == 1
 
 
-async def test_event_listener_category_change_logs_again(
+async def test_event_listener_category_change_stays_at_debug(
     hass: HomeAssistant,
     mock_hass_splunk: AsyncMock,
     mock_config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test switching from one failure category to another logs the new one too."""
+    """Test switching failure type mid-outage keeps logging at debug."""
     mock_config_entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -334,21 +332,22 @@ async def test_event_listener_category_change_logs_again(
             hass.states.async_set("sensor.test", f"unauthorized-{i}")
             await hass.async_block_till_done()
 
+    # Connection errors already log at debug on their own, so all 3 appear.
     connection_records = [
         record
         for record in caplog.records
-        if record.levelno == logging.DEBUG
-        and "Connection error sending to Splunk" in record.message
+        if "Connection error sending to Splunk" in record.message
     ]
-    assert len(connection_records) == 1
+    assert len(connection_records) == 3
+    assert all(record.levelno == logging.DEBUG for record in connection_records)
 
     unauthorized_records = [
         record
         for record in caplog.records
-        if record.levelno == logging.ERROR
-        and "Splunk token unauthorized" in record.message
+        if "Splunk token unauthorized" in record.message
     ]
-    assert len(unauthorized_records) == 1
+    assert len(unauthorized_records) == 3
+    assert all(record.levelno == logging.DEBUG for record in unauthorized_records)
 
     # Reauth still fires on every failure regardless of log suppression.
     flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
@@ -543,17 +542,17 @@ async def test_event_listener_recovery_from_debug_only_outage_stays_at_debug(
     assert recovery_records[0].levelno == logging.DEBUG
 
 
-async def test_event_listener_recovery_after_error_then_debug_stays_visible(
+async def test_event_listener_recovery_after_error_then_debug_capped_at_warning(
     hass: HomeAssistant,
     mock_hass_splunk: AsyncMock,
     mock_config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test recovery keeps the highest severity seen, not just the latest failure.
+    """Test recovery keeps the highest severity seen, capped at warning.
 
     An ERROR-level failure (unauthorized) followed by a DEBUG-level failure
-    (connection blip) before recovery must still surface the recovery at
-    ERROR, not be silently downgraded to DEBUG.
+    (connection blip) before recovery must surface the recovery at WARNING,
+    the highest severity a recovery message may ever reach.
     """
     mock_config_entry.add_to_hass(hass)
 
@@ -582,7 +581,7 @@ async def test_event_listener_recovery_after_error_then_debug_stays_visible(
         if "Sending events to Splunk has recovered" in record.message
     ]
     assert len(recovery_records) == 1
-    assert recovery_records[0].levelno == logging.ERROR
+    assert recovery_records[0].levelno == logging.WARNING
 
 
 async def test_event_listener_no_recovery_message_without_prior_failure(
@@ -605,127 +604,6 @@ async def test_event_listener_no_recovery_message_without_prior_failure(
         "Sending events to Splunk has recovered" in record.message
         for record in caplog.records
     )
-
-
-async def test_event_listener_out_of_order_completion_preserves_failure(
-    hass: HomeAssistant,
-    mock_hass_splunk: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test a slow success finishing after a fast failure doesn't erase it.
-
-    Each firing of the listener runs as its own task, so an older send that
-    is slow to resolve can complete after a newer send has already failed.
-    That late success must not clear the failure state or log a false
-    recovery.
-    """
-    mock_config_entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    async def delayed_queue(data: str, send: bool = True) -> bool:
-        if "slow-success" in data:
-            await asyncio.sleep(0.1)
-            return True
-        raise SplunkPayloadError(0, "Bad request", HTTPStatus.BAD_REQUEST)
-
-    mock_hass_splunk.queue.side_effect = delayed_queue
-
-    with caplog.at_level(logging.DEBUG):
-        # Dispatched first but resolves last.
-        hass.states.async_set("sensor.test", "slow-success")
-        # Dispatched second but resolves first.
-        hass.states.async_set("sensor.test", "fast-failure")
-        await hass.async_block_till_done()
-
-    assert not any(
-        "Sending events to Splunk has recovered" in record.message
-        for record in caplog.records
-    )
-
-    caplog.clear()
-    mock_hass_splunk.queue.side_effect = SplunkPayloadError(
-        0, "Bad request", HTTPStatus.BAD_REQUEST
-    )
-
-    with caplog.at_level(logging.DEBUG):
-        hass.states.async_set("sensor.test", "still-failing")
-        await hass.async_block_till_done()
-
-    # The failure category set by the fast failure must have survived the
-    # late-arriving success, so a same-category failure is suppressed again.
-    assert not any(
-        "Splunk payload error" in record.message for record in caplog.records
-    )
-
-
-async def test_event_listener_out_of_order_failure_after_success(
-    hass: HomeAssistant,
-    mock_hass_splunk: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test a slow failure finishing after a fast success is not discarded.
-
-    An older send that fails slowly can complete after a newer send has
-    already succeeded. That success advances the sequence gate, but the
-    late failure must still be recorded and logged: it is a fact about a
-    send that genuinely failed, not stale good news that can be dropped.
-    """
-    mock_config_entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    async def delayed_queue(data: str, send: bool = True) -> bool:
-        if "slow-failure" in data:
-            await asyncio.sleep(0.1)
-            raise SplunkPayloadError(0, "Bad request", HTTPStatus.BAD_REQUEST)
-        return True
-
-    mock_hass_splunk.queue.side_effect = delayed_queue
-
-    with caplog.at_level(logging.DEBUG):
-        # Dispatched first but resolves last.
-        hass.states.async_set("sensor.test", "slow-failure")
-        # Dispatched second but resolves first.
-        hass.states.async_set("sensor.test", "fast-success")
-        await hass.async_block_till_done()
-
-    # The late failure must still be logged even though a newer send already
-    # succeeded and advanced the sequence gate.
-    assert any("Splunk payload error" in record.message for record in caplog.records)
-
-    caplog.clear()
-    mock_hass_splunk.queue.side_effect = SplunkPayloadError(
-        0, "Bad request", HTTPStatus.BAD_REQUEST
-    )
-
-    with caplog.at_level(logging.DEBUG):
-        hass.states.async_set("sensor.test", "still-failing")
-        await hass.async_block_till_done()
-
-    # The failure category recorded by the late-arriving failure must have
-    # survived, so a same-category failure is suppressed.
-    assert not any(
-        "Splunk payload error" in record.message for record in caplog.records
-    )
-
-    caplog.clear()
-    mock_hass_splunk.queue.side_effect = None
-
-    with caplog.at_level(logging.DEBUG):
-        hass.states.async_set("sensor.test", "recovered")
-        await hass.async_block_till_done()
-
-    recovery_records = [
-        record
-        for record in caplog.records
-        if "Sending events to Splunk has recovered" in record.message
-    ]
-    assert len(recovery_records) == 1
 
 
 async def test_yaml_filter_only_no_deprecation_issue(

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -378,6 +378,11 @@ async def test_event_listener_category_change_logs_again(
             logging.WARNING,
             "Splunk response error: Internal Server Error",
         ),
+        (
+            SplunkPayloadError(0, "Bad request", HTTPStatus.BAD_REQUEST),
+            logging.WARNING,
+            "Splunk payload error: Bad request",
+        ),
     ],
 )
 async def test_event_listener_error_handling(

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -537,6 +537,48 @@ async def test_event_listener_recovery_from_debug_only_outage_stays_at_debug(
     assert recovery_records[0].levelno == logging.DEBUG
 
 
+async def test_event_listener_recovery_after_error_then_debug_stays_visible(
+    hass: HomeAssistant,
+    mock_hass_splunk: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test recovery keeps the highest severity seen, not just the latest failure.
+
+    An ERROR-level failure (unauthorized) followed by a DEBUG-level failure
+    (connection blip) before recovery must still surface the recovery at
+    ERROR, not be silently downgraded to DEBUG.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_hass_splunk.queue.side_effect = SplunkPayloadError(
+        0, "Unauthorized", HTTPStatus.UNAUTHORIZED
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        hass.states.async_set("sensor.test", "unauthorized")
+        await hass.async_block_till_done()
+
+        mock_hass_splunk.queue.side_effect = ClientConnectionError("Connection failed")
+        hass.states.async_set("sensor.test", "connection-blip")
+        await hass.async_block_till_done()
+
+        mock_hass_splunk.queue.side_effect = None
+        hass.states.async_set("sensor.test", "recovered")
+        await hass.async_block_till_done()
+
+    recovery_records = [
+        record
+        for record in caplog.records
+        if "Sending events to Splunk has recovered" in record.message
+    ]
+    assert len(recovery_records) == 1
+    assert recovery_records[0].levelno == logging.ERROR
+
+
 async def test_event_listener_no_recovery_message_without_prior_failure(
     hass: HomeAssistant,
     mock_hass_splunk: AsyncMock,

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -1,5 +1,6 @@
 """Test the Splunk integration init."""
 
+import asyncio
 from http import HTTPStatus
 import logging
 from unittest.mock import AsyncMock, MagicMock
@@ -603,6 +604,60 @@ async def test_event_listener_no_recovery_message_without_prior_failure(
     assert not any(
         "Sending events to Splunk has recovered" in record.message
         for record in caplog.records
+    )
+
+
+async def test_event_listener_out_of_order_completion_preserves_failure(
+    hass: HomeAssistant,
+    mock_hass_splunk: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a slow success finishing after a fast failure doesn't erase it.
+
+    Each firing of the listener runs as its own task, so an older send that
+    is slow to resolve can complete after a newer send has already failed.
+    That late success must not clear the failure state or log a false
+    recovery.
+    """
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    async def delayed_queue(data: str, send: bool = True) -> bool:
+        if "slow-success" in data:
+            await asyncio.sleep(0.1)
+            return True
+        raise SplunkPayloadError(0, "Bad request", HTTPStatus.BAD_REQUEST)
+
+    mock_hass_splunk.queue.side_effect = delayed_queue
+
+    with caplog.at_level(logging.DEBUG):
+        # Dispatched first but resolves last.
+        hass.states.async_set("sensor.test", "slow-success")
+        # Dispatched second but resolves first.
+        hass.states.async_set("sensor.test", "fast-failure")
+        await hass.async_block_till_done()
+
+    assert not any(
+        "Sending events to Splunk has recovered" in record.message
+        for record in caplog.records
+    )
+
+    caplog.clear()
+    mock_hass_splunk.queue.side_effect = SplunkPayloadError(
+        0, "Bad request", HTTPStatus.BAD_REQUEST
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        hass.states.async_set("sensor.test", "still-failing")
+        await hass.async_block_till_done()
+
+    # The failure category set by the fast failure must have survived the
+    # late-arriving success, so a same-category failure is suppressed again.
+    assert not any(
+        "Splunk payload error" in record.message for record in caplog.records
     )
 
 

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -253,65 +253,18 @@ async def test_event_listener_unauthorized(
     assert flows[0]["context"]["source"] == "reauth"
 
 
-async def test_event_listener_unauthorized_repeated_failures_log_once(
+async def test_event_listener_severity_escalation_logs_at_natural_level(
     hass: HomeAssistant,
     mock_hass_splunk: AsyncMock,
     mock_config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that a sustained run of 401s logs only the first one and still reauths."""
-    mock_config_entry.add_to_hass(hass)
+    """Test a failure more severe than the ongoing outage stays visible.
 
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    mock_hass_splunk.queue.side_effect = SplunkPayloadError(
-        0, "Unauthorized", HTTPStatus.UNAUTHORIZED
-    )
-
-    with caplog.at_level(logging.DEBUG):
-        for i in range(5):
-            hass.states.async_set("sensor.test", str(i))
-            await hass.async_block_till_done()
-
-    matching_records = [
-        record
-        for record in caplog.records
-        if record.levelno == logging.ERROR
-        and "Splunk token unauthorized" in record.message
-    ]
-    assert len(matching_records) == 1
-
-    # Reauth is still triggered on every failure; the config entries flow
-    # manager dedupes it into a single active flow.
-    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
-    assert len(flows) == 1
-    assert flows[0]["context"]["source"] == "reauth"
-
-    caplog.clear()
-    mock_hass_splunk.queue.side_effect = None
-
-    with caplog.at_level(logging.DEBUG):
-        hass.states.async_set("sensor.test", "recovered")
-        await hass.async_block_till_done()
-
-    # Recovery never logs higher than warning, even after an ERROR failure.
-    recovery_records = [
-        record
-        for record in caplog.records
-        if record.levelno == logging.WARNING
-        and "Sending events to Splunk has recovered" in record.message
-    ]
-    assert len(recovery_records) == 1
-
-
-async def test_event_listener_category_change_stays_at_debug(
-    hass: HomeAssistant,
-    mock_hass_splunk: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Test switching failure type mid-outage keeps logging at debug."""
+    A debug-level outage (connection errors) that escalates to an
+    unauthorized error must surface that escalation at its natural level,
+    not hide it at debug just because a failure was already in progress.
+    """
     mock_config_entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -341,13 +294,17 @@ async def test_event_listener_category_change_stays_at_debug(
     assert len(connection_records) == 3
     assert all(record.levelno == logging.DEBUG for record in connection_records)
 
+    # The escalation to unauthorized is more severe than the debug outage in
+    # progress, so the first one logs at its natural level; the rest, being
+    # an equal-severity repeat, fall back to debug.
     unauthorized_records = [
         record
         for record in caplog.records
         if "Splunk token unauthorized" in record.message
     ]
     assert len(unauthorized_records) == 3
-    assert all(record.levelno == logging.DEBUG for record in unauthorized_records)
+    assert unauthorized_records[0].levelno == logging.ERROR
+    assert all(record.levelno == logging.DEBUG for record in unauthorized_records[1:])
 
     # Reauth still fires on every failure regardless of log suppression.
     flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
@@ -432,6 +389,11 @@ async def test_event_listener_error_handling(
             "Splunk response error: Internal Server Error",
         ),
         (
+            SplunkPayloadError(0, "Unauthorized", HTTPStatus.UNAUTHORIZED),
+            logging.ERROR,
+            "Splunk token unauthorized",
+        ),
+        (
             ValueError("boom"),
             logging.ERROR,
             "Unexpected error sending event to Splunk",
@@ -447,7 +409,7 @@ async def test_event_listener_repeated_failures_log_once(
     expected_log_level: int,
     expected_message: str,
 ) -> None:
-    """Test that a sustained run of send failures logs only the first one."""
+    """Test a sustained run of failures logs once at its level, then at debug."""
     mock_config_entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -461,61 +423,89 @@ async def test_event_listener_repeated_failures_log_once(
             await hass.async_block_till_done()
 
     matching_records = [
-        record
-        for record in caplog.records
-        if record.levelno == expected_log_level and expected_message in record.message
+        record for record in caplog.records if expected_message in record.message
     ]
-    assert len(matching_records) == 1
+    assert len(matching_records) == 5
+    assert matching_records[0].levelno == expected_log_level
+    assert all(record.levelno == logging.DEBUG for record in matching_records[1:])
 
 
-async def test_event_listener_recovery_logs_once(
+@pytest.mark.parametrize(
+    ("failures", "expected_recovery_level"),
+    [
+        pytest.param(
+            [
+                ClientResponseError(
+                    request_info=MagicMock(),
+                    history=(),
+                    status=500,
+                    message="Internal Server Error",
+                )
+            ]
+            * 3,
+            logging.WARNING,
+            id="warning_only_outage",
+        ),
+        pytest.param(
+            [ClientConnectionError("Connection failed")] * 3,
+            logging.DEBUG,
+            id="debug_only_outage",
+        ),
+        pytest.param(
+            [SplunkPayloadError(0, "Unauthorized", HTTPStatus.UNAUTHORIZED)] * 3,
+            logging.WARNING,
+            id="error_only_outage_capped_at_warning",
+        ),
+        pytest.param(
+            [
+                SplunkPayloadError(0, "Unauthorized", HTTPStatus.UNAUTHORIZED),
+                ClientConnectionError("Connection failed"),
+            ],
+            logging.WARNING,
+            id="error_then_debug_capped_at_warning",
+        ),
+    ],
+)
+async def test_event_listener_recovery_level(
     hass: HomeAssistant,
     mock_hass_splunk: AsyncMock,
     mock_config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
+    failures: list[Exception],
+    expected_recovery_level: int,
 ) -> None:
-    """Test that recovery after failures logs exactly one recovery message."""
+    """Test recovery logs at the highest failure severity seen, capped at warning."""
     mock_config_entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    mock_hass_splunk.queue.side_effect = ClientResponseError(
-        request_info=MagicMock(),
-        history=(),
-        status=500,
-        message="Internal Server Error",
-    )
-
     with caplog.at_level(logging.DEBUG):
-        for i in range(3):
+        for i, failure in enumerate(failures):
+            mock_hass_splunk.queue.side_effect = failure
             hass.states.async_set("sensor.test", str(i))
             await hass.async_block_till_done()
 
         mock_hass_splunk.queue.side_effect = None
+        hass.states.async_set("sensor.test", "recovered")
+        await hass.async_block_till_done()
 
-        for i in range(3):
-            hass.states.async_set("sensor.test", f"recovered-{i}")
-            await hass.async_block_till_done()
-
-    # The suppressed failure (a 500 response) was logged at WARNING, so the
-    # recovery must be visible at WARNING too, not silently downgraded.
     recovery_records = [
         record
         for record in caplog.records
-        if record.levelno == logging.WARNING
-        and "Sending events to Splunk has recovered" in record.message
+        if "Sending events to Splunk has recovered" in record.message
     ]
     assert len(recovery_records) == 1
+    assert recovery_records[0].levelno == expected_recovery_level
 
 
-async def test_event_listener_recovery_from_debug_only_outage_stays_at_debug(
+async def test_event_listener_failure_after_recovery_logs_at_natural_level(
     hass: HomeAssistant,
     mock_hass_splunk: AsyncMock,
     mock_config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test recovery from a debug-only outage logs at debug, not at a normal level."""
+    """Test a new outage after a recovery logs at its natural level again."""
     mock_config_entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -524,64 +514,62 @@ async def test_event_listener_recovery_from_debug_only_outage_stays_at_debug(
     mock_hass_splunk.queue.side_effect = ClientConnectionError("Connection failed")
 
     with caplog.at_level(logging.DEBUG):
-        for i in range(3):
-            hass.states.async_set("sensor.test", str(i))
-            await hass.async_block_till_done()
+        hass.states.async_set("sensor.test", "first-outage")
+        await hass.async_block_till_done()
 
         mock_hass_splunk.queue.side_effect = None
-
         hass.states.async_set("sensor.test", "recovered")
         await hass.async_block_till_done()
 
-    recovery_records = [
-        record
+        caplog.clear()
+        mock_hass_splunk.queue.side_effect = ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=500,
+            message="Internal Server Error",
+        )
+        hass.states.async_set("sensor.test", "second-outage")
+        await hass.async_block_till_done()
+
+    assert any(
+        record.levelno == logging.WARNING
+        and "Splunk response error: Internal Server Error" in record.message
         for record in caplog.records
-        if "Sending events to Splunk has recovered" in record.message
-    ]
-    assert len(recovery_records) == 1
-    assert recovery_records[0].levelno == logging.DEBUG
+    )
 
 
-async def test_event_listener_recovery_after_error_then_debug_capped_at_warning(
+async def test_event_listener_coalesced_send_is_not_a_recovery(
     hass: HomeAssistant,
     mock_hass_splunk: AsyncMock,
     mock_config_entry: MockConfigEntry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test recovery keeps the highest severity seen, capped at warning.
+    """Test a send coalesced into an in-flight send isn't treated as success.
 
-    An ERROR-level failure (unauthorized) followed by a DEBUG-level failure
-    (connection blip) before recovery must surface the recovery at WARNING,
-    the highest severity a recovery message may ever reach.
+    hass_splunk.queue() returns False, without raising, when a send is
+    already in flight. That must not be read as a successful send: it would
+    falsely log a recovery and reset the outage state mid-outage.
     """
     mock_config_entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    mock_hass_splunk.queue.side_effect = SplunkPayloadError(
-        0, "Unauthorized", HTTPStatus.UNAUTHORIZED
-    )
+    mock_hass_splunk.queue.side_effect = [
+        ClientConnectionError("Connection failed"),
+        False,
+        ClientConnectionError("Connection failed"),
+    ]
 
     with caplog.at_level(logging.DEBUG):
-        hass.states.async_set("sensor.test", "unauthorized")
-        await hass.async_block_till_done()
+        for i in range(3):
+            hass.states.async_set("sensor.test", str(i))
+            await hass.async_block_till_done()
 
-        mock_hass_splunk.queue.side_effect = ClientConnectionError("Connection failed")
-        hass.states.async_set("sensor.test", "connection-blip")
-        await hass.async_block_till_done()
-
-        mock_hass_splunk.queue.side_effect = None
-        hass.states.async_set("sensor.test", "recovered")
-        await hass.async_block_till_done()
-
-    recovery_records = [
-        record
+    assert not any(
+        "Sending events to Splunk has recovered" in record.message
         for record in caplog.records
-        if "Sending events to Splunk has recovered" in record.message
-    ]
-    assert len(recovery_records) == 1
-    assert recovery_records[0].levelno == logging.WARNING
+    )
 
 
 async def test_event_listener_no_recovery_message_without_prior_failure(

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -295,10 +295,12 @@ async def test_event_listener_unauthorized_repeated_failures_log_once(
         hass.states.async_set("sensor.test", "recovered")
         await hass.async_block_till_done()
 
+    # Unauthorized failures are user-visible at ERROR, so the recovery that
+    # closes them out must be equally visible, not silently downgraded.
     recovery_records = [
         record
         for record in caplog.records
-        if record.levelno == logging.INFO
+        if record.levelno == logging.ERROR
         and "Sending events to Splunk has recovered" in record.message
     ]
     assert len(recovery_records) == 1
@@ -491,13 +493,48 @@ async def test_event_listener_recovery_logs_once(
             hass.states.async_set("sensor.test", f"recovered-{i}")
             await hass.async_block_till_done()
 
+    # The suppressed failure (a 500 response) was logged at WARNING, so the
+    # recovery must be visible at WARNING too, not silently downgraded.
     recovery_records = [
         record
         for record in caplog.records
-        if record.levelno == logging.INFO
+        if record.levelno == logging.WARNING
         and "Sending events to Splunk has recovered" in record.message
     ]
     assert len(recovery_records) == 1
+
+
+async def test_event_listener_recovery_from_debug_only_outage_stays_at_debug(
+    hass: HomeAssistant,
+    mock_hass_splunk: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test recovery from a debug-only outage logs at debug, not at a normal level."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_hass_splunk.queue.side_effect = ClientConnectionError("Connection failed")
+
+    with caplog.at_level(logging.DEBUG):
+        for i in range(3):
+            hass.states.async_set("sensor.test", str(i))
+            await hass.async_block_till_done()
+
+        mock_hass_splunk.queue.side_effect = None
+
+        hass.states.async_set("sensor.test", "recovered")
+        await hass.async_block_till_done()
+
+    recovery_records = [
+        record
+        for record in caplog.records
+        if "Sending events to Splunk has recovered" in record.message
+    ]
+    assert len(recovery_records) == 1
+    assert recovery_records[0].levelno == logging.DEBUG
 
 
 async def test_event_listener_no_recovery_message_without_prior_failure(

--- a/tests/components/splunk/test_init.py
+++ b/tests/components/splunk/test_init.py
@@ -253,6 +253,57 @@ async def test_event_listener_unauthorized(
     assert flows[0]["context"]["source"] == "reauth"
 
 
+async def test_event_listener_unauthorized_repeated_failures_log_once(
+    hass: HomeAssistant,
+    mock_hass_splunk: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a sustained run of 401s logs only the first one and still reauths."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    mock_hass_splunk.queue.side_effect = SplunkPayloadError(
+        0, "Unauthorized", HTTPStatus.UNAUTHORIZED
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        for i in range(5):
+            hass.states.async_set("sensor.test", str(i))
+            await hass.async_block_till_done()
+
+    matching_records = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.ERROR
+        and "Splunk token unauthorized" in record.message
+    ]
+    assert len(matching_records) == 1
+
+    # Reauth is still triggered on every failure; the config entries flow
+    # manager dedupes it into a single active flow.
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == "reauth"
+
+    caplog.clear()
+    mock_hass_splunk.queue.side_effect = None
+
+    with caplog.at_level(logging.DEBUG):
+        hass.states.async_set("sensor.test", "recovered")
+        await hass.async_block_till_done()
+
+    recovery_records = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.INFO
+        and "Sending events to Splunk has recovered" in record.message
+    ]
+    assert len(recovery_records) == 1
+
+
 @pytest.mark.parametrize(
     ("error", "expected_log_level", "expected_message"),
     [


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the Splunk endpoint is unreachable, misconfigured or rejecting payloads, `splunk_event_listener` logged once per event, and since it is registered on `EVENT_STATE_CHANGED` that is hundreds of warnings a minute on a busy instance, with the bare `except Exception` handler writing a full traceback each time, so a sustained outage buried everything else in the log; now the first failure of an outage logs at its natural level and every failure after it logs at debug until a send succeeds, whatever kind of failure it is, with the traceback kept for that first failure alone, and one `info` record when sending recovers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr



