### PR TITLE
Add access_token option to Matrix

### DIFF
--- a/homeassistant/components/matrix/__init__.py
+++ b/homeassistant/components/matrix/__init__.py
@@ -28,6 +28,7 @@ import voluptuous as vol
 
 from homeassistant.components.notify import ATTR_DATA, ATTR_MESSAGE, ATTR_TARGET
 from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_USERNAME,
@@ -67,6 +68,8 @@ CONF_EXPRESSION: Final = "expression"
 CONF_REACTION: Final = "reaction"
 
 CONF_USERNAME_REGEX = "^@[^:]*:.*"
+
+CREDENTIALS_MESSAGE = "Specify either 'password' or 'access_token', not both."
 
 EVENT_MATRIX_COMMAND = "matrix_command"
 
@@ -108,17 +111,25 @@ COMMAND_SCHEMA = vol.All(
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_HOMESERVER): cv.url,
-                vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
-                vol.Required(CONF_USERNAME): cv.matches_regex(CONF_USERNAME_REGEX),
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(CONF_ROOMS, default=[]): vol.All(
-                    cv.ensure_list, [cv.matches_regex(CONF_ROOMS_REGEX)]
-                ),
-                vol.Optional(CONF_COMMANDS, default=[]): [COMMAND_SCHEMA],
-            }
+        DOMAIN: vol.All(
+            vol.Schema(
+                {
+                    vol.Required(CONF_HOMESERVER): cv.url,
+                    vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
+                    vol.Required(CONF_USERNAME): cv.matches_regex(CONF_USERNAME_REGEX),
+                    vol.Exclusive(
+                        CONF_PASSWORD, "credentials", CREDENTIALS_MESSAGE
+                    ): cv.string,
+                    vol.Exclusive(
+                        CONF_ACCESS_TOKEN, "credentials", CREDENTIALS_MESSAGE
+                    ): cv.string,
+                    vol.Optional(CONF_ROOMS, default=[]): vol.All(
+                        cv.ensure_list, [cv.matches_regex(CONF_ROOMS_REGEX)]
+                    ),
+                    vol.Optional(CONF_COMMANDS, default=[]): [COMMAND_SCHEMA],
+                }
+            ),
+            cv.has_at_least_one_key(CONF_PASSWORD, CONF_ACCESS_TOKEN),
         )
     },
     extra=vol.ALLOW_EXTRA,
@@ -141,7 +152,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         config[CONF_HOMESERVER],
         config[CONF_VERIFY_SSL],
         config[CONF_USERNAME],
-        config[CONF_PASSWORD],
+        config.get(CONF_PASSWORD),
+        config.get(CONF_ACCESS_TOKEN),
         config[CONF_ROOMS],
         config[CONF_COMMANDS],
     )
@@ -163,7 +175,8 @@ class MatrixBot:
         homeserver: str,
         verify_ssl: bool,
         username: str,
-        password: str,
+        password: str | None,
+        access_token: str | None,
         listening_rooms: list[RoomAnyID],
         commands: list[ConfigCommand],
     ) -> None:
@@ -177,6 +190,7 @@ class MatrixBot:
         self._verify_tls = verify_ssl
         self._mx_id = username
         self._password = password
+        self._configured_access_token = access_token
 
         self._client = AsyncClient(
             homeserver=self._homeserver, user=self._mx_id, ssl=self._verify_tls
@@ -416,14 +430,21 @@ class MatrixBot:
     async def _login(self) -> None:
         """Log in to the Matrix homeserver.
 
-        Attempts to use the stored access token.
+        Attempts to use the configured access token, or else the one stored
+        from a previous session.
         If that fails, then tries using the password.
-        If that also fails, raises LocalProtocolError.
+        If that also fails, raises ConfigEntryAuthFailed.
         """
 
-        # If we have an access token
-        if (token := self._access_tokens.get(self._mx_id)) is not None:
+        token: str | None = None
+        if self._configured_access_token is not None:
+            token = self._configured_access_token
+            _LOGGER.debug("Restoring login from configured access token")
+        elif isinstance(stored_token := self._access_tokens.get(self._mx_id), str):
+            token = stored_token
             _LOGGER.debug("Restoring login from stored access token")
+
+        if token is not None:
             self._client.restore_login(
                 user_id=self._client.user_id,
                 device_id=self._client.device_id,
@@ -448,7 +469,7 @@ class MatrixBot:
                 )
 
         # If the token login did not succeed
-        if not self._client.logged_in:
+        if not self._client.logged_in and self._password is not None:
             response = await self._client.login(password=self._password)
             _LOGGER.debug("Logging in using password")
 
@@ -460,11 +481,12 @@ class MatrixBot:
                 )
 
         if not self._client.logged_in:
-            raise ConfigEntryAuthFailed(
-                "Login failed, both token and username/password are invalid"
-            )
+            raise ConfigEntryAuthFailed("Login failed, the credentials are invalid")
 
-        await self._store_auth_token(self._client.access_token)
+        # A configured access token is managed by the user, so only persist
+        # tokens that were obtained here.
+        if self._client.access_token != self._configured_access_token:
+            await self._store_auth_token(self._client.access_token)
 
     async def _handle_room_send(
         self, target_room: RoomAnyID, message_type: str, content: dict

--- a/homeassistant/components/matrix/__init__.py
+++ b/homeassistant/components/matrix/__init__.py
@@ -472,12 +472,21 @@ class MatrixBot:
                     ""  # Force a soft-logout if the homeserver didn't.
                 )
             elif isinstance(response, WhoamiResponse):
-                _LOGGER.debug(
-                    "Successfully restored login from access token:"
-                    " user_id '%s', device_id '%s'",
-                    response.user_id,
-                    response.device_id,
-                )
+                if response.user_id != self._mx_id:
+                    _LOGGER.warning(
+                        "The access token belongs to '%s', not to the configured"
+                        " username '%s'",
+                        response.user_id,
+                        self._mx_id,
+                    )
+                    self._client.access_token = ""
+                else:
+                    _LOGGER.debug(
+                        "Successfully restored login from access token:"
+                        " user_id '%s', device_id '%s'",
+                        response.user_id,
+                        response.device_id,
+                    )
 
         # If the token login did not succeed
         if not self._client.logged_in and self._password is not None:

--- a/homeassistant/components/matrix/__init__.py
+++ b/homeassistant/components/matrix/__init__.py
@@ -16,6 +16,7 @@ from nio.responses import (
     JoinError,
     JoinResponse,
     LoginError,
+    LoginInfoError,
     Response,
     RoomResolveAliasResponse,
     UploadError,
@@ -427,6 +428,16 @@ class MatrixBot:
             True,  # private=True
         )
 
