### PR TITLE
Bump solarman quality scale to silver

### DIFF
--- a/homeassistant/components/solarman/manifest.json
+++ b/homeassistant/components/solarman/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/solarman",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "quality_scale": "bronze",
+  "quality_scale": "silver",
   "requirements": ["solarman-opendata==0.0.3"],
   "zeroconf": ["_solarman._tcp.local."]
 }

--- a/homeassistant/components/solarman/quality_scale.yaml
+++ b/homeassistant/components/solarman/quality_scale.yaml
@@ -41,16 +41,16 @@ rules:
     status: exempt
     comment: |
       This integration does not have an options flow.
-  docs-installation-parameters: todo
+  docs-installation-parameters: done
   entity-unavailable: done
-  integration-owner: todo
+  integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow:
     status: exempt
     comment: |
       No authentication required.
-  test-coverage: todo
+  test-coverage: done
   # Gold
   devices: done
   diagnostics: todo


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump the `solarman` integration quality scale from Bronze to Silver.

- `quality_scale.yaml`: `docs-installation-parameters`, `integration-owner`, `test-coverage`: `todo` -> `done`.
- `manifest.json`: `quality_scale`: `bronze` -> `silver`.

Existing `done` and `exempt` entries (including their comments) and all Gold/Platinum `todo` entries are unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

## Quality scale checklist

Scope: Bronze (20) + Silver (10) = 30 rules; 3 rules change in this PR, the other 27 keep their existing `done`/`exempt`. Evidence links are pinned to the PR head commit `fb72b7265f8`.

### Bronze (20)

| Rule | Status | Evidence |
| --- | --- | --- |
| `action-setup` | exempt | Sensor platform only, no custom services: [const.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/const.py#L10), [sensor.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/sensor.py) |
| `appropriate-polling` | done | [const.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/const.py#L9) (30 s), [coordinator.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/coordinator.py#L34) |
| `brands` | done | [home-assistant/brands](https://github.com/home-assistant/brands/tree/master/core_integrations/solarman) |
| `common-modules` | done | [coordinator.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/coordinator.py), [entity.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/entity.py) |
| `config-flow-test-coverage` | done | [test_config_flow.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/tests/components/solarman/test_config_flow.py) |
| `config-flow` | done | [config_flow.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/config_flow.py#L39-L154) (user / zeroconf / discovery_confirm) |
| `dependency-transparency` | done | [manifest.json](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/manifest.json#L10) (`solarman-opendata==0.0.3`) |
| `docs-actions` | exempt | No actions; same as `action-setup` |
| `docs-conditions` | exempt | No condition platform |
| `docs-high-level-description` | done | [Solarman integration docs](https://www.home-assistant.io/integrations/solarman/) |
| `docs-installation-instructions` | done | [Configuration](https://www.home-assistant.io/integrations/solarman/#configuration) |
| `docs-removal-instructions` | done | [Removing the integration](https://www.home-assistant.io/integrations/solarman/#removing-the-integration) |
| `docs-triggers` | exempt | No trigger platform |
| `entity-event-setup` | exempt | [entity.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/entity.py#L11) (`CoordinatorEntity`, subscriptions managed by the framework) |
| `entity-unique-id` | done | [sensor.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/sensor.py#L276), [config_flow.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/config_flow.py#L67) |
| `has-entity-name` | done | [entity.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/entity.py#L14) |
| `runtime-data` | done | [__init__.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/__init__.py#L15), [coordinator.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/coordinator.py#L18) |
| `test-before-configure` | done | [config_flow.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/config_flow.py#L47-L59), [test_config_flow.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/tests/components/solarman/test_config_flow.py) |
| `test-before-setup` | done | [__init__.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/__init__.py#L13), [test_init.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/tests/components/solarman/test_init.py) |
| `unique-config-entry` | done | [config_flow.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/config_flow.py#L67) |

### Silver (10)

| Rule | Status | Evidence |
| --- | --- | --- |
| `action-exceptions` | exempt | No actions; same as `action-setup` |
| `config-entry-unloading` | done | [__init__.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/__init__.py#L20), [test_init.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/tests/components/solarman/test_init.py) |
| `docs-configuration-parameters` | exempt | No options flow; [config_flow.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/config_flow.py) has only user / zeroconf / discovery_confirm |
| `docs-installation-parameters` | done (changed in this PR) | [Configuration](https://www.home-assistant.io/integrations/solarman/#configuration); [const.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/const.py#L8) (`DEFAULT_PORT = 8080`) |
| `entity-unavailable` | done | [coordinator.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/coordinator.py#L46-L50), [test_sensor.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/tests/components/solarman/test_sensor.py) |
| `integration-owner` | done (changed in this PR) | [manifest.json](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/manifest.json#L4) (`@solarmanpv`); [first integration PR #152525](https://github.com/home-assistant/core/pull/152525) |
| `log-when-unavailable` | done | [coordinator.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/coordinator.py#L29-L35) (`DataUpdateCoordinator` default logging) |
| `parallel-updates` | done | [sensor.py](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/sensor.py#L27) (`PARALLEL_UPDATES = 0`) |
| `reauthentication-flow` | exempt | No authentication mechanism; [manifest.json](https://github.com/home-assistant/core/blob/fb72b7265f8e99010c1b6e8bbc4e8232a2ebf7bb/homeassistant/components/solarman/manifest.json) is `local_polling` |
| `test-coverage` | done (changed in this PR) | 6/6 modules 100% line coverage (150/150 statements), tests and snapshots pass: `pytest tests/components/solarman -q` |

## Validation

- `.venv/bin/python -m script.hassfest --integration-path homeassistant/components/solarman -p quality_scale,manifest` -> `Invalid integrations: 0`
- `pytest tests/components/solarman -q` -> all tests pass (17 tests, 66 snapshots at candidate `90258e6e`; re-confirm on the submitted candidate).
- `pytest tests/components/solarman --cov=homeassistant/components/solarman --cov-report=term-missing` -> 6/6 modules 100% (150/150 statements).