### PR TITLE
Fix Tesla sensors staying unknown after vehicle asleep on first refresh

### DIFF
--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -164,6 +164,20 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data = response["response"]
 
         except VehicleOffline:
+            if not self.updated_once:
+                # Still within the initial setup: don't let a vehicle that is
+                # asleep on the very first refresh masquerade as a successful
+                # update. self.data only has the listing data from __init__ at
+                # this point (no charge_state/vehicle_state/etc.), so silently
+                # returning it here would create entities that read as
+                # "unknown" forever, since nothing else forces an early retry
+                # (the next scheduled poll is up to VEHICLE_INTERVAL_SECONDS
+                # away, and if the vehicle is still asleep then, it repeats).
+                # Raising here lets async_config_entry_first_refresh() surface
+                # ConfigEntryNotReady instead, so the entry retries per the
+                # VEHICLE_FIRST_REFRESH_TIMEOUT budget above - which is the
+                # behavior that comment already documents as intended.
+                raise UpdateFailed("Vehicle was asleep during the initial refresh")
             self.data["state"] = TeslaFleetState.ASLEEP
             return self.data
         except RateLimited:

--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -163,7 +163,7 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             response = await self.api.vehicle_data(endpoints=self.endpoints)
             data = response["response"]
 
-        except VehicleOffline:
+        except VehicleOffline as err:
             if not self.updated_once:
                 # Still within the initial setup: don't let a vehicle that is
                 # asleep on the very first refresh masquerade as a successful
@@ -177,7 +177,9 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # ConfigEntryNotReady instead, so the entry retries per the
                 # VEHICLE_FIRST_REFRESH_TIMEOUT budget above - which is the
                 # behavior that comment already documents as intended.
-                raise UpdateFailed("Vehicle was asleep during the initial refresh")
+                raise UpdateFailed(
+                    "Vehicle was asleep during the initial refresh"
+                ) from err
             self.data["state"] = TeslaFleetState.ASLEEP
             return self.data
         except RateLimited:

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -117,6 +117,26 @@ async def test_vehicle_first_refresh_timeout(
     never.set()
 
 
+async def test_vehicle_first_refresh_offline_retries(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+    mock_vehicle_data: AsyncMock,
+) -> None:
+    """Test a vehicle asleep on the very first refresh retries setup.
+
+    Regression test for the vehicle being asleep during
+    async_config_entry_first_refresh(): this must not be treated as a
+    successful update (which would create entities that read "unknown"
+    forever), it should raise so the entry retries - see issue #146030.
+    """
+    mock_vehicle_data.side_effect = VehicleOffline
+
+    await setup_platform(hass, normal_config_entry)
+
+    assert normal_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert not hass.states.get("sensor.test_battery_level")
+
+
 async def test_oauth_refresh_expired(
     hass: HomeAssistant,
     normal_config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Tesla sensors (e.g. battery level, charge limit) can get stuck showing
"unknown" after a Home Assistant restart, with nothing in the logs, until
a manual command is sent to the vehicle (see #146030).

Root cause: TeslaFleetVehicleDataCoordinator seeds itself only with basic
vehicle-listing data at init - no telemetry (charge_state, vehicle_state,
etc.). Telemetry is only populated by a successful vehicle_data() fetch in
_async_update_data. If the vehicle happens to be asleep during the
coordinator's very first refresh (at config entry setup), the existing
VehicleOffline handler swallows this and returns the still-empty data as if
the update succeeded - no exception propagates, so setup completes with
entities that never got real data and will render "unknown" until a later
poll happens to catch the vehicle awake (up to 10 minutes away, repeating
indefinitely if it's asleep again next time).

This is also inconsistent with the comment already above
VEHICLE_FIRST_REFRESH_TIMEOUT, which documents the intended behavior as "a
sleeping vehicle raises ConfigEntryNotReady and the entry retries" - that
intent was never actually implemented for this specific code path.

Fix: only for the coordinator's genuine first-ever refresh
(not self.updated_once), raise UpdateFailed on VehicleOffline instead of
silently returning. This surfaces ConfigEntryNotReady through
async_config_entry_first_refresh(), so the entry retries per the existing
VEHICLE_FIRST_REFRESH_TIMEOUT budget - matching the documented intent.
Behavior for a vehicle going offline *after* a successful refresh, and the
existing RateLimited-on-first-refresh handling, are both untouched.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #146030
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