+    async def _password_login_supported(self) -> bool:
+        """Return whether the homeserver offers password login."""
+        response = await self._client.login_info()
+        if isinstance(response, LoginInfoError):
+            _LOGGER.debug(
+                "Could not retrieve the supported login flows: %s", response.message
+            )
+            return True
+        return "m.login.password" in response.flows
+
     async def _login(self) -> None:
         """Log in to the Matrix homeserver.
 
@@ -481,6 +492,14 @@ class MatrixBot:
                 )
 
         if not self._client.logged_in:
+            if (
+                self._password is not None
+                and not await self._password_login_supported()
+            ):
+                raise ConfigEntryAuthFailed(
+                    "The homeserver does not offer password login, configure the"
+                    " 'access_token' option instead"
+                )
             raise ConfigEntryAuthFailed("Login failed, the credentials are invalid")
 
         # A configured access token is managed by the user, so only persist

--- a/tests/components/matrix/conftest.py
+++ b/tests/components/matrix/conftest.py
@@ -74,6 +74,9 @@ TEST_MXID = "@user:example.com"
 TEST_DEVICE_ID = "FAKEID"
 TEST_PASSWORD = "password"
 TEST_TOKEN = "access_token"
+TEST_OTHER_MXID = "@other_user:example.com"
+TEST_OTHER_TOKEN = "other_access_token"
+TEST_TOKEN_OWNERS = {TEST_TOKEN: TEST_MXID, TEST_OTHER_TOKEN: TEST_OTHER_MXID}
 
 NIO_IMPORT_PREFIX = "homeassistant.components.matrix.nio."
 
@@ -116,11 +119,11 @@ class _MockAsyncClient(AsyncClient):
         self.access_token = ""
 
     async def whoami(self):
-        if self.access_token == TEST_TOKEN:
-            self.user_id = TEST_MXID
+        if (user_id := TEST_TOKEN_OWNERS.get(self.access_token)) is not None:
+            self.user_id = user_id
             self.device_id = TEST_DEVICE_ID
             return WhoamiResponse(
-                user_id=TEST_MXID, device_id=TEST_DEVICE_ID, is_guest=False
+                user_id=user_id, device_id=TEST_DEVICE_ID, is_guest=False
             )
         self.access_token = ""
         return WhoamiError(

--- a/tests/components/matrix/conftest.py
+++ b/tests/components/matrix/conftest.py
@@ -1,9 +1,11 @@
 """Define fixtures available for all tests."""
 
 from collections.abc import Generator
+from copy import deepcopy
 from pathlib import Path
 import re
 import tempfile
+from typing import Any
 from unittest.mock import patch
 
 from nio import (
@@ -41,6 +43,7 @@ from homeassistant.components.matrix.const import DOMAIN
 from homeassistant.components.matrix.notify import CONF_DEFAULT_ROOM
 from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PLATFORM,
@@ -173,6 +176,17 @@ MOCK_CONFIG_DATA = {
         CONF_DEFAULT_ROOM: TEST_DEFAULT_ROOM,
     },
 }
+
+
+def config_with_credentials(credentials: dict[str, str]) -> dict[str, Any]:
+    """Return MOCK_CONFIG_DATA with the password replaced by the given credentials."""
+    config = deepcopy(MOCK_CONFIG_DATA)
+    del config[DOMAIN][CONF_PASSWORD]
+    config[DOMAIN] |= credentials
+    return config
+
+
+MOCK_CONFIG_DATA_ACCESS_TOKEN = config_with_credentials({CONF_ACCESS_TOKEN: TEST_TOKEN})
 
 MOCK_WORD_COMMANDS = {
     TEST_ROOM_A_ID: {

--- a/tests/components/matrix/conftest.py
+++ b/tests/components/matrix/conftest.py
@@ -15,6 +15,7 @@ from nio import (
     JoinResponse,
     LocalProtocolError,
     LoginError,
+    LoginInfoResponse,
     LoginResponse,
     Response,
     RoomResolveAliasError,
@@ -94,6 +95,11 @@ class _MockAsyncClient(AsyncClient):
         if room_id in TEST_JOINABLE_ROOMS.values():
             return JoinResponse(room_id=room_id)
         return JoinError(message="Not allowed to join this room.")
+
+    login_flows: list[str] = ["m.login.password"]
+
+    async def login_info(self, *args, **kwargs):
+        return LoginInfoResponse(self.login_flows)
 
     async def login(self, *args, **kwargs):
         if kwargs.get("password") == TEST_PASSWORD or kwargs.get("token") == TEST_TOKEN:

--- a/tests/components/matrix/test_login.py
+++ b/tests/components/matrix/test_login.py
@@ -1,6 +1,7 @@
 """Test MatrixBot._login."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -14,11 +15,14 @@ from .conftest import TEST_DEVICE_ID, TEST_MXID, TEST_PASSWORD, TEST_TOKEN
 class LoginTestParameters:
     """Login parameters and expected result state."""
 
-    password: str
+    password: str | None
     access_token: dict[str, str]
     expected_login_state: bool
     expected_caplog_messages: set[str]
     expected_expection: type[Exception] | None = None
