### PR TITLE
Translate the remaining Tessie energy site setup exception

### DIFF
--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -159,7 +159,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
                 except (InvalidToken, Forbidden, SubscriptionRequired) as e:
                     raise ConfigEntryAuthFailed from e
                 except TeslaFleetError as e:
-                    raise ConfigEntryNotReady(getattr(e, "message", str(e))) from e
+                    raise ConfigEntryNotReady(
+                        translation_domain=DOMAIN,
+                        translation_key="cannot_connect",
+                    ) from e
                 except ClientError as e:
                     raise ConfigEntryNotReady from e
 

--- a/homeassistant/components/tessie/__init__.py
+++ b/homeassistant/components/tessie/__init__.py
@@ -76,16 +76,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
     try:
         state_of_all_vehicles = await tessie.list_vehicles(only_active=True)
     except (InvalidToken, MissingToken) as e:
-        raise ConfigEntryAuthFailed from e
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="auth_failed",
+        ) from e
     except RETRY_EXCEPTIONS as e:
-        raise ConfigEntryNotReady from e
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+        ) from e
     except TeslaFleetError as e:
         raise ConfigEntryError(
             translation_domain=DOMAIN,
             translation_key="cannot_connect",
         ) from e
     except ClientError as e:
-        raise ConfigEntryNotReady from e
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+        ) from e
 
     vehicles: list[TessieVehicleData] = []
     for vehicle in state_of_all_vehicles["results"]:
@@ -130,13 +139,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
     try:
         scopes = await tessie.scopes()
     except (TeslaFleetError, ClientError) as e:
-        raise ConfigEntryNotReady from e
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+        ) from e
 
     if Scope.ENERGY_DEVICE_DATA in scopes:
         try:
             products = (await tessie.products())["response"]
         except (TeslaFleetError, ClientError) as e:
-            raise ConfigEntryNotReady from e
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="cannot_connect",
+            ) from e
 
         for product in products:
             if "energy_site_id" in product:
@@ -157,14 +172,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: TessieConfigEntry) -> bo
                 try:
                     live_status = (await api.live_status())["response"]
                 except (InvalidToken, Forbidden, SubscriptionRequired) as e:
-                    raise ConfigEntryAuthFailed from e
+                    raise ConfigEntryAuthFailed(
+                        translation_domain=DOMAIN,
+                        translation_key="auth_failed",
+                    ) from e
                 except TeslaFleetError as e:
                     raise ConfigEntryNotReady(
                         translation_domain=DOMAIN,
                         translation_key="cannot_connect",
                     ) from e
                 except ClientError as e:
-                    raise ConfigEntryNotReady from e
+                    raise ConfigEntryNotReady(
+                        translation_domain=DOMAIN,
+                        translation_key="cannot_connect",
+                    ) from e
 
                 powerwall = (
                     product["components"]["battery"] or product["components"]["solar"]

--- a/homeassistant/components/tessie/coordinator.py
+++ b/homeassistant/components/tessie/coordinator.py
@@ -76,7 +76,10 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             vehicle = await self.api.state(use_cache=True)
         except (InvalidToken, MissingToken) as e:
-            raise ConfigEntryAuthFailed from e
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="auth_failed",
+            ) from e
         except TeslaFleetError as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -84,7 +87,10 @@ class TessieStateUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ) from e
         except ClientResponseError as e:
             if e.status == HTTPStatus.UNAUTHORIZED:
-                raise ConfigEntryAuthFailed from e
+                raise ConfigEntryAuthFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="auth_failed",
+                ) from e
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="cannot_connect",
@@ -132,7 +138,10 @@ class TessieEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             data = (await self.api.live_status())["response"]
         except (InvalidToken, MissingToken) as e:
-            raise ConfigEntryAuthFailed from e
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="auth_failed",
+            ) from e
         except TeslaFleetError as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,
@@ -172,7 +181,10 @@ class TessieEnergySiteInfoCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             data = (await self.api.site_info())["response"]
         except (InvalidToken, MissingToken) as e:
-            raise ConfigEntryAuthFailed from e
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="auth_failed",
+            ) from e
         except TeslaFleetError as e:
             raise UpdateFailed(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/tessie/quality_scale.yaml
+++ b/homeassistant/components/tessie/quality_scale.yaml
@@ -78,7 +78,7 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
-  exception-translations: todo
+  exception-translations: done
   icon-translations: done
   reconfiguration-flow: todo
   repair-issues: todo

--- a/tests/components/tessie/test_coordinator.py
+++ b/tests/components/tessie/test_coordinator.py
@@ -71,12 +71,16 @@ async def test_coordinator_auth(
     """Tests that the coordinator handles auth errors."""
 
     mock_get_state.side_effect = ERROR_AUTH
-    await setup_platform(hass, [Platform.BINARY_SENSOR])
+    entry = await setup_platform(hass, [Platform.BINARY_SENSOR])
+    coordinator = entry.runtime_data.vehicles[0].data_coordinator
 
     freezer.tick(WAIT)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     mock_get_state.assert_called_once()
+    assert coordinator.last_exception is not None
+    assert coordinator.last_exception.translation_domain == DOMAIN
+    assert coordinator.last_exception.translation_key == "auth_failed"
 
 
 async def test_coordinator_connection(
@@ -163,6 +167,8 @@ async def test_coordinator_reauth(
     mock.side_effect = side_effect
     entry = await setup_platform(hass, [Platform.SENSOR])
     assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert entry.error_reason_translation_domain == DOMAIN
+    assert entry.error_reason_translation_key == "auth_failed"
 
 
 async def test_coordinator_energy_history_error(

--- a/tests/components/tessie/test_coordinator.py
+++ b/tests/components/tessie/test_coordinator.py
@@ -5,7 +5,12 @@ from datetime import timedelta
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
-from tesla_fleet_api.exceptions import Forbidden, InvalidToken, MissingToken
+from tesla_fleet_api.exceptions import (
+    Forbidden,
+    InvalidToken,
+    MissingToken,
+    TeslaFleetError,
+)
 
 from homeassistant.components.tessie import PLATFORMS
 from homeassistant.components.tessie.const import DOMAIN
@@ -101,6 +106,53 @@ async def test_coordinator_connection(
     assert coordinator.last_exception.translation_key == "cannot_connect"
 
 
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(InvalidToken(), id="invalid_token"),
+        pytest.param(MissingToken(), id="missing_token"),
+    ],
+)
+async def test_coordinator_fleet_auth_failure(
+    hass: HomeAssistant,
+    mock_get_state,
+    freezer: FrozenDateTimeFactory,
+    exception: TeslaFleetError,
+) -> None:
+    """Tests that the coordinator translates tesla_fleet_api token errors."""
+
+    mock_get_state.side_effect = exception
+    entry = await setup_platform(hass, [Platform.BINARY_SENSOR])
+    coordinator = entry.runtime_data.vehicles[0].data_coordinator
+
+    freezer.tick(WAIT)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    mock_get_state.assert_called_once()
+    assert coordinator.last_exception is not None
+    assert coordinator.last_exception.translation_domain == DOMAIN
+    assert coordinator.last_exception.translation_key == "auth_failed"
+
+
+async def test_coordinator_fleet_error(
+    hass: HomeAssistant, mock_get_state, freezer: FrozenDateTimeFactory
+) -> None:
+    """Tests that the coordinator translates generic tesla_fleet_api errors."""
+
+    mock_get_state.side_effect = Forbidden()
+    entry = await setup_platform(hass, [Platform.BINARY_SENSOR])
+    coordinator = entry.runtime_data.vehicles[0].data_coordinator
+
+    freezer.tick(WAIT)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    mock_get_state.assert_called_once()
+    assert hass.states.get("binary_sensor.test_status").state == STATE_UNAVAILABLE
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert coordinator.last_exception.translation_domain == DOMAIN
+    assert coordinator.last_exception.translation_key == "cannot_connect"
+
+
 async def test_coordinator_live_error(
     hass: HomeAssistant, mock_live_status, freezer: FrozenDateTimeFactory
 ) -> None:
@@ -120,6 +172,36 @@ async def test_coordinator_live_error(
     assert isinstance(coordinator.last_exception, UpdateFailed)
     assert coordinator.last_exception.translation_domain == DOMAIN
     assert coordinator.last_exception.translation_key == "cannot_connect"
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(InvalidToken(), id="invalid_token"),
+        pytest.param(MissingToken(), id="missing_token"),
+    ],
+)
+async def test_coordinator_live_auth_failure(
+    hass: HomeAssistant,
+    mock_live_status,
+    freezer: FrozenDateTimeFactory,
+    exception: TeslaFleetError,
+) -> None:
+    """Tests that the energy live coordinator translates token errors on refresh."""
+
+    entry = await setup_platform(hass, [Platform.SENSOR])
+    coordinator = entry.runtime_data.energysites[0].live_coordinator
+    assert coordinator is not None
+
+    mock_live_status.reset_mock()
+    mock_live_status.side_effect = exception
+    freezer.tick(TESSIE_FLEET_API_SYNC_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    mock_live_status.assert_called_once()
+    assert coordinator.last_exception is not None
+    assert coordinator.last_exception.translation_domain == DOMAIN
+    assert coordinator.last_exception.translation_key == "auth_failed"
 
 
 async def test_coordinator_info_error(

--- a/tests/components/tessie/test_init.py
+++ b/tests/components/tessie/test_init.py
@@ -156,6 +156,18 @@ async def test_aiohttp_client_error_on_live_status_retries(
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
+async def test_fleet_error_on_live_status_retries(hass: HomeAssistant) -> None:
+    """Test that TeslaFleetError during live_status() triggers a translated SETUP_RETRY."""
+    with patch(
+        "tesla_fleet_api.tessie.EnergySite.live_status",
+        side_effect=TeslaFleetError,
+    ):
+        entry = await setup_platform(hass)
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.error_reason_translation_domain == DOMAIN
+    assert entry.error_reason_translation_key == "cannot_connect"
+
+
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_wall_connector_via_device_id(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Several `ConfigEntryAuthFailed` and `ConfigEntryNotReady` raises in `tessie` (the energy-site setup path in `__init__.py` and the auth failures in all four coordinators) were either passing the raw library message or raising bare `from e`, so the user saw untranslated library text. They now pass `translation_domain` and `translation_key`, reusing the existing `auth_failed` and `cannot_connect` keys, which makes the `exception-translations` quality-scale rule actually hold. Tests assert the translation keys on the coordinator auth paths.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
