### PR TITLE
Make ClimateEntity.async_turn_on idempotent

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -666,6 +666,9 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             await self.hass.async_add_executor_job(self.turn_on)
             return
 
+        if self.hvac_mode is not None and self.hvac_mode != HVACMode.OFF:
+            return
+
         # If there are only two HVAC modes, and one of those modes is OFF,
         # then we can just turn on the other mode.
         if len(self.hvac_modes) == 2 and HVACMode.OFF in self.hvac_modes:

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -451,6 +451,10 @@ async def test_turn_on_off_toggle(hass: HomeAssistant) -> None:
     await climate.async_turn_on()
     assert climate.hvac_mode == HVACMode.HEAT
 
+    # Turning on when already on should be a no-op
+    await climate.async_turn_on()
+    assert climate.hvac_mode == HVACMode.HEAT
+
     await climate.async_turn_off()
     assert climate.hvac_mode == HVACMode.OFF
 
@@ -458,6 +462,155 @@ async def test_turn_on_off_toggle(hass: HomeAssistant) -> None:
     assert climate.hvac_mode == HVACMode.HEAT
     await climate.async_toggle()
     assert climate.hvac_mode == HVACMode.OFF
+
+
+@pytest.mark.parametrize(
+    ("supported_modes", "initial_mode"),
+    [
+        pytest.param(
+            [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.HEAT_COOL],
+            HVACMode.COOL,
+            id="cool_with_heat_cool_supported",
+        ),
+        pytest.param(
+            [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.HEAT_COOL],
+            HVACMode.HEAT,
+            id="heat_with_heat_cool_supported",
+        ),
+        pytest.param(
+            [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.HEAT_COOL],
+            HVACMode.HEAT_COOL,
+            id="heat_cool_with_heat_cool_supported",
+        ),
+        pytest.param(
+            [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT],
+            HVACMode.COOL,
+            id="cool_without_heat_cool_supported",
+        ),
+        pytest.param(
+            [
+                HVACMode.OFF,
+                HVACMode.COOL,
+                HVACMode.HEAT,
+                HVACMode.FAN_ONLY,
+                HVACMode.DRY,
+            ],
+            HVACMode.FAN_ONLY,
+            id="fan_only",
+        ),
+        pytest.param(
+            [
+                HVACMode.OFF,
+                HVACMode.COOL,
+                HVACMode.HEAT,
+                HVACMode.FAN_ONLY,
+                HVACMode.DRY,
+            ],
+            HVACMode.DRY,
+            id="dry",
+        ),
+    ],
+)
+async def test_turn_on_already_on(
+    hass: HomeAssistant,
+    supported_modes: list[HVACMode],
+    initial_mode: HVACMode,
+) -> None:
+    """Test that async_turn_on does not alter the mode when entity is already on."""
+
+    class MockClimateEntityTest(MockClimateEntity):
+        """Mock Climate device."""
+
+        def __init__(self, modes: list[HVACMode]) -> None:
+            """Initialize mock climate entity."""
+            super().__init__()
+            self._attr_hvac_modes = modes
+            self._attr_hvac_mode = HVACMode.OFF
+            self.set_hvac_mode_calls: list[HVACMode] = []
+
+        @property
+        def hvac_modes(self) -> list[HVACMode]:
+            """Return hvac modes."""
+            return self._attr_hvac_modes
+
+        @property
+        def hvac_mode(self) -> HVACMode:
+            """Return hvac mode."""
+            return self._attr_hvac_mode
+
+        async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+            """Set new target hvac mode."""
+            self.set_hvac_mode_calls.append(hvac_mode)
+            self._attr_hvac_mode = hvac_mode
+
+    climate = MockClimateEntityTest(supported_modes)
+    climate.hass = hass
+
+    await climate.async_set_hvac_mode(initial_mode)
+    assert climate.hvac_mode == initial_mode
+    assert climate.set_hvac_mode_calls == [initial_mode]
+
+    # Turn on when already on should be an idempotent no-op
+    await climate.async_turn_on()
+    assert climate.hvac_mode == initial_mode
+    assert climate.set_hvac_mode_calls == [initial_mode]
+
+
+@pytest.mark.parametrize(
+    ("supported_modes", "expected_mode"),
+    [
+        pytest.param(
+            [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.HEAT_COOL],
+            HVACMode.HEAT_COOL,
+            id="picks_heat_cool_from_off",
+        ),
+        pytest.param(
+            [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT],
+            HVACMode.HEAT,
+            id="picks_heat_from_off",
+        ),
+        pytest.param(
+            [HVACMode.OFF, HVACMode.COOL],
+            HVACMode.COOL,
+            id="picks_cool_from_off",
+        ),
+    ],
+)
+async def test_turn_on_from_off(
+    hass: HomeAssistant,
+    supported_modes: list[HVACMode],
+    expected_mode: HVACMode,
+) -> None:
+    """Test that async_turn_on turns on the expected mode when entity is off."""
+
+    class MockClimateEntityTest(MockClimateEntity):
+        """Mock Climate device."""
+
+        def __init__(self, modes: list[HVACMode]) -> None:
+            """Initialize mock climate entity."""
+            super().__init__()
+            self._attr_hvac_modes = modes
+            self._attr_hvac_mode = HVACMode.OFF
+
+        @property
+        def hvac_modes(self) -> list[HVACMode]:
+            """Return hvac modes."""
+            return self._attr_hvac_modes
+
+        @property
+        def hvac_mode(self) -> HVACMode:
+            """Return hvac mode."""
+            return self._attr_hvac_mode
+
+        async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+            """Set new target hvac mode."""
+            self._attr_hvac_mode = hvac_mode
+
+    climate = MockClimateEntityTest(supported_modes)
+    climate.hass = hass
+
+    await climate.async_turn_on()
+    assert climate.hvac_mode == expected_mode
 
 
 async def test_sync_toggle(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Ensure `ClimateEntity.async_turn_on` is idempotent by returning early if the entity is already in an active HVAC mode.

This fixes an issue where Alexa changing the temperature on a Nest thermostat always changes its mode.

This PR may not be the correct solution to the problem, and the goal is to fix the problem described below. Other solution proposals by experienced core members would be very much welcome. (e.g. would a local nest fix be preferred, etc)

### Back Story & Issue #181904
In #181904, a user controlling a Nest thermostat via Alexa found that every voice temperature command (*"Alexa, set it to 77"*, *"Alexa, raise it 2 degrees"*) switched the thermostat from `cool` mode to `heat_cool` mode, and the requested setpoint was lost.

Inspecting the debug logs and API wire traces revealed the sequence:
    22:41:33.648 request[post json]={'command': 'sdm.devices.commands.ThermostatMode.SetMode', 'params': {'mode': 'HEATCOOL'}}
    22:41:33.761 [homeassistant.components.climate] Check valid temperature 25 C (77 F) in range 10 C - 32 C
    22:41:33.761 request[post json]={'command': 'sdm.devices.commands.ThermostatTemperatureSetpoint.SetCool', 'params': {'coolCelsius': 25.0}}

1. Any climate entity that exposes `OFF` in its `hvac_modes` or declares on/off features gets mapped to `Alexa.PowerController` in the `alexa` integration.
2. In Amazon Alexa's smart home directive pipeline, any interaction commanding an endpoint that implements `Alexa.PowerController` triggers an automatic `Alexa.PowerController.TurnOn` directive immediately before the setpoint directive (`SetTargetTemperature`).
3. When `TurnOn` arrives, `alexa` invokes the `climate.turn_on` action, which calls `ClimateEntity.async_turn_on`.
4. Because `ClimateEntity.async_turn_on` lacked a check for whether the entity was already running, it fell through to the `# Fake turn on` fallback loop:
       for mode in (HVACMode.HEAT_COOL, HVACMode.HEAT, HVACMode.COOL):
           if mode not in self.hvac_modes:
               continue
           await self.async_set_hvac_mode(mode)
           return
5. Since Nest (and many multi-mode thermostats) supports `HEAT_COOL`, it picked `HEAT_COOL` as the first match and switched the thermostat.
6. 113ms later, the second directive arrived with a single setpoint (`SetCool` at 25°C). The Google SDM API rejected `SetCool` because the thermostat had just been flipped to `HEATCOOL` mode (which requires a dual setpoint range). The user's setpoint was lost and the device was stranded in `heat_cool`.

This behavior does not even require Alexa to reproduce: calling `climate.turn_on` directly via Developer Tools or automations on an active thermostat running in `cool` mode immediately flips it to `heat_cool`.

### History & Prior Art
The absence of idempotency in `climate.turn_on` has been a recurring issue across several integrations and platforms:
* **ESPHome (#114157)**: Users reported `climate.turn_on` switching entities to `heat_cool` rather than maintaining or restoring their previous state.
* **MQTT Climate (#131358)**: Users similarly reported that calling `climate.turn_on` forced devices into `heat_cool`.
* **Z-Wave JS**: Recognizing this core pitfall, `zwave_js/climate.py` explicitly implemented custom guards in its own `async_turn_on`:
      # If current mode is not off, do nothing
      if self.hvac_mode != HVACMode.OFF:
          return
* **Google Assistant**: When integrating climate entities, Home Assistant's `google_assistant` developers explicitly chose **not** to attach the `OnOff` trait to thermostats, noting in `trait.py`:
      # We do not support "on" as we are unable to know how to restore the last mode.

### The Solution
Turning on an entity that is already active (`self.hvac_mode != HVACMode.OFF`) should be an idempotent no-op across all climate entities. This change adds an idempotency guard at the base `ClimateEntity.async_turn_on` level, protecting all climate entities from unwanted mode changes when `turn_on` is invoked on an active device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181904
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
