### PR TITLE
Serialize SleepIQ login to prevent concurrent 401 storms

### DIFF
--- a/homeassistant/components/sleepiq/__init__.py
+++ b/homeassistant/components/sleepiq/__init__.py
@@ -1,5 +1,6 @@
 """Support for SleepIQ from SleepNumber."""
 
+import asyncio
 import logging
 from typing import Any
 
@@ -64,6 +65,48 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
+def _serialize_login(gateway: AsyncSleepIQ) -> None:
+    """Wrap gateway.login so concurrent callers don't race.
+
+    The asyncsleepiq library retries a 401 by calling login() internally.
+    Three coordinators share one client, so an expired API key can trigger
+    three simultaneous logins. Each login issues a new key and invalidates
+    the previous one, so the last caller wins and the others retry with a
+    stale key, producing a cascading 401 storm.
+
+    The wrapper serializes login() with an asyncio.Lock and tracks a
+    generation counter. A caller that enters the lock after another caller
+    already completed skips the redundant login: on success it returns
+    immediately (the key is already fresh), on failure it re-raises the
+    cached exception so bad credentials don't trigger repeated attempts.
+    """
+    lock = asyncio.Lock()
+    generation = 0
+    last_error: BaseException | None = None
+    original_login = gateway.login
+
+    async def _locked_login(
+        email: str | None = None, password: str | None = None
+    ) -> None:
+        nonlocal generation, last_error
+        gen_at_entry = generation
+        async with lock:
+            if generation != gen_at_entry:
+                if last_error is not None:
+                    raise last_error
+                return
+            try:
+                await original_login(email, password)
+                last_error = None
+                generation += 1
+            except Exception as err:
+                last_error = err
+                generation += 1
+                raise
+
+    gateway.login = _locked_login  # type: ignore[method-assign]
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: SleepIQConfigEntry) -> bool:
     """Set up the SleepIQ config entry."""
     conf = entry.data
@@ -73,6 +116,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SleepIQConfigEntry) -> b
     client_session = async_create_clientsession(hass)
 
     gateway = AsyncSleepIQ(client_session=client_session)
+    _serialize_login(gateway)
 
     try:
         await gateway.login(email, password)

--- a/tests/components/sleepiq/test_init.py
+++ b/tests/components/sleepiq/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the SleepIQ integration."""
 
+import asyncio
 from collections.abc import Callable
 from datetime import timedelta
 from http import HTTPStatus
@@ -18,6 +19,7 @@ from asyncsleepiq import (
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.sleepiq import _serialize_login
 from homeassistant.components.sleepiq.const import DOMAIN, IS_IN_BED, SLEEP_NUMBER
 from homeassistant.components.sleepiq.coordinator import (
     LONGER_UPDATE_INTERVAL,
@@ -356,3 +358,88 @@ async def test_duplicate_beds_none_sleeper_ids_not_filtered(
     entry = await setup_platform(hass, "sensor")
     assert entry.state is ConfigEntryState.LOADED
     assert "ghost_001" in mock_asyncsleepiq.beds
+
+
+async def test_concurrent_logins_serialized(
+    hass: HomeAssistant,
+    mock_asyncsleepiq: MagicMock,
+) -> None:
+    """Test that concurrent login calls are serialized to one actual login."""
+    await setup_platform(hass, "sensor")
+
+    client = hass.config_entries.async_entries(DOMAIN)[0].runtime_data.client
+
+    real_call_count = 0
+
+    async def _counting_login(
+        email: str | None = None, password: str | None = None
+    ) -> None:
+        nonlocal real_call_count
+        real_call_count += 1
+        await asyncio.sleep(0.05)
+
+    client.login = _counting_login
+    _serialize_login(client)
+
+    tasks = [asyncio.create_task(client.login()) for _ in range(5)]
+    await asyncio.gather(*tasks)
+
+    assert real_call_count == 1
+
+
+async def test_login_serialization_allows_retry_after_failure(
+    hass: HomeAssistant,
+    mock_asyncsleepiq: MagicMock,
+) -> None:
+    """Test that a failed login does not increment the generation counter."""
+    await setup_platform(hass, "sensor")
+    client = hass.config_entries.async_entries(DOMAIN)[0].runtime_data.client
+
+    attempts = 0
+
+    async def _failing_then_succeeding(
+        email: str | None = None, password: str | None = None
+    ) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise SleepIQLoginException("transient")
+
+    client.login = _failing_then_succeeding
+    _serialize_login(client)
+
+    with pytest.raises(SleepIQLoginException):
+        await client.login()
+
+    assert attempts == 1
+
+    await client.login()
+    assert attempts == 2
+
+
+async def test_login_serialization_propagates_error_to_waiters(
+    hass: HomeAssistant,
+    mock_asyncsleepiq: MagicMock,
+) -> None:
+    """Test that waiters blocked behind a failed login receive the same error."""
+    await setup_platform(hass, "sensor")
+    client = hass.config_entries.async_entries(DOMAIN)[0].runtime_data.client
+
+    real_calls = 0
+
+    async def _slow_failure(
+        email: str | None = None, password: str | None = None
+    ) -> None:
+        nonlocal real_calls
+        real_calls += 1
+        await asyncio.sleep(0.05)
+        raise SleepIQLoginException("bad credentials")
+
+    client.login = _slow_failure
+    _serialize_login(client)
+
+    tasks = [asyncio.create_task(client.login()) for _ in range(3)]
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    assert real_calls == 1
+    assert all(isinstance(r, SleepIQLoginException) for r in results)

--- a/tests/components/sleepiq/test_init.py
+++ b/tests/components/sleepiq/test_init.py
@@ -391,7 +391,7 @@ async def test_login_serialization_allows_retry_after_failure(
     hass: HomeAssistant,
     mock_asyncsleepiq: MagicMock,
 ) -> None:
-    """Test that a failed login does not increment the generation counter."""
+    """Test that a fresh caller can retry after a prior login failure."""
     await setup_platform(hass, "sensor")
     client = hass.config_entries.async_entries(DOMAIN)[0].runtime_data.client
 


### PR DESCRIPTION
## Proposed change

Wrap `gateway.login()` with an `asyncio.Lock` and generation counter so concurrent coordinators don't race each other into invalidating API keys.

The SleepIQ integration runs three `DataUpdateCoordinator` instances (bed status at 60s, pause mode at 5m, sleep data at 1h) sharing a single `AsyncSleepIQ` client. The SleepIQ API invalidates old session keys when a new login occurs.

When the session key expires server-side, multiple coordinators can hit 401 simultaneously. The library's built-in retry calls `self.login()` from each coordinator concurrently. Each login issues a new key that invalidates the previous one, so the last caller wins and the others retry with a now-stale key, producing a cascading 401 storm that triggers `ConfigEntryAuthFailed` and a spurious reauth prompt.

On a successful login, subsequent waiters skip the redundant call and reuse the fresh key. On a failed login, subsequent waiters receive the cached exception instead of hammering the API with repeated bad-credential attempts.

The proper fix is login serialization in the `asyncsleepiq` library itself. This wraps the login at the integration level until the library addresses it.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #168511
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between the previous and current version has been added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr