### PR TITLE
Allow Nest fan mode when HVAC mode is off

### DIFF
--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -353,10 +353,6 @@ class ThermostatEntity(ClimateEntity):
         """Set new target fan mode."""
         if fan_mode not in self.fan_modes:
             raise ValueError(f"Unsupported fan_mode '{fan_mode}'")
-        if fan_mode == FAN_ON and self.hvac_mode == HVACMode.OFF:
-            raise ValueError(
-                "Cannot turn on fan, please set an HVAC mode (e.g. heat/cool) first"
-            )
         trait = self._device.traits[FanTrait.NAME]
         duration = None
         if fan_mode != FAN_OFF:
@@ -372,12 +368,6 @@ class ThermostatEntity(ClimateEntity):
         """Set a short term fan timer."""
         if not self.supported_features & ClimateEntityFeature.FAN_MODE:
             raise HomeAssistantError(f"Entity {self.entity_id} does not support fan")
-
-        if self.hvac_mode == HVACMode.OFF:
-            raise HomeAssistantError(
-                f"Cannot turn on fan for {self.entity_id},"
-                " please set an HVAC mode (e.g. heat/cool) first"
-            )
 
         seconds = int(duration.total_seconds())
         if seconds <= 0 or seconds > MAX_FAN_DURATION:

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -1155,16 +1155,25 @@ async def test_set_fan_timer_hvac_off(
     )
     await setup_platform()
 
-    with pytest.raises(HomeAssistantError, match="Cannot turn on fan"):
-        await hass.services.async_call(
-            DOMAIN,
-            "set_fan_timer",
-            {
-                "entity_id": "climate.my_thermostat",
-                "duration": {"minutes": 15},
-            },
-            blocking=True,
-        )
+    await hass.services.async_call(
+        DOMAIN,
+        "set_fan_timer",
+        {
+            "entity_id": "climate.my_thermostat",
+            "duration": {"minutes": 15},
+        },
+        blocking=True,
+    )
+
+    assert auth.method == "post"
+    assert auth.url == DEVICE_COMMAND
+    assert auth.json == {
+        "command": "sdm.devices.commands.Fan.SetTimer",
+        "params": {
+            "duration": "900s",
+            "timerMode": "ON",
+        },
+    }
 
 
 async def test_set_fan_timer_no_fan(
@@ -1313,9 +1322,30 @@ async def test_thermostat_set_fan_when_off(
         | ClimateEntityFeature.TURN_ON
     )
 
-    # Fan cannot be turned on when HVAC is off
-    with pytest.raises(ValueError):
-        await common.async_set_fan_mode(hass, FAN_ON, entity_id="climate.my_thermostat")
+    # Turn off fan mode
+    await common.async_set_fan_mode(hass, FAN_OFF, entity_id="climate.my_thermostat")
+    await hass.async_block_till_done()
+
+    assert auth.method == "post"
+    assert auth.url == DEVICE_COMMAND
+    assert auth.json == {
+        "command": "sdm.devices.commands.Fan.SetTimer",
+        "params": {"timerMode": "OFF"},
+    }
+
+    # Turn on fan mode
+    await common.async_set_fan_mode(hass, FAN_ON, entity_id="climate.my_thermostat")
+    await hass.async_block_till_done()
+
+    assert auth.method == "post"
+    assert auth.url == DEVICE_COMMAND
+    assert auth.json == {
+        "command": "sdm.devices.commands.Fan.SetTimer",
+        "params": {
+            "duration": "43200s",
+            "timerMode": "ON",
+        },
+    }
 
 
 async def test_thermostat_fan_empty(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allow turning on the fan and setting fan timers on Nest thermostats when the HVAC mode is `OFF`.

In June 2022 (#73422), support for `HVAC_MODE_FAN_ONLY` was removed because Google's SDM API does not define `FAN_ONLY` as an HVAC mode. At that time, Google's official support article ([answer/9296419](https://support.google.com/googlenest/answer/9296419?hl=en)) stated:
> *"... you can only run the fan when your thermostat is set to Heat, Cool, or Heat • Cool. You can't run the fan when your thermostat is Off."*

Based on that upstream constraint, a client-side check (`if fan_mode == FAN_ON and self.hvac_mode == HVACMode.OFF: raise ValueError(...)`) was added to `async_set_fan_mode`, and later mirrored in `async_set_fan_timer` (#170367).

Google Nest thermostats have since been updated to support running the fan independently while the thermostat is off, and Google updated the support documentation ([answer/9296419](https://support.google.com/googlenest/answer/9296419?hl=en)):
> *"You can run your system's fan independently of heating or cooling. This allows the fan to run even when heating or cooling isn't active."*
> *"Fan timer can start even if the thermostat is set to Off."*
> *"Tip: When the fan is turned on manually, your Nest Thermostat allows it to remain active even when the thermostat is set to Off mode."*
> *"Tip: Nest Learning Thermostat (4th gen), Nest Learning Thermostat (3rd gen), and Nest Thermostat E allow the fan to remain active even when the thermostat is set to Off mode, as long as the fan was turned on manually."*

The Google SDM API (`sdm.devices.commands.Fan.SetTimer`) has no requirement that the thermostat HVAC mode must be active; the fan timer functions independently as long as the thermostat has a G wire terminal connected.

This PR removes the artificial client-side `HVACMode.OFF` checks from `async_set_fan_mode` and `async_set_fan_timer`, and updates unit tests accordingly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #143469
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr