### PR TITLE
Check custom integration requirements against Home Assistant in hassfest

### DIFF
--- a/script/hassfest/docker.py
+++ b/script/hassfest/docker.py
@@ -97,7 +97,7 @@ SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 ENTRYPOINT ["/usr/src/homeassistant/script/hassfest/docker/entrypoint.sh"]
 WORKDIR "/github/workspace"
 
-COPY --parents requirements.txt homeassistant/ script /usr/src/homeassistant/
+COPY --parents requirements.txt requirements_all.txt homeassistant/ script /usr/src/homeassistant/
 
 # Uv creates a lock file in /tmp
 RUN --mount=type=tmpfs,target=/tmp \

--- a/script/hassfest/docker/Dockerfile
+++ b/script/hassfest/docker/Dockerfile
@@ -12,7 +12,7 @@ SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 ENTRYPOINT ["/usr/src/homeassistant/script/hassfest/docker/entrypoint.sh"]
 WORKDIR "/github/workspace"
 
-COPY --parents requirements.txt homeassistant/ script /usr/src/homeassistant/
+COPY --parents requirements.txt requirements_all.txt homeassistant/ script /usr/src/homeassistant/
 
 # Uv creates a lock file in /tmp
 RUN --mount=type=tmpfs,target=/tmp \

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -518,15 +518,19 @@ def _specifiers_conflict(left: SpecifierSet, right: SpecifierSet) -> bool:
     )
 
 
-def validate_custom_requirements(integration: Integration, config: Config) -> None:
+def validate_custom_requirements(integration: Integration, config: Config) -> bool:
     """Validate a custom integration against the requirements of Home Assistant.
 
     Custom integrations are installed into the same Python environment as Home
     Assistant itself. A requirement that rules out the version Home Assistant
     needs takes the whole installation down with it.
+
+    Returns if valid.
     """
     if integration.core:
-        return
+        return True
+
+    start_errors = len(integration.errors)
 
     core_requirements = _load_requirement_file(config.root / "requirements.txt")
     all_requirements = _load_requirement_file(config.root / "requirements_all.txt")
@@ -605,13 +609,18 @@ def validate_custom_requirements(integration: Integration, config: Config) -> No
                 "instead, so it can follow along when Home Assistant updates it.",
             )
 
+    return len(integration.errors) == start_errors
+
 
 def validate_requirements(integration: Integration, config: Config) -> None:
     """Validate requirements."""
     if not validate_requirements_format(integration):
         return
 
-    validate_custom_requirements(integration, config)
+    # Installing a requirement we already rejected would downgrade the
+    # environment hassfest itself runs in.
+    if not validate_custom_requirements(integration, config):
+        return
 
     integration_requirements = set()
     integration_packages = set()

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -2,16 +2,22 @@
 
 from collections import deque
 from collections.abc import Collection
+from contextlib import suppress
 from functools import cache
 from importlib.metadata import PackageMetadata, files, metadata
 import json
 import os
+from pathlib import Path
 import re
 import subprocess
 import sys
 from typing import Any, TypedDict
 
 from awesomeversion import AwesomeVersion, AwesomeVersionStrategy
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
 from tqdm import tqdm
 
 import homeassistant.util.package as pkg_util
@@ -371,7 +377,8 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
     # Check if we are doing format-only validation.
     if not config.requirements:
         for integration in integrations.values():
-            validate_requirements_format(integration)
+            if validate_requirements_format(integration):
+                validate_custom_requirements(integration, config)
         return
 
     # check for incompatible requirements
@@ -430,6 +437,123 @@ def validate_requirements_format(integration: Integration) -> bool:
                     continue
 
     return len(integration.errors) == start_errors
+
+
+@cache
+def _load_requirement_file(path: Path) -> dict[str, SpecifierSet]:
+    """Read a pip requirements file into a map of package name to version specifier."""
+    requirements: dict[str, SpecifierSet] = {}
+    if not path.is_file():
+        return requirements
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+
+        # Skip comments and pip options such as "-r requirements.txt"
+        if not line or line.startswith(("#", "-")):
+            continue
+
+        try:
+            requirement = Requirement(line)
+        except InvalidRequirement:
+            continue
+
+        requirements[canonicalize_name(requirement.name)] = requirement.specifier
+
+    return requirements
+
+
+def _probe_versions(*specifier_sets: SpecifierSet) -> set[Version]:
+    """Return the versions worth probing to compare specifier sets.
+
+    A specifier set describes a union of version intervals, so a non-empty
+    intersection of two of them always contains a version that sits on, just
+    below, or just above one of the boundaries either of them mentions.
+    """
+    versions = {Version("0")}
+
+    for specifiers in specifier_sets:
+        for specifier in specifiers:
+            boundary = specifier.version.removesuffix(".*")
+            for suffix in ("", ".dev0", ".post0"):
+                with suppress(InvalidVersion):
+                    versions.add(Version(f"{boundary}{suffix}"))
+
+    return versions
+
+
+def _specifiers_conflict(left: SpecifierSet, right: SpecifierSet) -> bool:
+    """Return if no single version can satisfy both specifier sets."""
+    return not any(
+        left.contains(version, prereleases=True)
+        and right.contains(version, prereleases=True)
+        for version in _probe_versions(left, right)
+    )
+
+
+def validate_custom_requirements(integration: Integration, config: Config) -> None:
+    """Validate a custom integration against the requirements of Home Assistant.
+
+    Custom integrations are installed into the same Python environment as Home
+    Assistant itself. A requirement that rules out the version Home Assistant
+    needs takes the whole installation down with it.
+    """
+    if integration.core:
+        return
+
+    core_requirements = _load_requirement_file(config.root / "requirements.txt")
+    all_requirements = _load_requirement_file(config.root / "requirements_all.txt")
+    constraints = _load_requirement_file(
+        config.root / "homeassistant/package_constraints.txt"
+    )
+
+    for req in integration.requirements:
+        try:
+            requirement = Requirement(req)
+        except InvalidRequirement:
+            continue
+
+        if requirement.marker and not requirement.marker.evaluate():
+            continue
+
+        package = canonicalize_name(requirement.name)
+
+        if package in core_requirements:
+            integration.add_error(
+                "requirements",
+                f"Requirement {req} is a dependency of Home Assistant itself and "
+                "must not be listed in the manifest of a custom integration.",
+            )
+            continue
+
+        for source, pinned in (
+            ("Home Assistant depends on", all_requirements.get(package)),
+            ("Home Assistant's package constraints require", constraints.get(package)),
+        ):
+            if pinned is None:
+                continue
+
+            if _specifiers_conflict(requirement.specifier, pinned):
+                integration.add_error(
+                    "requirements",
+                    f"Requirement {req} is incompatible with {package}{pinned}, "
+                    f"which {source}.",
+                )
+                break
+
+            if exact := sorted(
+                specifier.version.removesuffix(".*")
+                for specifier in requirement.specifier
+                if specifier.operator in ("==", "===")
+            ):
+                integration.add_error(
+                    "requirements",
+                    f"Requirement {req} pins a package {source} "
+                    f"({package}{pinned}). Use a minimum version "
+                    f'("{package}>={exact[0]}") instead, so it can follow along '
+                    "when Home Assistant updates it.",
+                )
+                break
 
 
 def validate_requirements(integration: Integration) -> None:

--- a/script/hassfest/requirements.py
+++ b/script/hassfest/requirements.py
@@ -89,6 +89,27 @@ PACKAGE_CHECK_VERSION_RANGE_EXCEPTIONS: dict[str, dict[str, set[str]]] = {
     },
 }
 
+# Constraints use an impossible version to prohibit a package altogether.
+PROHIBITED_VERSION = "1000000000.0.0"
+
+# Hassfest runs the Python version Home Assistant requires, but on a single
+# platform. Markers are evaluated against every platform a requirement could
+# land on, so one is only skipped when it can never be installed at all.
+MARKER_ENVIRONMENTS = tuple(
+    {
+        "os_name": os_name,
+        "platform_machine": platform_machine,
+        "platform_system": platform_system,
+        "sys_platform": sys_platform,
+    }
+    for os_name, platform_system, sys_platform in (
+        ("posix", "Linux", "linux"),
+        ("posix", "Darwin", "darwin"),
+        ("nt", "Windows", "win32"),
+    )
+    for platform_machine in ("aarch64", "armv7l", "i686", "x86_64")
+)
+
 PACKAGE_REGEX = re.compile(
     r"^(?:--.+\s)?([-_,\.\w\d\[\]]+)(==|>=|<=|~=|!=|<|>|===)*(.*)$"
 )
@@ -386,7 +407,7 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
     disable_tqdm = bool(config.specific_integrations or os.environ.get("CI"))
 
     for integration in tqdm(integrations.values(), disable=disable_tqdm):
-        validate_requirements(integration)
+        validate_requirements(integration, config)
 
 
 def validate_requirements_format(integration: Integration) -> bool:
@@ -458,7 +479,11 @@ def _load_requirement_file(path: Path) -> dict[str, SpecifierSet]:
         except InvalidRequirement:
             continue
 
-        requirements[canonicalize_name(requirement.name)] = requirement.specifier
+        # These files can name a package more than once, each line narrows it.
+        package = canonicalize_name(requirement.name)
+        requirements[package] = (
+            requirements.get(package, SpecifierSet()) & requirement.specifier
+        )
 
     return requirements
 
@@ -468,14 +493,16 @@ def _probe_versions(*specifier_sets: SpecifierSet) -> set[Version]:
 
     A specifier set describes a union of version intervals, so a non-empty
     intersection of two of them always contains a version that sits on, just
-    below, or just above one of the boundaries either of them mentions.
+    below, or just above one of the boundaries either of them mentions. The
+    release suffix covers boundaries that exclude their own pre and post
+    releases, such as ">1.0" not allowing "1.0.post0".
     """
     versions = {Version("0")}
 
     for specifiers in specifier_sets:
         for specifier in specifiers:
             boundary = specifier.version.removesuffix(".*")
-            for suffix in ("", ".dev0", ".post0"):
+            for suffix in ("", ".dev0", ".post0", ".0.0.1"):
                 with suppress(InvalidVersion):
                     versions.add(Version(f"{boundary}{suffix}"))
 
@@ -513,7 +540,10 @@ def validate_custom_requirements(integration: Integration, config: Config) -> No
         except InvalidRequirement:
             continue
 
-        if requirement.marker and not requirement.marker.evaluate():
+        if requirement.marker and not any(
+            requirement.marker.evaluate(environment)
+            for environment in MARKER_ENVIRONMENTS
+        ):
             continue
 
         package = canonicalize_name(requirement.name)
@@ -526,40 +556,62 @@ def validate_custom_requirements(integration: Integration, config: Config) -> No
             )
             continue
 
-        for source, pinned in (
-            ("Home Assistant depends on", all_requirements.get(package)),
-            ("Home Assistant's package constraints require", constraints.get(package)),
+        pinned = all_requirements.get(package)
+        constraint = constraints.get(package)
+
+        if constraint is not None and any(
+            specifier.version == PROHIBITED_VERSION for specifier in constraint
         ):
-            if pinned is None:
-                continue
+            integration.add_error(
+                "requirements",
+                f"Requirement {req} is prohibited by Home Assistant, "
+                f"{package} must not be installed.",
+            )
+            continue
 
-            if _specifiers_conflict(requirement.specifier, pinned):
-                integration.add_error(
-                    "requirements",
-                    f"Requirement {req} is incompatible with {package}{pinned}, "
-                    f"which {source}.",
-                )
-                break
+        if pinned is not None and _specifiers_conflict(requirement.specifier, pinned):
+            integration.add_error(
+                "requirements",
+                f"Requirement {req} is incompatible with {package}{pinned}, which "
+                "Home Assistant depends on.",
+            )
+            continue
 
-            if exact := sorted(
-                specifier.version.removesuffix(".*")
+        if constraint is not None and _specifiers_conflict(
+            requirement.specifier, constraint
+        ):
+            integration.add_error(
+                "requirements",
+                f"Requirement {req} is incompatible with {package}{constraint}, "
+                "which Home Assistant's package constraints require.",
+            )
+            continue
+
+        # Pinning a package Home Assistant ships breaks the moment we bump it.
+        # Constrained packages are left alone, we only bound those.
+        if pinned is not None and (
+            exact := sorted(
+                specifier.version
                 for specifier in requirement.specifier
                 if specifier.operator in ("==", "===")
-            ):
-                integration.add_error(
-                    "requirements",
-                    f"Requirement {req} pins a package {source} "
-                    f"({package}{pinned}). Use a minimum version "
-                    f'("{package}>={exact[0]}") instead, so it can follow along '
-                    "when Home Assistant updates it.",
-                )
-                break
+                and not specifier.version.endswith(".*")
+            )
+        ):
+            suggestion = f"{package}>={exact[0]}"
+            integration.add_error(
+                "requirements",
+                f"Requirement {req} pins a package Home Assistant depends on "
+                f'({package}{pinned}). Use a minimum version ("{suggestion}") '
+                "instead, so it can follow along when Home Assistant updates it.",
+            )
 
 
-def validate_requirements(integration: Integration) -> None:
+def validate_requirements(integration: Integration, config: Config) -> None:
     """Validate requirements."""
     if not validate_requirements_format(integration):
         return
+
+    validate_custom_requirements(integration, config)
 
     integration_requirements = set()
     integration_packages = set()

--- a/tests/hassfest/test_requirements.py
+++ b/tests/hassfest/test_requirements.py
@@ -349,7 +349,14 @@ def core_config(tmp_path: Path) -> Generator[Config]:
         "-r requirements.txt\n\n# homeassistant.components.modbus\npymodbus==3.13.1\n"
     )
     (tmp_path / "homeassistant" / "package_constraints.txt").write_text(
-        "pymodbus==3.13.1\naiofiles>=24.1.0\n"
+        "pymodbus==3.13.1\n"
+        "aiofiles>=24.1.0\n"
+        "poetry==1000000000.0.0\n"
+        "tenacity!=8.4.0\n"
+        "auth0-python<5.0\n"
+        # Listed twice, as package_constraints.txt does for some packages
+        "dupe-package<2.0\n"
+        "dupe-package>=1.5\n"
     )
 
     _load_requirement_file.cache_clear()
@@ -412,6 +419,31 @@ def custom_integration(core_config: Config) -> Integration:
             "which Home Assistant's package constraints require.",
             id="violates_package_constraint",
         ),
+        pytest.param(
+            "poetry>=1",
+            "Requirement poetry>=1 is prohibited by Home Assistant, poetry must "
+            "not be installed.",
+            id="prohibited_package",
+        ),
+        pytest.param(
+            "pymodbus==3.6.2;platform_machine=='aarch64'",
+            "Requirement pymodbus==3.6.2;platform_machine=='aarch64' is "
+            "incompatible with pymodbus==3.13.1, which Home Assistant depends on.",
+            id="marker_applying_on_another_platform",
+        ),
+        pytest.param(
+            "tenacity==8.4.0",
+            "Requirement tenacity==8.4.0 is incompatible with tenacity!=8.4.0, "
+            "which Home Assistant's package constraints require.",
+            id="violates_excluded_version",
+        ),
+        pytest.param(
+            "dupe-package==3.0",
+            "Requirement dupe-package==3.0 is incompatible with "
+            "dupe-package<2.0,>=1.5, which Home Assistant's package constraints "
+            "require.",
+            id="violates_merged_constraints",
+        ),
     ],
 )
 def test_validate_custom_requirements_invalid(
@@ -436,6 +468,13 @@ def test_validate_custom_requirements_invalid(
         pytest.param("aiofiles>=25.0.0", id="within_package_constraint"),
         pytest.param("unknown-package==1.2.3", id="unknown_package"),
         pytest.param("pymodbus==3.6.2;python_version<'3.0'", id="marker_not_applying"),
+        pytest.param("aiofiles>25,<25.0.1", id="range_excluding_own_boundaries"),
+        pytest.param("pymodbus>3.13.0,<4", id="range_around_core_version"),
+        pytest.param("pymodbus==3.13.*", id="wildcard_matching_core_version"),
+        pytest.param("pymodbus~=3.13.1", id="compatible_release"),
+        pytest.param("tenacity>8.4.0,<9", id="range_around_excluded_version"),
+        pytest.param("auth0-python==4.9.0", id="pinned_package_we_only_constrain"),
+        pytest.param("dupe-package==1.7", id="within_merged_constraints"),
         pytest.param("git+https://github.com/user/project.git@1.2.3", id="git_url"),
     ],
 )

--- a/tests/hassfest/test_requirements.py
+++ b/tests/hassfest/test_requirements.py
@@ -455,8 +455,7 @@ def test_validate_custom_requirements_invalid(
     """Test custom integration requirements that clash with Home Assistant."""
     custom_integration.manifest["requirements"] = [requirement]
 
-    validate_custom_requirements(custom_integration, core_config)
-
+    assert not validate_custom_requirements(custom_integration, core_config)
     assert [x.error for x in custom_integration.errors] == [error]
 
 
@@ -484,8 +483,7 @@ def test_validate_custom_requirements_valid(
     """Test custom integration requirements that Home Assistant is fine with."""
     custom_integration.manifest["requirements"] = [requirement]
 
-    validate_custom_requirements(custom_integration, core_config)
-
+    assert validate_custom_requirements(custom_integration, core_config)
     assert not custom_integration.errors
 
 
@@ -496,6 +494,5 @@ def test_validate_custom_requirements_skips_core(
     custom_integration.path = core_config.root / "homeassistant/components/modbus"
     custom_integration.manifest["requirements"] = ["pymodbus==3.13.1"]
 
-    validate_custom_requirements(custom_integration, core_config)
-
+    assert validate_custom_requirements(custom_integration, core_config)
     assert not custom_integration.errors

--- a/tests/hassfest/test_requirements.py
+++ b/tests/hassfest/test_requirements.py
@@ -12,9 +12,11 @@ from script.hassfest.requirements import (
     FORBIDDEN_PACKAGE_NAMES,
     PACKAGE_CHECK_PREPARE_UPDATE,
     PACKAGE_CHECK_VERSION_RANGE,
+    _load_requirement_file,
     _packages_checked_files_cache,
     check_dependency_files,
     check_dependency_version_range,
+    validate_custom_requirements,
     validate_requirements_format,
 )
 
@@ -332,3 +334,129 @@ def test_check_dependency_file_names(integration: Integration) -> None:
         assert check_dependency_files(integration, package, pkg, ()) is True
         assert mock_files.call_count == 1
         assert len(integration.errors) == 0
+
+
+@pytest.fixture
+def core_config(tmp_path: Path) -> Generator[Config]:
+    """Fixture for a Config pointing at a stubbed Home Assistant checkout."""
+    (tmp_path / "homeassistant").mkdir()
+    (tmp_path / "requirements.txt").write_text(
+        "# Home Assistant Core\n"
+        "-c homeassistant/package_constraints.txt\n"
+        "aiohttp==3.14.3\n"
+    )
+    (tmp_path / "requirements_all.txt").write_text(
+        "-r requirements.txt\n\n# homeassistant.components.modbus\npymodbus==3.13.1\n"
+    )
+    (tmp_path / "homeassistant" / "package_constraints.txt").write_text(
+        "pymodbus==3.13.1\naiofiles>=24.1.0\n"
+    )
+
+    _load_requirement_file.cache_clear()
+    yield Config(
+        root=tmp_path,
+        specific_integrations=None,
+        action="validate",
+        requirements=False,
+    )
+    _load_requirement_file.cache_clear()
+
+
+@pytest.fixture
+def custom_integration(core_config: Config) -> Integration:
+    """Fixture for a custom integration validated against a stubbed core."""
+    return Integration(
+        path=Path("custom_components/test").absolute(),
+        _config=core_config,
+        _manifest={
+            "domain": "test",
+            "documentation": "https://example.com",
+            "name": "test",
+            "codeowners": ["@awesome"],
+            "requirements": [],
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("requirement", "error"),
+    [
+        pytest.param(
+            "aiohttp==3.14.3",
+            "Requirement aiohttp==3.14.3 is a dependency of Home Assistant itself "
+            "and must not be listed in the manifest of a custom integration.",
+            id="core_dependency",
+        ),
+        pytest.param(
+            "pymodbus==3.6.2",
+            "Requirement pymodbus==3.6.2 is incompatible with pymodbus==3.13.1, "
+            "which Home Assistant depends on.",
+            id="pinned_below_core",
+        ),
+        pytest.param(
+            "pymodbus>=3.20.0",
+            "Requirement pymodbus>=3.20.0 is incompatible with pymodbus==3.13.1, "
+            "which Home Assistant depends on.",
+            id="minimum_above_core",
+        ),
+        pytest.param(
+            "pymodbus==3.13.1",
+            "Requirement pymodbus==3.13.1 pins a package Home Assistant depends on "
+            '(pymodbus==3.13.1). Use a minimum version ("pymodbus>=3.13.1") instead, '
+            "so it can follow along when Home Assistant updates it.",
+            id="pinned_to_core_version",
+        ),
+        pytest.param(
+            "aiofiles<24.0.0",
+            "Requirement aiofiles<24.0.0 is incompatible with aiofiles>=24.1.0, "
+            "which Home Assistant's package constraints require.",
+            id="violates_package_constraint",
+        ),
+    ],
+)
+def test_validate_custom_requirements_invalid(
+    custom_integration: Integration,
+    core_config: Config,
+    requirement: str,
+    error: str,
+) -> None:
+    """Test custom integration requirements that clash with Home Assistant."""
+    custom_integration.manifest["requirements"] = [requirement]
+
+    validate_custom_requirements(custom_integration, core_config)
+
+    assert [x.error for x in custom_integration.errors] == [error]
+
+
+@pytest.mark.parametrize(
+    "requirement",
+    [
+        pytest.param("pymodbus>=3.10.0", id="minimum_below_core"),
+        pytest.param("pymodbus>=3.13.1", id="minimum_equal_to_core"),
+        pytest.param("aiofiles>=25.0.0", id="within_package_constraint"),
+        pytest.param("unknown-package==1.2.3", id="unknown_package"),
+        pytest.param("pymodbus==3.6.2;python_version<'3.0'", id="marker_not_applying"),
+        pytest.param("git+https://github.com/user/project.git@1.2.3", id="git_url"),
+    ],
+)
+def test_validate_custom_requirements_valid(
+    custom_integration: Integration, core_config: Config, requirement: str
+) -> None:
+    """Test custom integration requirements that Home Assistant is fine with."""
+    custom_integration.manifest["requirements"] = [requirement]
+
+    validate_custom_requirements(custom_integration, core_config)
+
+    assert not custom_integration.errors
+
+
+def test_validate_custom_requirements_skips_core(
+    custom_integration: Integration, core_config: Config
+) -> None:
+    """Test core integrations are exempt, they are what we validate against."""
+    custom_integration.path = core_config.root / "homeassistant/components/modbus"
+    custom_integration.manifest["requirements"] = ["pymodbus==3.13.1"]
+
+    validate_custom_requirements(custom_integration, core_config)
+
+    assert not custom_integration.errors


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Not a breaking change for Home Assistant users, but it is a new hard failure for custom integration repositories that run the `home-assistant/actions/hassfest` action. See the blast radius section below.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A custom integration installs its requirements into the same Python environment as Home Assistant itself. When it pins a package Home Assistant also needs, pip happily downgrades that package and takes the whole installation down with it. We have seen this in the wild: a Modbus custom integration hard-pinning `pymodbus`, and a Meural custom integration bricking itself on a pinned dependency.

This adds a hassfest check that validates a manifest's `requirements` against Home Assistant itself. It runs for non-core integrations only, so bundled integrations are untouched, and it is a pure file read, so it also works in the format-only path the `home-assistant/actions/hassfest` action uses (that action never passes `--requirements`).

Four rules:

1. A package listed in `requirements.txt` may not appear in a custom integration manifest at all. Home Assistant already depends on it, so redeclaring it can only cause a resolver conflict.
2. A requirement may not exclude the version pinned in `requirements_all.txt`. On top of that, an exact `==` pin on a package Home Assistant also ships is rejected in favour of `>=`, because such a pin is a landmine the moment we bump the package. Packages we only put a bound on in the constraints file are left alone here, pinning those is fine.
3. A requirement may not conflict with `homeassistant/package_constraints.txt`.
4. A package the constraints file prohibits outright with the impossible `1000000000.0.0` version (`poetry`, `pysnmplib`, `get-mac`) may not be required at all.

Version comparison uses `packaging`, not string equality. `_specifiers_conflict()` decides whether any single version can satisfy both specifier sets by probing around every boundary either of them mentions: the boundary itself, its `.dev0` and `.post0` neighbours, and a version just above it in release space. That last one matters, because PEP 440 does not let `>1` match `1.post0`, so open ranges such as `aiomqtt>2.5.0,<3` against our `aiomqtt>=2.5.0` would otherwise look like a conflict.

Environment markers are evaluated against every platform a requirement could land on, not the runner's own. A requirement is skipped only when its marker holds on none of them, so `pymodbus==3.6.2; platform_machine == "aarch64"` is still checked on an x86 runner. Git URL requirements are ignored.

`requirements_all.txt` was not part of the hassfest Docker image, so it is added to the `COPY --parents` line in `script/hassfest/docker.py` and the checked-in Dockerfile is regenerated.

### Blast radius

Ran the new check against the manifests of 15 popular HACS integrations. Five fail, and all five findings are real:

| Integration | Finding |
| --- | --- |
| adaptive_lighting | `ulid-transform` is a Home Assistant Core dependency |
| alexa_media | `packaging>=20.3` is a Home Assistant Core dependency |
| hacs | `aiogithubapi>=22.10.1` is a Home Assistant Core dependency |
| pyscript | `watchdog==6.0.0` exact pin on a package we also ship |
| solaredge_modbus_multi | `awesomeversion>=25.5.0` is a Home Assistant Core dependency |

So roughly a third of that sample starts failing on day one. Everything is a hard error right now. Opening this as a draft because that rollout question is worth discussing first: `add_warning_or_error` is already available if we want a warning-only grace period before this bites.

### Verification

- `pytest tests/hassfest` passes, 20 new cases.
- `_specifiers_conflict()` was fuzzed against a brute-force search over a dense version grid, 60000 random specifier pairs across all PEP 440 operator forms. No false positives, and no case where it claimed no conflict while the grid found no satisfying version.
- Parsing audited against the real files: 58/58, 1160/1160 and 131/133 packages loaded, nothing silently dropped. The 131 is the two packages `package_constraints.txt` lists twice, whose specifiers are combined rather than overwritten.
- Full hassfest run over all 1518 bundled integrations: no new errors.
- Built the hassfest image locally and ran `docker run --rm -v $PWD://github/workspace` against a custom integration with deliberately bad pins. The errors surface through the real entrypoint and `--integration-path`.

### Known gap

An implicit upper bound is not flagged. `~=3.13.1` and `==3.13.*` both stop allowing the next major version, but neither is treated as an exact pin, so rule 2 leaves them alone. Only `==` and `===` on a concrete version are caught.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
