### PR TITLE
Consolidate Duco capability recovery tests

### DIFF
--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -265,16 +265,41 @@ async def test_setup_entry_retries_on_bypass_temperature_failure(
     assert mock_config_entry.error_reason_translation_placeholders is None
 
 
-async def test_empty_bypass_temperature_targets_are_retried(
+@pytest.mark.parametrize(
+    ("initial_zone_ids", "initial_missing_entity_ids"),
+    [
+        pytest.param(
+            frozenset(),
+            (
+                "number.living_bypass_target_1",
+                "number.living_bypass_target_2",
+            ),
+            id="empty",
+        ),
+        pytest.param(
+            frozenset({2}),
+            ("number.living_bypass_target_1",),
+            id="zone_1_missing",
+        ),
+    ],
+)
+async def test_bypass_temperature_targets_are_retried(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_bypass_supply_temperature_targets: dict[int, BypassSupplyTemperatureTarget],
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
+    initial_zone_ids: frozenset[int],
+    initial_missing_entity_ids: tuple[str, ...],
 ) -> None:
-    """Test empty bypass targets are retried and can later create entities."""
+    """Test missing bypass targets are retried and create number entities."""
+    initial_targets = {
+        zone_id: target
+        for zone_id, target in mock_bypass_supply_temperature_targets.items()
+        if zone_id in initial_zone_ids
+    }
     mock_duco_client.async_get_bypass_supply_temperature_targets.side_effect = [
-        {},
+        initial_targets,
         mock_bypass_supply_temperature_targets.copy(),
     ]
     mock_config_entry.add_to_hass(hass)
@@ -283,45 +308,17 @@ async def test_empty_bypass_temperature_targets_are_retried(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert hass.states.get("number.living_bypass_target_1") is None
-    assert hass.states.get("number.living_bypass_target_2") is None
+    for entity_id in initial_missing_entity_ids:
+        assert hass.states.get(entity_id) is None
     mock_duco_client.async_get_bypass_supply_temperature_targets.assert_awaited_once_with()
 
     await async_fire_coordinator_update(hass, freezer)
 
     assert mock_duco_client.async_get_bypass_supply_temperature_targets.await_count == 2
-    assert hass.states.get("number.living_bypass_target_1") is not None
-    assert hass.states.get("number.living_bypass_target_2") is not None
-
-
-async def test_missing_bypass_temperature_targets_are_retried(
-    hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
-    mock_bypass_supply_temperature_targets: dict[int, BypassSupplyTemperatureTarget],
-    mock_config_entry: MockConfigEntry,
-    mock_duco_client: AsyncMock,
-) -> None:
-    """Test missing bypass targets are retried and can later create entities."""
-    targets_without_zone_1 = {
-        k: v for k, v in mock_bypass_supply_temperature_targets.items() if k != 1
-    }
-    mock_duco_client.async_get_bypass_supply_temperature_targets.side_effect = [
-        targets_without_zone_1,
-        mock_bypass_supply_temperature_targets.copy(),
-    ]
-    mock_config_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert hass.states.get("number.living_bypass_target_1") is None
-
-    await async_fire_coordinator_update(hass, freezer)
-
     state = hass.states.get("number.living_bypass_target_1")
     assert state is not None
     assert state.state == "20.0"
+    assert hass.states.get("number.living_bypass_target_2") is not None
 
 
 async def test_setup_entry_ignores_node_name_config_failures(

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -259,19 +259,27 @@ async def test_lan_info_failures_keep_node_entities_available(
     assert state.state == "-60"
 
 
-async def test_time_filter_remaining_missing_is_retried(
+@pytest.mark.parametrize(
+    "initial_time_filter_remain",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param(DucoError("heat recovery info error"), id="transient_failure"),
+    ],
+)
+async def test_time_filter_remaining_is_retried(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
     mock_sensor_nodes: list[Node],
     freezer: FrozenDateTimeFactory,
+    initial_time_filter_remain: DucoError | None,
 ) -> None:
-    """Test a missing filter timer does not create the sensor but is retried."""
+    """Test unavailable filter timer data is retried and can create the sensor."""
     mock_duco_client.async_get_nodes.return_value = mock_sensor_nodes
-
-    mock_duco_client.async_get_time_filter_remaining = AsyncMock(
-        side_effect=[None, 180]
-    )
+    mock_duco_client.async_get_time_filter_remaining.side_effect = [
+        initial_time_filter_remain,
+        180,
+    ]
 
     await setup_platform_integration(hass, mock_config_entry, [Platform.SENSOR])
 

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -342,30 +342,6 @@ async def test_partial_ventilation_temperatures_only_expose_available_sensor_val
     assert hass.states.get("sensor.living_exhaust_air_temperature") is None
 
 
-async def test_time_filter_remaining_transient_failure_recovers_sensor_creation(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_duco_client: AsyncMock,
-    mock_sensor_nodes: list[Node],
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test the filter timer sensor is added once a transient startup failure recovers."""
-    mock_duco_client.async_get_nodes.return_value = mock_sensor_nodes
-    mock_duco_client.async_get_time_filter_remaining = AsyncMock(
-        side_effect=[DucoError("heat recovery info error"), 180]
-    )
-
-    await setup_platform_integration(hass, mock_config_entry, [Platform.SENSOR])
-
-    assert hass.states.get(FILTER_REMAINING_ENTITY_ID) is None
-
-    await async_fire_coordinator_update(hass, freezer)
-
-    state = hass.states.get(FILTER_REMAINING_ENTITY_ID)
-    assert state is not None
-    assert state.state == "180"
-
-
 @pytest.mark.parametrize(
     (
         "node_id",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Consolidate equivalent Duco capability recovery tests without changing their coverage.

- Parameterize missing and transiently unavailable filter timer data, which both leave the optional sensor absent until the next coordinator update.
- Parameterize empty and partially missing bypass target data, which both add the missing number entities after the next coordinator update.
- Keep setup failures, temperature capability behavior, registry behavior, and node topology scenarios separate where their observable contracts differ.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
