### PR TITLE
Report UniFi WAN latency as unknown when a monitor is unresponsive

### DIFF
--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -263,11 +263,6 @@ def async_device_wan_latency_value_fn(
         # Checked by async_device_wan_latency_supported_fn
         assert target
 
-    # A monitor that got no response omits "latency_average" entirely, which
-    # aiounifi types as NotRequired. Defaulting it to 0 reported a failed probe
-    # as 0 ms - the one value that reads as a perfect result rather than as
-    # missing data, which inverts the meaning of the sensor. Return None so the
-    # state becomes unknown instead.
     return target.get("latency_average")
 
 

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -263,7 +263,12 @@ def async_device_wan_latency_value_fn(
         # Checked by async_device_wan_latency_supported_fn
         assert target
 
-    return target.get("latency_average", 0)
+    # A monitor that got no response omits "latency_average" entirely, which
+    # aiounifi types as NotRequired. Defaulting it to 0 reported a failed probe
+    # as 0 ms - the one value that reads as a perfect result rather than as
+    # missing data, which inverts the meaning of the sensor. Return None so the
+    # state becomes unknown instead.
+    return target.get("latency_average")
 
 
 @callback

--- a/tests/components/unifi/snapshots/test_sensor.ambr
+++ b/tests/components/unifi/snapshots/test_sensor.ambr
@@ -815,7 +815,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': 'unknown',
   })
 # ---
 # name: test_entity_and_device_data[wlan_payload0-device_payload0-client_payload0-config_entry_options0][sensor.mock_name_cloudflare_wan_latency-entry]
@@ -931,7 +931,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': 'unknown',
   })
 # ---
 # name: test_entity_and_device_data[wlan_payload0-device_payload0-client_payload0-config_entry_options0][sensor.mock_name_google_wan_latency-entry]