+    configured_access_token: str | None = None
+    unexpected_caplog_messages: set[str] = field(default_factory=set)
+    expected_token_stored: bool = True
 
 
 good_password_missing_token = LoginTestParameters(
@@ -63,6 +67,7 @@ bad_password_bad_access_token = LoginTestParameters(
         "Login by password failed: status_code, LoginError",
     },
     expected_expection=ConfigEntryAuthFailed,
+    expected_token_stored=False,
 )
 
 bad_password_missing_access_token = LoginTestParameters(
@@ -74,6 +79,50 @@ bad_password_missing_access_token = LoginTestParameters(
         "Login by password failed: status_code, LoginError",
     },
     expected_expection=ConfigEntryAuthFailed,
+    expected_token_stored=False,
+)
+
+configured_token_no_password = LoginTestParameters(
+    password=None,
+    configured_access_token=TEST_TOKEN,
+    access_token={},
+    expected_login_state=True,
+    expected_caplog_messages={
+        "Restoring login from configured access token",
+        "Successfully restored login from access token:"
+        f" user_id '{TEST_MXID}', device_id '{TEST_DEVICE_ID}'",
+    },
+    unexpected_caplog_messages={"Logging in using password"},
+    expected_token_stored=False,
+)
+
+configured_token_overrides_stored_token = LoginTestParameters(
+    password=None,
+    configured_access_token=TEST_TOKEN,
+    access_token={TEST_MXID: "WrongToken"},
+    expected_login_state=True,
+    expected_caplog_messages={
+        "Restoring login from configured access token",
+        "Successfully restored login from access token:"
+        f" user_id '{TEST_MXID}', device_id '{TEST_DEVICE_ID}'",
+    },
+    unexpected_caplog_messages={"Restoring login from stored access token"},
+    expected_token_stored=False,
+)
+
+bad_configured_token_no_password = LoginTestParameters(
+    password=None,
+    configured_access_token="WrongToken",
+    access_token={},
+    expected_login_state=False,
+    expected_caplog_messages={
+        "Restoring login from configured access token",
+        "Restoring login from access token failed:"
+        " M_UNKNOWN_TOKEN, Invalid access token passed.",
+    },
+    unexpected_caplog_messages={"Logging in using password"},
+    expected_expection=ConfigEntryAuthFailed,
+    expected_token_stored=False,
 )
 
 
@@ -85,15 +134,24 @@ bad_password_missing_access_token = LoginTestParameters(
         bad_password_good_access_token,
         bad_password_bad_access_token,
         bad_password_missing_access_token,
+        configured_token_no_password,
+        configured_token_overrides_stored_token,
+        bad_configured_token_no_password,
     ],
 )
 async def test_login(
-    matrix_bot: MatrixBot, caplog: pytest.LogCaptureFixture, params: LoginTestParameters
+    matrix_bot: MatrixBot,
+    caplog: pytest.LogCaptureFixture,
+    mock_save_json: MagicMock,
+    params: LoginTestParameters,
 ) -> None:
     """Test logging in with the given parameters and expected state."""
     await matrix_bot._client.logout()
     matrix_bot._password = params.password
+    matrix_bot._configured_access_token = params.configured_access_token
     matrix_bot._access_tokens = params.access_token
+    # The matrix_bot fixture already logged in and stored a token during startup.
+    mock_save_json.reset_mock()
 
     if params.expected_expection:
         with pytest.raises(params.expected_expection):
