### PR TITLE
Use offset selector for sun and calendar trigger offsets

### DIFF
--- a/homeassistant/components/calendar/strings.json
+++ b/homeassistant/components/calendar/strings.json
@@ -63,14 +63,6 @@
       "title": "Detected use of deprecated action calendar.list_events"
     }
   },
-  "selector": {
-    "trigger_offset_type": {
-      "options": {
-        "after": "After",
-        "before": "Before"
-      }
-    }
-  },
   "services": {
     "create_event": {
       "description": "Adds a new calendar event.",
@@ -137,10 +129,6 @@
         "offset": {
           "description": "Offset from the end of the event.",
           "name": "Offset"
-        },
-        "offset_type": {
-          "description": "Whether to trigger before or after the end of the event, if an offset is defined.",
-          "name": "Offset type"
         }
       },
       "name": "Calendar event ended"
@@ -151,10 +139,6 @@
         "offset": {
           "description": "Offset from the start of the event.",
           "name": "Offset"
-        },
-        "offset_type": {
-          "description": "Whether to trigger before or after the start of the event, if an offset is defined.",
-          "name": "Offset type"
         }
       },
       "name": "Calendar event started"

--- a/homeassistant/components/calendar/trigger.py
+++ b/homeassistant/components/calendar/trigger.py
@@ -26,12 +26,15 @@ from homeassistant.helpers.event import (
     async_track_point_in_time,
     async_track_time_interval,
 )
+from homeassistant.helpers.selector import OffsetSelector, OffsetSelectorConfig
 from homeassistant.helpers.target import TargetEntityChangeTracker, TargetSelection
 from homeassistant.helpers.trigger import (
     Trigger,
     TriggerActionRunner,
     TriggerConfig,
     TriggerNotTriggeredReporter,
+    migrate_legacy_offset_options,
+    offset_selector_to_timedelta,
 )
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
@@ -45,9 +48,7 @@ EVENT_START = "start"
 EVENT_END = "end"
 UPDATE_INTERVAL = datetime.timedelta(minutes=15)
 
-CONF_OFFSET_TYPE = "offset_type"
-OFFSET_TYPE_BEFORE = "before"
-OFFSET_TYPE_AFTER = "after"
+_OFFSET_SELECTOR = OffsetSelector(OffsetSelectorConfig(enable_day=True))
 
 
 _SINGLE_ENTITY_EVENT_OPTIONS_SCHEMA = {
@@ -64,12 +65,14 @@ _SINGLE_ENTITY_EVENT_TRIGGER_SCHEMA = vol.Schema(
 
 _EVENT_TRIGGER_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_OPTIONS, default={}): {
-            vol.Required(CONF_OFFSET, default=datetime.timedelta(0)): cv.time_period,
-            vol.Required(CONF_OFFSET_TYPE, default=OFFSET_TYPE_BEFORE): vol.In(
-                {OFFSET_TYPE_BEFORE, OFFSET_TYPE_AFTER}
-            ),
-        },
+        vol.Required(CONF_OPTIONS, default={}): vol.All(
+            migrate_legacy_offset_options,
+            {
+                vol.Optional(CONF_OFFSET): vol.All(
+                    _OFFSET_SELECTOR, offset_selector_to_timedelta
+                )
+            },
+        ),
         vol.Required(CONF_TARGET): cv.TARGET_FIELDS,
     }
 )
@@ -465,11 +468,7 @@ class EventTrigger(Trigger):
     ) -> CALLBACK_TYPE:
         """Attach a trigger."""
 
-        offset = self._options[CONF_OFFSET]
-        offset_type = self._options[CONF_OFFSET_TYPE]
-
-        if offset_type == OFFSET_TYPE_BEFORE:
-            offset = -offset
+        offset = self._options.get(CONF_OFFSET, datetime.timedelta(0))
 
         target_selection = TargetSelection(self._target)
         if not target_selection.has_any_target:

--- a/homeassistant/components/calendar/triggers.yaml
+++ b/homeassistant/components/calendar/triggers.yaml
@@ -6,22 +6,10 @@
     offset:
       required: true
       default:
-        days: 0
-        hours: 0
-        minutes: 0
-        seconds: 0
+        type: none
       selector:
-        duration:
+        offset:
           enable_day: true
-    offset_type:
-      required: true
-      default: before
-      selector:
-        select:
-          translation_key: trigger_offset_type
-          options:
-            - before
-            - after
 
 event_started: *trigger_common
 event_ended: *trigger_common

--- a/homeassistant/components/sun/strings.json
+++ b/homeassistant/components/sun/strings.json
@@ -4,10 +4,8 @@
     "period_description": "The time of day to consider: the morning, the evening, or either.",
     "period_name": "Period",
     "trigger_for_name": "For at least",
-    "trigger_offset_description": "Time to offset the trigger from the solar event.",
+    "trigger_offset_description": "Time to trigger before or after the solar event.",
     "trigger_offset_name": "Offset",
-    "trigger_offset_type_description": "Whether to trigger before or after the solar event.",
-    "trigger_offset_type_name": "Offset type",
     "trigger_threshold_name": "Threshold type",
     "twilight_type_description": "The phase of twilight.",
     "twilight_type_name": "Twilight type"
@@ -136,12 +134,6 @@
         "morning": "Morning"
       }
     },
-    "trigger_offset_type": {
-      "options": {
-        "after": "After",
-        "before": "Before"
-      }
-    },
     "twilight_type": {
       "options": {
         "any": "Any",
@@ -160,10 +152,6 @@
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
         },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
-        },
         "period": {
           "description": "[%key:component::sun::common::period_description%]",
           "name": "[%key:component::sun::common::period_name%]"
@@ -177,10 +165,6 @@
         "offset": {
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
-        },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
         },
         "period": {
           "description": "[%key:component::sun::common::period_description%]",
@@ -196,10 +180,6 @@
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
         },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
-        },
         "type": {
           "description": "[%key:component::sun::common::twilight_type_description%]",
           "name": "[%key:component::sun::common::twilight_type_name%]"
@@ -213,10 +193,6 @@
         "offset": {
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
-        },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
         },
         "type": {
           "description": "[%key:component::sun::common::twilight_type_description%]",
@@ -253,10 +229,6 @@
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
         },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
-        },
         "period": {
           "description": "[%key:component::sun::common::period_description%]",
           "name": "[%key:component::sun::common::period_name%]"
@@ -271,10 +243,6 @@
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
         },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
-        },
         "period": {
           "description": "[%key:component::sun::common::period_description%]",
           "name": "[%key:component::sun::common::period_name%]"
@@ -288,10 +256,6 @@
         "offset": {
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
-        },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
         }
       },
       "name": "Midnight sun ended"
@@ -302,10 +266,6 @@
         "offset": {
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
-        },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
         }
       },
       "name": "Midnight sun started"
@@ -316,10 +276,6 @@
         "offset": {
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
-        },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
         }
       },
       "name": "Polar night ended"
@@ -330,10 +286,6 @@
         "offset": {
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
-        },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
         }
       },
       "name": "Polar night started"
@@ -344,10 +296,6 @@
         "offset": {
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
-        },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
         }
       },
       "name": "Solar midnight"
@@ -358,10 +306,6 @@
         "offset": {
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
-        },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
         }
       },
       "name": "Solar noon"
@@ -372,10 +316,6 @@
         "offset": {
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
-        },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
         }
       },
       "name": "Sunrise"
@@ -386,10 +326,6 @@
         "offset": {
           "description": "[%key:component::sun::common::trigger_offset_description%]",
           "name": "[%key:component::sun::common::trigger_offset_name%]"
-        },
-        "offset_type": {
-          "description": "[%key:component::sun::common::trigger_offset_type_description%]",
-          "name": "[%key:component::sun::common::trigger_offset_type_name%]"
         }
       },
       "name": "Sunset"

--- a/homeassistant/components/sun/trigger.py
+++ b/homeassistant/components/sun/trigger.py
@@ -29,6 +29,8 @@ from homeassistant.helpers.selector import (
     NumericThresholdMode,
     NumericThresholdSelector,
     NumericThresholdSelectorConfig,
+    OffsetSelector,
+    OffsetSelectorConfig,
 )
 from homeassistant.helpers.sun import (
     get_astral_event_next,
@@ -43,6 +45,8 @@ from homeassistant.helpers.trigger import (
     TriggerActionRunner,
     TriggerConfig,
     TriggerNotTriggeredReporter,
+    migrate_legacy_offset_options,
+    offset_selector_to_timedelta,
 )
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
@@ -76,17 +80,10 @@ _PERIOD_MORNING = "morning"
 _PERIOD_EVENING = "evening"
 _PERIODS = (_PERIOD_ANY, _PERIOD_MORNING, _PERIOD_EVENING)
 
-CONF_OFFSET_TYPE = "offset_type"
-OFFSET_TYPE_BEFORE = "before"
-OFFSET_TYPE_AFTER = "after"
+_OFFSET_SELECTOR = OffsetSelector(OffsetSelectorConfig(enable_day=True))
 
-# Offset options shared by the solar event triggers. A positive offset combined
-# with an offset type of "before" fires earlier than the event; "after" later.
 _OFFSET_OPTIONS: dict[vol.Marker, Any] = {
-    vol.Required(CONF_OFFSET, default=timedelta(0)): cv.time_period,
-    vol.Required(CONF_OFFSET_TYPE, default=OFFSET_TYPE_BEFORE): vol.In(
-        {OFFSET_TYPE_BEFORE, OFFSET_TYPE_AFTER}
-    ),
+    vol.Optional(CONF_OFFSET): vol.All(_OFFSET_SELECTOR, offset_selector_to_timedelta),
 }
 
 # Sun elevation at each twilight boundary.
@@ -160,7 +157,11 @@ class SunElevationCrossedTrigger(
 
 
 _EVENT_TRIGGER_SCHEMA = vol.Schema(
-    {vol.Required(CONF_OPTIONS, default=dict): {**_OFFSET_OPTIONS}}
+    {
+        vol.Required(CONF_OPTIONS, default=dict): vol.All(
+            migrate_legacy_offset_options, {**_OFFSET_OPTIONS}
+        )
+    }
 )
 
 
@@ -188,10 +189,7 @@ class SunEventTrigger(Trigger):
         """Initialize the trigger."""
         super().__init__(hass, config)
         self._options = config.options or {}
-        offset = self._options.get(CONF_OFFSET) or timedelta(0)
-        if self._options.get(CONF_OFFSET_TYPE) == OFFSET_TYPE_BEFORE:
-            offset = -offset
-        self._offset = offset
+        self._offset: timedelta = self._options.get(CONF_OFFSET, timedelta(0))
 
     def _get_next_event(self, utc_point_in_time: datetime) -> datetime | None:
         """Return the next time this solar event occurs.
@@ -280,12 +278,15 @@ class SolarMidnightTrigger(SunEventTrigger):
 
 _DAWN_DUSK_TRIGGER_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_OPTIONS, default=dict): {
-            vol.Optional(CONF_TYPE, default=_TWILIGHT_CIVIL): vol.In(
-                _TWILIGHT_ELEVATIONS
-            ),
-            **_OFFSET_OPTIONS,
-        }
+        vol.Required(CONF_OPTIONS, default=dict): vol.All(
+            migrate_legacy_offset_options,
+            {
+                vol.Optional(CONF_TYPE, default=_TWILIGHT_CIVIL): vol.In(
+                    _TWILIGHT_ELEVATIONS
+                ),
+                **_OFFSET_OPTIONS,
+            },
+        )
     }
 )
 
@@ -332,10 +333,13 @@ class DuskTrigger(SunDawnDuskTrigger):
 
 _GOLDEN_BLUE_HOUR_TRIGGER_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_OPTIONS, default=dict): {
-            vol.Optional(CONF_PERIOD, default=_PERIOD_ANY): vol.In(_PERIODS),
-            **_OFFSET_OPTIONS,
-        }
+        vol.Required(CONF_OPTIONS, default=dict): vol.All(
+            migrate_legacy_offset_options,
+            {
+                vol.Optional(CONF_PERIOD, default=_PERIOD_ANY): vol.In(_PERIODS),
+                **_OFFSET_OPTIONS,
+            },
+        )
     }
 )
 

--- a/homeassistant/components/sun/triggers.yaml
+++ b/homeassistant/components/sun/triggers.yaml
@@ -30,22 +30,10 @@
   offset:
     required: true
     default:
-      days: 0
-      hours: 0
-      minutes: 0
-      seconds: 0
+      type: none
     selector:
-      duration:
+      offset:
         enable_day: true
-  offset_type:
-    required: true
-    default: before
-    selector:
-      select:
-        translation_key: trigger_offset_type
-        options:
-          - before
-          - after
 
 .elevation_threshold_entity: &trigger_elevation_threshold_entity
   - domain: input_number

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -34,6 +34,7 @@ from homeassistant.const import (
     CONF_EVENT_DATA,
     CONF_FOR,
     CONF_ID,
+    CONF_OFFSET,
     CONF_OPTIONS,
     CONF_PLATFORM,
     CONF_SELECTOR,
@@ -87,6 +88,7 @@ from .selector import (
     NumericThresholdSelector,
     NumericThresholdSelectorConfig,
     NumericThresholdType,
+    OffsetType,
     TargetSelector,
 )
 from .target import (
@@ -373,6 +375,47 @@ ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR = ENTITY_STATE_TRIGGER_SCHEMA.extend(
         },
     }
 )
+
+
+CONF_OFFSET_TYPE = "offset_type"
+
+
+def migrate_legacy_offset_options(options: Any) -> Any:
+    """Convert the released offset + offset_type pair to an offset selector value."""
+    if not isinstance(options, dict):
+        return options
+    offset = options.get(CONF_OFFSET)
+    if isinstance(offset, dict) and "type" in offset:
+        return {key: val for key, val in options.items() if key != CONF_OFFSET_TYPE}
+    if offset is None and CONF_OFFSET_TYPE not in options:
+        return options
+    options = dict(options)
+    offset_type = vol.Coerce(OffsetType)(
+        options.pop(CONF_OFFSET_TYPE, OffsetType.BEFORE)
+    )
+    signed_offset = cv.time_period(timedelta(0) if offset is None else offset)
+    if offset_type == OffsetType.BEFORE:
+        signed_offset = -signed_offset
+    if signed_offset == timedelta(0):
+        options[CONF_OFFSET] = {"type": OffsetType.NONE}
+    else:
+        options[CONF_OFFSET] = {
+            "type": OffsetType.BEFORE
+            if signed_offset < timedelta(0)
+            else OffsetType.AFTER,
+            "duration": {"seconds": abs(signed_offset).total_seconds()},
+        }
+    return options
+
+
+def offset_selector_to_timedelta(value: dict[str, Any]) -> timedelta:
+    """Convert an offset selector value to a signed timedelta, negative for before."""
+    if value["type"] == OffsetType.NONE:
+        return timedelta(0)
+    offset: timedelta = cv.time_period(value["duration"])
+    if value["type"] == OffsetType.BEFORE:
+        return -offset
+    return offset
 
 
 def _report_not_triggered_noop(reason: str, /, **data: Any) -> None:

--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -20,13 +20,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components import automation, calendar
-from homeassistant.components.calendar.trigger import (
-    CONF_OFFSET_TYPE,
-    EVENT_END,
-    EVENT_START,
-    OFFSET_TYPE_AFTER,
-    OFFSET_TYPE_BEFORE,
-)
+from homeassistant.components.calendar.trigger import EVENT_END, EVENT_START
 from homeassistant.const import (
     ATTR_AREA_ID,
     ATTR_DEVICE_ID,
@@ -45,6 +39,7 @@ from homeassistant.helpers import (
     entity_registry as er,
     label_registry as lr,
 )
+from homeassistant.helpers.trigger import CONF_OFFSET_TYPE
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -142,6 +137,7 @@ class TargetTriggerFormat(TriggerFormat):
     """Target trigger format using event_started/ended."""
 
     id: str = "target"
+    legacy_offset: bool = False
 
     def get_platform(self, event_type: str) -> str:
         """Get the platform string for trigger payload assertions."""
@@ -158,20 +154,23 @@ class TargetTriggerFormat(TriggerFormat):
             CONF_TARGET: {"entity_id": entity_id},
         }
         if offset:
-            options: dict[str, Any] = {}
-            # Convert signed offset to offset + offset_type
-            if offset < datetime.timedelta(0):
-                options[CONF_OFFSET] = -offset
-                options[CONF_OFFSET_TYPE] = OFFSET_TYPE_BEFORE
+            offset_type = "before" if offset < datetime.timedelta(0) else "after"
+            duration = {"seconds": abs(offset).total_seconds()}
+            if self.legacy_offset:
+                options = {CONF_OFFSET: duration, CONF_OFFSET_TYPE: offset_type}
             else:
-                options[CONF_OFFSET] = offset
-                options[CONF_OFFSET_TYPE] = OFFSET_TYPE_AFTER
+                options = {CONF_OFFSET: {"type": offset_type, "duration": duration}}
             trigger_data[CONF_OPTIONS] = options
         return trigger_data
 
 
 TRIGGER_FORMATS = [LegacyTriggerFormat(), TargetTriggerFormat()]
 TRIGGER_FORMAT_IDS = [fmt.id for fmt in TRIGGER_FORMATS]
+OFFSET_TRIGGER_FORMATS = [
+    *TRIGGER_FORMATS,
+    TargetTriggerFormat(id="target_legacy_offset", legacy_offset=True),
+]
+OFFSET_TRIGGER_FORMAT_IDS = [fmt.id for fmt in OFFSET_TRIGGER_FORMATS]
 
 
 @pytest.fixture(params=TRIGGER_FORMATS, ids=TRIGGER_FORMAT_IDS)
@@ -446,6 +445,9 @@ async def test_event_start_trigger(
 
 
 @pytest.mark.parametrize(
+    "trigger_format", OFFSET_TRIGGER_FORMATS, ids=OFFSET_TRIGGER_FORMAT_IDS
+)
+@pytest.mark.parametrize(
     ("offset_delta"),
     [
         datetime.timedelta(hours=-1),
@@ -515,6 +517,9 @@ async def test_event_end_trigger(
         ]
 
 
+@pytest.mark.parametrize(
+    "trigger_format", OFFSET_TRIGGER_FORMATS, ids=OFFSET_TRIGGER_FORMAT_IDS
+)
 @pytest.mark.parametrize(
     ("offset_delta"),
     [

--- a/tests/components/sun/test_trigger.py
+++ b/tests/components/sun/test_trigger.py
@@ -51,6 +51,38 @@ _DAWN_DUSK = {
     ),
 }
 
+# One hour offsets in the offset selector shape and in the released
+# offset + offset_type pair, with the sign the trigger must apply.
+_OFFSET_OPTIONS = [
+    pytest.param(
+        {"offset": {"type": "before", "duration": {"hours": 1}}}, -1, id="before"
+    ),
+    pytest.param(
+        {"offset": {"type": "after", "duration": {"hours": 1}}}, 1, id="after"
+    ),
+    pytest.param(
+        {"offset": {"type": "before", "duration": "01:00:00"}}, -1, id="before_string"
+    ),
+    pytest.param(
+        {"offset": {"hours": 1}, "offset_type": "before"}, -1, id="legacy_before"
+    ),
+    pytest.param(
+        {"offset": {"hours": 1}, "offset_type": "after"}, 1, id="legacy_after"
+    ),
+    pytest.param({"offset": "01:00:00"}, -1, id="legacy_default_type"),
+    pytest.param(
+        {"offset": "-01:00:00", "offset_type": "before"}, 1, id="legacy_negative"
+    ),
+    pytest.param(
+        {
+            "offset": {"type": "before", "duration": {"hours": 1}},
+            "offset_type": "after",
+        },
+        -1,
+        id="stale_offset_type",
+    ),
+]
+
 
 @pytest.fixture(autouse=True)
 async def setup_comp(hass: HomeAssistant) -> None:
@@ -350,17 +382,13 @@ async def test_dawn_defaults_to_civil(
         ("sun.solar_midnight", "midnight"),
     ],
 )
-@pytest.mark.parametrize(
-    ("offset_type", "sign"),
-    [("before", -1), ("after", 1)],
-    ids=["before", "after"],
-)
+@pytest.mark.parametrize(("offset_options", "sign"), _OFFSET_OPTIONS)
 async def test_event_trigger_offset(
     hass: HomeAssistant,
     service_calls: list[ServiceCall],
     trigger_key: str,
     astral_event: str,
-    offset_type: str,
+    offset_options: dict[str, Any],
     sign: int,
 ) -> None:
     """Test the solar event triggers apply a before/after time offset."""
@@ -370,7 +398,7 @@ async def test_event_trigger_offset(
             hass,
             {
                 "platform": trigger_key,
-                "options": {"offset": {"hours": 1}, "offset_type": offset_type},
+                "options": offset_options,
             },
             {},
         )
@@ -387,16 +415,12 @@ async def test_event_trigger_offset(
 
 
 @pytest.mark.parametrize("trigger_key", ["sun.dawn", "sun.dusk"])
-@pytest.mark.parametrize(
-    ("offset_type", "sign"),
-    [("before", -1), ("after", 1)],
-    ids=["before", "after"],
-)
+@pytest.mark.parametrize(("offset_options", "sign"), _OFFSET_OPTIONS)
 async def test_dawn_dusk_trigger_offset(
     hass: HomeAssistant,
     service_calls: list[ServiceCall],
     trigger_key: str,
-    offset_type: str,
+    offset_options: dict[str, Any],
     sign: int,
 ) -> None:
     """Test the dawn and dusk triggers apply a before/after time offset."""
@@ -407,7 +431,7 @@ async def test_dawn_dusk_trigger_offset(
             hass,
             {
                 "platform": trigger_key,
-                "options": {"offset": {"hours": 1}, "offset_type": offset_type},
+                "options": offset_options,
             },
             {},
         )
@@ -731,11 +755,7 @@ async def test_golden_hour_defaults_to_any(
         ("sun.golden_hour_ended", "evening", "dusk", 4),
     ],
 )
-@pytest.mark.parametrize(
-    ("offset_type", "sign"),
-    [("before", -1), ("after", 1)],
-    ids=["before", "after"],
-)
+@pytest.mark.parametrize(("offset_options", "sign"), _OFFSET_OPTIONS)
 async def test_golden_blue_hour_trigger_offset(
     hass: HomeAssistant,
     service_calls: list[ServiceCall],
@@ -743,7 +763,7 @@ async def test_golden_blue_hour_trigger_offset(
     period: str,
     event: str,
     depression: int,
-    offset_type: str,
+    offset_options: dict[str, Any],
     sign: int,
 ) -> None:
     """Test the golden/blue hour triggers apply a before/after time offset."""
@@ -753,11 +773,7 @@ async def test_golden_blue_hour_trigger_offset(
             hass,
             {
                 "platform": trigger_key,
-                "options": {
-                    "period": period,
-                    "offset": {"hours": 1},
-                    "offset_type": offset_type,
-                },
+                "options": {"period": period, **offset_options},
             },
             {},
         )
@@ -866,7 +882,7 @@ async def test_midnight_sun_trigger_offset_catches_pending_crossing(
             hass,
             {
                 "platform": "sun.midnight_sun_started",
-                "options": {"offset": {"days": 3}, "offset_type": "after"},
+                "options": {"offset": {"type": "after", "duration": {"days": 3}}},
             },
             {},
         )

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -91,6 +91,8 @@ from homeassistant.helpers.trigger import (
     make_entity_origin_state_trigger,
     make_entity_target_state_trigger,
     make_entity_transition_trigger,
+    migrate_legacy_offset_options,
+    offset_selector_to_timedelta,
 )
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import Integration, async_get_integration
@@ -6275,3 +6277,90 @@ def test_entity_state_trigger_schema_behavior_invalid(behavior: str) -> None:
     }
     with pytest.raises(vol.Invalid):
         ENTITY_STATE_TRIGGER_SCHEMA_WITH_BEHAVIOR(config)
+
+
+@pytest.mark.parametrize(
+    ("options", "expected"),
+    [
+        pytest.param({}, {}, id="empty"),
+        pytest.param("not a dict", "not a dict", id="not_a_dict"),
+        pytest.param(
+            {"offset": {"type": "none"}}, {"offset": {"type": "none"}}, id="none"
+        ),
+        pytest.param(
+            {
+                "offset": {"type": "before", "duration": {"hours": 1}},
+                "offset_type": "x",
+            },
+            {"offset": {"type": "before", "duration": {"hours": 1}}},
+            id="stale_offset_type",
+        ),
+        pytest.param(
+            {"offset": {"hours": 1}, "offset_type": "before"},
+            {"offset": {"type": "before", "duration": {"seconds": 3600.0}}},
+            id="legacy_before",
+        ),
+        pytest.param(
+            {"offset": "01:00:00", "offset_type": "after"},
+            {"offset": {"type": "after", "duration": {"seconds": 3600.0}}},
+            id="legacy_after",
+        ),
+        pytest.param(
+            {"offset": "-01:00:00"},
+            {"offset": {"type": "after", "duration": {"seconds": 3600.0}}},
+            id="legacy_negative_default_before",
+        ),
+        pytest.param(
+            {"offset": {"hours": 0}, "offset_type": "before"},
+            {"offset": {"type": "none"}},
+            id="legacy_zero",
+        ),
+        pytest.param(
+            {"offset_type": "after"},
+            {"offset": {"type": "none"}},
+            id="legacy_type_only",
+        ),
+    ],
+)
+def test_migrate_legacy_offset_options(options: Any, expected: Any) -> None:
+    """Test the legacy offset pair is converted to an offset selector value."""
+    assert migrate_legacy_offset_options(options) == expected
+
+
+def test_migrate_legacy_offset_options_invalid_type() -> None:
+    """Test an invalid legacy offset type is rejected."""
+    with pytest.raises(vol.Invalid):
+        migrate_legacy_offset_options({"offset": {"hours": 1}, "offset_type": "x"})
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param({"type": "none"}, datetime.timedelta(0), id="none"),
+        pytest.param(
+            {"type": "before", "duration": {"minutes": 5}},
+            datetime.timedelta(minutes=-5),
+            id="before",
+        ),
+        pytest.param(
+            {"type": "after", "duration": {"days": 1}},
+            datetime.timedelta(days=1),
+            id="after",
+        ),
+        pytest.param(
+            {"type": "before", "duration": "00:30:00"},
+            datetime.timedelta(minutes=-30),
+            id="before_string",
+        ),
+        pytest.param(
+            {"type": "after", "duration": 90},
+            datetime.timedelta(seconds=90),
+            id="after_seconds",
+        ),
+    ],
+)
+def test_offset_selector_to_timedelta(
+    value: dict[str, Any], expected: datetime.timedelta
+) -> None:
+    """Test an offset selector value is converted to a signed timedelta."""
+    assert offset_selector_to_timedelta(value) == expected


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Depends on #181838, which adds the `offset` selector. Only the second commit belongs to this PR.

The sun triggers (sunrise, sunset, dawn, dusk, golden and blue hour, midnight sun, polar night, solar noon and midnight) and the calendar `event_started` and `event_ended` triggers currently expose the offset as two fields, `offset` (duration) and `offset_type` (before/after). This replaces them with a single `offset` field using the new selector, so the trigger summary can be formatted from one value.

Before:

```yaml
triggers:
  - trigger: sun.sunset
    options:
      offset:
        minutes: 30
      offset_type: before
```

After:

```yaml
triggers:
  - trigger: sun.sunset
    options:
      offset:
        type: before
        duration:
          minutes: 30
```

The default is `{type: none}`.

Existing automations keep working without being rewritten: before validation, the trigger schemas convert the released pair (and a bare `offset` without `offset_type`, which keeps its `before` default) into the new shape, and an `offset_type` left behind by the editor next to a new style `offset` is ignored. The conversion and the value to timedelta helper live in `homeassistant/helpers/trigger.py` so both integrations share them. The legacy top level `platform: sun` and `platform: calendar` trigger formats are untouched.

The `trigger_offset_type` select translations are removed from both integrations since the frontend translates before/after inside the selector.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/54105

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
