### PR TITLE
Move websocket registration to async_setup in HTML5 integration

### DIFF
--- a/homeassistant/components/html5/__init__.py
+++ b/homeassistant/components/html5/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 from .services import async_setup_services
+from .websocket_api import async_register_websocket_api
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
@@ -18,6 +19,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the HTML5 services."""
 
     async_setup_services(hass)
+    async_register_websocket_api(hass)
     return True
 
 

--- a/homeassistant/components/html5/notify.py
+++ b/homeassistant/components/html5/notify.py
@@ -20,7 +20,6 @@ from pywebpush import WebPusher, WebPushException, webpush_async
 import voluptuous as vol
 from voluptuous.humanize import humanize_error
 
-from homeassistant.components import websocket_api
 from homeassistant.components.http import KEY_HASS, HomeAssistantView
 from homeassistant.components.notify import (
     ATTR_DATA,
@@ -31,10 +30,9 @@ from homeassistant.components.notify import (
     NotifyEntity,
     NotifyEntityFeature,
 )
-from homeassistant.components.websocket_api import ActiveConnection
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_NAME, URL_ROOT
-from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -54,7 +52,6 @@ from .const import (
     ATTR_TTL,
     ATTR_VAPID_EMAIL,
     ATTR_VAPID_PRV_KEY,
-    ATTR_VAPID_PUB_KEY,
     DOMAIN,
     REGISTRATIONS_FILE,
     SERVICE_DISMISS,
@@ -89,11 +86,6 @@ DEFAULT_BADGE = "/static/images/notification-badge.png"
 DEFAULT_ICON = "/static/icons/favicon-192x192.png"
 
 ATTR_JWT = "jwt"
-
-WS_TYPE_APPKEY = "notify/html5/appkey"
-SCHEMA_WS_APPKEY = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
-    {vol.Required("type"): WS_TYPE_APPKEY}
-)
 
 # The number of days after the moment a notification is sent that a JWT
 # is valid.
@@ -178,19 +170,8 @@ async def async_get_service(
 
     registrations = await hass.async_add_executor_job(_load_config, json_path)
 
-    vapid_pub_key: str = discovery_info[ATTR_VAPID_PUB_KEY]
     vapid_prv_key: str = discovery_info[ATTR_VAPID_PRV_KEY]
     vapid_email: str = discovery_info[ATTR_VAPID_EMAIL]
-
-    @callback
-    def websocket_appkey(
-        _hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
-    ) -> None:
-        connection.send_message(websocket_api.result_message(msg["id"], vapid_pub_key))
-
-    websocket_api.async_register_command(
-        hass, WS_TYPE_APPKEY, websocket_appkey, SCHEMA_WS_APPKEY
-    )
 
     hass.http.register_view(HTML5PushRegistrationView(registrations, json_path))
     hass.http.register_view(HTML5PushCallbackView(registrations))

--- a/homeassistant/components/html5/websocket_api.py
+++ b/homeassistant/components/html5/websocket_api.py
@@ -1,0 +1,41 @@
+"""HTML5 Websocket API."""
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.service import async_get_config_entry
+
+from .const import ATTR_VAPID_PUB_KEY, DOMAIN
+
+WS_TYPE_APPKEY = "notify/html5/appkey"
+SCHEMA_WS_APPKEY = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
+    {vol.Required("type"): WS_TYPE_APPKEY}
+)
+
+
+@callback
+def async_register_websocket_api(hass: HomeAssistant) -> None:
+    """Register the websocket API."""
+
+    websocket_api.async_register_command(hass, websocket_appkey)
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): WS_TYPE_APPKEY,
+    }
+)
+@websocket_api.async_response
+async def websocket_appkey(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Handle request for the VAPID public key."""
+    entry = async_get_config_entry(hass, DOMAIN, None)
+    connection.send_message(
+        websocket_api.result_message(msg["id"], entry.data[ATTR_VAPID_PUB_KEY])
+    )

--- a/homeassistant/components/html5/websocket_api.py
+++ b/homeassistant/components/html5/websocket_api.py
@@ -11,9 +11,6 @@ from homeassistant.helpers.service import async_get_config_entry
 from .const import ATTR_VAPID_PUB_KEY, DOMAIN
 
 WS_TYPE_APPKEY = "notify/html5/appkey"
-SCHEMA_WS_APPKEY = websocket_api.BASE_COMMAND_MESSAGE_SCHEMA.extend(
-    {vol.Required("type"): WS_TYPE_APPKEY}
-)
 
 
 @callback

--- a/tests/components/html5/test_websocket_api.py
+++ b/tests/components/html5/test_websocket_api.py
@@ -1,0 +1,32 @@
+"""Tests for HTML5 Websocket API."""
+
+from homeassistant.components.html5.websocket_api import WS_TYPE_APPKEY
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from .conftest import MOCK_CONF_PUB_KEY
+
+from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
+
+
+async def test_websocket_appkey(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test websocket appkey command."""
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id({"type": WS_TYPE_APPKEY})
+    response = await client.receive_json()
+
+    assert response["success"]
+    assert response["result"] == MOCK_CONF_PUB_KEY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


- The registration is moved to `async_setup` in the `__init__.py` module
- The Websocket command is not in it's own module ` websocket_api.py`
- A test for the websocket command was added

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