@@ -102,6 +160,8 @@ async def test_login(
         await matrix_bot._login()
     assert matrix_bot._client.logged_in == params.expected_login_state
     assert set(caplog.messages).issuperset(params.expected_caplog_messages)
+    assert set(caplog.messages).isdisjoint(params.unexpected_caplog_messages)
+    assert mock_save_json.called == params.expected_token_stored
 
 
 async def test_get_auth_tokens(matrix_bot: MatrixBot, mock_load_json) -> None:

--- a/tests/components/matrix/test_login.py
+++ b/tests/components/matrix/test_login.py
@@ -164,6 +164,21 @@ async def test_login(
     assert mock_save_json.called == params.expected_token_stored
 
 
+async def test_login_password_not_supported(
+    matrix_bot: MatrixBot, mock_save_json: MagicMock
+) -> None:
+    """Test the error raised when the homeserver has no password login flow."""
+    await matrix_bot._client.logout()
+    matrix_bot._password = "WrongPassword"
+    matrix_bot._access_tokens = {}
+    matrix_bot._client.login_flows = ["m.login.sso", "m.login.token"]
+    mock_save_json.reset_mock()
+
+    with pytest.raises(ConfigEntryAuthFailed, match="does not offer password login"):
+        await matrix_bot._login()
+    mock_save_json.assert_not_called()
+
+
 async def test_get_auth_tokens(matrix_bot: MatrixBot, mock_load_json) -> None:
     """Test loading access_tokens from a mocked file."""
 

--- a/tests/components/matrix/test_login.py
+++ b/tests/components/matrix/test_login.py
@@ -8,7 +8,14 @@ import pytest
 from homeassistant.components.matrix import MatrixBot
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 
-from .conftest import TEST_DEVICE_ID, TEST_MXID, TEST_PASSWORD, TEST_TOKEN
+from .conftest import (
+    TEST_DEVICE_ID,
+    TEST_MXID,
+    TEST_OTHER_MXID,
+    TEST_OTHER_TOKEN,
+    TEST_PASSWORD,
+    TEST_TOKEN,
+)
 
 
 @dataclass
@@ -125,6 +132,33 @@ bad_configured_token_no_password = LoginTestParameters(
     expected_token_stored=False,
 )
 
+configured_token_for_other_user = LoginTestParameters(
+    password=None,
+    configured_access_token=TEST_OTHER_TOKEN,
+    access_token={},
+    expected_login_state=False,
+    expected_caplog_messages={
+        "Restoring login from configured access token",
+        f"The access token belongs to '{TEST_OTHER_MXID}', not to the configured"
+        f" username '{TEST_MXID}'",
+    },
+    unexpected_caplog_messages={"Logging in using password"},
+    expected_expection=ConfigEntryAuthFailed,
+    expected_token_stored=False,
+)
+
+stored_token_for_other_user = LoginTestParameters(
+    password=TEST_PASSWORD,
+    access_token={TEST_MXID: TEST_OTHER_TOKEN},
+    expected_login_state=True,
+    expected_caplog_messages={
+        "Restoring login from stored access token",
+        f"The access token belongs to '{TEST_OTHER_MXID}', not to the configured"
+        f" username '{TEST_MXID}'",
+        "Logging in using password",
+    },
+)
+
 
 @pytest.mark.parametrize(
     "params",
@@ -137,6 +171,8 @@ bad_configured_token_no_password = LoginTestParameters(
         configured_token_no_password,
         configured_token_overrides_stored_token,
         bad_configured_token_no_password,
+        configured_token_for_other_user,
+        stored_token_for_other_user,
     ],
 )
 async def test_login(

--- a/tests/components/matrix/test_matrix_bot.py
+++ b/tests/components/matrix/test_matrix_bot.py
@@ -1,5 +1,9 @@
 """Configure and test MatrixBot."""
 
+from unittest.mock import MagicMock
+
+import pytest
+
 from homeassistant.components.matrix import MatrixBot
 from homeassistant.components.matrix.const import (
     DOMAIN,
@@ -7,9 +11,17 @@ from homeassistant.components.matrix.const import (
     SERVICE_SEND_MESSAGE,
 )
 from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
-from .conftest import TEST_NOTIFIER_NAME
+from .conftest import (
+    MOCK_CONFIG_DATA_ACCESS_TOKEN,
+    TEST_NOTIFIER_NAME,
+    TEST_PASSWORD,
+    TEST_TOKEN,
+    config_with_credentials,
+)
 
 
 async def test_services(hass: HomeAssistant, matrix_bot: MatrixBot) -> None:
@@ -25,3 +37,44 @@ async def test_services(hass: HomeAssistant, matrix_bot: MatrixBot) -> None:
     # Verify that the matrix notifier is registered
     assert (notify_service := services.get(NOTIFY_DOMAIN))
     assert TEST_NOTIFIER_NAME in notify_service
+
+
+@pytest.mark.usefixtures("mock_client", "mock_allowed_path")
+async def test_setup_with_access_token(
+    hass: HomeAssistant, mock_save_json: MagicMock
+) -> None:
+    """Test setting up with an access_token instead of a password."""
+    assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG_DATA_ACCESS_TOKEN)
+    await hass.async_block_till_done()
+
+    assert isinstance(matrix_bot := hass.data[DOMAIN], MatrixBot)
+    assert matrix_bot._password is None
+    assert matrix_bot._configured_access_token == TEST_TOKEN
+
+    await hass.async_start()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert matrix_bot._client.logged_in
+    # A user-managed access token is not copied into the session file.
+    mock_save_json.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "credentials",
+    [
+        pytest.param({}, id="no_credentials"),
+        pytest.param(
+            {CONF_PASSWORD: TEST_PASSWORD, CONF_ACCESS_TOKEN: TEST_TOKEN},
+            id="both_credentials",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_client", "mock_save_json")
+async def test_invalid_credentials_config(
+    hass: HomeAssistant, credentials: dict[str, str]
+) -> None:
+    """Test that exactly one of password and access_token is required."""
+    assert not await async_setup_component(
+        hass, DOMAIN, config_with_credentials(credentials)
+    )
+    assert DOMAIN not in hass.data


### PR DESCRIPTION
## Proposed change
The Matrix integration can only authenticate with a username and password. Homeservers that use Matrix Authentication Service (MAS) with an external SSO provider disable password login, which leaves the integration with no credential it can use.

MAS (as well as Synapse) allows to create long lived access tokens instead, which can still be used even with disabled password login. People on home-assistant/core#104138 work around the gap by writing the file that stores the token retrieved automatically when using a password-login by hand. This PR makes the token a configuration option instead:

```yaml
matrix:
  homeserver: https://matrix.example.org
  username: "@bot:example.org"
  access_token: !secret matrix_access_token
  rooms:
    - "!room:example.org"
```

`password` and `access_token` are mutually exclusive and exactly one is required, so existing configurations are unaffected.

Behavior:

- A configured access token takes precedence over the one cached in `.matrix.conf`.
- The password branch is skipped when no password is configured, so a rejected token fails immediately instead of attempting a login that cannot succeed.
- A configured token is not written to `.matrix.conf`. It is a credential the user manages, so Home Assistant does not persist a copy of it.
- Reading the stored token is now guarded with `isinstance(..., str)`, which a  `str | None` local requires.

The second commit improves the failure that sends people here in the first place. A homeserver without password login answers a password attempt with a bare `M_UNKNOWN, Invalid login type`, which says nothing about what to do. When the login has failed, the integration now checks the advertised login flows and, if `m.login.password` is not among them, raises:

`The homeserver does not offer password login, configure the 'access_token' option instead`

This was verified against a live Matrix Authentication Service homeserver with `passwords.enabled: false`, which advertises only `m.login.sso` and `m.login.token`.

The existing log messages are unchanged, so the five existing login tests still apply as written. Three new cases cover a configured token with no password, a configured token taking precedence over a stored one, and a rejected configured token; two more tests cover the schema accepting a token-only configuration and rejecting both credentials or neither.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

(classified like this because #104138 is classified as a "bug". It also could be a new feature tbh.

## Additional information
- This PR fixes or closes issue: fixes #104138
- This PR is related to issue:
- Link to documentation pull request: home-assistant/home-assistant.io#48070
- Link to developer documentation pull request:
- Link to frontend pull request:


## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
(unfortunately, i have not yet. I'll look into it!)

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
