### PR TITLE
Adjust hue to not access DeviceEntry.config_entries

### DIFF
--- a/homeassistant/components/hue/device_trigger.py
+++ b/homeassistant/components/hue/device_trigger.py
@@ -47,8 +47,9 @@ async def async_validate_trigger_config(
     ) is None:
         raise InvalidDeviceAutomationConfig(f"Device ID {device_id} is not valid")
 
+    entry_ids = _device_config_entry_ids(device_entry)
     for entry in entries:
-        if entry.entry_id not in device_entry.config_entries:
+        if entry.entry_id not in entry_ids:
             continue
         bridge = entry.runtime_data
         if bridge.api_version == 1:
@@ -72,11 +73,12 @@ async def async_attach_trigger(
     ) is None:
         raise InvalidDeviceAutomationConfig(f"Device ID {device_id} is not valid")
 
+    entry_ids = _device_config_entry_ids(device_entry)
     entry: HueConfigEntry | None = next(
         (
             entry
             for entry in hass.config_entries.async_entries(DOMAIN)
-            if entry.entry_id in device_entry.config_entries
+            if entry.entry_id in entry_ids
         ),
         None,
     )
@@ -112,8 +114,9 @@ async def async_get_triggers(
 
     # Iterate all config entries for this device
     # and work out the bridge version
+    entry_ids = _device_config_entry_ids(device_entry)
     for entry in entries:
-        if entry.entry_id not in device_entry.config_entries:
+        if entry.entry_id not in entry_ids:
             continue
         bridge = entry.runtime_data
 
@@ -121,6 +124,17 @@ async def async_get_triggers(
             return async_get_triggers_v1(bridge, device_entry)
         return async_get_triggers_v2(bridge, device_entry)
     return []
+
+
+def _device_config_entry_ids(device_entry: dr.DeviceEntry) -> set[str]:
+    """Return the ids of the config entries the device belongs to.
+
+    A restored composite has no single owning config entry; the union of the
+    split devices' config entries covers every owning domain.
+    """
+    if device_entry.is_composite_device:
+        return device_entry.config_entries
+    return {device_entry.config_entry_id}
 
 
 async def _async_attach_bridge_trigger(

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 from aiohue.v2.models.button import ButtonEvent
+import attr
 import pytest
 from pytest_unordered import unordered
 
@@ -137,6 +138,79 @@ async def test_get_triggers(
                 "platform": "device",
                 "domain": hue.DOMAIN,
                 "device_id": hue_wall_switch_device.id,
+                "unique_id": resource_id,
+                "type": event_type.value,
+                "subtype": control_id,
+                "metadata": {},
+            }
+            for event_type in (
+                ButtonEvent.INITIAL_PRESS,
+                ButtonEvent.LONG_RELEASE,
+                ButtonEvent.REPEAT,
+                ButtonEvent.LONG_PRESS,
+                ButtonEvent.SHORT_RELEASE,
+            )
+            for control_id, resource_id in (
+                (1, "c658d3d8-a013-4b81-8ac6-78b248537e70"),
+                (2, "be1eb834-bdf5-4d26-8fba-7b1feaa83a9d"),
+            )
+        ),
+    ]
+
+    assert triggers == unordered(expected_triggers)
+
+
+async def test_get_triggers_for_composite_device_id(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test we get the expected triggers for a pre-migration composite device id."""
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+    await setup_platform(
+        hass, mock_bridge_v2, [Platform.BINARY_SENSOR, Platform.SENSOR]
+    )
+    hue_wall_switch_device = device_registry.async_get_device_by_identifier(
+        (hue.DOMAIN, WALL_SWITCH_DEVICE_ID), mock_bridge_v2.config_entry.entry_id
+    )
+    other_entry = MockConfigEntry(domain="other")
+    other_entry.add_to_hass(hass)
+    other_device = device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id, identifiers={("other", "1")}
+    )
+    composite_id = "composite00000000000000000000ab"
+    # Simulate a migration split: both devices carry the pre-migration composite id
+    device_registry._devices[hue_wall_switch_device.id] = attr.evolve(
+        hue_wall_switch_device, composite_device_id=composite_id
+    )
+    device_registry._devices[other_device.id] = attr.evolve(
+        other_device, composite_device_id=composite_id
+    )
+
+    triggers = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, composite_id
+    )
+
+    hue_bat_sensor = entity_registry.async_get(
+        "sensor.wall_switch_with_2_controls_battery"
+    )
+    trigger_batt = {
+        "platform": "device",
+        "domain": "sensor",
+        "device_id": composite_id,
+        "type": "battery_level",
+        "entity_id": hue_bat_sensor.id,
+        "metadata": {"secondary": True},
+    }
+    expected_triggers = [
+        trigger_batt,
+        *(
+            {
+                "platform": "device",
+                "domain": hue.DOMAIN,
+                "device_id": composite_id,
                 "unique_id": resource_id,
                 "type": event_type.value,
                 "subtype": control_id,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adjust hue to not access `DeviceEntry.config_entries`, instead use helper `async_get_device_and_config_entry_for_domain` to find the device and config entry

### Rationale:
`DeviceEntry.config_entries` is a remnant from the multi config entry device design.

Note: It is possible for hue devices to be tied to multiple hue config entries if a it has been moved between hubs, but that case was not handled by the existing code which acts on the first hue config entry found so I didn't care about handling it in the updated code either.

This is a slop-free replacement of <https://github.com/home-assistant/core/pull/181912>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
