### PR TITLE
Fill unfinished current hour from short-term stats in statistics_during_period

### DIFF
--- a/homeassistant/components/energy/websocket_api.py
+++ b/homeassistant/components/energy/websocket_api.py
@@ -270,6 +270,12 @@ async def ws_get_fossil_energy_consumption(
     statistic_ids = set(msg["energy_statistic_ids"])
     statistic_ids.add(msg["co2_statistic_id"])
 
+    # Snapshot before the executor job so hour-rollover during the query still
+    # matches a synthesized current-hour energy row without a CO₂ mean.
+    current_hour_start_ts = (
+        dt_util.utcnow().replace(minute=0, second=0, microsecond=0).timestamp()
+    )
+
     # Fetch energy + CO2 statistics
     statistics = await recorder.get_instance(hass).async_add_executor_job(
         recorder.statistics.statistics_during_period,
@@ -338,14 +344,21 @@ async def ws_get_fossil_energy_consumption(
         {
             period["start"]: period["mean"]
             for period in statistics.get(msg["co2_statistic_id"], {})
+            if period.get("mean") is not None
         },
     )
 
-    # Calculate amount of fossil based energy, assume 100% fossil if missing
-    fossil_energy = [
-        {"start": start, "delta": delta * indexed_co2_statistics.get(start, 100) / 100}
-        for start, delta in merged_energy_statistics.items()
-    ]
+    # Calculate amount of fossil based energy. Historical hours missing CO₂ still
+    # assume 100% fossil, but skip the unfinished current hour when energy change
+    # has no matching mean (partial-hour synthesis does not invent CO₂ means).
+    fossil_energy: list[dict[str, Any]] = []
+    for start, delta in merged_energy_statistics.items():
+        co2_percentage = indexed_co2_statistics.get(start)
+        if co2_percentage is None:
+            if start == current_hour_start_ts:
+                continue
+            co2_percentage = 100
+        fossil_energy.append({"start": start, "delta": delta * co2_percentage / 100})
 
     if msg["period"] == "hour":
         reduced_fossil_energy = [

--- a/homeassistant/components/energy/websocket_api.py
+++ b/homeassistant/components/energy/websocket_api.py
@@ -3,7 +3,6 @@
 import asyncio
 from collections import defaultdict
 from collections.abc import Callable, Coroutine
-from datetime import timedelta
 import functools
 from itertools import chain
 from typing import Any, cast
@@ -310,7 +309,6 @@ async def ws_get_fossil_energy_consumption(
         stat_list: list[dict[str, Any]],
         same_period: Callable[[float, float], bool],
         period_start_end: Callable[[float], tuple[float, float]],
-        period: timedelta,
     ) -> list[dict[str, Any]]:
         """Reduce hourly deltas to daily or monthly deltas."""
         result: list[dict[str, Any]] = []
@@ -318,7 +316,7 @@ async def ws_get_fossil_energy_consumption(
         if not stat_list:
             return result
         prev_stat: dict[str, Any] = stat_list[0]
-        fake_stat = {"start": stat_list[-1]["start"] + period.total_seconds()}
+        fake_stat = {"start": period_start_end(stat_list[-1]["start"])[1]}
 
         # Loop over the hourly deltas + a fake entry to end the period
         for statistic in chain(stat_list, (fake_stat,)):
@@ -377,7 +375,6 @@ async def ws_get_fossil_energy_consumption(
             fossil_energy,
             _same_day_ts,
             _day_start_end_ts,
-            timedelta(days=1),
         )
     else:
         (
@@ -388,7 +385,6 @@ async def ws_get_fossil_energy_consumption(
             fossil_energy,
             _same_month_ts,
             _month_start_end_ts,
-            timedelta(days=1),
         )
 
     result = {period["start"]: period["delta"] for period in reduced_fossil_energy}

--- a/homeassistant/components/energy/websocket_api.py
+++ b/homeassistant/components/energy/websocket_api.py
@@ -270,22 +270,24 @@ async def ws_get_fossil_energy_consumption(
     statistic_ids = set(msg["energy_statistic_ids"])
     statistic_ids.add(msg["co2_statistic_id"])
 
-    # Snapshot before the executor job so hour-rollover during the query still
-    # matches a synthesized current-hour energy row without a CO₂ mean.
-    current_hour_start_ts = (
-        dt_util.utcnow().replace(minute=0, second=0, microsecond=0).timestamp()
-    )
+    # One clock snapshot for both synthesis and the open-hour CO₂ skip so an
+    # hour rollover during the executor job cannot desync them.
+    now = dt_util.utcnow()
+    current_hour_start_ts = now.replace(minute=0, second=0, microsecond=0).timestamp()
 
     # Fetch energy + CO2 statistics
     statistics = await recorder.get_instance(hass).async_add_executor_job(
-        recorder.statistics.statistics_during_period,
-        hass,
-        start_time,
-        end_time,
-        statistic_ids,
-        "hour",
-        {"energy": UnitOfEnergy.KILO_WATT_HOUR},
-        {"mean", "change"},
+        functools.partial(
+            recorder.statistics.statistics_during_period,
+            hass,
+            start_time,
+            end_time,
+            statistic_ids,
+            "hour",
+            {"energy": UnitOfEnergy.KILO_WATT_HOUR},
+            {"mean", "change"},
+            now=now,
+        )
     )
 
     def _combine_change_statistics(

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -2152,9 +2152,7 @@ def _synthesize_current_hour_from_short_term(
         return {}
 
     query_ids = [
-        meta_id
-        for meta_id, meta in metadata.values()
-        if meta["has_sum"] and (metadata_ids is None or meta_id in metadata_ids)
+        meta_id for meta_id, meta in metadata.values() if meta["has_sum"]
     ]
     if not query_ids:
         return {}

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -2135,7 +2135,9 @@ def _synthesize_current_hour_from_short_term(
     current_hour_start_ts = current_hour_start.timestamp()
     current_hour_end_ts = (current_hour_start + Statistics.duration).timestamp()
 
-    if start_time.timestamp() >= current_hour_end_ts:
+    # Match the long-term query bound: only include the partial hour when its
+    # start is >= the requested start_time (not merely before the hour ends).
+    if start_time.timestamp() > current_hour_start_ts:
         return {}
     if end_time is not None and end_time.timestamp() <= current_hour_start_ts:
         return {}
@@ -2172,10 +2174,10 @@ def _synthesize_current_hour_from_short_term(
         statistic_id = metadata_by_id_row["statistic_id"]
         unit_class = metadata_by_id_row["unit_class"]
         state_unit = unit = metadata_by_id_row["unit_of_measurement"]
-        if ha_state := hass.states.get(statistic_id):
-            state_unit = ha_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        if state_obj := hass.states.get(statistic_id):
+            state_unit = state_obj.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         convert = _get_statistic_to_display_unit_converter(
-            unit_class, unit, state_unit, units, allow_none=False
+            unit_class, unit, state_unit, units
         )
 
         stats_row: StatisticsRow = {

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -2124,10 +2124,16 @@ def _synthesize_current_hour_from_short_term(
 
     Only sum/state/last_reset are filled. Mean/min/max are intentionally omitted:
     a partial hour must not change day/week/month aggregates for mean sensors the
-    way an unweighted hourly reduce would. Uses the same last-sum rule as
-    ``_compile_hourly_statistics``.
+    way an unweighted hourly reduce would. Requests that include mean/min/max are
+    skipped entirely so callers like fossil energy (change+mean) do not get a
+    partial energy row without a matching CO₂ mean. Uses the same last-sum rule
+    as ``_compile_hourly_statistics``.
     """
     if not types & {"sum", "state", "last_reset"}:
+        return {}
+    # Requests that also want mean/min/max (e.g. fossil energy with change+mean)
+    # must not get a partial sum/change row without a matching mean row.
+    if types & {"mean", "min", "max"}:
         return {}
 
     now = dt_util.utcnow()
@@ -2174,8 +2180,10 @@ def _synthesize_current_hour_from_short_term(
         statistic_id = metadata_by_id_row["statistic_id"]
         unit_class = metadata_by_id_row["unit_class"]
         state_unit = unit = metadata_by_id_row["unit_of_measurement"]
-        if state_obj := hass.states.get(statistic_id):
-            state_unit = state_obj.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        if ha_state := hass.states.get(statistic_id):
+            state_unit = ha_state.attributes.get(
+                EntityStateAttribute.UNIT_OF_MEASUREMENT
+            )
         convert = _get_statistic_to_display_unit_converter(
             unit_class, unit, state_unit, units
         )
@@ -2201,15 +2209,15 @@ def _synthesize_current_hour_from_short_term(
 
 def _merge_partial_current_hour(
     result: dict[str, list[StatisticsRow]],
-    partial: dict[str, StatisticsRow],
+    partial_hour: dict[str, StatisticsRow],
 ) -> dict[str, list[StatisticsRow]]:
     """Append synthesized current-hour rows when not already present."""
-    if not partial:
+    if not partial_hour:
         return result
     if not result:
-        return {statistic_id: [row] for statistic_id, row in partial.items()}
+        return {statistic_id: [row] for statistic_id, row in partial_hour.items()}
 
-    for statistic_id, row in partial.items():
+    for statistic_id, row in partial_hour.items():
         rows = result.get(statistic_id)
         if not rows:
             result[statistic_id] = [row]

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -2087,6 +2087,136 @@ def _augment_result_with_change(
             prev_sum = _sum
 
 
+def _partial_current_hour_last_sum_stmt(
+    start_time_ts: float,
+    end_time_ts: float,
+    metadata_ids: list[int],
+) -> StatementLambdaElement:
+    """Latest short-term sum row per metadata_id in [start_time_ts, end_time_ts)."""
+    return lambda_stmt(
+        lambda: (
+            select(
+                subquery := (
+                    select(*QUERY_STATISTICS_SUMMARY_SUM)
+                    .filter(StatisticsShortTerm.metadata_id.in_(metadata_ids))
+                    .filter(StatisticsShortTerm.start_ts >= start_time_ts)
+                    .filter(StatisticsShortTerm.start_ts < end_time_ts)
+                    .subquery()
+                )
+            )
+            .filter(subquery.c.rownum == 1)
+            .order_by(subquery.c.metadata_id)
+        )
+    )
+
+
+def _synthesize_current_hour_from_short_term(
+    hass: HomeAssistant,
+    session: Session,
+    start_time: datetime,
+    end_time: datetime | None,
+    metadata: dict[str, tuple[int, StatisticMetaData]],
+    metadata_ids: list[int] | None,
+    units: dict[str, str] | None,
+    types: set[Literal["last_reset", "max", "mean", "min", "state", "sum"]],
+) -> dict[str, StatisticsRow]:
+    """Build a partial hourly sum bucket for the unfinished current hour.
+
+    Only sum/state/last_reset are filled. Mean/min/max are intentionally omitted:
+    a partial hour must not change day/week/month aggregates for mean sensors the
+    way an unweighted hourly reduce would. Uses the same last-sum rule as
+    ``_compile_hourly_statistics``.
+    """
+    if not types & {"sum", "state", "last_reset"}:
+        return {}
+
+    now = dt_util.utcnow()
+    current_hour_start = now.replace(minute=0, second=0, microsecond=0)
+    current_hour_start_ts = current_hour_start.timestamp()
+    current_hour_end_ts = (current_hour_start + Statistics.duration).timestamp()
+
+    if start_time.timestamp() >= current_hour_end_ts:
+        return {}
+    if end_time is not None and end_time.timestamp() <= current_hour_start_ts:
+        return {}
+
+    short_term_end_ts = min(current_hour_end_ts, now.timestamp())
+    if end_time is not None:
+        short_term_end_ts = min(short_term_end_ts, end_time.timestamp())
+    if short_term_end_ts <= current_hour_start_ts:
+        return {}
+
+    query_ids = [
+        meta_id
+        for meta_id, meta in metadata.values()
+        if meta["has_sum"] and (metadata_ids is None or meta_id in metadata_ids)
+    ]
+    if not query_ids:
+        return {}
+
+    stats = execute_stmt_lambda_element(
+        session,
+        _partial_current_hour_last_sum_stmt(
+            current_hour_start_ts, short_term_end_ts, query_ids
+        ),
+        orm_rows=False,
+    )
+    if not stats:
+        return {}
+
+    metadata_by_id = dict(metadata.values())
+    result: dict[str, StatisticsRow] = {}
+    for stat in stats:
+        metadata_id, _start, last_reset_ts, state, _sum, _ = stat
+        metadata_by_id_row = metadata_by_id[metadata_id]
+        statistic_id = metadata_by_id_row["statistic_id"]
+        unit_class = metadata_by_id_row["unit_class"]
+        state_unit = unit = metadata_by_id_row["unit_of_measurement"]
+        if ha_state := hass.states.get(statistic_id):
+            state_unit = ha_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+        convert = _get_statistic_to_display_unit_converter(
+            unit_class, unit, state_unit, units, allow_none=False
+        )
+
+        stats_row: StatisticsRow = {
+            "start": current_hour_start_ts,
+            "end": current_hour_end_ts,
+        }
+        if "last_reset" in types:
+            stats_row["last_reset"] = last_reset_ts
+        if "state" in types:
+            stats_row["state"] = (
+                None if state is None else convert(state) if convert else state
+            )
+        if "sum" in types:
+            stats_row["sum"] = (
+                None if _sum is None else convert(_sum) if convert else _sum
+            )
+        result[statistic_id] = stats_row
+
+    return result
+
+
+def _merge_partial_current_hour(
+    result: dict[str, list[StatisticsRow]],
+    partial: dict[str, StatisticsRow],
+) -> dict[str, list[StatisticsRow]]:
+    """Append synthesized current-hour rows when not already present."""
+    if not partial:
+        return result
+    if not result:
+        return {statistic_id: [row] for statistic_id, row in partial.items()}
+
+    for statistic_id, row in partial.items():
+        rows = result.get(statistic_id)
+        if not rows:
+            result[statistic_id] = [row]
+            continue
+        if rows[-1]["start"] < row["start"]:
+            rows.append(row)
+    return result
+
+
 def _statistics_during_period_with_session(
     hass: HomeAssistant,
     session: Session,
@@ -2101,6 +2231,12 @@ def _statistics_during_period_with_session(
 
     If end_time is omitted, returns statistics newer than or equal to start_time.
     If statistic_ids is omitted, returns statistics for all statistics ids.
+
+    For periods based on hourly long-term statistics (hour/day/week/month/year),
+    the unfinished current hour is filled from short-term (5-minute) sum statistics
+    using the same last-sum rule as hourly compilation. Day/week/month/year reduce
+    then include that partial hour automatically. Mean/min/max are not synthesized
+    so partial hours do not skew reduced aggregates for mean sensors.
     """
     if statistic_ids is not None and not isinstance(statistic_ids, set):
         # This is for backwards compatibility to avoid a breaking change
@@ -2180,19 +2316,38 @@ def _statistics_during_period_with_session(
         Sequence[Row], execute_stmt_lambda_element(session, stmt, orm_rows=False)
     )
 
-    if not stats:
-        return {}
+    result: dict[str, list[StatisticsRow]] = {}
+    if stats:
+        result = _sorted_statistics_to_dict(
+            hass,
+            stats,
+            statistic_ids,
+            metadata,
+            True,
+            table,
+            units,
+            types,
+        )
 
-    result = _sorted_statistics_to_dict(
-        hass,
-        stats,
-        statistic_ids,
-        metadata,
-        True,
-        table,
-        units,
-        types,
-    )
+    # Fill the unfinished current hour from short-term sum stats before reduce so
+    # day/week/month/year buckets include in-progress energy for free.
+    if period != "5minute":
+        result = _merge_partial_current_hour(
+            result,
+            _synthesize_current_hour_from_short_term(
+                hass,
+                session,
+                start_time,
+                end_time,
+                metadata,
+                metadata_ids,
+                units,
+                types,
+            ),
+        )
+
+    if not result:
+        return {}
 
     if period == "day":
         result = _reduce_statistics_per_day(result, types, metadata)

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -2124,16 +2124,11 @@ def _synthesize_current_hour_from_short_term(
 
     Only sum/state/last_reset are filled. Mean/min/max are intentionally omitted:
     a partial hour must not change day/week/month aggregates for mean sensors the
-    way an unweighted hourly reduce would. Requests that include mean/min/max are
-    skipped entirely so callers like fossil energy (change+mean) do not get a
-    partial energy row without a matching CO₂ mean. Uses the same last-sum rule
-    as ``_compile_hourly_statistics``.
+    way an unweighted hourly reduce would. Callers that need paired mean values
+    (e.g. fossil energy) must handle a missing current-hour mean themselves.
+    Uses the same last-sum rule as ``_compile_hourly_statistics``.
     """
     if not types & {"sum", "state", "last_reset"}:
-        return {}
-    # Requests that also want mean/min/max (e.g. fossil energy with change+mean)
-    # must not get a partial sum/change row without a matching mean row.
-    if types & {"mean", "min", "max"}:
         return {}
 
     now = dt_util.utcnow()

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -2119,6 +2119,7 @@ def _synthesize_current_hour_from_short_term(
     metadata_ids: list[int] | None,
     units: dict[str, str] | None,
     types: set[Literal["last_reset", "max", "mean", "min", "state", "sum"]],
+    now: datetime | None = None,
 ) -> dict[str, StatisticsRow]:
     """Build a partial hourly sum bucket for the unfinished current hour.
 
@@ -2127,11 +2128,15 @@ def _synthesize_current_hour_from_short_term(
     way an unweighted hourly reduce would. Callers that need paired mean values
     (e.g. fossil energy) must handle a missing current-hour mean themselves.
     Uses the same last-sum rule as ``_compile_hourly_statistics``.
+
+    Pass ``now`` when the caller must match the synthesized hour (for example
+    fossil energy skipping an open hour without a CO₂ mean).
     """
     if not types & {"sum", "state", "last_reset"}:
         return {}
 
-    now = dt_util.utcnow()
+    if now is None:
+        now = dt_util.utcnow()
     current_hour_start = now.replace(minute=0, second=0, microsecond=0)
     current_hour_start_ts = current_hour_start.timestamp()
     current_hour_end_ts = (current_hour_start + Statistics.duration).timestamp()
@@ -2231,6 +2236,7 @@ def _statistics_during_period_with_session(
     period: Literal["5minute", "day", "hour", "week", "month", "year"],
     units: dict[str, str] | None,
     _types: set[Literal["change", "last_reset", "max", "mean", "min", "state", "sum"]],
+    now: datetime | None = None,
 ) -> dict[str, list[StatisticsRow]]:
     """Return statistic data points during UTC period start_time - end_time.
 
@@ -2348,6 +2354,7 @@ def _statistics_during_period_with_session(
                 metadata_ids,
                 units,
                 types,
+                now=now,
             ),
         )
 
@@ -2389,11 +2396,16 @@ def statistics_during_period(
     period: Literal["5minute", "day", "hour", "week", "month", "year"],
     units: dict[str, str] | None,
     types: set[Literal["change", "last_reset", "max", "mean", "min", "state", "sum"]],
+    *,
+    now: datetime | None = None,
 ) -> dict[str, list[StatisticsRow]]:
     """Return statistic data points during UTC period start_time - end_time.
 
     If end_time is omitted, returns statistics newer than or equal to start_time.
     If statistic_ids is omitted, returns statistics for all statistics ids.
+
+    Optional ``now`` pins the unfinished current-hour synthesis to one clock
+    snapshot so callers can match that hour without a rollover race.
     """
     with session_scope(hass=hass, read_only=True) as session:
         return _statistics_during_period_with_session(
@@ -2405,6 +2417,7 @@ def statistics_during_period(
             period,
             units,
             types,
+            now=now,
         )
 
 

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -2151,9 +2151,7 @@ def _synthesize_current_hour_from_short_term(
     if short_term_end_ts <= current_hour_start_ts:
         return {}
 
-    query_ids = [
-        meta_id for meta_id, meta in metadata.values() if meta["has_sum"]
-    ]
+    query_ids = [meta_id for meta_id, meta in metadata.values() if meta["has_sum"]]
     if not query_ids:
         return {}
 

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -1183,13 +1183,11 @@ def _reduce_statistics(
     stats: dict[str, list[StatisticsRow]],
     same_period: Callable[[float, float], bool],
     period_start_end: Callable[[float], tuple[float, float]],
-    period: timedelta,
     types: set[Literal["last_reset", "max", "mean", "min", "state", "sum"]],
     metadata: dict[str, tuple[int, StatisticMetaData]],
 ) -> dict[str, list[StatisticsRow]]:
     """Reduce hourly statistics to daily or monthly statistics."""
     result: dict[str, list[StatisticsRow]] = defaultdict(list)
-    period_seconds = period.total_seconds()
     _want_mean = "mean" in types
     _want_min = "min" in types
     _want_max = "max" in types
@@ -1201,7 +1199,12 @@ def _reduce_statistics(
         mean_values: list[tuple[float, float]] = []
         min_values: list[float] = []
         prev_stat: StatisticsRow = stat_list[0]
-        fake_entry: StatisticsRow = {"start": stat_list[-1]["start"] + period_seconds}
+        # Use the real local period end, not last_start + fixed duration: on a
+        # 25-hour fall-back day, +24h stays in the same local day and a lone
+        # partial-hour row would never flush.
+        fake_entry: StatisticsRow = {
+            "start": period_start_end(stat_list[-1]["start"])[1]
+        }
 
         # Loop over the hourly statistics + a fake entry to end the period
         for statistic in chain(stat_list, (fake_entry,)):
@@ -1294,9 +1297,7 @@ def _reduce_statistics_per_day(
 ) -> dict[str, list[StatisticsRow]]:
     """Reduce hourly statistics to daily statistics."""
     _same_day_ts, _day_start_end_ts = reduce_day_ts_factory()
-    return _reduce_statistics(
-        stats, _same_day_ts, _day_start_end_ts, timedelta(days=1), types, metadata
-    )
+    return _reduce_statistics(stats, _same_day_ts, _day_start_end_ts, types, metadata)
 
 
 def reduce_week_ts_factory() -> tuple[
@@ -1344,9 +1345,7 @@ def _reduce_statistics_per_week(
 ) -> dict[str, list[StatisticsRow]]:
     """Reduce hourly statistics to weekly statistics."""
     _same_week_ts, _week_start_end_ts = reduce_week_ts_factory()
-    return _reduce_statistics(
-        stats, _same_week_ts, _week_start_end_ts, timedelta(days=7), types, metadata
-    )
+    return _reduce_statistics(stats, _same_week_ts, _week_start_end_ts, types, metadata)
 
 
 def _find_month_end_time(timestamp: datetime) -> datetime:
@@ -1400,7 +1399,7 @@ def _reduce_statistics_per_month(
     """Reduce hourly statistics to monthly statistics."""
     _same_month_ts, _month_start_end_ts = reduce_month_ts_factory()
     return _reduce_statistics(
-        stats, _same_month_ts, _month_start_end_ts, timedelta(days=31), types, metadata
+        stats, _same_month_ts, _month_start_end_ts, types, metadata
     )
 
 
@@ -1448,9 +1447,7 @@ def _reduce_statistics_per_year(
 ) -> dict[str, list[StatisticsRow]]:
     """Reduce hourly statistics to yearly statistics."""
     _same_year_ts, _year_start_end_ts = reduce_year_ts_factory()
-    return _reduce_statistics(
-        stats, _same_year_ts, _year_start_end_ts, timedelta(days=366), types, metadata
-    )
+    return _reduce_statistics(stats, _same_year_ts, _year_start_end_ts, types, metadata)
 
 
 def _generate_statistics_during_period_stmt(

--- a/tests/components/energy/test_websocket_api.py
+++ b/tests/components/energy/test_websocket_api.py
@@ -1,5 +1,6 @@
 """Test the Energy websocket API."""
 
+from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
@@ -7,8 +8,14 @@ import pytest
 
 from homeassistant.components.energy import DOMAIN, data, is_configured
 from homeassistant.components.recorder import Recorder
+from homeassistant.components.recorder.db_schema import StatisticsShortTerm
 from homeassistant.components.recorder.models import StatisticMeanType
-from homeassistant.components.recorder.statistics import async_add_external_statistics
+from homeassistant.components.recorder.statistics import (
+    async_add_external_statistics,
+    async_import_statistics,
+    get_metadata,
+)
+from homeassistant.components.recorder.util import session_scope
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -1179,6 +1186,112 @@ async def test_fossil_energy_consumption_check_missing_hour(
         hour3.isoformat(),
         hour4.isoformat(),
     ]
+
+
+@pytest.mark.freeze_time("2024-03-15 14:17:00+00:00")
+async def test_fossil_energy_consumption_skips_open_hour_without_co2(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Open-hour energy without a CO₂ mean must not default to 100% fossil."""
+    await hass.config.async_set_time_zone("UTC")
+    await async_setup_component(hass, "history", {})
+    await async_setup_component(hass, "sensor", {})
+    await async_recorder_block_till_done(hass)
+
+    hour_12 = dt_util.as_utc(dt_util.parse_datetime("2024-03-15 12:00:00+00:00"))
+    hour_13 = dt_util.as_utc(dt_util.parse_datetime("2024-03-15 13:00:00+00:00"))
+    hour_14 = dt_util.as_utc(dt_util.parse_datetime("2024-03-15 14:00:00+00:00"))
+    day_start = dt_util.as_utc(dt_util.parse_datetime("2024-03-15 00:00:00+00:00"))
+    day_end = dt_util.as_utc(dt_util.parse_datetime("2024-03-16 00:00:00+00:00"))
+
+    energy_id = "sensor.total_energy_import"
+    co2_id = "sensor.fossil_percentage"
+
+    async_import_statistics(
+        hass,
+        {
+            "has_sum": True,
+            "mean_type": StatisticMeanType.NONE,
+            "name": "Total imported energy",
+            "source": "recorder",
+            "statistic_id": energy_id,
+            "unit_class": "energy",
+            "unit_of_measurement": "kWh",
+        },
+        (
+            {
+                "start": hour_12,
+                "last_reset": None,
+                "state": 10.0,
+                "sum": 10.0,
+            },
+            {
+                "start": hour_13,
+                "last_reset": None,
+                "state": 20.0,
+                "sum": 20.0,
+            },
+        ),
+    )
+    async_import_statistics(
+        hass,
+        {
+            "has_sum": False,
+            "mean_type": StatisticMeanType.ARITHMETIC,
+            "name": "Fossil percentage",
+            "source": "recorder",
+            "statistic_id": co2_id,
+            "unit_class": None,
+            "unit_of_measurement": "%",
+        },
+        (
+            {"start": hour_12, "mean": 50.0, "min": 50.0, "max": 50.0},
+            {"start": hour_13, "mean": 20.0, "min": 20.0, "max": 20.0},
+        ),
+    )
+    await async_wait_recording_done(hass)
+
+    metadata_id = get_metadata(hass, statistic_ids={energy_id})[energy_id][0]
+    with session_scope(hass=hass) as session:
+        for minutes, state, sum_ in (
+            (0, 25.0, 25.0),
+            (5, 30.0, 30.0),
+            (10, 35.0, 35.0),
+        ):
+            session.add(
+                StatisticsShortTerm.from_stats(
+                    metadata_id,
+                    {
+                        "start": hour_14 + timedelta(minutes=minutes),
+                        "last_reset": None,
+                        "state": state,
+                        "sum": sum_,
+                    },
+                )
+            )
+    await async_wait_recording_done(hass)
+
+    client = await hass_ws_client()
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "energy/fossil_energy_consumption",
+            "start_time": day_start.isoformat(),
+            "end_time": day_end.isoformat(),
+            "energy_statistic_ids": [energy_id],
+            "co2_statistic_id": co2_id,
+            "period": "hour",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    # hour_12 change 10 * 50% = 5; hour_13 change 10 * 20% = 2.
+    # Open hour_14 has energy change but no CO₂ mean — omit, do not use 100%.
+    assert response["result"] == {
+        hour_12.isoformat(): pytest.approx(5.0),
+        hour_13.isoformat(): pytest.approx(2.0),
+    }
+    assert hour_14.isoformat() not in response["result"]
 
 
 @pytest.mark.freeze_time("2021-08-01 00:00:00+00:00")

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -4739,13 +4739,43 @@ async def test_statistics_during_period_fills_current_hour_from_short_term(
     )
     assert mid_hour_stats == {}
 
-    # Mean alongside change (fossil energy) must not synthesize a partial sum row
-    # without a matching mean row for other sensors in the same response.
+    # Fossil energy requests change+mean for energy and CO₂ together. Keep a
+    # mean-capable statistic in the request so mean is not discarded before the
+    # partial-hour guard runs.
+    co2_id = "sensor.co2_intensity"
+    async_import_statistics(
+        hass,
+        {
+            "has_sum": False,
+            "mean_type": StatisticMeanType.ARITHMETIC,
+            "name": "CO2 intensity",
+            "source": "recorder",
+            "statistic_id": co2_id,
+            "unit_class": None,
+            "unit_of_measurement": "gCO2eq/kWh",
+        },
+        (
+            {
+                "start": hour_12,
+                "mean": 40.0,
+                "min": 40.0,
+                "max": 40.0,
+            },
+            {
+                "start": hour_13,
+                "mean": 50.0,
+                "min": 50.0,
+                "max": 50.0,
+            },
+        ),
+    )
+    await async_wait_recording_done(hass)
+
     mean_and_change = statistics_during_period(
         hass,
         day_start,
         period="hour",
-        statistic_ids={statistic_id},
+        statistic_ids={statistic_id, co2_id},
         types={"mean", "change"},
     )
     assert [row["start"] for row in mean_and_change.get(statistic_id, [])] == [

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -4739,9 +4739,8 @@ async def test_statistics_during_period_fills_current_hour_from_short_term(
     )
     assert mid_hour_stats == {}
 
-    # Fossil energy requests change+mean for energy and CO₂ together. Keep a
-    # mean-capable statistic in the request so mean is not discarded before the
-    # partial-hour guard runs.
+    # Mixed mean+change requests still get a partial energy sum/change row;
+    # mean/min/max stay omitted on that row so mean sensors are not skewed.
     co2_id = "sensor.co2_intensity"
     async_import_statistics(
         hass,
@@ -4778,7 +4777,26 @@ async def test_statistics_during_period_fills_current_hour_from_short_term(
         statistic_ids={statistic_id, co2_id},
         types={"mean", "change"},
     )
-    assert [row["start"] for row in mean_and_change.get(statistic_id, [])] == [
+    assert mean_and_change[statistic_id] == [
+        {
+            "start": process_timestamp(hour_12).timestamp(),
+            "end": process_timestamp(hour_12 + timedelta(hours=1)).timestamp(),
+            "mean": None,
+            "change": pytest.approx(10.0),
+        },
+        {
+            "start": process_timestamp(hour_13).timestamp(),
+            "end": process_timestamp(hour_13 + timedelta(hours=1)).timestamp(),
+            "mean": None,
+            "change": pytest.approx(10.0),
+        },
+        {
+            "start": process_timestamp(hour_14).timestamp(),
+            "end": process_timestamp(hour_14 + timedelta(hours=1)).timestamp(),
+            "change": pytest.approx(15.0),
+        },
+    ]
+    assert [row["start"] for row in mean_and_change[co2_id]] == [
         process_timestamp(hour_12).timestamp(),
         process_timestamp(hour_13).timestamp(),
     ]

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -4728,6 +4728,17 @@ async def test_statistics_during_period_fills_current_hour_from_short_term(
         ]
     }
 
+    # Mid-hour start must not synthesize a bucket that starts before start_time.
+    mid_hour_start = hour_14 + timedelta(minutes=30)
+    mid_hour_stats = statistics_during_period(
+        hass,
+        mid_hour_start,
+        period="hour",
+        statistic_ids={statistic_id},
+        types={"sum"},
+    )
+    assert mid_hour_stats == {}
+
 
 @pytest.mark.freeze_time("2024-03-15 00:12:00+00:00")
 @pytest.mark.usefixtures("recorder_mock")

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -4896,6 +4896,82 @@ async def test_statistics_during_period_current_hour_only_short_term(
     }
 
 
+@pytest.mark.freeze_time("2024-11-03 04:17:00+00:00")
+@pytest.mark.usefixtures("recorder_mock")
+async def test_statistics_during_period_partial_hour_on_dst_fallback_day(
+    hass: HomeAssistant,
+) -> None:
+    """Day reduce must flush a lone partial hour on a 25-hour fall-back day."""
+    await hass.config.async_set_time_zone("America/New_York")
+    statistic_id = "sensor.total_energy_import"
+    metadata = {
+        "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
+        "name": "Total imported energy",
+        "source": "recorder",
+        "statistic_id": statistic_id,
+        "unit_class": "energy",
+        "unit_of_measurement": "kWh",
+    }
+    # Local midnight on the fall-back day (EDT); +24h would still be Nov 3.
+    hour_0 = dt_util.parse_datetime("2024-11-03 04:00:00+00:00")
+    day_end = dt_util.parse_datetime("2024-11-04 05:00:00+00:00")
+    yesterday_hour = dt_util.parse_datetime("2024-11-03 03:00:00+00:00")
+    assert hour_0 and day_end and yesterday_hour
+    day_start = hour_0
+
+    async_import_statistics(
+        hass,
+        metadata,
+        ({"start": yesterday_hour, "last_reset": None, "state": 5.0, "sum": 5.0},),
+    )
+    await async_wait_recording_done(hass)
+
+    metadata_id = get_metadata(hass, statistic_ids={statistic_id})[statistic_id][0]
+    with session_scope(hass=hass) as session:
+        session.add(
+            StatisticsShortTerm.from_stats(
+                metadata_id,
+                {
+                    "start": hour_0,
+                    "last_reset": None,
+                    "state": 8.0,
+                    "sum": 8.0,
+                },
+            )
+        )
+        session.add(
+            StatisticsShortTerm.from_stats(
+                metadata_id,
+                {
+                    "start": hour_0 + timedelta(minutes=5),
+                    "last_reset": None,
+                    "state": 11.0,
+                    "sum": 11.0,
+                },
+            )
+        )
+    await async_wait_recording_done(hass)
+
+    day_stats = statistics_during_period(
+        hass,
+        day_start,
+        period="day",
+        statistic_ids={statistic_id},
+        types={"sum", "change"},
+    )
+    assert day_stats == {
+        statistic_id: [
+            {
+                "start": process_timestamp(day_start).timestamp(),
+                "end": process_timestamp(day_end).timestamp(),
+                "sum": pytest.approx(11.0),
+                "change": pytest.approx(6.0),
+            }
+        ]
+    }
+
+
 # The STATISTIC_UNIT_TO_UNIT_CONVERTER keys are sorted to ensure that pytest runs are
 # consistent and avoid `different tests were collected between gw0 and gw1`
 @pytest.mark.parametrize(

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -4602,6 +4602,227 @@ async def test_get_statistics_service_missing_mandatory_keys(
         )
 
 
+@pytest.mark.freeze_time("2024-03-15 14:17:00+00:00")
+@pytest.mark.usefixtures("recorder_mock")
+async def test_statistics_during_period_fills_current_hour_from_short_term(
+    hass: HomeAssistant,
+) -> None:
+    """Fill the unfinished current hour from short-term stats for hour and day."""
+    await hass.config.async_set_time_zone("UTC")
+    statistic_id = "sensor.total_energy_import"
+    metadata = {
+        "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
+        "name": "Total imported energy",
+        "source": "recorder",
+        "statistic_id": statistic_id,
+        "unit_class": "energy",
+        "unit_of_measurement": "kWh",
+    }
+    hour_12 = dt_util.parse_datetime("2024-03-15 12:00:00+00:00")
+    hour_13 = dt_util.parse_datetime("2024-03-15 13:00:00+00:00")
+    hour_14 = dt_util.parse_datetime("2024-03-15 14:00:00+00:00")
+    day_start = dt_util.parse_datetime("2024-03-15 00:00:00+00:00")
+    day_end = dt_util.parse_datetime("2024-03-16 00:00:00+00:00")
+    assert hour_12 and hour_13 and hour_14 and day_start and day_end
+
+    async_import_statistics(
+        hass,
+        metadata,
+        (
+            {"start": hour_12, "last_reset": None, "state": 10.0, "sum": 10.0},
+            {"start": hour_13, "last_reset": None, "state": 20.0, "sum": 20.0},
+        ),
+    )
+    await async_wait_recording_done(hass)
+
+    metadata_id = get_metadata(hass, statistic_ids={statistic_id})[statistic_id][0]
+    with session_scope(hass=hass) as session:
+        for minutes, state, sum_ in (
+            (0, 25.0, 25.0),
+            (5, 30.0, 30.0),
+            (10, 35.0, 35.0),
+        ):
+            session.add(
+                StatisticsShortTerm.from_stats(
+                    metadata_id,
+                    {
+                        "start": hour_14 + timedelta(minutes=minutes),
+                        "last_reset": None,
+                        "state": state,
+                        "sum": sum_,
+                    },
+                )
+            )
+    await async_wait_recording_done(hass)
+
+    hour_stats = statistics_during_period(
+        hass,
+        day_start,
+        period="hour",
+        statistic_ids={statistic_id},
+        types={"sum", "state"},
+    )
+    assert hour_stats == {
+        statistic_id: [
+            {
+                "start": process_timestamp(hour_12).timestamp(),
+                "end": process_timestamp(hour_12 + timedelta(hours=1)).timestamp(),
+                "state": pytest.approx(10.0),
+                "sum": pytest.approx(10.0),
+            },
+            {
+                "start": process_timestamp(hour_13).timestamp(),
+                "end": process_timestamp(hour_13 + timedelta(hours=1)).timestamp(),
+                "state": pytest.approx(20.0),
+                "sum": pytest.approx(20.0),
+            },
+            {
+                "start": process_timestamp(hour_14).timestamp(),
+                "end": process_timestamp(hour_14 + timedelta(hours=1)).timestamp(),
+                "state": pytest.approx(35.0),
+                "sum": pytest.approx(35.0),
+            },
+        ]
+    }
+
+    day_stats = statistics_during_period(
+        hass,
+        day_start,
+        period="day",
+        statistic_ids={statistic_id},
+        types={"sum", "state"},
+    )
+    assert day_stats == {
+        statistic_id: [
+            {
+                "start": process_timestamp(day_start).timestamp(),
+                "end": process_timestamp(day_end).timestamp(),
+                "state": pytest.approx(35.0),
+                "sum": pytest.approx(35.0),
+            }
+        ]
+    }
+
+    # Historical range ending before the current hour must not include it.
+    past_stats = statistics_during_period(
+        hass,
+        day_start,
+        end_time=hour_14,
+        period="hour",
+        statistic_ids={statistic_id},
+        types={"sum"},
+    )
+    assert past_stats == {
+        statistic_id: [
+            {
+                "start": process_timestamp(hour_12).timestamp(),
+                "end": process_timestamp(hour_12 + timedelta(hours=1)).timestamp(),
+                "sum": pytest.approx(10.0),
+            },
+            {
+                "start": process_timestamp(hour_13).timestamp(),
+                "end": process_timestamp(hour_13 + timedelta(hours=1)).timestamp(),
+                "sum": pytest.approx(20.0),
+            },
+        ]
+    }
+
+
+@pytest.mark.freeze_time("2024-03-15 00:12:00+00:00")
+@pytest.mark.usefixtures("recorder_mock")
+async def test_statistics_during_period_current_hour_only_short_term(
+    hass: HomeAssistant,
+) -> None:
+    """Return a partial current hour when only short-term rows exist yet."""
+    await hass.config.async_set_time_zone("UTC")
+    statistic_id = "sensor.total_energy_import"
+    metadata = {
+        "has_sum": True,
+        "mean_type": StatisticMeanType.NONE,
+        "name": "Total imported energy",
+        "source": "recorder",
+        "statistic_id": statistic_id,
+        "unit_class": "energy",
+        "unit_of_measurement": "kWh",
+    }
+    # Seed metadata via a previous-day hourly row, then only short-term for today.
+    yesterday_hour = dt_util.parse_datetime("2024-03-14 23:00:00+00:00")
+    hour_0 = dt_util.parse_datetime("2024-03-15 00:00:00+00:00")
+    day_end = dt_util.parse_datetime("2024-03-16 00:00:00+00:00")
+    assert yesterday_hour and hour_0 and day_end
+    day_start = hour_0
+
+    async_import_statistics(
+        hass,
+        metadata,
+        ({"start": yesterday_hour, "last_reset": None, "state": 5.0, "sum": 5.0},),
+    )
+    await async_wait_recording_done(hass)
+
+    metadata_id = get_metadata(hass, statistic_ids={statistic_id})[statistic_id][0]
+    with session_scope(hass=hass) as session:
+        session.add(
+            StatisticsShortTerm.from_stats(
+                metadata_id,
+                {
+                    "start": hour_0,
+                    "last_reset": None,
+                    "state": 8.0,
+                    "sum": 8.0,
+                },
+            )
+        )
+        session.add(
+            StatisticsShortTerm.from_stats(
+                metadata_id,
+                {
+                    "start": hour_0 + timedelta(minutes=5),
+                    "last_reset": None,
+                    "state": 11.0,
+                    "sum": 11.0,
+                },
+            )
+        )
+    await async_wait_recording_done(hass)
+
+    hour_stats = statistics_during_period(
+        hass,
+        day_start,
+        period="hour",
+        statistic_ids={statistic_id},
+        types={"sum", "change"},
+    )
+    assert hour_stats == {
+        statistic_id: [
+            {
+                "start": process_timestamp(hour_0).timestamp(),
+                "end": process_timestamp(hour_0 + timedelta(hours=1)).timestamp(),
+                "sum": pytest.approx(11.0),
+                "change": pytest.approx(6.0),
+            }
+        ]
+    }
+
+    day_stats = statistics_during_period(
+        hass,
+        day_start,
+        period="day",
+        statistic_ids={statistic_id},
+        types={"sum", "change"},
+    )
+    assert day_stats == {
+        statistic_id: [
+            {
+                "start": process_timestamp(day_start).timestamp(),
+                "end": process_timestamp(day_end).timestamp(),
+                "sum": pytest.approx(11.0),
+                "change": pytest.approx(6.0),
+            }
+        ]
+    }
+
+
 # The STATISTIC_UNIT_TO_UNIT_CONVERTER keys are sorted to ensure that pytest runs are
 # consistent and avoid `different tests were collected between gw0 and gw1`
 @pytest.mark.parametrize(

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -4739,6 +4739,20 @@ async def test_statistics_during_period_fills_current_hour_from_short_term(
     )
     assert mid_hour_stats == {}
 
+    # Mean alongside change (fossil energy) must not synthesize a partial sum row
+    # without a matching mean row for other sensors in the same response.
+    mean_and_change = statistics_during_period(
+        hass,
+        day_start,
+        period="hour",
+        statistic_ids={statistic_id},
+        types={"mean", "change"},
+    )
+    assert [row["start"] for row in mean_and_change.get(statistic_id, [])] == [
+        process_timestamp(hour_12).timestamp(),
+        process_timestamp(hour_13).timestamp(),
+    ]
+
 
 @pytest.mark.freeze_time("2024-03-15 00:12:00+00:00")
 @pytest.mark.usefixtures("recorder_mock")


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
    write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Plural `statistics_during_period` for hour/day/week/month/year only returned **completed** hourly long-term rows. Energy "today" therefore missed the open hour, and early after midnight the series could be empty until the first hour compiled.

This PR synthesizes a partial current-hour **sum** bucket from `statistics_short_term` (same last-sum rule as hourly compilation) and merges it into the hourly series **before** day/week/month/year reduce. Those periods then include in-progress energy automatically.

Mean/min/max are intentionally not synthesized so a partial hour does not skew reduced climate/mean aggregates the way an unweighted hourly reduce would.

Related frontend draft that currently works around this with an hour-0 `5minute` switch: home-assistant/frontend#54101 — with this core change we may be able to pivot away from that approach.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request: home-assistant/frontend#54101

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting your PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

## Test plan
- [ ] `statistics_during_period` hour period includes a partial current-hour sum/state from short-term when the hour is unfinished
- [ ] Day (and by extension week/month/year) reduce includes that partial hour
- [ ] Historical ranges ending before the current hour do not get a synthesized bucket
- [ ] Early after midnight with only short-term rows still returns a partial hour (and day) with correct change vs previous sum
- [ ] Mean/min/max-only queries are unchanged (no partial-hour synthesis)
- [ ] Existing recorder statistics tests still pass

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr