### PR TITLE
Add support for multiple camera stream sources

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -121,6 +121,14 @@ class CameraEntityFeature(IntFlag):
     STREAM = 2
 
 
+@dataclass(frozen=True)
+class CameraStreamSource:
+    """A camera stream source."""
+
+    url: str
+    orientation: Orientation | None = None
+
+
 DEFAULT_CONTENT_TYPE: Final = "image/jpeg"
 ENTITY_IMAGE_URL: Final = "/api/camera_proxy/{0}?token={1}"
 
@@ -565,6 +573,16 @@ class Camera(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         and StreamType.HLS.
         """
         return None
+
+    async def async_get_stream_sources(self) -> list[CameraStreamSource]:
+        """Return the ordered stream sources for the camera.
+
+        The first source is the primary source. A source without an orientation
+        uses the orientation configured for the camera.
+        """
+        if source := await self.stream_source():
+            return [CameraStreamSource(source)]
+        return []
 
     async def async_handle_async_webrtc_offer(
         self, offer_sdp: str, session_id: str, send_message: WebRTCSendMessage

--- a/homeassistant/components/camera/webrtc.py
+++ b/homeassistant/components/camera/webrtc.py
@@ -362,9 +362,10 @@ async def async_get_supported_provider(
 ) -> CameraWebRTCProvider | None:
     """Return the first supported provider for the camera."""
     providers = hass.data.get(DATA_WEBRTC_PROVIDERS)
-    if not providers or not (stream_source := await camera.stream_source()):
+    if not providers or not (stream_sources := await camera.async_get_stream_sources()):
         return None
 
+    stream_source = stream_sources[0].url
     for provider in providers:
         if provider.async_is_supported(stream_source):
             return provider

--- a/homeassistant/components/go2rtc/__init__.py
+++ b/homeassistant/components/go2rtc/__init__.py
@@ -268,6 +268,31 @@ class _SessionInfo:
     camera: Camera
 
 
+def _apply_orientation(stream_source: str, orientation: Orientation) -> str:
+    """Apply an orientation to a go2rtc stream source."""
+    if orientation is Orientation.NO_TRANSFORM:
+        return stream_source
+
+    if not stream_source.startswith(_FFMPEG):
+        stream_source = _FFMPEG + ":" + stream_source
+    stream_source += "#video=h264#audio=copy"
+    match orientation:
+        case Orientation.MIRROR:
+            return stream_source + "#raw=-vf hflip"
+        case Orientation.ROTATE_180:
+            return stream_source + "#rotate=180"
+        case Orientation.FLIP:
+            return stream_source + "#raw=-vf vflip"
+        case Orientation.ROTATE_LEFT_AND_FLIP:
+            return stream_source + "#raw=-vf transpose=2,vflip"
+        case Orientation.ROTATE_LEFT:
+            return stream_source + "#rotate=-90"
+        case Orientation.ROTATE_RIGHT_AND_FLIP:
+            return stream_source + "#raw=-vf transpose=1,vflip"
+        case Orientation.ROTATE_RIGHT:
+            return stream_source + "#rotate=90"
+
+
 class WebRTCProvider(CameraWebRTCProvider):
     """WebRTC provider."""
 
@@ -376,56 +401,43 @@ class WebRTCProvider(CameraWebRTCProvider):
 
     async def _update_stream_source(self, camera: Camera) -> None:
         """Update the stream source in go2rtc config if needed."""
-        if not (stream_source := await camera.stream_source()):
+        if not (stream_sources := await camera.async_get_stream_sources()):
             await self._close_camera_sessions(camera)
             raise HomeAssistantError("Camera has no stream source")
 
+        source_urls = [source.url for source in stream_sources]
         if camera.platform.platform_name == "generic":
             # This is a workaround to use ffmpeg for generic cameras
-            # A proper fix will be added in the future together
-            # with supporting multiple streams per camera
-            stream_source = "ffmpeg:" + stream_source
+            source_urls[0] = "ffmpeg:" + source_urls[0]
 
-        if not self.async_is_supported(stream_source):
+        if not all(self.async_is_supported(source) for source in source_urls):
             await self._close_camera_sessions(camera)
             raise HomeAssistantError("Stream source is not supported by go2rtc")
 
         camera_prefs = await get_dynamic_camera_stream_settings(
             self._hass, camera.entity_id
         )
-        if camera_prefs.orientation is not Orientation.NO_TRANSFORM:
-            # Camera orientation manually set by user
-            if not stream_source.startswith(_FFMPEG):
-                stream_source = _FFMPEG + ":" + stream_source
-            stream_source += "#video=h264#audio=copy"
-            match camera_prefs.orientation:
-                case Orientation.MIRROR:
-                    stream_source += "#raw=-vf hflip"
-                case Orientation.ROTATE_180:
-                    stream_source += "#rotate=180"
-                case Orientation.FLIP:
-                    stream_source += "#raw=-vf vflip"
-                case Orientation.ROTATE_LEFT_AND_FLIP:
-                    # Cannot use any filter when using raw one
-                    stream_source += "#raw=-vf transpose=2,vflip"
-                case Orientation.ROTATE_LEFT:
-                    stream_source += "#rotate=-90"
-                case Orientation.ROTATE_RIGHT_AND_FLIP:
-                    # Cannot use any filter when using raw one
-                    stream_source += "#raw=-vf transpose=1,vflip"
-                case Orientation.ROTATE_RIGHT:
-                    stream_source += "#rotate=90"
+        source_urls = [
+            _apply_orientation(
+                source_url,
+                source.orientation
+                if source.orientation is not None
+                else camera_prefs.orientation,
+            )
+            for source_url, source in zip(source_urls, stream_sources, strict=True)
+        ]
 
         streams = await self._rest_client.streams.list()
         identifier = get_camera_identifier(camera)
 
-        if (stream := streams.get(identifier)) is None or not any(
-            stream_source == producer.url for producer in stream.producers
+        if (stream := streams.get(identifier)) is None or not all(
+            any(source == producer.url for producer in stream.producers)
+            for source in source_urls
         ):
             await self._rest_client.streams.add(
                 identifier,
                 [
-                    stream_source,
+                    *source_urls,
                     # We are setting any ffmpeg rtsp related logs to debug
                     # Connection problems to the camera will be
                     # logged by the first stream

--- a/tests/components/go2rtc/__init__.py
+++ b/tests/components/go2rtc/__init__.py
@@ -1,6 +1,10 @@
 """Go2rtc tests."""
 
-from homeassistant.components.camera import Camera, CameraEntityFeature
+from homeassistant.components.camera import (
+    Camera,
+    CameraEntityFeature,
+    CameraStreamSource,
+)
 
 
 class MockCamera(Camera):
@@ -12,12 +16,17 @@ class MockCamera(Camera):
         """Initialize the mock entity."""
         super().__init__()
         self._stream_source: str | None = "rtsp://stream"
+        self._stream_sources: list[CameraStreamSource] | None = None
         self._attr_unique_id = unique_id
         self._attr_name = name
 
     def set_stream_source(self, stream_source: str | None) -> None:
         """Set the stream source."""
         self._stream_source = stream_source
+
+    def set_stream_sources(self, stream_sources: list[CameraStreamSource]) -> None:
+        """Set the stream sources."""
+        self._stream_sources = stream_sources
 
     async def stream_source(self) -> str | None:
         """Return the source of the stream.
@@ -26,6 +35,12 @@ class MockCamera(Camera):
         and StreamType.HLS.
         """
         return self._stream_source
+
+    async def async_get_stream_sources(self) -> list[CameraStreamSource]:
+        """Return all sources of the stream."""
+        if self._stream_sources is not None:
+            return self._stream_sources.copy()
+        return await super().async_get_stream_sources()
 
     @property
     def use_stream_for_stills(self) -> bool:

--- a/tests/components/go2rtc/test_init.py
+++ b/tests/components/go2rtc/test_init.py
@@ -25,7 +25,9 @@ from webrtc_models import RTCIceCandidateInit
 
 from homeassistant.components.camera import (
     DATA_CAMERA_PREFS,
+    Camera,
     CameraPreferences,
+    CameraStreamSource,
     DynamicStreamSettings,
     StreamType,
     WebRTCAnswer as HAWebRTCAnswer,
@@ -1003,6 +1005,62 @@ async def test_async_get_image(
         HomeAssistantError, match="Stream source is not supported by go2rtc"
     ):
         await async_get_image(hass, camera.entity_id)
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_multiple_stream_sources(
+    rest_client: AsyncMock,
+    init_test_integration: MockCamera,
+) -> None:
+    """Test registering multiple camera stream sources as producers."""
+    camera = init_test_integration
+    camera.set_stream_sources(
+        [
+            CameraStreamSource("rtsp://video", Orientation.ROTATE_LEFT),
+            CameraStreamSource("rtsp://backchannel", Orientation.NO_TRANSFORM),
+        ]
+    )
+    assert isinstance(camera.webrtc_provider, WebRTCProvider)
+
+    await camera.webrtc_provider.async_get_image(camera)
+
+    identifier = get_camera_identifier(camera)
+    rest_client.streams.add.assert_called_once_with(
+        identifier,
+        [
+            "ffmpeg:rtsp://video#video=h264#audio=copy#rotate=-90",
+            "rtsp://backchannel",
+            f"ffmpeg:{identifier}#audio=opus#query=log_level=debug",
+        ],
+    )
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_legacy_stream_source_interface(
+    rest_client: AsyncMock,
+    init_test_integration: MockCamera,
+) -> None:
+    """Test cameras implementing only stream_source remain supported."""
+    camera = init_test_integration
+    camera.set_stream_source("rtsp://legacy")
+
+    with patch.object(
+        MockCamera,
+        "async_get_stream_sources",
+        Camera.async_get_stream_sources,
+    ):
+        await camera.async_refresh_providers()
+        assert isinstance(camera.webrtc_provider, WebRTCProvider)
+        await camera.webrtc_provider.async_get_image(camera)
+
+    identifier = get_camera_identifier(camera)
+    rest_client.streams.add.assert_called_once_with(
+        identifier,
+        [
+            "rtsp://legacy",
+            f"ffmpeg:{identifier}#audio=opus#query=log_level=debug",
+        ],
+    )
 
 
 @pytest.mark.usefixtures("init_integration")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a backward-compatible camera API for exposing multiple ordered stream sources.

Camera integrations can override `async_get_stream_sources()` and return `CameraStreamSource` descriptors. Each descriptor contains a URL and an optional orientation:

- The first source is the primary source used for WebRTC provider selection.
- An omitted orientation inherits the camera-wide orientation preference.
- An explicit orientation is applied only to that producer.
- `Orientation.NO_TRANSFORM` allows audio or backchannel producers to opt out of camera-wide transforms.

The default implementation wraps the existing `stream_source()` result, so integrations using the legacy single-source interface continue to work without modification.

The go2rtc provider registers every source as a producer for the same logical camera stream and retains the existing Opus audio producer.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/48053
- Link to frontend pull request:

## Checklist
<!--
  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