@@ -1047,7 +1047,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': 'unknown',
   })
 # ---
 # name: test_entity_and_device_data[wlan_payload0-device_payload0-client_payload0-config_entry_options0][sensor.mock_name_microsoft_wan_latency-entry]

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1712,25 +1712,17 @@ async def test_device_uptime(
 @pytest.mark.parametrize(
     ("monitor_id", "state", "index_to_update", "monitor_update", "updated_state"),
     [
-        # Microsoft
         pytest.param(
-            "microsoft_wan", "56", 0, {"latency_average": "20"}, "20", id="microsoft"
+            "microsoft_wan", "56", 0, {"latency_average": 20}, "20", id="microsoft"
         ),
-        # Google
+        pytest.param("google_wan", "53", 1, {"latency_average": 90}, "90", id="google"),
         pytest.param(
-            "google_wan", "53", 1, {"latency_average": "90"}, "90", id="google"
+            "cloudflare_wan", "30", 2, {"latency_average": 80}, "80", id="cloudflare"
         ),
-        # Cloudflare
-        pytest.param(
-            "cloudflare_wan", "30", 2, {"latency_average": "80"}, "80", id="cloudflare"
-        ),
-        # Microsoft no response
         pytest.param(
             "microsoft_wan", "56", 0, {}, STATE_UNKNOWN, id="microsoft_no_response"
         ),
-        # Google no response
         pytest.param("google_wan", "53", 1, {}, STATE_UNKNOWN, id="google_no_response"),
-        # Cloudflare no response
         pytest.param(
             "cloudflare_wan", "30", 2, {}, STATE_UNKNOWN, id="cloudflare_no_response"
         ),

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1710,14 +1710,30 @@ async def test_device_uptime(
     ],
 )
 @pytest.mark.parametrize(
-    ("monitor_id", "state", "updated_state", "index_to_update"),
+    ("monitor_id", "state", "index_to_update", "monitor_update", "updated_state"),
     [
         # Microsoft
-        ("microsoft_wan", "56", "20", 0),
+        pytest.param(
+            "microsoft_wan", "56", 0, {"latency_average": "20"}, "20", id="microsoft"
+        ),
         # Google
-        ("google_wan", "53", "90", 1),
+        pytest.param(
+            "google_wan", "53", 1, {"latency_average": "90"}, "90", id="google"
+        ),
         # Cloudflare
-        ("cloudflare_wan", "30", "80", 2),
+        pytest.param(
+            "cloudflare_wan", "30", 2, {"latency_average": "80"}, "80", id="cloudflare"
+        ),
+        # Microsoft no response
+        pytest.param(
+            "microsoft_wan", "56", 0, {}, STATE_UNKNOWN, id="microsoft_no_response"
+        ),
+        # Google no response
+        pytest.param("google_wan", "53", 1, {}, STATE_UNKNOWN, id="google_no_response"),
+        # Cloudflare no response
+        pytest.param(
+            "cloudflare_wan", "30", 2, {}, STATE_UNKNOWN, id="cloudflare_no_response"
+        ),
     ],
 )
 @pytest.mark.usefixtures("config_entry_setup")
@@ -1728,8 +1744,9 @@ async def test_wan_monitor_latency(
     device_payload: list[dict[str, Any]],
     monitor_id: str,
     state: str,
-    updated_state: str,
     index_to_update: int,
+    monitor_update: dict[str, Any],
+    updated_state: str,
 ) -> None:
     """Verify that wan latency sensors are working as expected."""
     entity_id = f"sensor.mock_name_{monitor_id}_latency"
@@ -1757,68 +1774,15 @@ async def test_wan_monitor_latency(
     # Verify sensor state
     assert hass.states.get(entity_id).state == state
 
-    # Verify state update
-    device = device_payload[0]
-    device["uptime_stats"]["WAN"]["monitors"][index_to_update]["latency_average"] = (
-        updated_state
-    )
-
+    # Update state
+    device = deepcopy(device_payload[0])
+    monitor = device["uptime_stats"]["WAN"]["monitors"][index_to_update]
+    monitor.pop("latency_average")
+    monitor.update(monitor_update)
     mock_websocket_message(message=MessageKey.DEVICE, data=device)
 
+    # Verify state update
     assert hass.states.get(entity_id).state == updated_state
-
-
-@pytest.mark.parametrize(
-    "device_payload",
-    [
-        [
-            {
-                "board_rev": 2,
-                "device_id": "mock-id",
-                "ip": "10.0.1.1",
-                "mac": "10:00:00:00:01:01",
-                "last_seen": 1562600145,
-                "model": "US16P150",
-                "name": "mock-name",
-                "port_overrides": [],
-                "uptime_stats": {
-                    "WAN": {
-                        "monitors": [
-                            # A monitor that got no response omits
-                            # "latency_average" rather than reporting a value.
-                            {
-                                "availability": 0.0,
-                                "target": "www.microsoft.com",
-                                "type": "icmp",
-                            },
-                        ],
-                    },
-                },
-                "state": 1,
-                "type": "usw",
-                "version": "4.0.42.10433",
-            }
-        ]
-    ],
-)
-@pytest.mark.usefixtures("config_entry_setup")
-async def test_wan_monitor_latency_unresponsive_monitor(
-    hass: HomeAssistant,
-    entity_registry: er.EntityRegistry,
-) -> None:
-    """Verify an unresponsive monitor reports unknown rather than 0 ms."""
-    entity_id = "sensor.mock_name_microsoft_wan_latency"
-
-    entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
-    await hass.async_block_till_done()
-
-    async_fire_time_changed(
-        hass,
-        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
-    )
-    await hass.async_block_till_done()
-
-    assert hass.states.get(entity_id).state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1784,6 +1784,59 @@ async def test_wan_monitor_latency(
                 "uptime_stats": {
                     "WAN": {
                         "monitors": [
+                            # A monitor that got no response omits
+                            # "latency_average" rather than reporting a value.
+                            {
+                                "availability": 0.0,
+                                "target": "www.microsoft.com",
+                                "type": "icmp",
+                            },
+                        ],
+                    },
+                },
+                "state": 1,
+                "type": "usw",
+                "version": "4.0.42.10433",
+            }
+        ]
+    ],
+)
+@pytest.mark.usefixtures("config_entry_setup")
+async def test_wan_monitor_latency_unresponsive_monitor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Verify an unresponsive monitor reports unknown rather than 0 ms."""
+    entity_id = "sensor.mock_name_microsoft_wan_latency"
+
+    entity_registry.async_update_entity(entity_id=entity_id, disabled_by=None)
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "device_payload",
+    [
+        [
+            {
+                "board_rev": 2,
+                "device_id": "mock-id",
+                "ip": "10.0.1.1",
+                "mac": "10:00:00:00:01:01",
+                "last_seen": 1562600145,
+                "model": "US16P150",
+                "name": "mock-name",
+                "port_overrides": [],
+                "uptime_stats": {
+                    "WAN": {
+                        "monitors": [
                             {
                                 "availability": 100.0,
                                 "latency_average": 30,


### PR DESCRIPTION
## Proposed change

A WAN uptime monitor that received no response omits `latency_average` from its
payload entirely — aiounifi types the field as `NotRequired` for exactly this
reason. `async_device_wan_latency_value_fn` defaulted the missing key to `0`, so
a probe that failed reported `0 ms`.

For a latency measurement `0` is not a neutral placeholder, it is the *best
possible reading*. So the sensor was not merely blind during an outage, it was
inverted: a dead probe pulled the reported latency down and made a degraded
uplink look healthier than a working one. On a gateway with three monitors per
WAN, one dark target is enough to drag the figure well below the truth.

The value function is already typed `int | None`, so returning `None` leaves the
state `unknown` and needs no signature change.

`unknown` rather than `unavailable` is deliberate: the gateway is reachable and
answering, it is the probe *target* that did not reply. The entity exists, its
value is simply not known.

This repository's own fixtures already contained the failure shape — the WAN2
monitors in `test_sensor.py` report `availability: 0.0` with no
`latency_average`, and the committed snapshot recorded their state as `'0'`.
Those three snapshot entries now read `'unknown'`. A regression test has been added to 
`test_wan_monitor_latency` to assert it directly.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

I have marked this a bugfix rather than a breaking change, but it does change a
visible value: an unresponsive monitor now reports `unknown` where it previously
reported `0`, so anyone whose template keys on `0` will see the difference. My
reading is that a sensor which reported a wrong value and now reports nothing is
a fix, not a break — but if you would rather it carried a breaking-change note
for the release notes, say so and I will add one.

Verified against a live gateway payload as well as the fixtures: a UDM reporting
three WAN interfaces, one of whose monitors sat at `availability: 0.0` with
`latency_average` absent. That sensor went from `0` to `unknown` while the five
healthy monitors on the same device were unchanged, and a websocket device update
took it to a real value and back to `unknown` when the probe went dark again, so
it does not latch.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---

AI assistance disclosure, per the [AI policy](https://developers.home-assistant.io/docs/ai_policy):
this change was written with [Claude Code](https://claude.com/claude-code), as recorded by the
`Co-Authored-By` trailer on the commit.
