### PR TITLE
Fix wolflink Bronze rule compliance: inject-websession, test-before-setup, config-flow-test-coverage

### DIFF
--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 from httpx import RequestError
 from wolf_comm.models import Device
-from wolf_comm.token_auth import InvalidAuth
+from wolf_comm.token_auth import InvalidAuth, PortalUnavailable
 from wolf_comm.wolf_client import FetchFailed, WolfClient
 
 from homeassistant.config_entries import ConfigEntry
@@ -34,6 +34,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: WolflinkConfigEntry) -> 
 
     try:
         devices = await wolf_client.fetch_system_list()
+    except PortalUnavailable as exception:
+        raise ConfigEntryNotReady(f"Portal unavailable: {exception}") from exception
     except InvalidAuth as exception:
         raise ConfigEntryAuthFailed(f"Invalid credentials: {exception}") from exception
     except (FetchFailed, RequestError) as exception:

--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -5,12 +5,13 @@ import logging
 
 from httpx import RequestError
 from wolf_comm.models import Device
+from wolf_comm.token_auth import InvalidAuth
 from wolf_comm.wolf_client import FetchFailed, WolfClient
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.httpx_client import create_async_httpx_client
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
@@ -33,6 +34,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: WolflinkConfigEntry) -> 
 
     try:
         devices = await wolf_client.fetch_system_list()
+    except InvalidAuth as exception:
+        raise ConfigEntryAuthFailed(f"Invalid credentials: {exception}") from exception
     except (FetchFailed, RequestError) as exception:
         raise ConfigEntryNotReady(
             f"Error communicating with API: {exception}"

--- a/homeassistant/components/wolflink/config_flow.py
+++ b/homeassistant/components/wolflink/config_flow.py
@@ -10,6 +10,7 @@ from wolf_comm.wolf_client import FetchFailed, WolfClient
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers.httpx_client import create_async_httpx_client
 
 from .const import DOMAIN
 
@@ -41,10 +42,14 @@ class WolfLinkConfigFlow(ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(user_input[CONF_USERNAME].lower())
             self._abort_if_unique_id_configured()
 
-            wolf_client = WolfClient(
-                user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
-            )
             try:
+                wolf_client = WolfClient(
+                    user_input[CONF_USERNAME],
+                    user_input[CONF_PASSWORD],
+                    client=create_async_httpx_client(
+                        hass=self.hass, verify_ssl=False, timeout=20
+                    ),
+                )
                 devices = await wolf_client.fetch_system_list()
             except RequestError, FetchFailed:
                 errors["base"] = "cannot_connect"

--- a/homeassistant/components/wolflink/config_flow.py
+++ b/homeassistant/components/wolflink/config_flow.py
@@ -1,11 +1,12 @@
 """Config flow for Wolf SmartSet Service integration."""
 
+from collections.abc import Mapping
 import logging
-from typing import override
+from typing import Any, override
 
 from httpx import RequestError
 import voluptuous as vol
-from wolf_comm.token_auth import InvalidAuth
+from wolf_comm.token_auth import InvalidAuth, PasswordToLong, PortalUnavailable
 from wolf_comm.wolf_client import FetchFailed, WolfClient
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -19,6 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 USER_SCHEMA = vol.Schema(
     {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
 )
+
+REAUTH_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
 
 
 class WolfLinkConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -51,7 +54,9 @@ class WolfLinkConfigFlow(ConfigFlow, domain=DOMAIN):
                     ),
                 )
                 devices = await wolf_client.fetch_system_list()
-            except RequestError, FetchFailed:
+            except PasswordToLong:
+                errors["base"] = "password_too_long"
+            except PortalUnavailable, RequestError, FetchFailed:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
@@ -70,4 +75,50 @@ class WolfLinkConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
         return self.async_show_form(
             step_id="user", data_schema=USER_SCHEMA, errors=errors
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle reauthentication."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reauthentication confirmation."""
+        errors: dict[str, str] = {}
+        reauth_entry = self._get_reauth_entry()
+        if user_input is not None:
+            try:
+                wolf_client = WolfClient(
+                    reauth_entry.data[CONF_USERNAME],
+                    user_input[CONF_PASSWORD],
+                    client=create_async_httpx_client(
+                        hass=self.hass, verify_ssl=False, timeout=20
+                    ),
+                )
+                await wolf_client.fetch_system_list()
+            except PasswordToLong:
+                errors["base"] = "password_too_long"
+            except PortalUnavailable, RequestError, FetchFailed:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data={
+                        **reauth_entry.data,
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=REAUTH_SCHEMA,
+            description_placeholders={CONF_USERNAME: reauth_entry.data[CONF_USERNAME]},
+            errors=errors,
         )

--- a/homeassistant/components/wolflink/strings.json
+++ b/homeassistant/components/wolflink/strings.json
@@ -2,14 +2,23 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
-      "no_devices": "No devices were found on this account."
+      "no_devices": "No devices were found on this account.",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "password_too_long": "Password must be 30 characters or fewer.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "description": "Re-enter the password for {username} to reauthenticate.",
+        "title": "[%key:common::config_flow::title::reauth%]"
+      },
       "user": {
         "data": {
           "password": "[%key:common::config_flow::data::password%]",

--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the Wolf SmartSet Service config flow."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from httpx import RequestError
 import pytest
@@ -44,16 +44,13 @@ async def test_show_form(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
 
 
-async def test_create_entry(hass: HomeAssistant) -> None:
+async def test_create_entry(hass: HomeAssistant, mock_wolflink: MagicMock) -> None:
     """Test entry creation only stores credentials, not the device list."""
     result = await _start_user_flow(hass)
+    mock_wolflink.fetch_system_list.return_value = [DEVICE, SECOND_DEVICE]
 
-    with (
-        patch(
-            "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
-            return_value=[DEVICE, SECOND_DEVICE],
-        ),
-        patch("homeassistant.components.wolflink.async_setup_entry", return_value=True),
+    with patch(
+        "homeassistant.components.wolflink.async_setup_entry", return_value=True
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=INPUT_CONFIG
@@ -74,28 +71,26 @@ async def test_create_entry(hass: HomeAssistant) -> None:
     ],
 )
 async def test_user_flow_errors(
-    hass: HomeAssistant, side_effect: Exception, expected_error: str
+    hass: HomeAssistant,
+    mock_wolflink: MagicMock,
+    side_effect: Exception,
+    expected_error: str,
 ) -> None:
-    """Test error handling in the user step keeps the form open with errors."""
+    """Test error handling keeps the form open and the flow can recover."""
     result = await _start_user_flow(hass)
 
-    with patch(
-        "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
-        side_effect=side_effect,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=INPUT_CONFIG
-        )
+    mock_wolflink.fetch_system_list.side_effect = side_effect
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=INPUT_CONFIG
+    )
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": expected_error}
 
-    with (
-        patch(
-            "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
-            return_value=[DEVICE],
-        ),
-        patch("homeassistant.components.wolflink.async_setup_entry", return_value=True),
+    mock_wolflink.fetch_system_list.side_effect = None
+    mock_wolflink.fetch_system_list.return_value = [DEVICE]
+    with patch(
+        "homeassistant.components.wolflink.async_setup_entry", return_value=True
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input=INPUT_CONFIG
@@ -104,17 +99,14 @@ async def test_user_flow_errors(
     assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
-async def test_no_devices_abort(hass: HomeAssistant) -> None:
+async def test_no_devices_abort(hass: HomeAssistant, mock_wolflink: MagicMock) -> None:
     """Test we abort if the account has no devices."""
     result = await _start_user_flow(hass)
+    mock_wolflink.fetch_system_list.return_value = []
 
-    with patch(
-        "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
-        return_value=[],
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=INPUT_CONFIG
-        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=INPUT_CONFIG
+    )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "no_devices"

--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -158,3 +158,35 @@ async def test_reauth_flow(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
     assert mock_config_entry.data[CONF_PASSWORD] == "new-password"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        pytest.param(PasswordToLong, "password_too_long", id="password_too_long"),
+        pytest.param(PortalUnavailable, "cannot_connect", id="portal_unavailable"),
+        pytest.param(RequestError("boom"), "cannot_connect", id="cannot_connect"),
+        pytest.param(Exception("boom"), "unknown", id="unknown"),
+    ],
+)
+async def test_reauth_flow_errors(
+    hass: HomeAssistant,
+    mock_wolflink: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    side_effect: Exception,
+    expected_error: str,
+) -> None:
+    """Test reauth error handling keeps the form open with the correct error."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    mock_wolflink.fetch_system_list.side_effect = side_effect
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_PASSWORD: "wrong-password"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected_error}

--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -90,6 +90,19 @@ async def test_user_flow_errors(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": expected_error}
 
+    with (
+        patch(
+            "homeassistant.components.wolflink.config_flow.WolfClient.fetch_system_list",
+            return_value=[DEVICE],
+        ),
+        patch("homeassistant.components.wolflink.async_setup_entry", return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input=INPUT_CONFIG
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
 
 async def test_no_devices_abort(hass: HomeAssistant) -> None:
     """Test we abort if the account has no devices."""

--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 from httpx import RequestError
 import pytest
 from wolf_comm.models import Device
-from wolf_comm.token_auth import InvalidAuth
+from wolf_comm.token_auth import InvalidAuth, PasswordToLong, PortalUnavailable
 
 from homeassistant import config_entries
 from homeassistant.components.wolflink.const import DOMAIN
@@ -66,7 +66,9 @@ async def test_create_entry(hass: HomeAssistant, mock_wolflink: MagicMock) -> No
     ("side_effect", "expected_error"),
     [
         pytest.param(InvalidAuth, "invalid_auth", id="invalid_auth"),
+        pytest.param(PortalUnavailable, "cannot_connect", id="portal_unavailable"),
         pytest.param(RequestError("boom"), "cannot_connect", id="cannot_connect"),
+        pytest.param(PasswordToLong, "password_too_long", id="password_too_long"),
         pytest.param(Exception("boom"), "unknown", id="unknown"),
     ],
 )
@@ -126,3 +128,33 @@ async def test_already_configured_aborts(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_reauth_flow(
+    hass: HomeAssistant,
+    mock_wolflink: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reauthentication updates the password and reloads the entry."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    mock_wolflink.fetch_system_list.side_effect = InvalidAuth
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_PASSWORD: "wrong-password"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    mock_wolflink.fetch_system_list.side_effect = None
+    mock_wolflink.fetch_system_list.return_value = [DEVICE]
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_PASSWORD: "new-password"}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data[CONF_PASSWORD] == "new-password"

--- a/tests/components/wolflink/test_init.py
+++ b/tests/components/wolflink/test_init.py
@@ -8,7 +8,7 @@ from freezegun.api import FrozenDateTimeFactory
 from httpx import RequestError
 import pytest
 from wolf_comm.models import Device
-from wolf_comm.token_auth import InvalidAuth
+from wolf_comm.token_auth import InvalidAuth, PortalUnavailable
 from wolf_comm.wolf_client import FetchFailed, ParameterReadError
 
 from homeassistant.components.wolflink.const import DOMAIN, MANUFACTURER
@@ -446,6 +446,32 @@ async def test_setup_fetch_parameters_fails(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert not hass.states.async_entity_ids("sensor")
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_state"),
+    [
+        pytest.param(
+            PortalUnavailable, ConfigEntryState.SETUP_RETRY, id="portal_unavailable"
+        ),
+        pytest.param(InvalidAuth, ConfigEntryState.SETUP_ERROR, id="invalid_auth"),
+    ],
+)
+async def test_setup_fetch_system_list_fails(
+    hass: HomeAssistant,
+    mock_wolflink: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    side_effect: type[Exception],
+    expected_state: ConfigEntryState,
+) -> None:
+    """Test fetch_system_list errors put the entry in the correct error state."""
+    mock_wolflink.fetch_system_list.side_effect = side_effect
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is expected_state
 
 
 async def test_system_share_id_forwarded_to_state_list(


### PR DESCRIPTION

## Proposed change

Addresses outstanding review comments on #174502 (wolflink Bronze quality scale PR).

**`test-before-setup`**: `async_setup_entry` now catches `InvalidAuth` from `fetch_system_list()` and raises `ConfigEntryAuthFailed` so expired credentials trigger a reauthentication flow instead of an unexpected setup exception.

**`inject-websession`**: The config flow now passes an HA-managed `httpx` client to `WolfClient` via `create_async_httpx_client`, replacing the unmanaged `AsyncClient` that wolf-comm previously created internally. `WolfClient` construction is also moved inside the `try` block so constructor exceptions (e.g. `PasswordToLong`) are caught and surfaced as flow errors.

**`config-flow-test-coverage`**: Config flow tests are refactored to use the shared `mock_wolflink` fixture. Error-path tests now retry with valid credentials after each error case to prove the flow can recover and reach `CREATE_ENTRY`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #174502
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr