### PR TITLE
Allow HassIO.send_command to handle plaintext responses

### DIFF
--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -87,8 +87,20 @@ class HassIO:
             )
 
             if response.status != HTTPStatus.OK:
-                error = await response.json(encoding="utf-8")
-                if error.get(ATTR_RESULT) == "error":
+                try:
+                    error = await response.json(encoding="utf-8")
+                except (aiohttp.ContentTypeError, ValueError) as err:
+                    error_text = await response.text(encoding="utf-8")
+                    _LOGGER.error(
+                        "Request to %s method %s returned with code %d: %s",
+                        command,
+                        method,
+                        response.status,
+                        error_text,
+                    )
+                    raise HassioAPIError(error_text) from err
+
+                if isinstance(error, dict) and error.get(ATTR_RESULT) == "error":
                     raise HassioAPIError(error.get(ATTR_MESSAGE))
 
                 _LOGGER.error(
@@ -99,15 +111,22 @@ class HassIO:
                 )
                 raise HassioAPIError
 
-            if return_text:
+            if return_text or (
+                response.content_type and response.content_type.startswith("text/")
+            ):
                 return await response.text(encoding="utf-8")
 
-            return await response.json(encoding="utf-8")
+            try:
+                return await response.json(encoding="utf-8")
+            except aiohttp.ContentTypeError:
+                return await response.text(encoding="utf-8")
+            except ValueError:
+                return await response.text(encoding="utf-8")
 
         except TimeoutError:
             _LOGGER.error("Timeout on %s request", command)
 
-        except aiohttp.ClientError as err:
+        except (aiohttp.ClientError, ValueError) as err:
             _LOGGER.error("Client error on %s request %s", command, err)
 
         raise HassioAPIError

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -148,16 +148,19 @@ async def websocket_supervisor_api(
             params=msg.get(ATTR_PARAMS),
         )
     except HassioAPIError as err:
-        _LOGGER.error("Failed to to call %s - %s", msg[ATTR_ENDPOINT], err)
+        _LOGGER.error("Failed to call %s - %s", msg[ATTR_ENDPOINT], err)
         connection.send_error(
             msg[WS_ID], code=websocket_api.ERR_UNKNOWN_ERROR, message=str(err)
         )
     else:
-        data = result.get(ATTR_DATA, {})
-        # Remove options from add-on info for non-admin users, as options can contain
-        # sensitive information and the frontend does not require it for ingress.
-        if not connection.user.is_admin and WS_ADDONS_INFO_ENDPOINT.match(command):
-            data.pop("options", None)
+        if isinstance(result, dict):
+            data = result.get(ATTR_DATA, {})
+            # Remove options from add-on info for non-admin users, as options can contain
+            # sensitive information and the frontend does not require it for ingress.
+            if not connection.user.is_admin and WS_ADDONS_INFO_ENDPOINT.match(command):
+                data.pop("options", None)
+        else:
+            data = result
         connection.send_result(msg[WS_ID], data)
 
 

--- a/tests/components/hassio/test_handler.py
+++ b/tests/components/hassio/test_handler.py
@@ -3,6 +3,7 @@
 from typing import Any, Literal
 
 from aiohttp import hdrs, web
+from aiohttp.pytest_plugin import AiohttpRawServer
 import pytest
 
 from homeassistant.components.hassio.handler import HassIO, HassioAPIError
@@ -20,7 +21,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 )
 @pytest.mark.usefixtures("socket_enabled")
 async def test_api_headers(
-    aiohttp_raw_server,  # 'aiohttp_raw_server' must be before 'hass'!
+    aiohttp_raw_server: AiohttpRawServer,  # 'aiohttp_raw_server' must be before 'hass'!
     hass: HomeAssistant,
     api_call: str,
     method: Literal["GET", "POST"],
@@ -72,3 +73,118 @@ async def test_send_command_invalid_command(hass: HomeAssistant) -> None:
     with pytest.raises(HassioAPIError):
         # relative path with percent encoding
         await hassio.send_command("test/%2E%2E/bad")
+
+
+@pytest.mark.usefixtures("socket_enabled")
+async def test_send_command_text_response(
+    aiohttp_raw_server: AiohttpRawServer,  # 'aiohttp_raw_server' must be before 'hass'!
+    hass: HomeAssistant,
+) -> None:
+    """Test send command returns plain text when response is text/plain."""
+    log_data = "2026-09-09 10:00:00 WARNING (MainThread) [test] sample log\n"
+
+    async def mock_handler(request: web.Request) -> web.Response:
+        """Return plain text logs."""
+        return web.Response(text=log_data, content_type="text/plain")
+
+    server = await aiohttp_raw_server(mock_handler)
+    hassio_handler = HassIO(
+        hass.loop,
+        async_get_clientsession(hass),
+        f"{server.host}:{server.port}",
+    )
+
+    result = await hassio_handler.send_command("/core/logs", method="GET")
+    assert result == log_data
+
+
+@pytest.mark.usefixtures("socket_enabled")
+async def test_send_command_non_json_error(
+    aiohttp_raw_server: AiohttpRawServer,  # 'aiohttp_raw_server' must be before 'hass'!
+    hass: HomeAssistant,
+) -> None:
+    """Test send command raises HassioAPIError with body text when error response is not JSON."""
+
+    async def mock_handler(request: web.Request) -> web.Response:
+        """Return 502 Bad Gateway text."""
+        return web.Response(
+            text="502 Bad Gateway", status=502, content_type="text/plain"
+        )
+
+    server = await aiohttp_raw_server(mock_handler)
+    hassio_handler = HassIO(
+        hass.loop,
+        async_get_clientsession(hass),
+        f"{server.host}:{server.port}",
+    )
+
+    with pytest.raises(HassioAPIError, match="502 Bad Gateway"):
+        await hassio_handler.send_command("/core/logs", method="GET")
+
+
+@pytest.mark.usefixtures("socket_enabled")
+async def test_send_command_non_dict_json_error(
+    aiohttp_raw_server: AiohttpRawServer,  # 'aiohttp_raw_server' must be before 'hass'!
+    hass: HomeAssistant,
+) -> None:
+    """Test non-dict JSON error payload raises HassioAPIError, not AttributeError."""
+
+    async def mock_handler(request: web.Request) -> web.Response:
+        """Return 400 with a JSON list body."""
+        return web.json_response(["error"], status=400)
+
+    server = await aiohttp_raw_server(mock_handler)
+    hassio_handler = HassIO(
+        hass.loop,
+        async_get_clientsession(hass),
+        f"{server.host}:{server.port}",
+    )
+
+    with pytest.raises(HassioAPIError):
+        await hassio_handler.send_command("/core/logs", method="GET")
+
+
+@pytest.mark.usefixtures("socket_enabled")
+async def test_send_command_octet_stream_fallback(
+    aiohttp_raw_server: AiohttpRawServer,  # 'aiohttp_raw_server' must be before 'hass'!
+    hass: HomeAssistant,
+) -> None:
+    """Test send command falls back to text on unexpected mimetype (#116470)."""
+    log_data = "2026-09-09 10:00:00 WARNING (MainThread) [test] octet-stream log\n"
+
+    async def mock_handler(request: web.Request) -> web.Response:
+        """Return text body with a fallback mimetype."""
+        return web.Response(text=log_data, content_type="application/octet-stream")
+
+    server = await aiohttp_raw_server(mock_handler)
+    hassio_handler = HassIO(
+        hass.loop,
+        async_get_clientsession(hass),
+        f"{server.host}:{server.port}",
+    )
+
+    result = await hassio_handler.send_command("/core/logs", method="GET")
+    assert result == log_data
+
+
+@pytest.mark.usefixtures("socket_enabled")
+async def test_send_command_invalid_json_fallback(
+    aiohttp_raw_server: AiohttpRawServer,  # 'aiohttp_raw_server' must be before 'hass'!
+    hass: HomeAssistant,
+) -> None:
+    """Test send command falls back to text on JSON mimetype with invalid body."""
+    raw_body = "not valid json"
+
+    async def mock_handler(request: web.Request) -> web.Response:
+        """Return invalid JSON body with JSON mimetype."""
+        return web.Response(text=raw_body, content_type="application/json")
+
+    server = await aiohttp_raw_server(mock_handler)
+    hassio_handler = HassIO(
+        hass.loop,
+        async_get_clientsession(hass),
+        f"{server.host}:{server.port}",
+    )
+
+    result = await hassio_handler.send_command("/core/logs", method="GET")
+    assert result == raw_body

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -286,6 +286,67 @@ async def test_websocket_supervisor_api_error_without_msg(
 
 
 @pytest.mark.usefixtures("hassio_env")
+async def test_websocket_supervisor_api_text_response(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test Supervisor websocket api with text/plain response."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    websocket_client = await hass_ws_client(hass)
+    log_content = "2026-09-09 10:00:00 WARNING (MainThread) [test] core logs\n"
+    aioclient_mock.get(
+        "http://127.0.0.1/core/logs",
+        text=log_content,
+        headers={"Content-Type": "text/plain; charset=utf-8"},
+    )
+
+    await websocket_client.send_json(
+        {
+            WS_ID: 1,
+            WS_TYPE: WS_TYPE_API,
+            ATTR_ENDPOINT: "/core/logs",
+            ATTR_METHOD: "get",
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["success"] is True
+    assert msg["result"] == log_content
+
+
+@pytest.mark.usefixtures("hassio_env")
+async def test_websocket_supervisor_api_plain_error(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test Supervisor websocket api non-JSON error handling."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    websocket_client = await hass_ws_client(hass)
+    aioclient_mock.get(
+        "http://127.0.0.1/ping",
+        text="502 Bad Gateway",
+        status=502,
+        headers={"Content-Type": "text/plain; charset=utf-8"},
+    )
+
+    await websocket_client.send_json(
+        {
+            WS_ID: 1,
+            WS_TYPE: WS_TYPE_API,
+            ATTR_ENDPOINT: "/ping",
+            ATTR_METHOD: "get",
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["success"] is False
+    assert msg["error"]["code"] == "unknown_error"
+    assert msg["error"]["message"] == "502 Bad Gateway"
+
+
+@pytest.mark.usefixtures("hassio_env")
 async def test_websocket_non_admin_user(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,


### PR DESCRIPTION
## Proposed change

Allow `HassIO.send_command` and `websocket_supervisor_api` to handle plaintext responses.

When calling plaintext endpoints (such as `/core/logs`) via `websocket_supervisor_api`, Supervisor returns `text/plain`. Because `send_command` defaulted to decoding JSON, this resulted in:
`Client error on /core/logs request 200, message='Attempt to decode JSON with unexpected mimetype: text/plain'`

This change:
1. Returns `response.text()` when `response.content_type` starts with `text/` or if JSON decoding raises `aiohttp.ContentTypeError` or `ValueError` (malformed JSON body).
2. Allows `websocket_supervisor_api` to return string results when the command response is not a dictionary.
3. If an error response (non-200) contains a plaintext body (e.g. a 502/504 status from a proxy), reads the body as text so the message is kept in `HassioAPIError`.
4. Guards the non-200 JSON branch with `isinstance(error, dict)` so non-dict JSON error payloads don't raise `AttributeError`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

<details>
<summary>Log trace (Before Fix)</summary>

```text
[homeassistant.components.hassio.handler] Client error on /core/logs request 200, message='Attempt to decode JSON with unexpected mimetype: text/plain', url='http://172.30.32.2/core/logs'
[homeassistant.components.hassio] Failed to to call /core/logs -
```
</details>

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/