### PR TITLE
feature: Enable suspending of automations for a time

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -51,6 +51,7 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.helpers.issue_registry import (
     IssueSeverity,
     async_create_issue,
@@ -79,6 +80,7 @@ from homeassistant.helpers.trace import (
     trace_path,
 )
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import dt as dt_util
 from homeassistant.util.dt import parse_datetime
 from homeassistant.util.hass_dict import HassKey
 
@@ -102,6 +104,7 @@ ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
 CONF_SKIP_CONDITION = "skip_condition"
 CONF_STOP_ACTIONS = "stop_actions"
+CONF_UNTIL = "until"
 DEFAULT_STOP_ACTIONS = True
 
 EVENT_AUTOMATION_RELOADED = "automation_reloaded"
@@ -111,6 +114,7 @@ ATTR_LAST_TRIGGERED = "last_triggered"
 ATTR_SOURCE = "source"
 ATTR_VARIABLES = "variables"
 SERVICE_TRIGGER = "trigger"
+SERVICE_SUSPEND = "suspend"
 
 
 class IfAction(condition_helper.ConditionsChecker):
@@ -284,6 +288,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         {vol.Optional(CONF_STOP_ACTIONS, default=DEFAULT_STOP_ACTIONS): cv.boolean},
         "async_turn_off",
     )
+    component.async_register_entity_service(
+        SERVICE_SUSPEND,
+        {vol.Optional(CONF_UNTIL, default=None): vol.Any(cv.datetime, None)},
+        "async_suspend",
+    )
 
     async def reload_service_handler(service_call: ServiceCall) -> None:
         """Remove all automations and load new ones from config."""
@@ -375,6 +384,10 @@ class BaseAutomationEntity(ToggleEntity, ABC):
         skip_condition: bool = False,
     ) -> ScriptRunResult | None:
         """Trigger automation."""
+
+    @abstractmethod
+    async def async_suspend(self, until: Any = None) -> None:
+        """Suspend the automation until a specific datetime or resume if None."""
 
 
 class UnavailableAutomationEntity(BaseAutomationEntity):
@@ -473,6 +486,10 @@ class UnavailableAutomationEntity(BaseAutomationEntity):
     ) -> None:
         """Trigger automation."""
 
+    @override
+    async def async_suspend(self, until: Any = None) -> None:
+        """Suspend the automation until a specific datetime or resume if None."""
+
 
 class AutomationEntity(BaseAutomationEntity, RestoreEntity):
     """Entity to show status of entity."""
@@ -509,6 +526,8 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
         self._blueprint_inputs = blueprint_inputs
         self._trace_config = trace_config
         self._attr_unique_id = automation_id
+        self._suspended_until: datetime | None = None
+        self._async_unsub_suspend: CALLBACK_TYPE | None = None
 
     @property
     @override
@@ -521,6 +540,10 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
             AutomationEntityStateAttribute.MODE: self.action_script.script_mode,
             AutomationEntityStateAttribute.CUR: self.action_script.runs,
         }
+        if self._suspended_until is not None:
+            attrs[AutomationEntityStateAttribute.SUSPENDED_UNTIL] = (
+                self._suspended_until.isoformat()
+            )
         if self.action_script.supports_max:
             attrs[AutomationEntityStateAttribute.MAX] = self.action_script.max_runs
         return attrs
@@ -633,6 +656,20 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
             )
             if last_triggered is not None:
                 self.action_script.last_triggered = parse_datetime(last_triggered)
+            if suspended_until_str := state.attributes.get(
+                AutomationEntityStateAttribute.SUSPENDED_UNTIL
+            ):
+                if (suspended_until := parse_datetime(suspended_until_str)) is not None:
+                    if suspended_until > dt_util.utcnow():
+                        self._suspended_until = suspended_until
+                        enable_automation = False
+                        self._async_unsub_suspend = async_track_point_in_utc_time(
+                            self.hass,
+                            self._async_suspended_timer_finished,
+                            suspended_until,
+                        )
+                    else:
+                        enable_automation = True
             self._logger.debug(
                 "Loaded automation %s with state %s from state storage last state %s",
                 self.entity_id,
@@ -658,15 +695,52 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
         if enable_automation:
             await self._async_enable()
 
+    @callback
+    def _clear_suspend_timer(self) -> None:
+        """Clear active suspend timer and reset suspended_until."""
+        if self._async_unsub_suspend is not None:
+            self._async_unsub_suspend()
+            self._async_unsub_suspend = None
+        self._suspended_until = None
+
+    async def _async_suspended_timer_finished(self, now: datetime) -> None:
+        """Handle suspend timer expiring."""
+        self._clear_suspend_timer()
+        await self._async_enable()
+        self.async_write_ha_state()
+
+    @override
+    async def async_suspend(self, until: datetime | None = None) -> None:
+        """Suspend the automation until a specific datetime or resume if None."""
+        self._clear_suspend_timer()
+        if until is not None:
+            utc_until = dt_util.as_utc(until)
+            if utc_until > dt_util.utcnow():
+                self._suspended_until = utc_until
+                self._async_unsub_suspend = async_track_point_in_utc_time(
+                    self.hass,
+                    self._async_suspended_timer_finished,
+                    utc_until,
+                )
+                await self._async_disable()
+                self.async_write_ha_state()
+                return
+
+        # If until is None or in the past, re-enable
+        await self._async_enable()
+        self.async_write_ha_state()
+
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on and update the state."""
+        self._clear_suspend_timer()
         await self._async_enable()
         self.async_write_ha_state()
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
+        self._clear_suspend_timer()
         if CONF_STOP_ACTIONS in kwargs:
             await self._async_disable(kwargs[CONF_STOP_ACTIONS])
         else:
@@ -820,6 +894,7 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
     @override
     async def async_will_remove_from_hass(self) -> None:
         """Remove listeners when removing automation from Home Assistant."""
+        self._clear_suspend_timer()
         await super().async_will_remove_from_hass()
         if self.registry_entry and self.registry_entry.entity_id != self.entity_id:
             # Entity ID change, do not unload the script or conditions as they will

--- a/homeassistant/components/automation/const.py
+++ b/homeassistant/components/automation/const.py
@@ -20,6 +20,7 @@ class AutomationEntityStateAttribute(StrEnum):
     MODE = "mode"
     CUR = "current"
     MAX = "max"
+    SUSPENDED_UNTIL = "suspended_until"
 
 
 CONF_HIDE_ENTITY = "hide_entity"

--- a/homeassistant/components/automation/services.yaml
+++ b/homeassistant/components/automation/services.yaml
@@ -19,6 +19,15 @@ toggle:
     entity:
       domain: automation
 
+suspend:
+  target:
+    entity:
+      domain: automation
+  fields:
+    until:
+      selector:
+        datetime:
+
 trigger:
   target:
     entity:

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -4379,6 +4379,235 @@ async def test_automation_records_not_triggered_trace(
     assert traces[0]["not_triggered"] is True
     assert traces[0]["script_execution"] == "not_triggered"
 
+
+async def test_automation_suspend_and_resume(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Test suspending an automation and having it resume after timer fires."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "alias": "hello",
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "action": {"action": "test.automation", "entity_id": "hello.world"},
+            }
+        },
+    )
+    assert automation.is_on(hass, "automation.hello")
+
+    # Suspend for 1 hour
+    now = dt_util.utcnow()
+    suspend_time = now + timedelta(hours=1)
+    await hass.services.async_call(
+        automation.DOMAIN,
+        "suspend",
+        {
+            "entity_id": "automation.hello",
+            "until": suspend_time.isoformat(),
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Automation should now be off (disabled) and have suspended_until attribute
+    state = hass.states.get("automation.hello")
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert state.attributes.get("suspended_until") == suspend_time.isoformat()
+
+    # Triggering the event while suspended should not call the action
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+    # Fast forward time past the suspend time
+    async_fire_time_changed(hass, suspend_time + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    # Automation should now be on (enabled) and suspended_until should be gone
+    state = hass.states.get("automation.hello")
+    assert state is not None
+    assert state.state == STATE_ON
+    assert "suspended_until" not in state.attributes
+
+    # Triggering now should execute the action
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
+async def test_automation_suspend_manual_enable_clears_timer(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Test enabling a suspended automation clears the suspend timer and attribute."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "alias": "hello",
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "action": {"action": "test.automation", "entity_id": "hello.world"},
+            }
+        },
+    )
+    suspend_time = dt_util.utcnow() + timedelta(hours=1)
+    await hass.services.async_call(
+        automation.DOMAIN,
+        "suspend",
+        {
+            "entity_id": "automation.hello",
+            "until": suspend_time.isoformat(),
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # Manually turn on
+    await hass.services.async_call(
+        automation.DOMAIN,
+        SERVICE_TURN_ON,
+        {"entity_id": "automation.hello"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("automation.hello")
+    assert state is not None
+    assert state.state == STATE_ON
+    assert "suspended_until" not in state.attributes
+
+    # Fast forward time to when timer would have expired; ensure no extra toggle or issues
+    async_fire_time_changed(hass, suspend_time + timedelta(seconds=1))
+    await hass.async_block_till_done()
+    assert automation.is_on(hass, "automation.hello")
+
+
+async def test_automation_suspend_with_none_resumes(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Test calling suspend with no 'until' or until=None resumes the automation."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "alias": "hello",
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "action": {"action": "test.automation", "entity_id": "hello.world"},
+            }
+        },
+    )
+    suspend_time = dt_util.utcnow() + timedelta(hours=1)
+    await hass.services.async_call(
+        automation.DOMAIN,
+        "suspend",
+        {
+            "entity_id": "automation.hello",
+            "until": suspend_time.isoformat(),
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert not automation.is_on(hass, "automation.hello")
+
+    # Call suspend without until (or until=None)
+    await hass.services.async_call(
+        automation.DOMAIN,
+        "suspend",
+        {
+            "entity_id": "automation.hello",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("automation.hello")
+    assert state is not None
+    assert state.state == STATE_ON
+    assert "suspended_until" not in state.attributes
+
+
+async def test_automation_restore_suspended_future(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Test state restore when suspended_until is in the future."""
+    suspend_time = dt_util.utcnow() + timedelta(hours=2)
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                "automation.hello",
+                STATE_OFF,
+                {"suspended_until": suspend_time.isoformat()},
+            ),
+        ),
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "alias": "hello",
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "action": {"action": "test.automation", "entity_id": "hello.world"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("automation.hello")
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert state.attributes.get("suspended_until") == suspend_time.isoformat()
+
+    # Advance time past suspend_time
+    async_fire_time_changed(hass, suspend_time + timedelta(seconds=1))
+    await hass.async_block_till_done()
+
+    state = hass.states.get("automation.hello")
+    assert state is not None
+    assert state.state == STATE_ON
+    assert "suspended_until" not in state.attributes
+
+
+async def test_automation_restore_suspended_past(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Test state restore when suspended_until has already passed."""
+    suspend_time = dt_util.utcnow() - timedelta(minutes=10)
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                "automation.hello",
+                STATE_OFF,
+                {"suspended_until": suspend_time.isoformat()},
+            ),
+        ),
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "alias": "hello",
+                "trigger": {"platform": "event", "event_type": "test_event"},
+                "action": {"action": "test.automation", "entity_id": "hello.world"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("automation.hello")
+    assert state is not None
+    assert state.state == STATE_ON
+    assert "suspended_until" not in state.attributes
+
     await client.send_json(
         {
             "id": next_id(),


### PR DESCRIPTION
## Proposed change

Automations can be suspended by specifying suspend end time. This will disable the automation now and re-enable it when the suspend end time is reached. Any manual toggling of the state of the automation removes the suspend state and timer.

Home Assistant reboots and the system being off when the timer is reached are handled. Unit tests are added.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/54109

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
