### PR TITLE
Fix stop service in modbus

### DIFF
--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -155,7 +155,7 @@ SERVICE_WRITE_REGISTER = "write_register"
 SERVICE_STOP = "stop"
 
 # dispatcher signals
-SIGNAL_STOP_ENTITY = "modbus.stop"
+SIGNAL_STOP_ENTITY = "modbus.stop_{}"
 
 # integration names
 DEFAULT_HUB = "modbus_hub"

--- a/homeassistant/components/modbus/entity.py
+++ b/homeassistant/components/modbus/entity.py
@@ -149,7 +149,11 @@ class ModbusBaseEntity(Entity):
             )
         )
         self.async_on_remove(
-            async_dispatcher_connect(self.hass, SIGNAL_STOP_ENTITY, self.async_disable)
+            async_dispatcher_connect(
+                self.hass,
+                SIGNAL_STOP_ENTITY.format(self._hub.name),
+                self.async_disable,
+            )
         )
 
 

--- a/homeassistant/components/modbus/services.py
+++ b/homeassistant/components/modbus/services.py
@@ -101,7 +101,7 @@ async def _async_stop_hub(service: ServiceCall) -> None:
     """Stop Modbus hub."""
     hass = service.hass
     hub = _get_hubs(hass)[service.data[ATTR_HUB]]
-    async_dispatcher_send(hass, SIGNAL_STOP_ENTITY)
+    async_dispatcher_send(hass, SIGNAL_STOP_ENTITY.format(hub.name))
     await hub.async_close()
 
 

--- a/tests/components/modbus/test_services.py
+++ b/tests/components/modbus/test_services.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.entity_platform import async_get_platforms
 from homeassistant.setup import async_setup_component
 
 from tests.common import get_fixture_path
@@ -162,3 +163,50 @@ async def test_service_after_failed_reload_raises(
         await hass.services.async_call(DOMAIN, service, data, blocking=True)
 
     assert err.value.translation_key == "not_loaded"
+
+
+TEST_HUB_A = "hub_a"
+TEST_HUB_B = "hub_b"
+
+
+def _two_hub_config() -> dict:
+    """Return a config with two hubs, each exposing one sensor."""
+    return {
+        DOMAIN: [
+            {
+                CONF_NAME: name,
+                CONF_TYPE: "tcp",
+                CONF_HOST: "modbusHost",
+                CONF_PORT: port,
+                CONF_SENSORS: [{CONF_NAME: f"sensor_{name}", CONF_ADDRESS: 1}],
+            }
+            for name, port in ((TEST_HUB_A, 5501), (TEST_HUB_B, 5502))
+        ]
+    }
+
+
+@pytest.mark.usefixtures("mock_pymodbus")
+async def test_stop_only_disables_the_selected_hub(hass: HomeAssistant) -> None:
+    """Test stopping one hub leaves the other hub's entities alone."""
+    assert await async_setup_component(hass, DOMAIN, _two_hub_config())
+    await hass.async_block_till_done()
+
+    # async_disable only flips availability, it does not write the state, so the
+    # entity objects rather than the state machine show the effect.
+    entities = {
+        entity.entity_id: entity
+        for platform in async_get_platforms(hass, DOMAIN)
+        for entity in platform.entities.values()
+    }
+    entity_a = entities[f"sensor.sensor_{TEST_HUB_A}"]
+    entity_b = entities[f"sensor.sensor_{TEST_HUB_B}"]
+    assert entity_a.available
+    assert entity_b.available
+
+    await hass.services.async_call(
+        DOMAIN, SERVICE_STOP, {ATTR_HUB: TEST_HUB_A}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert not entity_a.available
+    assert entity_b.available


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Whilst working on the modbus service migration, the LLMs kept complaining about this existing bug in the modbus component:
> `modbus.stop` takes a required `hub:` argument but dispatched a single global signal, so it disabled every Modbus entity while closing only the named hub.

I felt this did not belong in the migration process, and I have this PR standalone instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
