### PR TITLE
Register a device for the Ruuvi Gateway Bluetooth scanner

### DIFF
--- a/homeassistant/components/ruuvi_gateway/__init__.py
+++ b/homeassistant/components/ruuvi_gateway/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from homeassistant.components.bluetooth import async_remove_scanner
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
@@ -34,3 +35,11 @@ async def async_unload_entry(
 ) -> bool:
     """Unload a config entry."""
     return True
+
+
+async def async_remove_entry(
+    hass: HomeAssistant, entry: RuuviGatewayConfigEntry
+) -> None:
+    """Remove a config entry."""
+    if mac_address := entry.unique_id:
+        async_remove_scanner(hass, mac_address.upper())

--- a/homeassistant/components/ruuvi_gateway/bluetooth.py
+++ b/homeassistant/components/ruuvi_gateway/bluetooth.py
@@ -12,6 +12,7 @@ from homeassistant.components.bluetooth import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 
+from .const import DOMAIN
 from .coordinator import RuuviGatewayUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -71,7 +72,9 @@ def async_connect_scanner(
 ) -> tuple[RuuviGatewayScanner, CALLBACK_TYPE]:
     """Connect scanner and start polling."""
     assert entry.unique_id is not None
-    source = str(entry.unique_id)
+    # Scanner sources are upper case MAC addresses everywhere else in core, and
+    # the device registry does not normalise CONNECTION_BLUETOOTH values.
+    source = str(entry.unique_id).upper()
     _LOGGER.debug(
         "%s [%s]: Connecting scanner",
         entry.title,
@@ -83,7 +86,12 @@ def async_connect_scanner(
         coordinator=coordinator,
     )
     unload_callbacks = [
-        async_register_scanner(hass, scanner),
+        async_register_scanner(
+            hass,
+            scanner,
+            source_domain=DOMAIN,
+            source_config_entry_id=entry.entry_id,
+        ),
         scanner.async_setup(),
         scanner.start_polling(),
     ]

--- a/tests/components/ruuvi_gateway/test_init.py
+++ b/tests/components/ruuvi_gateway/test_init.py
@@ -1,0 +1,40 @@
+"""Test the Ruuvi Gateway setup."""
+
+from homeassistant.components.bluetooth import DOMAIN as BLUETOOTH_DOMAIN
+from homeassistant.components.ruuvi_gateway.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .consts import BASE_DATA, EXPECTED_TITLE, GATEWAY_MAC, GATEWAY_MAC_LOWER
+
+from tests.common import MockConfigEntry
+
+
+async def test_scanner_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the scanner gets a device entry that can hold an area."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=GATEWAY_MAC_LOWER,
+        title=EXPECTED_TITLE,
+        data=BASE_DATA,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    scanner_entry = hass.config_entries.async_entry_for_domain_unique_id(
+        BLUETOOTH_DOMAIN, GATEWAY_MAC
+    )
+    assert scanner_entry is not None
+
+    device_entry = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_BLUETOOTH, GATEWAY_MAC), scanner_entry.entry_id
+    )
+    assert device_entry is not None

--- a/tests/components/ruuvi_gateway/test_init.py
+++ b/tests/components/ruuvi_gateway/test_init.py
@@ -38,3 +38,36 @@ async def test_scanner_device(
         (dr.CONNECTION_BLUETOOTH, GATEWAY_MAC), scanner_entry.entry_id
     )
     assert device_entry is not None
+
+
+async def test_scanner_removed_with_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Test removing the entry also removes the scanner's Bluetooth entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=GATEWAY_MAC_LOWER,
+        title=EXPECTED_TITLE,
+        data=BASE_DATA,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.config_entries.async_entry_for_domain_unique_id(
+            BLUETOOTH_DOMAIN, GATEWAY_MAC
+        )
+        is not None
+    )
+
+    assert await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.config_entries.async_entry_for_domain_unique_id(
+            BLUETOOTH_DOMAIN, GATEWAY_MAC
+        )
+        is None
+    )


### PR DESCRIPTION
## Breaking change

<!--
If your PR contains a breaking change for existing users, it is important
to tell them what breaks, how to make it work again and why we did this.
This piece of text is published with the release notes, so it helps if you
write it towards our users, not us.
Note: Remove this section if this PR is NOT a breaking change.
\-->

None.

## Proposed change

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug
or resolves a feature request, be sure to link to that issue in the
additional information section.
\-->

`ruuvi_gateway` registers a `BaseHaRemoteScanner`, but it calls
`async_register_scanner(hass, scanner)` with none of the source arguments. Without
`source_domain` and `source_config_entry_id`, `BluetoothManager.async_register_hass_scanner`
skips the integration-discovery flow, so no `bluetooth` config entry is created and
`bluetooth.async_update_device` never runs. The gateway therefore has no entry in the
device registry at all.

The integration ships no entity platforms and no `DeviceInfo` of its own either, so this
is the one Bluetooth scanner in core with nowhere to put an area. On the Bluetooth
integration page the gateway is simply absent, and anything that resolves a scanner's
room by looking up its device — Bermuda, for instance — cannot find it and cannot be
fixed by the user, because there is no object on which to set the area.

The other three scanner providers in core (`esphome`, `shelly`, `smlight`) already pass
the source arguments and get their device entry from the Bluetooth integration. This does
the same for `ruuvi_gateway`. `source_device_id` stays unset because the integration has
no device of its own to hang the scanner off; the scanner device then stands alone and
holds its own area, which is what we want here. `source_model` stays unset too — the
gateway's history endpoint reports only the MAC, no model string.

The scanner source is upper-cased in the same change. `_normalize_connections` only
normalises `CONNECTION_NETWORK_MAC`, so a `CONNECTION_BLUETOOTH` value is stored and
matched exactly as given, and everything else in core registers the upper-case form:
local adapters through `ADAPTER_ADDRESS`, esphome through the proxy's own MAC, and shelly
through an explicit `format_mac(...).upper()` in `bluetooth_source`. `ruuvi_gateway`
derives its source from `entry.unique_id`, which `format_mac` lower-cases, so without
this the new device entry would be the only lower-case one and would not match a lookup
written for any of the others.

Because no `bluetooth` entry exists for these gateways today, there is nothing to
migrate: the case change costs an orphaned advertisement-history key in
`bluetooth.remote_scanners` and nothing else. Doing it later, once entries exist, would
mean a unique-id migration.

Verified against a live Ruuvi Gateway on 2026.9.1. Before the change the device registry
had no entry for `cf:ec:4f:ef:79:6d`; after it, a `bluetooth` config entry
`CF:EC:4F:EF:79:6D` is created with `source_domain: ruuvi_gateway`, and the device
`Ruuvi Gateway 79:6D (CF:EC:4F:EF:79:6D)` appears with
`connections={("bluetooth", "CF:EC:4F:EF:79:6D")}` and takes an area like any other
scanner.

## Type of change

<!--
What type of change does your PR introduce to Home Assistant?
NOTE: Please, check only 1! box!
If your PR requires multiple boxes to be checked, you'll most likely need to
split it into multiple PRs. This makes things easier and faster to code review.
\-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
Details are important, and help maintainers processing your PR.
Please be sure to fill out additional details, if applicable.
\-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look
for before merging your code.

AI tools are welcome, but contributors are responsible for *fully*
understanding the code before submitting a PR. Please follow our AI policy:
https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist\]\[dev-checklist]
- [x] I have followed the [perfect PR recommendations\]\[perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io\]\[docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file\]\[manifest-docs] has all fields filled out correctly.  
  Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
  Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
This project is very active and we have a high turnover of pull requests.

Unfortunately, the number of incoming pull requests is higher than what our
reviewers can review and merge so there is a long backlog of pull requests
waiting for review. You can help here!

By reviewing another pull request, you will help raise the code quality of
that pull request and the final review will be faster. This way the general
pace of pull request reviews will go up and your wait time will go down.

When picking a pull request to review, try to choose one that hasn't yet
been reviewed.

Thanks for helping out!
\-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests](https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure) in this repository.

<!--
Thank you for contributing <3

Below, some useful links you could explore:
\-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr