### PR TITLE
Fix Yoto card slot sensor name

### DIFF
--- a/homeassistant/components/yoto/strings.json
+++ b/homeassistant/components/yoto/strings.json
@@ -80,7 +80,7 @@
     },
     "sensor": {
       "card_insertion_state": {
-        "name": "Card slot",
+        "name": "Content source",
         "state": {
           "none": "Empty",
           "physical": "Physical card",

--- a/homeassistant/components/yoto/strings.json
+++ b/homeassistant/components/yoto/strings.json
@@ -82,7 +82,7 @@
       "card_insertion_state": {
         "name": "Content source",
         "state": {
-          "none": "Empty",
+          "none": "None",
           "physical": "Physical card",
           "remote": "Remote",
           "streaming": "Streaming"

--- a/tests/components/yoto/snapshots/test_sensor.ambr
+++ b/tests/components/yoto/snapshots/test_sensor.ambr
@@ -54,7 +54,7 @@
     'state': '75',
   })
 # ---
-# name: test_all_entities[sensor.nursery_yoto_card_slot-entry]
+# name: test_all_entities[sensor.nursery_yoto_content_source-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -75,7 +75,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.nursery_yoto_card_slot',
+    'entity_id': 'sensor.nursery_yoto_content_source',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -83,12 +83,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Card slot',
+    'object_id_base': 'Content source',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
-    'original_name': 'Card slot',
+    'original_name': 'Content source',
     'platform': 'yoto',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -98,11 +98,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_entities[sensor.nursery_yoto_card_slot-state]
+# name: test_all_entities[sensor.nursery_yoto_content_source-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Nursery Yoto Card slot',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Nursery Yoto Content source',
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'none',
         'physical',
@@ -111,7 +111,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.nursery_yoto_card_slot',
+    'entity_id': 'sensor.nursery_yoto_content_source',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
## Proposed change

Rename the Yoto "Card slot" sensor to "Content source" and its "Empty" state to "None".

Two of its states, "Remote" (content started from the app) and "Streaming" (Yoto Radio or another stream), have nothing to do with the physical card slot: the sensor reports where the audio comes from. Entity key and IDs are unchanged.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/48057
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

