### PR TITLE
Fix swallowed exceptions in mochad action handlers

### DIFF
--- a/homeassistant/components/mochad/light.py
+++ b/homeassistant/components/mochad/light.py
@@ -15,6 +15,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.const import CONF_ADDRESS, CONF_DEVICES, CONF_NAME, CONF_PLATFORM
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -119,9 +120,12 @@ class MochadLight(LightEntity):
                     self._adjust_brightness(brightness)
                 self._attr_brightness = brightness
                 self._attr_is_on = True
-            # pylint: disable-next=home-assistant-action-swallowed-exception
             except (MochadException, OSError) as exc:
-                _LOGGER.error("Error with mochad communication: %s", exc)
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="turn_on_failed",
+                    translation_placeholders={"error": str(exc)},
+                ) from exc
 
     @override
     def turn_off(self, **kwargs: Any) -> None:
@@ -138,6 +142,9 @@ class MochadLight(LightEntity):
                 if self._brightness_levels == 31:
                     self._attr_brightness = 0
                 self._attr_is_on = False
-            # pylint: disable-next=home-assistant-action-swallowed-exception
             except (MochadException, OSError) as exc:
-                _LOGGER.error("Error with mochad communication: %s", exc)
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="turn_off_failed",
+                    translation_placeholders={"error": str(exc)},
+                ) from exc

--- a/homeassistant/components/mochad/strings.json
+++ b/homeassistant/components/mochad/strings.json
@@ -1,0 +1,10 @@
+{
+  "exceptions": {
+    "turn_off_failed": {
+      "message": "Failed to turn off X10 device: {error}"
+    },
+    "turn_on_failed": {
+      "message": "Failed to turn on X10 device: {error}"
+    }
+  }
+}

--- a/homeassistant/components/mochad/switch.py
+++ b/homeassistant/components/mochad/switch.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import CONF_ADDRESS, CONF_DEVICES, CONF_NAME, CONF_PLATFORM
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -79,9 +80,12 @@ class MochadSwitch(SwitchEntity):
                 if self._comm_type == "pl":
                     self._controller.read_data()
                 self._attr_is_on = True
-            # pylint: disable-next=home-assistant-action-swallowed-exception
             except (MochadException, OSError) as exc:
-                _LOGGER.error("Error with mochad communication: %s", exc)
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="turn_on_failed",
+                    translation_placeholders={"error": str(exc)},
+                ) from exc
 
     @override
     def turn_off(self, **kwargs: Any) -> None:
@@ -97,9 +101,12 @@ class MochadSwitch(SwitchEntity):
                 if self._comm_type == "pl":
                     self._controller.read_data()
                 self._attr_is_on = False
-            # pylint: disable-next=home-assistant-action-swallowed-exception
             except (MochadException, OSError) as exc:
-                _LOGGER.error("Error with mochad communication: %s", exc)
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="turn_off_failed",
+                    translation_placeholders={"error": str(exc)},
+                ) from exc
 
     def _get_device_status(self) -> bool:
         """Get the status of the switch from mochad."""

--- a/tests/components/mochad/test_light.py
+++ b/tests/components/mochad/test_light.py
@@ -2,11 +2,13 @@
 
 from unittest import mock
 
+from pymochad.exceptions import MochadException
 import pytest
 
 from homeassistant.components import light
-from homeassistant.components.mochad import light as mochad
+from homeassistant.components.mochad import DOMAIN, light as mochad
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 
@@ -65,3 +67,20 @@ async def test_turn_off(light_mock) -> None:
     """Test turn_off."""
     light_mock.turn_off()
     light_mock.light.send_cmd.assert_called_once_with("off")
+
+
+@pytest.mark.parametrize(
+    ("brightness", "action", "translation_key"),
+    [(32, "turn_on", "turn_on_failed"), (32, "turn_off", "turn_off_failed")],
+)
+async def test_action_raises_on_communication_error(
+    light_mock: mochad.MochadLight, action: str, translation_key: str
+) -> None:
+    """Test that a failed action raises instead of being swallowed."""
+    light_mock.light.send_cmd.side_effect = MochadException("boom")
+    with pytest.raises(HomeAssistantError) as exc_info:
+        getattr(light_mock, action)()
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == translation_key
+    assert "error" in exc_info.value.translation_placeholders

--- a/tests/components/mochad/test_switch.py
+++ b/tests/components/mochad/test_switch.py
@@ -2,11 +2,13 @@
 
 from unittest import mock
 
+from pymochad.exceptions import MochadException
 import pytest
 
 from homeassistant.components import switch
-from homeassistant.components.mochad import switch as mochad
+from homeassistant.components.mochad import DOMAIN, switch as mochad
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockEntityPlatform
@@ -59,3 +61,24 @@ async def test_turn_off(switch_mock) -> None:
     """Test turn_off."""
     switch_mock.turn_off()
     switch_mock.switch.send_cmd.assert_called_once_with("off")
+
+
+@pytest.mark.parametrize(
+    ("action", "translation_key"),
+    [("turn_on", "turn_on_failed"), ("turn_off", "turn_off_failed")],
+)
+async def test_action_raises_on_communication_error(
+    switch_mock: mochad.MochadSwitch, action: str, translation_key: str
+) -> None:
+    """Test that a failed action raises instead of being swallowed."""
+    with mock.patch(
+        "homeassistant.components.mochad.switch.MochadException",
+        MochadException,
+    ):
+        switch_mock.switch.send_cmd.side_effect = MochadException("boom")
+        with pytest.raises(HomeAssistantError) as exc_info:
+            getattr(switch_mock, action)()
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == translation_key
+    assert "error" in exc_info.value.translation_placeholders


### PR DESCRIPTION
## Breaking change

<!-- If your PR contains a breaking change for existing users, it is important
to tell them what breaks, how to make it work again and why we did this.
This piece of text is published with the release notes, so it helps if you
write it towards our users, not us.
Note: Remove this section if this PR is NOT a breaking change. -->

## Proposed change

<!-- Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug
or resolves a feature request, be sure to link to that issue in the
additional information section. -->

failing switch and light actions in the mochad integration only logged the error, so the user got no feedback in the UI and automations kept running as if the action succeeded

this raises HomeAssistantError with a translated message instead (translation keys turn_on_failed / turn_off_failed), which is what #170671 asks for, and removes the four pylint disables

### Steps to reproduce

1. run `.venv/bin/python -m pytest tests/components/mochad/ -q` on dev without the fix
2. Expected: a failing turn_on/turn_off call raises HomeAssistantError
3. Actual (raw output on untouched dev): `Failed: DID NOT RAISE <class 'homeassistant.exceptions.HomeAssistantError'>`, the call succeeds silently while the error only shows in the logs

## Type of change

<!-- What type of change does your PR introduce to Home Assistant?
NOTE: Please, check only 1! box!
If your PR requires multiple boxes to be checked, you'll most likely need to
split it into multiple PRs. This makes things easier and faster to code review. -->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!-- Details are important, and help maintainers processing your PR.
Please be sure to fill out additional details, if applicable. -->

- This PR fixes or closes issue: fixes #170671
- This PR is related to issue: home-assistant/epics#64
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look
for before merging your code.

AI tools are welcome, but contributors are responsible for *fully*
understanding the code before submitting a PR. Please follow our AI policy:
https://developers.home-assistant.io/docs/ai_policy -->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
