### PR TITLE
Adjust hue to not access DeviceEntry.config_entries

### DIFF
--- a/homeassistant/components/hue/device_trigger.py
+++ b/homeassistant/components/hue/device_trigger.py
@@ -35,26 +35,21 @@ async def async_validate_trigger_config(
     hass: HomeAssistant, config: ConfigType
 ) -> ConfigType:
     """Validate config."""
-    entries: list[HueConfigEntry] = hass.config_entries.async_loaded_entries(DOMAIN)
-    if not entries:
-        # happens at startup
-        return config
     device_id = config[CONF_DEVICE_ID]
-    # lookup device in HASS DeviceRegistry
-    dev_reg: dr.DeviceRegistry = dr.async_get(hass)
-    if (
-        device_entry := dev_reg.async_get(device_id, include_child_devices=False)
-    ) is None:
+    config_entry: HueConfigEntry | None
+    device_entry, config_entry = dr.async_get_device_and_config_entry_for_domain(
+        hass, device_id, domain=DOMAIN
+    )
+    if device_entry is None:
         raise InvalidDeviceAutomationConfig(f"Device ID {device_id} is not valid")
-
-    for entry in entries:
-        if entry.entry_id not in device_entry.config_entries:
-            continue
-        bridge = entry.runtime_data
-        if bridge.api_version == 1:
-            return await async_validate_trigger_config_v1(bridge, device_entry, config)
-        return await async_validate_trigger_config_v2(bridge, device_entry, config)
-    return config
+    if config_entry is None or config_entry.state is not ConfigEntryState.LOADED:
+        # Happens at startup: the device_automation framework only calls this
+        # validator once the owning entry is loaded, so stay lenient here.
+        return config
+    bridge = config_entry.runtime_data
+    if bridge.api_version == 1:
+        return await async_validate_trigger_config_v1(bridge, device_entry, config)
+    return await async_validate_trigger_config_v2(bridge, device_entry, config)
 
 
 async def async_attach_trigger(
@@ -65,34 +60,25 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
     device_id = config[CONF_DEVICE_ID]
-    # lookup device in HASS DeviceRegistry
-    dev_reg: dr.DeviceRegistry = dr.async_get(hass)
-    if (
-        device_entry := dev_reg.async_get(device_id, include_child_devices=False)
-    ) is None:
-        raise InvalidDeviceAutomationConfig(f"Device ID {device_id} is not valid")
-
-    entry: HueConfigEntry | None = next(
-        (
-            entry
-            for entry in hass.config_entries.async_entries(DOMAIN)
-            if entry.entry_id in device_entry.config_entries
-        ),
-        None,
+    config_entry: HueConfigEntry | None
+    device, config_entry = dr.async_get_device_and_config_entry_for_domain(
+        hass, device_id, domain=DOMAIN
     )
-    if entry is None:
+    if device is None:
+        raise InvalidDeviceAutomationConfig(f"Device ID {device_id} is not valid")
+    if config_entry is None:
         raise InvalidDeviceAutomationConfig(
             f"Device ID {device_id} is not found on any Hue bridge"
         )
 
-    if entry.state is not ConfigEntryState.LOADED:
+    if config_entry.state is not ConfigEntryState.LOADED:
         # The bridge is still setting up when automations are attached at startup.
         return _async_attach_on_entry_load(
-            hass, entry, device_entry, config, action, trigger_info
+            hass, config_entry, device, config, action, trigger_info
         )
 
     return await _async_attach_bridge_trigger(
-        entry, device_entry, config, action, trigger_info
+        config_entry, device, config, action, trigger_info
     )
 
 
@@ -100,27 +86,24 @@ async def async_get_triggers(
     hass: HomeAssistant, device_id: str
 ) -> list[dict[str, Any]]:
     """Get device triggers for given (hass) device id."""
-    entries: list[HueConfigEntry] = hass.config_entries.async_loaded_entries(DOMAIN)
-    if not entries:
-        return []
-    # lookup device in HASS DeviceRegistry
     dev_reg: dr.DeviceRegistry = dr.async_get(hass)
+    # The device may be a restored composite; keep it so the returned triggers
+    # echo the requested device id (async_get_device_automations keys its
+    # results by that id).
     if (
         device_entry := dev_reg.async_get(device_id, include_child_devices=False)
     ) is None:
         raise ValueError(f"Device ID {device_id} is not valid")
-
-    # Iterate all config entries for this device
-    # and work out the bridge version
-    for entry in entries:
-        if entry.entry_id not in device_entry.config_entries:
-            continue
-        bridge = entry.runtime_data
-
-        if bridge.api_version == 1:
-            return async_get_triggers_v1(bridge, device_entry)
-        return async_get_triggers_v2(bridge, device_entry)
-    return []
+    config_entry: HueConfigEntry | None
+    _, config_entry = dr.async_get_device_and_config_entry_for_domain(
+        hass, device_id, domain=DOMAIN
+    )
+    if config_entry is None or config_entry.state is not ConfigEntryState.LOADED:
+        return []
+    bridge = config_entry.runtime_data
+    if bridge.api_version == 1:
+        return async_get_triggers_v1(bridge, device_entry)
+    return async_get_triggers_v2(bridge, device_entry)
 
 
 async def _async_attach_bridge_trigger(

--- a/homeassistant/components/hue/device_trigger.py
+++ b/homeassistant/components/hue/device_trigger.py
@@ -36,20 +36,21 @@ async def async_validate_trigger_config(
 ) -> ConfigType:
     """Validate config."""
     device_id = config[CONF_DEVICE_ID]
-    config_entry: HueConfigEntry | None
-    device_entry, config_entry = dr.async_get_device_and_config_entry_for_domain(
-        hass, device_id, domain=DOMAIN
-    )
-    if device_entry is None:
+    dev_reg = dr.async_get(hass)
+    if (
+        device_entry := dev_reg.async_get(device_id, include_child_devices=False)
+    ) is None:
         raise InvalidDeviceAutomationConfig(f"Device ID {device_id} is not valid")
-    if config_entry is None or config_entry.state is not ConfigEntryState.LOADED:
+    entry = _async_get_hue_entry(hass, device_entry)
+    if entry is None or entry.state is not ConfigEntryState.LOADED:
         # Happens at startup: the device_automation framework only calls this
         # validator once the owning entry is loaded, so stay lenient here.
         return config
-    bridge = config_entry.runtime_data
+    bridge = entry.runtime_data
+    bridge_device = _async_get_bridge_device(hass, device_entry, entry)
     if bridge.api_version == 1:
-        return await async_validate_trigger_config_v1(bridge, device_entry, config)
-    return await async_validate_trigger_config_v2(bridge, device_entry, config)
+        return await async_validate_trigger_config_v1(bridge, bridge_device, config)
+    return await async_validate_trigger_config_v2(bridge, bridge_device, config)
 
 
 async def async_attach_trigger(
@@ -60,25 +61,27 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
     device_id = config[CONF_DEVICE_ID]
-    config_entry: HueConfigEntry | None
-    device, config_entry = dr.async_get_device_and_config_entry_for_domain(
-        hass, device_id, domain=DOMAIN
-    )
-    if device is None:
+    dev_reg = dr.async_get(hass)
+    if (
+        device_entry := dev_reg.async_get(device_id, include_child_devices=False)
+    ) is None:
         raise InvalidDeviceAutomationConfig(f"Device ID {device_id} is not valid")
-    if config_entry is None:
+    if (entry := _async_get_hue_entry(hass, device_entry)) is None:
         raise InvalidDeviceAutomationConfig(
             f"Device ID {device_id} is not found on any Hue bridge"
         )
+    # Unlike async_get_triggers, the bridge must be given the device it knows
+    # itself: a v1 bridge matches its events by the split device's id.
+    bridge_device = _async_get_bridge_device(hass, device_entry, entry)
 
-    if config_entry.state is not ConfigEntryState.LOADED:
+    if entry.state is not ConfigEntryState.LOADED:
         # The bridge is still setting up when automations are attached at startup.
         return _async_attach_on_entry_load(
-            hass, config_entry, device, config, action, trigger_info
+            hass, entry, bridge_device, config, action, trigger_info
         )
 
     return await _async_attach_bridge_trigger(
-        config_entry, device, config, action, trigger_info
+        entry, bridge_device, config, action, trigger_info
     )
 
 
@@ -86,24 +89,74 @@ async def async_get_triggers(
     hass: HomeAssistant, device_id: str
 ) -> list[dict[str, Any]]:
     """Get device triggers for given (hass) device id."""
-    dev_reg: dr.DeviceRegistry = dr.async_get(hass)
-    # The device may be a restored composite; keep it so the returned triggers
-    # echo the requested device id (async_get_device_automations keys its
-    # results by that id).
+    dev_reg = dr.async_get(hass)
+    # A restored composite is passed to the bridge as-is, so the returned triggers
+    # echo the requested device id (async_get_device_automations keys its results
+    # by that id).
     if (
         device_entry := dev_reg.async_get(device_id, include_child_devices=False)
     ) is None:
         raise ValueError(f"Device ID {device_id} is not valid")
-    config_entry: HueConfigEntry | None
-    _, config_entry = dr.async_get_device_and_config_entry_for_domain(
-        hass, device_id, domain=DOMAIN
-    )
-    if config_entry is None or config_entry.state is not ConfigEntryState.LOADED:
+    entry = _async_get_hue_entry(hass, device_entry)
+    if entry is None or entry.state is not ConfigEntryState.LOADED:
         return []
-    bridge = config_entry.runtime_data
+    bridge = entry.runtime_data
     if bridge.api_version == 1:
         return async_get_triggers_v1(bridge, device_entry)
     return async_get_triggers_v2(bridge, device_entry)
+
+
+@callback
+def _async_get_hue_entry(
+    hass: HomeAssistant, device_entry: dr.DeviceEntry
+) -> HueConfigEntry | None:
+    """Return the Hue config entry the device belongs to, preferring a loaded one.
+
+    A device is connected to a single Hue bridge at a time, so a device belonging
+    to several Hue config entries is pathological. A loaded entry is preferred
+    anyway, in case the bridge of one of them was decommissioned and its entry
+    only disabled.
+    """
+    if not device_entry.is_composite_device:
+        entry = hass.config_entries.async_get_entry(device_entry.config_entry_id)
+        if entry is None or entry.domain != DOMAIN:
+            return None
+        return entry
+    entries = [
+        entry
+        for entry_id in device_entry.config_entries
+        if (entry := hass.config_entries.async_get_entry(entry_id)) is not None
+        and entry.domain == DOMAIN
+    ]
+    for entry in entries:
+        if entry.state is ConfigEntryState.LOADED:
+            return entry
+    # Fall back to a not loaded entry, attaching a trigger waits for it to load
+    return entries[0] if entries else None
+
+
+@callback
+def _async_get_bridge_device(
+    hass: HomeAssistant, device_entry: dr.DeviceEntry, entry: HueConfigEntry
+) -> dr.DeviceEntry:
+    """Return the device as known by the bridge of the given config entry.
+
+    A bridge only knows the split device belonging to its own config entry, not
+    the restored composite spanning several config entries.
+    """
+    if not device_entry.is_composite_device:
+        return device_entry
+    dev_reg = dr.async_get(hass)
+    return next(
+        (
+            split_device
+            for split_device in dev_reg.async_get_devices_for_composite_device_id(
+                device_entry.id
+            )
+            if split_device.config_entry_id == entry.entry_id
+        ),
+        device_entry,
+    )
 
 
 async def _async_attach_bridge_trigger(

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -187,17 +187,32 @@ async def test_get_triggers_for_removed_device(
     assert triggers == []
 
 
+@pytest.mark.parametrize(
+    ("other_domain", "other_identifiers"),
+    [
+        pytest.param("other", {("other", "1")}, id="foreign_entry"),
+        pytest.param(
+            hue.DOMAIN,
+            {(hue.DOMAIN, "00:17:88:01:10:3e:3a:dc")},
+            id="stale_hue_entry",
+        ),
+    ],
+)
 async def test_get_triggers_for_composite_device_id(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     mock_bridge_v2: Mock,
     v2_resources_test_data: JsonArrayType,
+    other_domain: str,
+    other_identifiers: set[tuple[str, str]],
 ) -> None:
     """Test the trigger list for a pre-migration composite id echoes that id.
 
     async_get_device_automations keys its results by the requested device id,
     so the returned triggers must reference the composite id, not the split.
+    The triggers come from the loaded bridge, also when the composite spans the
+    not loaded entry of a stale Hue bridge.
     """
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
     await setup_platform(
@@ -206,10 +221,11 @@ async def test_get_triggers_for_composite_device_id(
     hue_wall_switch_device = device_registry.async_get_device_by_identifier(
         (hue.DOMAIN, WALL_SWITCH_DEVICE_ID), mock_bridge_v2.config_entry.entry_id
     )
-    other_entry = MockConfigEntry(domain="other")
+    other_entry = MockConfigEntry(domain=other_domain)
     other_entry.add_to_hass(hass)
+    assert other_entry.state is not ConfigEntryState.LOADED
     other_device = device_registry.async_get_or_create(
-        config_entry_id=other_entry.entry_id, identifiers={("other", "1")}
+        config_entry_id=other_entry.entry_id, identifiers=other_identifiers
     )
     composite_id = "composite00000000000000000000ab"
     # Simulate a migration split: both devices carry the pre-migration composite id

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 from aiohue.v2.models.button import ButtonEvent
+import attr
 import pytest
 from pytest_unordered import unordered
 
@@ -184,6 +185,122 @@ async def test_get_triggers_for_removed_device(
         hass, DeviceAutomationType.TRIGGER, orphaned_device.id
     )
     assert triggers == []
+
+
+async def test_get_triggers_for_composite_device_id(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+) -> None:
+    """Test the trigger list for a pre-migration composite id echoes that id.
+
+    async_get_device_automations keys its results by the requested device id,
+    so the returned triggers must reference the composite id, not the split.
+    """
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+    await setup_platform(
+        hass, mock_bridge_v2, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
+    hue_wall_switch_device = device_registry.async_get_device_by_identifier(
+        (hue.DOMAIN, WALL_SWITCH_DEVICE_ID), mock_bridge_v2.config_entry.entry_id
+    )
+    other_entry = MockConfigEntry(domain="other")
+    other_entry.add_to_hass(hass)
+    other_device = device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id, identifiers={("other", "1")}
+    )
+    composite_id = "composite00000000000000000000ab"
+    # Simulate a migration split: both devices carry the pre-migration composite id
+    device_registry._devices[hue_wall_switch_device.id] = attr.evolve(
+        hue_wall_switch_device, composite_device_id=composite_id
+    )
+    device_registry._devices[other_device.id] = attr.evolve(
+        other_device, composite_device_id=composite_id
+    )
+
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, composite_id
+    )
+
+    hue_bat_sensor = entity_registry.async_get(
+        "sensor.wall_switch_with_2_controls_battery"
+    )
+    trigger_batt = {
+        "platform": "device",
+        "domain": "sensor",
+        "device_id": composite_id,
+        "type": "battery_level",
+        "entity_id": hue_bat_sensor.id,
+        "metadata": {"secondary": True},
+    }
+    expected_triggers = [
+        trigger_batt,
+        *(
+            {
+                "platform": "device",
+                "domain": hue.DOMAIN,
+                "device_id": composite_id,
+                "unique_id": resource_id,
+                "type": event_type.value,
+                "subtype": control_id,
+                "metadata": {},
+            }
+            for event_type in (
+                ButtonEvent.INITIAL_PRESS,
+                ButtonEvent.LONG_RELEASE,
+                ButtonEvent.REPEAT,
+                ButtonEvent.LONG_PRESS,
+                ButtonEvent.SHORT_RELEASE,
+            )
+            for control_id, resource_id in (
+                (1, "c658d3d8-a013-4b81-8ac6-78b248537e70"),
+                (2, "be1eb834-bdf5-4d26-8fba-7b1feaa83a9d"),
+            )
+        ),
+    ]
+    assert triggers == unordered(expected_triggers)
+
+
+async def test_get_triggers_when_config_entry_not_loaded(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test no triggers are returned while the owning entry is not loaded."""
+    config_entry = create_config_entry(api_version=2)
+    config_entry.add_to_hass(hass)
+    wall_switch_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(hue.DOMAIN, WALL_SWITCH_DEVICE_ID)},
+    )
+    assert config_entry.state is not ConfigEntryState.LOADED
+
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, wall_switch_device.id
+    )
+    assert triggers == []
+
+
+async def test_validate_trigger_config_when_config_entry_not_loaded(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test the trigger config passes through while the owning entry is not loaded."""
+    config_entry = create_config_entry(api_version=2)
+    config_entry.add_to_hass(hass)
+    wall_switch_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(hue.DOMAIN, WALL_SWITCH_DEVICE_ID)},
+    )
+    assert config_entry.state is not ConfigEntryState.LOADED
+    config = {
+        CONF_PLATFORM: "device",
+        CONF_DOMAIN: hue.DOMAIN,
+        CONF_DEVICE_ID: wall_switch_device.id,
+        CONF_TYPE: ButtonEvent.INITIAL_PRESS.value,
+        "subtype": 1,
+    }
+
+    assert await device_trigger.async_validate_trigger_config(hass, config) == config
 
 
 async def test_if_fires_when_config_entry_loads_late(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust hue to not access `DeviceEntry.config_entries`, instead use helper `async_get_device_and_config_entry_for_domain` to find the device and config entry

### Rationale:
`DeviceEntry.config_entries` is a remnant from the multi config entry device design.

Note: It is possible for hue devices to be tied to multiple hue config entries if a it has been moved between hubs, but that case was not handled by the existing code which acts on the first hue config entry found so I didn't care about handling it in the updated code either.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
