### PR TITLE
Add PAC input and picture mode controls

### DIFF
--- a/homeassistant/components/panasonic_viera/__init__.py
+++ b/homeassistant/components/panasonic_viera/__init__.py
@@ -51,7 +51,7 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-PLATFORMS = [Platform.MEDIA_PLAYER, Platform.REMOTE]
+PLATFORMS = [Platform.MEDIA_PLAYER, Platform.REMOTE, Platform.SELECT]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -153,6 +153,10 @@ class Remote:
         self.volume: float = 0
         self.muted: bool = False
         self.playing: bool = True
+        self.source: str | None = None
+        self.sources: list[str] | None = None
+        self.picture_mode: str | None = None
+        self.picture_modes: list[str] | None = None
 
     async def async_create_remote_control(self, during_setup: bool = False) -> None:
         """Create remote control."""
@@ -192,6 +196,17 @@ class Remote:
         assert self._control is not None
         self.muted = self._control.get_mute()
         self.volume = self._control.get_volume() / 100
+        try:
+            self.sources = self._control.list_inputs()
+            self.source = self._control.get_input()
+            self.picture_modes = self._control.list_picture_modes()
+            self.picture_mode = self._control.get_picture_mode()
+        except (SOAPError, HTTPError, URLError, OSError) as err:
+            _LOGGER.debug("PAC controls are unavailable: %s", err)
+            self.sources = None
+            self.source = None
+            self.picture_modes = None
+            self.picture_mode = None
 
     async def async_send_key(self, key: Keys | str) -> None:
         """Send a key to the TV and handle exceptions."""
@@ -229,6 +244,22 @@ class Remote:
         assert self._control is not None
         volume = int(volume * 100)
         await self._handle_errors(self._control.set_volume, volume)
+
+    async def async_set_input(self, source: str) -> str | None:
+        """Select an input through Panasonic PAC."""
+        assert self._control is not None
+        result = await self._handle_errors(self._control.set_input, source)
+        if result is not None:
+            self.source = result
+        return result
+
+    async def async_set_picture_mode(self, picture_mode: str) -> str | None:
+        """Select a picture mode through Panasonic PAC."""
+        assert self._control is not None
+        result = await self._handle_errors(self._control.set_picture_mode, picture_mode)
+        if result is not None:
+            self.picture_mode = result
+        return result
 
     async def async_play_media(self, media_type: MediaType, media_id: str) -> None:
         """Play media."""

--- a/homeassistant/components/panasonic_viera/manifest.json
+++ b/homeassistant/components/panasonic_viera/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["panasonic_viera"],
-  "requirements": ["panasonic-viera==0.4.4"]
+  "requirements": ["panasonic-viera==0.4.5"]
 }

--- a/homeassistant/components/panasonic_viera/media_player.py
+++ b/homeassistant/components/panasonic_viera/media_player.py
@@ -109,6 +109,27 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
         """Boolean if volume is currently muted."""
         return self._remote.muted
 
+    @property
+    @override
+    def source(self) -> str | None:
+        """Return the selected PAC input."""
+        return self._remote.source
+
+    @property
+    @override
+    def source_list(self) -> list[str] | None:
+        """Return PAC inputs when they are supported by the TV."""
+        return self._remote.sources
+
+    @property
+    @override
+    def supported_features(self) -> MediaPlayerEntityFeature:
+        """Return the features exposed by this TV model."""
+        features = self._attr_supported_features
+        if self._remote.sources is not None:
+            features |= MediaPlayerEntityFeature.SELECT_SOURCE
+        return features
+
     async def async_update(self) -> None:
         """Retrieve the latest data."""
         await self._remote.async_update()
@@ -142,6 +163,11 @@ class PanasonicVieraTVEntity(MediaPlayerEntity):
     async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         await self._remote.async_set_volume(volume)
+
+    @override
+    async def async_select_source(self, source: str) -> None:
+        """Select a source through PAC."""
+        await self._remote.async_set_input(source)
 
     @override
     async def async_media_play_pause(self) -> None:

--- a/homeassistant/components/panasonic_viera/select.py
+++ b/homeassistant/components/panasonic_viera/select.py
@@ -1,0 +1,85 @@
+"""Picture mode selection support for Panasonic Viera TVs."""
+
+from typing import Any, override
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.const import ATTR_MANUFACTURER, CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import PanasonicVieraConfigEntry, Remote
+from .const import (
+    ATTR_DEVICE_INFO,
+    ATTR_MODEL_NUMBER,
+    ATTR_UDN,
+    DEFAULT_MANUFACTURER,
+    DEFAULT_MODEL_NUMBER,
+    DOMAIN,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: PanasonicVieraConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the PAC picture mode selector when supported by the TV."""
+    remote = config_entry.runtime_data
+    if remote.picture_modes is None:
+        return
+    config = config_entry.data
+    async_add_entities(
+        [
+            PanasonicVieraPictureModeEntity(
+                remote, config[CONF_NAME], config[ATTR_DEVICE_INFO]
+            )
+        ]
+    )
+
+
+class PanasonicVieraPictureModeEntity(SelectEntity):
+    """Representation of a Panasonic PAC picture mode selector."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Picture mode"
+
+    def __init__(
+        self, remote: Remote, name: str, device_info: dict[str, Any] | None
+    ) -> None:
+        """Initialize the picture mode selector."""
+        self._remote = remote
+        if device_info is not None:
+            self._attr_unique_id = f"{device_info[ATTR_UDN]}_picture_mode"
+            self._attr_device_info = DeviceInfo(
+                identifiers={(DOMAIN, device_info[ATTR_UDN])},
+                manufacturer=device_info.get(ATTR_MANUFACTURER, DEFAULT_MANUFACTURER),
+                model=device_info.get(ATTR_MODEL_NUMBER, DEFAULT_MODEL_NUMBER),
+                name=name,
+            )
+        else:
+            self._attr_name = f"{name} Picture mode"
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return whether PAC picture modes remain available."""
+        return self._remote.available and self._remote.picture_modes is not None
+
+    @property
+    @override
+    def current_option(self) -> str | None:
+        """Return the current PAC picture mode."""
+        return self._remote.picture_mode
+
+    @property
+    @override
+    def options(self) -> list[str]:
+        """Return the picture modes exposed by PAC."""
+        return self._remote.picture_modes or []
+
+    @override
+    async def async_select_option(self, option: str) -> None:
+        """Select a PAC picture mode."""
+        await self._remote.async_set_picture_mode(option)
+        self.async_write_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1881,7 +1881,7 @@ pajgps-api==0.4.0
 panacotta==0.2
 
 # homeassistant.components.panasonic_viera
-panasonic-viera==0.4.4
+panasonic-viera==0.4.5
 
 # homeassistant.components.dunehd
 pdunehd==1.3.3

--- a/tests/components/panasonic_viera/conftest.py
+++ b/tests/components/panasonic_viera/conftest.py
@@ -85,6 +85,12 @@ def get_mock_remote(
     mock_remote.send_key = Mock()
 
     mock_remote.get_volume = Mock(return_value=100)
+    mock_remote.list_inputs = Mock(return_value=["TV", "HDMI1", "HDMI2"])
+    mock_remote.get_input = Mock(return_value="HDMI1")
+    mock_remote.set_input = Mock(return_value="HDMI2")
+    mock_remote.list_picture_modes = Mock(return_value=["Normal", "Cinema", "Game"])
+    mock_remote.get_picture_mode = Mock(return_value="Normal")
+    mock_remote.set_picture_mode = Mock(return_value="Cinema")
 
     return mock_remote
 

--- a/tests/components/panasonic_viera/test_media_player.py
+++ b/tests/components/panasonic_viera/test_media_player.py
@@ -4,11 +4,37 @@ from datetime import timedelta
 from unittest.mock import Mock
 from urllib.error import HTTPError, URLError
 
+from homeassistant.components.media_player import (
+    ATTR_INPUT_SOURCE,
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    SERVICE_SELECT_SOURCE,
+    MediaPlayerEntityFeature,
+)
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_pac_input_source(
+    hass: HomeAssistant, init_integration: MockConfigEntry, mock_remote: Mock
+) -> None:
+    """Test PAC inputs are exposed through the standard media player API."""
+    state = hass.states.get("media_player.panasonic_viera_tv")
+    assert state.attributes["source"] == "HDMI1"
+    assert state.attributes["source_list"] == ["TV", "HDMI1", "HDMI2"]
+    assert (
+        state.attributes["supported_features"] & MediaPlayerEntityFeature.SELECT_SOURCE
+    )
+
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_SELECT_SOURCE,
+        {"entity_id": state.entity_id, ATTR_INPUT_SOURCE: "HDMI2"},
+        blocking=True,
+    )
+    mock_remote.set_input.assert_called_once_with("HDMI2")
 
 
 async def test_media_player_handle_URLerror(

--- a/tests/components/panasonic_viera/test_select.py
+++ b/tests/components/panasonic_viera/test_select.py
@@ -1,0 +1,66 @@
+"""Tests for Panasonic Viera PAC picture mode selection."""
+
+from unittest.mock import Mock, patch
+
+from panasonic_viera import SOAPError
+
+from homeassistant.components.media_player import MediaPlayerEntityFeature
+from homeassistant.components.panasonic_viera.const import ATTR_UDN, DOMAIN
+from homeassistant.components.select import (
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_OPTION
+from homeassistant.core import HomeAssistant
+
+from .conftest import (
+    MOCK_CONFIG_DATA,
+    MOCK_DEVICE_INFO,
+    MOCK_ENCRYPTION_DATA,
+    get_mock_remote,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def test_picture_mode_select(
+    hass: HomeAssistant, init_integration: MockConfigEntry, mock_remote: Mock
+) -> None:
+    """Test PAC picture modes are exposed as a select entity."""
+    state = hass.states.get("select.panasonic_viera_tv_picture_mode")
+    assert state.state == "Normal"
+    assert state.attributes["options"] == ["Normal", "Cinema", "Game"]
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {"entity_id": state.entity_id, ATTR_OPTION: "Cinema"},
+        blocking=True,
+    )
+    mock_remote.set_picture_mode.assert_called_once_with("Cinema")
+
+
+async def test_no_picture_mode_select_without_pac(hass: HomeAssistant) -> None:
+    """Test PAC entities are not added for televisions without PAC support."""
+    mock_remote = get_mock_remote()
+    mock_remote.list_inputs.side_effect = SOAPError("unsupported")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_DEVICE_INFO[ATTR_UDN],
+        data={**MOCK_CONFIG_DATA, **MOCK_ENCRYPTION_DATA, **MOCK_DEVICE_INFO},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.panasonic_viera.RemoteControl",
+        return_value=mock_remote,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get("select.panasonic_viera_tv_picture_mode") is None
+    state = hass.states.get("media_player.panasonic_viera_tv")
+    assert (
+        not state.attributes["supported_features"]
+        & MediaPlayerEntityFeature.SELECT_SOURCE
+    )


### PR DESCRIPTION
## Dependency status

This draft requires the release of [`panasonic-viera` 0.4.5](https://github.com/florianholzapfel/panasonic-viera/pull/65). It is intentionally kept as a draft until that release is available on PyPI.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Expose PAC-backed inputs as media-player sources and add a picture-mode select for compatible Panasonic Viera televisions. The integration remains unchanged for devices that do not support PAC.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Library dependency: https://github.com/florianholzapfel/panasonic-viera/pull/65
- Library change comparison: https://github.com/florianholzapfel/panasonic-viera/compare/0.4.4...cc9a9ddbc46a0cac0ad2b210366d636cd0b0907a
- Local verification: `uv run --no-sync pytest -q tests/components/panasonic_viera` (35 passed).
- Formatting: scoped Ruff check and format passed.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

- Global Hassfest is pending: this local environment lacks the unrelated `infrared_protocols` dependency required during startup.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

