### PR TITLE
Fix atag climate snapshot

### DIFF
--- a/tests/components/atag/snapshots/test_climate.ambr
+++ b/tests/components/atag/snapshots/test_climate.ambr
@@ -78,6 +78,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'heat',
+    'state': 'auto',
   })
 # ---


### PR DESCRIPTION
## Proposed change

Fixes `tests/components/atag/test_climate.py::test_all_entities`, which is currently failing on `dev`.

Two PRs merged 40 minutes apart today. #181823 added `test_all_entities` plus the new `snapshots/test_climate.ambr`, recording `'state': 'heat'`. #181796 then bumped pyatag to 0.3.7.1, which swaps the `ch_control_mode` mapping in `pyatag/const.py` from `{0: "heat", 1: "auto"}` to `{0: "auto", 1: "heat"}`. That PR correctly updated the inline `HVACMode.HEAT` → `HVACMode.AUTO` assertion in `test_update_failed`, but its branch predated the snapshot file, so the `.ambr` was left stale. The test fixture sets `"ch_control_mode": 0`, so `hvac_mode` is now `auto`.

Snapshot regenerated with `--snapshot-update`; `tests/components/atag` passes (14 passed).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #181823, #181796
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
