### PR TITLE
Preserve form values on error in Remote Calendar config flow

### DIFF
--- a/homeassistant/components/remote_calendar/config_flow.py
+++ b/homeassistant/components/remote_calendar/config_flow.py
@@ -71,12 +71,8 @@ class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                     return await self.async_step_auth()
             if res.status_code == HTTPStatus.FORBIDDEN:
                 errors["base"] = "forbidden"
-                return self.async_show_form(
-                    step_id="user",
-                    data_schema=STEP_USER_DATA_SCHEMA,
-                    errors=errors,
-                )
-            res.raise_for_status()
+            else:
+                res.raise_for_status()
         except TimeoutException as err:
             errors["base"] = "timeout_connect"
             _LOGGER.debug(
@@ -86,18 +82,21 @@ class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
             errors["base"] = "cannot_connect"
             _LOGGER.debug("An error occurred: %s", str(err) or type(err).__name__)
         else:
-            try:
-                await parse_calendar(self.hass, res.text)
-            except InvalidIcsException:
-                errors["base"] = "invalid_ics_file"
-            else:
-                return self.async_create_entry(
-                    title=user_input[CONF_CALENDAR_NAME], data=user_input
-                )
+            if not errors:
+                try:
+                    await parse_calendar(self.hass, res.text)
+                except InvalidIcsException:
+                    errors["base"] = "invalid_ics_file"
+                else:
+                    return self.async_create_entry(
+                        title=user_input[CONF_CALENDAR_NAME], data=user_input
+                    )
 
         return self.async_show_form(
             step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA, user_input
+            ),
             errors=errors,
         )
 

--- a/tests/components/remote_calendar/test_config_flow.py
+++ b/tests/components/remote_calendar/test_config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from . import setup_integration
 from .conftest import CALENDAR_NAME, CALENDER_URL
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, get_schema_suggested_value
 
 
 @respx.mock
@@ -77,6 +77,61 @@ async def test_form_import_webcal(hass: HomeAssistant, ics_content: str) -> None
     }
 
 
+@respx.mock
+async def test_form_import_webcal_error(hass: HomeAssistant, ics_content: str) -> None:
+    """Test webcal URL error re-displays form with suggested values."""
+    respx.get(CALENDER_URL).mock(side_effect=HTTPError("Connection failed"))
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_CALENDAR_NAME: CALENDAR_NAME,
+            CONF_URL: "webcal://some.calendar.com/calendar.ics",
+            CONF_VERIFY_SSL: False,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_CALENDAR_NAME)
+        == CALENDAR_NAME
+    )
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_URL)
+        == CALENDER_URL
+    )
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_VERIFY_SSL)
+        is False
+    )
+
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(
+            status_code=200,
+            text=ics_content,
+        )
+    )
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_CALENDAR_NAME: CALENDAR_NAME,
+            CONF_URL: CALENDER_URL,
+            CONF_VERIFY_SSL: False,
+        },
+    )
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == CALENDAR_NAME
+    assert result3["data"] == {
+        CONF_CALENDAR_NAME: CALENDAR_NAME,
+        CONF_URL: CALENDER_URL,
+        CONF_VERIFY_SSL: False,
+    }
+
+
 @pytest.mark.parametrize(
     ("side_effect", "base_error"),
     [
@@ -108,6 +163,14 @@ async def test_form_invalid_url(
     )
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": base_error}
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_CALENDAR_NAME)
+        == CALENDAR_NAME
+    )
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_URL)
+        == "invalid-url.com"
+    )
     respx.get(CALENDER_URL).mock(
         return_value=Response(
             status_code=200,
@@ -167,6 +230,11 @@ async def test_unsupported_inputs(
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_CALENDAR_NAME)
+        == CALENDAR_NAME
+    )
+    assert get_schema_suggested_value(result2["data_schema"].schema, CONF_URL) == url
     assert log_message in caplog.text
     ## It's not possible to test a successful config flow because,
     ## we need to mock httpx.get here and then the exception isn't
@@ -204,6 +272,14 @@ async def test_form_http_status_error(
     )
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": error}
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_CALENDAR_NAME)
+        == CALENDAR_NAME
+    )
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_URL)
+        == CALENDER_URL
+    )
     respx.get(CALENDER_URL).mock(
         return_value=Response(
             status_code=200,
@@ -252,6 +328,18 @@ async def test_no_valid_calendar(hass: HomeAssistant, ics_content: str) -> None:
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": "invalid_ics_file"}
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_CALENDAR_NAME)
+        == CALENDAR_NAME
+    )
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_URL)
+        == CALENDER_URL
+    )
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_VERIFY_SSL)
+        is True
+    )
     respx.get(CALENDER_URL).mock(
         return_value=Response(
             status_code=200,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the Remote Calendar config flow display on errors.

When configuring a Remote Calendar integration, entering an invalid URL or experiencing an error (e.g. connection error with a webcal link, 403 forbidden, timeout, or invalid ICS file) caused `async_step_user` to re-display the form with `STEP_USER_DATA_SCHEMA` without suggested values. As a result, the form was reset and all previously entered values (calendar name, URL, verify SSL) were cleared.

This PR will show the user form on error while preserving user input. In addition, 403 Forbidden handling has been simplified to flow into the same return path.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr