### PR TITLE
Remove unshared ScorpionTrack vehicles automatically

### DIFF
--- a/homeassistant/components/scorpiontrack/__init__.py
+++ b/homeassistant/components/scorpiontrack/__init__.py
@@ -2,10 +2,12 @@
 
 from pyscorpiontrack import ScorpionTrackClient
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_SHARE_TOKEN, PLATFORMS
+from .const import CONF_SHARE_TOKEN, DOMAIN, PLATFORMS
 from .coordinator import ScorpionTrackConfigEntry, ScorpionTrackCoordinator
 
 
@@ -30,3 +32,19 @@ async def async_unload_entry(
 ) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    entry: ScorpionTrackConfigEntry,
+    device_entry: dr.AnyDeviceEntry,
+) -> bool:
+    """Allow manual removal of vehicles no longer included in the share."""
+    if entry.state is not ConfigEntryState.LOADED:
+        return False
+
+    coordinator = entry.runtime_data
+    return coordinator.last_update_success and not any(
+        (DOMAIN, f"{coordinator.data.id}_{vehicle_id}") in device_entry.identifiers
+        for vehicle_id in coordinator.vehicles_by_id
+    )

--- a/homeassistant/components/scorpiontrack/__init__.py
+++ b/homeassistant/components/scorpiontrack/__init__.py
@@ -2,12 +2,10 @@
 
 from pyscorpiontrack import ScorpionTrackClient
 
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_SHARE_TOKEN, DOMAIN, PLATFORMS
+from .const import CONF_SHARE_TOKEN, PLATFORMS
 from .coordinator import ScorpionTrackConfigEntry, ScorpionTrackCoordinator
 
 
@@ -32,19 +30,3 @@ async def async_unload_entry(
 ) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-
-async def async_remove_config_entry_device(
-    hass: HomeAssistant,
-    entry: ScorpionTrackConfigEntry,
-    device_entry: dr.AnyDeviceEntry,
-) -> bool:
-    """Allow manual removal of vehicles no longer included in the share."""
-    if entry.state is not ConfigEntryState.LOADED:
-        return False
-
-    coordinator = entry.runtime_data
-    return coordinator.last_update_success and not any(
-        (DOMAIN, f"{coordinator.data.id}_{vehicle_id}") in device_entry.identifiers
-        for vehicle_id in coordinator.vehicles_by_id
-    )

--- a/homeassistant/components/scorpiontrack/binary_sensor.py
+++ b/homeassistant/components/scorpiontrack/binary_sensor.py
@@ -24,6 +24,7 @@ async def async_setup_entry(
     @callback
     def async_add_new_vehicles() -> None:
         """Add ignition sensors for vehicles newly included in the share."""
+        known_vehicles.intersection_update(coordinator.vehicles_by_id)
         new_vehicles = coordinator.vehicles_by_id.keys() - known_vehicles
         if not new_vehicles:
             return

--- a/homeassistant/components/scorpiontrack/coordinator.py
+++ b/homeassistant/components/scorpiontrack/coordinator.py
@@ -15,6 +15,7 @@ from pyscorpiontrack import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
@@ -27,6 +28,8 @@ type ScorpionTrackConfigEntry = ConfigEntry[ScorpionTrackCoordinator]
 
 class ScorpionTrackCoordinator(DataUpdateCoordinator[ScorpionTrackShare]):
     """Coordinate shared-location updates."""
+
+    config_entry: ScorpionTrackConfigEntry
 
     def __init__(
         self,
@@ -68,4 +71,14 @@ class ScorpionTrackCoordinator(DataUpdateCoordinator[ScorpionTrackShare]):
             ) from err
         else:
             self.vehicles_by_id = {vehicle.id: vehicle for vehicle in share.vehicles}
+            device_registry = dr.async_get(self.hass)
+            vehicle_identifiers = {
+                (DOMAIN, f"{share.id}_{vehicle_id}")
+                for vehicle_id in self.vehicles_by_id
+            }
+            for device in dr.async_entries_for_config_entry(
+                device_registry, self.config_entry.entry_id
+            ):
+                if device.identifiers.isdisjoint(vehicle_identifiers):
+                    device_registry.async_remove_device(device.id)
             return share

--- a/homeassistant/components/scorpiontrack/device_tracker.py
+++ b/homeassistant/components/scorpiontrack/device_tracker.py
@@ -26,6 +26,7 @@ async def async_setup_entry(
     @callback
     def async_add_new_vehicles() -> None:
         """Add trackers for vehicles newly included in the share."""
+        known_vehicles.intersection_update(coordinator.vehicles_by_id)
         new_vehicles = coordinator.vehicles_by_id.keys() - known_vehicles
         if not new_vehicles:
             return

--- a/homeassistant/components/scorpiontrack/quality_scale.yaml
+++ b/homeassistant/components/scorpiontrack/quality_scale.yaml
@@ -83,7 +83,7 @@ rules:
   icon-translations: done
   reconfiguration-flow: todo
   repair-issues: todo
-  stale-devices: todo
+  stale-devices: done
 
   # Platinum
   async-dependency: done

--- a/homeassistant/components/scorpiontrack/sensor.py
+++ b/homeassistant/components/scorpiontrack/sensor.py
@@ -79,6 +79,7 @@ async def async_setup_entry(
     @callback
     def async_add_new_vehicles() -> None:
         """Add sensors for vehicles newly included in the share."""
+        known_vehicles.intersection_update(coordinator.vehicles_by_id)
         new_vehicles = coordinator.vehicles_by_id.keys() - known_vehicles
         if not new_vehicles:
             return

--- a/tests/components/scorpiontrack/test_binary_sensor.py
+++ b/tests/components/scorpiontrack/test_binary_sensor.py
@@ -93,14 +93,14 @@ async def test_ignition_binary_sensor_availability(
     assert state.state == expected_state
 
 
-async def test_removed_vehicle_makes_ignition_binary_sensor_unavailable(
+async def test_removed_vehicle_removes_ignition_binary_sensor(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
     mock_share: ScorpionTrackShare,
     mock_scorpiontrack_client: AsyncMock,
 ) -> None:
-    """Test ignition becomes unavailable if its vehicle leaves the share."""
+    """Test ignition is removed if its vehicle leaves the share."""
     await setup_integration(hass, mock_config_entry)
 
     mock_scorpiontrack_client.async_get_share.return_value = replace(
@@ -110,9 +110,7 @@ async def test_removed_vehicle_makes_ignition_binary_sensor_unavailable(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    state = hass.states.get(ENTITY_ID)
-    assert state is not None
-    assert state.state == STATE_UNAVAILABLE
+    assert hass.states.get(ENTITY_ID) is None
 
 
 async def test_ignition_binary_sensor_uses_existing_vehicle_device(

--- a/tests/components/scorpiontrack/test_device_removal.py
+++ b/tests/components/scorpiontrack/test_device_removal.py
@@ -1,0 +1,211 @@
+"""Test manual removal of ScorpionTrack vehicles."""
+
+from dataclasses import replace
+from unittest.mock import AsyncMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+from pyscorpiontrack import ScorpionTrackConnectionError, ScorpionTrackShare
+import pytest
+
+from homeassistant.components.scorpiontrack.const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.typing import WebSocketGenerator
+
+
+@pytest.mark.parametrize("latitude", [51.5074, None])
+async def test_shared_vehicle_cannot_be_removed(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+    latitude: float | None,
+) -> None:
+    """Protect shared vehicles even when their GPS location is missing."""
+    vehicle = mock_share.vehicles[0]
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share,
+        vehicles=(
+            replace(vehicle, position=replace(vehicle.position, latitude=latitude)),
+        ),
+    )
+    await setup_integration(hass, mock_config_entry)
+    assert await async_setup_component(hass, "config", {})
+    client = await hass_ws_client(hass)
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "101_1"), mock_config_entry.entry_id
+    )
+    assert device is not None
+    assert mock_config_entry.supports_remove_device
+
+    result = await client.remove_device(device.id)
+
+    assert not result["success"]
+    assert device_registry.async_get(device.id) is not None
+    mock_scorpiontrack_client.async_get_share.assert_awaited_once_with()
+
+
+async def test_removal_requires_successful_update(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Do not allow removal using stale data after an update fails."""
+    await setup_integration(hass, mock_config_entry)
+    assert await async_setup_component(hass, "config", {})
+    client = await hass_ws_client(hass)
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "101_1"), mock_config_entry.entry_id
+    )
+    assert device is not None
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, vehicles=()
+    )
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    mock_scorpiontrack_client.async_get_share.side_effect = (
+        ScorpionTrackConnectionError()
+    )
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    client = await hass_ws_client(hass)
+    result = await client.remove_device(device.id)
+    assert not result["success"]
+    assert device_registry.async_get(device.id) is not None
+
+    mock_scorpiontrack_client.async_get_share.side_effect = None
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    client = await hass_ws_client(hass)
+    result = await client.remove_device(device.id)
+    await hass.async_block_till_done()
+    assert result["success"]
+    assert device_registry.async_get(device.id) is None
+    assert not er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    mock_scorpiontrack_client.async_get_share.assert_awaited_with()
+    assert mock_scorpiontrack_client.async_get_share.await_count == 4
+
+
+async def test_deleted_vehicle_returns_after_reload(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Remove one share's device and restore a returning vehicle on reload."""
+    await setup_integration(hass, mock_config_entry)
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    original_ids = {entity.entity_id for entity in entities}
+    other_entry = MockConfigEntry(
+        domain=DOMAIN, unique_id="202", data={"share_token": "other-token"}
+    )
+    other_client = AsyncMock()
+    other_client.async_get_share.return_value = replace(mock_share, id=202)
+    with patch(
+        "homeassistant.components.scorpiontrack.ScorpionTrackClient",
+        return_value=other_client,
+    ):
+        await setup_integration(hass, other_entry)
+    other_entities = er.async_entries_for_config_entry(
+        entity_registry, other_entry.entry_id
+    )
+    assert await async_setup_component(hass, "config", {})
+    client = await hass_ws_client(hass)
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "101_1"), mock_config_entry.entry_id
+    )
+    assert device is not None
+
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, vehicles=()
+    )
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    result = await client.remove_device(device.id)
+    await hass.async_block_till_done()
+    assert result["success"]
+    assert device_registry.async_get(device.id) is None
+    assert not er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    assert all(hass.states.get(entity_id) is None for entity_id in original_ids)
+
+    mock_scorpiontrack_client.async_get_share.return_value = mock_share
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert not er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+
+    assert await hass.config_entries.async_reload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert {
+        entity.entity_id
+        for entity in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+    } == original_ids
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "101_1"), mock_config_entry.entry_id
+        )
+        is not None
+    )
+    assert (
+        entity_registry.async_get("sensor.ab12_cde_heading").disabled_by
+        is er.RegistryEntryDisabler.INTEGRATION
+    )
+    assert (
+        er.async_entries_for_config_entry(entity_registry, other_entry.entry_id)
+        == other_entities
+    )
+    assert mock_scorpiontrack_client.async_get_share.await_count == 4
+
+
+async def test_unloaded_entry_cannot_remove_devices(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Reject removal when the integration is not loaded."""
+    await setup_integration(hass, mock_config_entry)
+    assert await async_setup_component(hass, "config", {})
+    client = await hass_ws_client(hass)
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "101_1"), mock_config_entry.entry_id
+    )
+    assert device is not None
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await client.remove_device(device.id)
+
+    assert not result["success"]
+    assert device_registry.async_get(device.id) is not None

--- a/tests/components/scorpiontrack/test_device_removal.py
+++ b/tests/components/scorpiontrack/test_device_removal.py
@@ -1,34 +1,43 @@
-"""Test manual removal of ScorpionTrack vehicles."""
+"""Test automatic removal of ScorpionTrack vehicles."""
 
 from dataclasses import replace
 from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
-from pyscorpiontrack import ScorpionTrackConnectionError, ScorpionTrackShare
+from pyscorpiontrack import (
+    ScorpionTrackConnectionError,
+    ScorpionTrackInvalidTokenError,
+    ScorpionTrackShare,
+    ScorpionTrackShareUnavailableError,
+)
 import pytest
 
 from homeassistant.components.scorpiontrack.const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.setup import async_setup_component
 
 from . import setup_integration
 
 from tests.common import MockConfigEntry, async_fire_time_changed
-from tests.typing import WebSocketGenerator
 
 
 @pytest.mark.parametrize("latitude", [51.5074, None])
-async def test_shared_vehicle_cannot_be_removed(
+async def test_shared_vehicle_is_kept(
     hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
+    freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
     mock_share: ScorpionTrackShare,
     mock_scorpiontrack_client: AsyncMock,
     device_registry: dr.DeviceRegistry,
     latitude: float | None,
 ) -> None:
-    """Protect shared vehicles even when their GPS location is missing."""
+    """Keep shared vehicles even when their GPS location is missing."""
+    await setup_integration(hass, mock_config_entry)
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "101_1"), mock_config_entry.entry_id
+    )
+    assert device is not None
     vehicle = mock_share.vehicles[0]
     mock_scorpiontrack_client.async_get_share.return_value = replace(
         mock_share,
@@ -36,40 +45,56 @@ async def test_shared_vehicle_cannot_be_removed(
             replace(vehicle, position=replace(vehicle.position, latitude=latitude)),
         ),
     )
-    await setup_integration(hass, mock_config_entry)
-    assert await async_setup_component(hass, "config", {})
-    client = await hass_ws_client(hass)
-    device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, "101_1"), mock_config_entry.entry_id
-    )
-    assert device is not None
-    assert mock_config_entry.supports_remove_device
 
-    result = await client.remove_device(device.id)
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
-    assert not result["success"]
-    assert device_registry.async_get(device.id) is not None
-    mock_scorpiontrack_client.async_get_share.assert_awaited_once_with()
+    assert device_registry.async_get(device.id) == device
+    assert mock_scorpiontrack_client.async_get_share.await_count == 2
 
 
-async def test_removal_requires_successful_update(
+@pytest.mark.parametrize(
+    "exception",
+    [
+        ScorpionTrackConnectionError(),
+        ScorpionTrackInvalidTokenError(),
+        ScorpionTrackShareUnavailableError(),
+    ],
+)
+async def test_failed_update_keeps_devices(
     hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
     freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
     mock_share: ScorpionTrackShare,
     mock_scorpiontrack_client: AsyncMock,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
+    exception: Exception,
 ) -> None:
-    """Do not allow removal using stale data after an update fails."""
+    """Remove absent vehicles only once a successful update confirms it."""
     await setup_integration(hass, mock_config_entry)
-    assert await async_setup_component(hass, "config", {})
-    client = await hass_ws_client(hass)
     device = device_registry.async_get_device_by_identifier(
         (DOMAIN, "101_1"), mock_config_entry.entry_id
     )
     assert device is not None
+    entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    mock_scorpiontrack_client.async_get_share.side_effect = exception
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert device_registry.async_get(device.id) == device
+    assert (
+        er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id)
+        == entities
+    )
+    assert hass.states.get("sensor.ab12_cde_speed").state == STATE_UNAVAILABLE
+
+    mock_scorpiontrack_client.async_get_share.side_effect = None
     mock_scorpiontrack_client.async_get_share.return_value = replace(
         mock_share, vehicles=()
     )
@@ -77,36 +102,14 @@ async def test_removal_requires_successful_update(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    mock_scorpiontrack_client.async_get_share.side_effect = (
-        ScorpionTrackConnectionError()
-    )
-    freezer.tick(DEFAULT_SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    client = await hass_ws_client(hass)
-    result = await client.remove_device(device.id)
-    assert not result["success"]
-    assert device_registry.async_get(device.id) is not None
-
-    mock_scorpiontrack_client.async_get_share.side_effect = None
-    freezer.tick(DEFAULT_SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-    client = await hass_ws_client(hass)
-    result = await client.remove_device(device.id)
-    await hass.async_block_till_done()
-    assert result["success"]
     assert device_registry.async_get(device.id) is None
     assert not er.async_entries_for_config_entry(
         entity_registry, mock_config_entry.entry_id
     )
-    mock_scorpiontrack_client.async_get_share.assert_awaited_with()
-    assert mock_scorpiontrack_client.async_get_share.await_count == 4
 
 
-async def test_deleted_vehicle_returns_after_reload(
+async def test_removed_vehicle_returns(
     hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
     freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
     mock_share: ScorpionTrackShare,
@@ -114,12 +117,18 @@ async def test_deleted_vehicle_returns_after_reload(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Remove one share's device and restore a returning vehicle on reload."""
+    """Remove only this share's device and rediscover it without a reload."""
     await setup_integration(hass, mock_config_entry)
-    entities = er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
+    entity_registry.async_update_entity(
+        "sensor.ab12_cde_speed", new_entity_id="sensor.vehicle_speed", name="My speed"
     )
-    original_ids = {entity.entity_id for entity in entities}
+    await hass.async_block_till_done()
+    original_entities = {
+        entity.entity_id: entity.id
+        for entity in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+    }
     other_entry = MockConfigEntry(
         domain=DOMAIN, unique_id="202", data={"share_token": "other-token"}
     )
@@ -133,8 +142,6 @@ async def test_deleted_vehicle_returns_after_reload(
     other_entities = er.async_entries_for_config_entry(
         entity_registry, other_entry.entry_id
     )
-    assert await async_setup_component(hass, "config", {})
-    client = await hass_ws_client(hass)
     device = device_registry.async_get_device_by_identifier(
         (DOMAIN, "101_1"), mock_config_entry.entry_id
     )
@@ -146,31 +153,29 @@ async def test_deleted_vehicle_returns_after_reload(
     freezer.tick(DEFAULT_SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    result = await client.remove_device(device.id)
-    await hass.async_block_till_done()
-    assert result["success"]
+
     assert device_registry.async_get(device.id) is None
     assert not er.async_entries_for_config_entry(
         entity_registry, mock_config_entry.entry_id
     )
-    assert all(hass.states.get(entity_id) is None for entity_id in original_ids)
+    assert all(hass.states.get(entity_id) is None for entity_id in original_entities)
+    assert er.async_entries_for_config_entry(entity_registry, other_entry.entry_id) == (
+        other_entities
+    )
 
     mock_scorpiontrack_client.async_get_share.return_value = mock_share
     freezer.tick(DEFAULT_SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert not er.async_entries_for_config_entry(
-        entity_registry, mock_config_entry.entry_id
-    )
 
-    assert await hass.config_entries.async_reload(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
     assert {
-        entity.entity_id
+        entity.entity_id: entity.id
         for entity in er.async_entries_for_config_entry(
             entity_registry, mock_config_entry.entry_id
         )
-    } == original_ids
+    } == original_entities
+    assert hass.states.get("sensor.vehicle_speed").state != STATE_UNAVAILABLE
+    assert entity_registry.async_get("sensor.vehicle_speed").name == "My speed"
     assert (
         device_registry.async_get_device_by_identifier(
             (DOMAIN, "101_1"), mock_config_entry.entry_id
@@ -181,31 +186,35 @@ async def test_deleted_vehicle_returns_after_reload(
         entity_registry.async_get("sensor.ab12_cde_heading").disabled_by
         is er.RegistryEntryDisabler.INTEGRATION
     )
-    assert (
-        er.async_entries_for_config_entry(entity_registry, other_entry.entry_id)
-        == other_entities
+    assert er.async_entries_for_config_entry(entity_registry, other_entry.entry_id) == (
+        other_entities
     )
-    assert mock_scorpiontrack_client.async_get_share.await_count == 4
+    assert mock_scorpiontrack_client.async_get_share.await_count == 3
 
 
-async def test_unloaded_entry_cannot_remove_devices(
+async def test_vehicle_removed_while_unloaded(
     hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
     mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
     device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
 ) -> None:
-    """Reject removal when the integration is not loaded."""
+    """Clean up saved devices absent from the first successful setup response."""
     await setup_integration(hass, mock_config_entry)
-    assert await async_setup_component(hass, "config", {})
-    client = await hass_ws_client(hass)
     device = device_registry.async_get_device_by_identifier(
         (DOMAIN, "101_1"), mock_config_entry.entry_id
     )
     assert device is not None
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, vehicles=()
+    )
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    result = await client.remove_device(device.id)
-
-    assert not result["success"]
-    assert device_registry.async_get(device.id) is not None
+    assert device_registry.async_get(device.id) is None
+    assert not er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )

--- a/tests/components/scorpiontrack/test_device_tracker.py
+++ b/tests/components/scorpiontrack/test_device_tracker.py
@@ -33,14 +33,14 @@ async def test_device_tracker_state(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-async def test_removed_vehicle_becomes_unavailable(
+async def test_removed_vehicle_removes_tracker(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
     mock_share: ScorpionTrackShare,
     mock_scorpiontrack_client: AsyncMock,
 ) -> None:
-    """Test a tracker becomes unavailable if its vehicle leaves the share."""
+    """Test a tracker is removed if its vehicle leaves the share."""
     await setup_integration(hass, mock_config_entry)
 
     mock_scorpiontrack_client.async_get_share.return_value = replace(
@@ -50,9 +50,7 @@ async def test_removed_vehicle_becomes_unavailable(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    state = hass.states.get("device_tracker.ab12_cde")
-    assert state is not None
-    assert state.state == STATE_UNAVAILABLE
+    assert hass.states.get("device_tracker.ab12_cde") is None
 
 
 async def test_connection_error_makes_tracker_unavailable(

--- a/tests/components/scorpiontrack/test_init.py
+++ b/tests/components/scorpiontrack/test_init.py
@@ -147,7 +147,9 @@ async def test_vehicle_added_after_setup(
     freezer.tick(DEFAULT_SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+    assert hass.states.get(entity_id) is None
+    assert entity_registry.async_get(entity_id) is None
+    assert device_registry.async_get(device.id) is None
 
     mock_scorpiontrack_client.async_get_share.return_value = updated_share
     freezer.tick(DEFAULT_SCAN_INTERVAL)

--- a/tests/components/scorpiontrack/test_sensor.py
+++ b/tests/components/scorpiontrack/test_sensor.py
@@ -194,7 +194,7 @@ async def test_speed_sensor_availability(
         pytest.param(HEADING_ENTITY_ID, id="heading"),
     ],
 )
-async def test_removed_vehicle_makes_sensor_unavailable(
+async def test_removed_vehicle_removes_sensor(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
@@ -202,7 +202,7 @@ async def test_removed_vehicle_makes_sensor_unavailable(
     mock_scorpiontrack_client: AsyncMock,
     entity_id: str,
 ) -> None:
-    """Test a sensor becomes unavailable if its vehicle leaves the share."""
+    """Test a sensor is removed if its vehicle leaves the share."""
     await setup_integration(hass, mock_config_entry)
 
     mock_scorpiontrack_client.async_get_share.return_value = replace(
@@ -212,9 +212,7 @@ async def test_removed_vehicle_makes_sensor_unavailable(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    state = hass.states.get(entity_id)
-    assert state is not None
-    assert state.state == STATE_UNAVAILABLE
+    assert hass.states.get(entity_id) is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I am removing vehicle devices automatically after a successful update confirms that they are no longer in the ScorpionTrack share.

Failed updates and missing GPS data do not remove shared vehicles.

If a vehicle is shared again, its device and entities are created on the next successful update without reloading. The existing entity unique IDs are unchanged.

I ran the ScorpionTrack Core tests to check removal, returning vehicles, failed updates, and setup. All 57 tests passed. I also ran a separate local check that confirmed existing speed history and hourly statistics remain after removal and return.

I have not yet completed the live share removal and return test on my development VM.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/48060
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
