### PR TITLE
Add offset selector

### DIFF
--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -1815,6 +1815,65 @@ class ObjectSelector(Selector[ObjectSelectorConfig]):
         return data
 
 
+class OffsetType(StrEnum):
+    """Possible directions for an offset selector value."""
+
+    NONE = "none"
+    BEFORE = "before"
+    AFTER = "after"
+
+
+class OffsetSelectorConfig(BaseSelectorConfig, total=False):
+    """Class to represent an offset selector config."""
+
+    enable_day: bool
+    enable_millisecond: bool
+
+
+def _validate_offset_duration(value: Any) -> Any:
+    cv.positive_time_period(value)
+    return value
+
+
+def _validate_offset_type_duration(value: dict[str, Any]) -> dict[str, Any]:
+    if value["type"] == OffsetType.NONE:
+        return {"type": value["type"]}
+    if "duration" not in value:
+        raise vol.Invalid("required key not provided", ["duration"])
+    return value
+
+
+_OFFSET_VALUE_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            vol.Required("type"): vol.All(
+                vol.Coerce(OffsetType), lambda val: val.value
+            ),
+            vol.Optional("duration"): _validate_offset_duration,
+        }
+    ),
+    _validate_offset_type_duration,
+)
+
+
+@SELECTORS.register("offset")
+class OffsetSelector(Selector[OffsetSelectorConfig]):
+    """Selector for a duration before or after a reference point in time."""
+
+    selector_type = "offset"
+
+    CONFIG_SCHEMA = make_selector_config_schema(
+        {
+            vol.Optional("enable_day"): cv.boolean,
+            vol.Optional("enable_millisecond"): cv.boolean,
+        }
+    )
+
+    def __call__(self, data: Any) -> dict[str, Any]:
+        """Validate the passed selection."""
+        return cast(dict[str, Any], _OFFSET_VALUE_SCHEMA(data))
+
+
 class QrErrorCorrectionLevel(StrEnum):
     """Possible error correction levels for QR code selector."""
 

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -1844,6 +1844,46 @@ def test_duration_selector_schema(schema, valid_selections, invalid_selections) 
 
 
 @pytest.mark.parametrize(
+    "schema",
+    [{}, {"enable_day": True, "enable_millisecond": True}],
+)
+def test_offset_selector_schema(schema: dict[str, Any]) -> None:
+    """Test offset selector."""
+    _test_selector(
+        "offset",
+        schema,
+        (
+            {"type": "none"},
+            {"type": "before", "duration": {"hours": 1}},
+            {"type": "after", "duration": {"days": 1, "minutes": 30}},
+            {"type": "after", "duration": {"milliseconds": 500}},
+            {"type": "before", "duration": "00:30:00"},
+            {"type": "after", "duration": 90},
+        ),
+        (
+            None,
+            {},
+            {"type": "before"},
+            {"type": "after"},
+            {"duration": {"hours": 1}},
+            {"type": "during", "duration": {"hours": 1}},
+            {"type": "before", "duration": {}},
+            {"type": "before", "duration": {"seconds": -1}},
+            {"type": "before", "duration": "-00:30:00"},
+            {"type": "before", "duration": "later"},
+        ),
+    )
+
+
+def test_offset_selector_none_drops_duration() -> None:
+    """Test a duration is dropped when the offset type is none."""
+    offset_selector = selector.OffsetSelector()
+    assert offset_selector({"type": "none", "duration": {"hours": 1}}) == {
+        "type": "none"
+    }
+
+
+@pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
     [
         (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Triggers that fire some time before or after a reference moment (a solar event, the start of a calendar event) currently need two fields: a `duration` selector for the offset and a `select` for before/after. That works in the editor, but the two values are meaningless on their own: the summary we are building for triggers and conditions is formatted per selector, so it cannot describe "30 minutes before sunset" from two separate fields.

This adds an `offset` selector that carries both in one value.

Field definition in a `triggers.yaml`, before:

```yaml
offset:
  required: true
  default:
    hours: 0
    minutes: 0
    seconds: 0
  selector:
    duration:
      enable_day: true
offset_type:
  required: true
  default: before
  selector:
    select:
      translation_key: trigger_offset_type
      options:
        - before
        - after
```

After:

```yaml
offset:
  required: true
  default:
    type: none
  selector:
    offset:
      enable_day: true
```

Value written by the editor, before:

```yaml
offset:
  minutes: 30
offset_type: before
```

After:

```yaml
offset:
  type: before      # none, before or after
  duration:
    minutes: 30
```

`duration` accepts what the `for` field accepts (a dict, a `HH:MM:SS` string or a number of seconds), must be positive, is required for `before` and `after` and is dropped for `none`. The selector config mirrors the duration selector with `enable_day` and `enable_millisecond`. Before/after are translated by the frontend inside the selector, like above/below in the numeric threshold selector, so integrations do not need a translation key for them.

The sun and calendar triggers move to this selector in #181839, stacked on this one.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/54104

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
