### PR TITLE
Bump zhong-hong-hvac to 1.0.21

### DIFF
--- a/homeassistant/components/zhong_hong/manifest.json
+++ b/homeassistant/components/zhong_hong/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "loggers": ["zhong_hong_hvac"],
   "quality_scale": "legacy",
-  "requirements": ["zhong-hong-hvac==1.0.19"]
+  "requirements": ["zhong-hong-hvac==1.0.21"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3555,7 +3555,7 @@ zha-quirks==2.2.2
 zha==2.2.2
 
 # homeassistant.components.zhong_hong
-zhong-hong-hvac==1.0.19
+zhong-hong-hvac==1.0.21
 
 # homeassistant.components.ziggo_mediabox_xl
 ziggo-mediabox-xl==1.1.0


### PR DESCRIPTION
## Proposed change

Bump `zhong-hong-hvac` from 1.0.19 to 1.0.21, which fixes three races in the connection lifecycle. All are reachable today, and a coordinator polling the gateway on a timer would meet them far more often, which is what turned them up.

The gateway takes one connection at a time, so a connection left open that nobody is listening to is the one the next attempt is refused by. Two of the three are ways to end up holding exactly that.

**A stopped hub reconnects the socket a send in flight lost.** `stop_listen()` closes the socket, but a `send()` already on its way out finds it gone and reconnects, and `_ensure_socket()` opened one for any caller that came along afterwards. A stopped hub now refuses to open a socket, and `send()` gives up at once rather than spending its retries finding that out; starting to listen again, or a discovery, puts it back to work.

**A connect already in flight claims its socket after the stop.** `stop_listen()` does not take the socket lock, and cannot — it has to be able to interrupt a connect. So it can run all the way through while `open_socket()` is connecting, find nothing to close because the socket does not exist yet, and leave the connect to then assign a live socket nobody will ever close. Whoever is left holding it now notices: `open_socket()` looks again before claiming it, closes it, and tells the caller. (1.0.20 closed the first path and not this one; 1.0.21 covers it.)

**`start_listen()` returns before the listener thread is running.** `Thread.start()` returning says the thread was created, not that it has run, and `thread_main()` is what sets the flag `connected` requires. A caller that asks about the gateway the moment `start_listen()` returns could be told a healthy one had been lost, and act on it — for an integration, a setup that goes to `SETUP_RETRY` for no reason. It now waits to be told the thread is running, and warns rather than blocking for good if it never is.

- Library diff: https://github.com/crhan/ZhongHongHVAC/compare/v1.0.19...v1.0.21
- Release notes: https://github.com/crhan/ZhongHongHVAC/releases/tag/v1.0.21 and https://github.com/crhan/ZhongHongHVAC/releases/tag/v1.0.20

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #181897
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The manifest file has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
