### PR TITLE
Bump iseo-argo-ble to 0.9.10

### DIFF
--- a/homeassistant/components/iseo_argo_ble/manifest.json
+++ b/homeassistant/components/iseo_argo_ble/manifest.json
@@ -75,5 +75,5 @@
   "iot_class": "local_polling",
   "loggers": ["iseo_argo_ble"],
   "quality_scale": "bronze",
-  "requirements": ["iseo-argo-ble==0.9.8"]
+  "requirements": ["iseo-argo-ble==0.9.10"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1426,7 +1426,7 @@ irm-kmi-api==1.1.1
 isal==1.8.0
 
 # homeassistant.components.iseo_argo_ble
-iseo-argo-ble==0.9.8
+iseo-argo-ble==0.9.10
 
 # homeassistant.components.gogogate2
 ismartgate==5.0.2


### PR DESCRIPTION
## Proposed change

Bumps `iseo-argo-ble` from 0.9.8 to 0.9.10. Two fixes, both about not losing an access-log read the lock has already destroyed:

- **0.9.9** — reading the access log is destructive: every `GET_UNREAD` page the lock hands over advances its read pointer, so those entries are gone from the device whether or not the caller ever sees them. `gw_read_unread_logs()` already returned the pages drained so far when a page timed out or came back with an error status, but the *request* was outside that guard — a failed BLE write, or the link dropping before a later page could be asked for, raised straight out and discarded everything already consumed. Send and receive are now covered by the same guard, for `BleakError` and `OSError` as well as timeouts.
- **0.9.10** — `_connected_client()` awaited `client.disconnect()` unguarded in its `finally`, so a `BleakError` on teardown replaced whatever the session had produced. That undid the accumulate-on-failure handling above, and could also discard a write the lock had already accepted.

Split out of #181105 as a dedicated bump, per review. #181104 and #181105 will be rebased on it and carry no manifest change of their own.

- Diff: https://github.com/FezVrasta/iseo-argo-ble/compare/v0.9.8...v0.9.10
- Release notes: [v0.9.9](https://github.com/FezVrasta/iseo-argo-ble/releases/tag/v0.9.9), [v0.9.10](https://github.com/FezVrasta/iseo-argo-ble/releases/tag/v0.9.10)

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #181105, #181104
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
