### PR TITLE
Avoid accessing DeviceEntry.config_entries in tests

### DIFF
--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -247,10 +247,8 @@ async def test_migration_from_v1_to_v2(
     )
     assert migrated_device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert migrated_device.id == device.id
-    assert migrated_device.config_entries == {mock_config_entry.entry_id}
-    assert migrated_device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert migrated_device.config_entry_id == mock_config_entry.entry_id
+    assert migrated_device.config_subentry_id == subentry.subentry_id
 
 
 @pytest.mark.parametrize(
@@ -459,12 +457,8 @@ async def test_migration_from_v1_disabled(
         )
         assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
         assert device.id == devices[subentry_data["device"]].id
-        assert device.config_entries == {
-            mock_config_entries[main_config_entry].entry_id
-        }
-        assert device.config_entries_subentries == {
-            mock_config_entries[main_config_entry].entry_id: {subentry.subentry_id}
-        }
+        assert device.config_entry_id == mock_config_entries[main_config_entry].entry_id
+        assert device.config_subentry_id == subentry.subentry_id
         assert device.disabled_by is subentry_data["device_disabled_by"]
 
 
@@ -554,8 +548,8 @@ async def test_migration_from_v1_to_v2_with_multiple_keys(
             (DOMAIN, list(entry.subentries.values())[0].subentry_id), entry.entry_id
         )
         assert dev is not None
-        assert dev.config_entries == {entry.entry_id}
-        assert dev.config_entries_subentries == {entry.entry_id: {subentry.subentry_id}}
+        assert dev.config_entry_id == entry.entry_id
+        assert dev.config_subentry_id == subentry.subentry_id
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
@@ -655,10 +649,8 @@ async def test_migration_from_v1_to_v2_with_same_keys(
             (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
         assert dev is not None
-        assert dev.config_entries == {mock_config_entry.entry_id}
-        assert dev.config_entries_subentries == {
-            mock_config_entry.entry_id: {subentry.subentry_id}
-        }
+        assert dev.config_entry_id == mock_config_entry.entry_id
+        assert dev.config_subentry_id == subentry.subentry_id
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
@@ -779,10 +771,8 @@ async def test_migration_from_v2_1_to_v2_2(
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert device.id == device_1.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
     subentry = conversation_subentries[1]
 
@@ -800,10 +790,8 @@ async def test_migration_from_v2_1_to_v2_2(
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert device.id == device_2.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
 
 @pytest.mark.parametrize(

--- a/tests/components/bluetooth/test_base_scanner.py
+++ b/tests/components/bluetooth/test_base_scanner.py
@@ -581,7 +581,7 @@ async def test_remote_scanner_bluetooth_config_entry(
         (dr.CONNECTION_BLUETOOTH, scanner.source), adapter_entry.entry_id
     )
     assert dev is not None
-    assert dev.config_entries == {adapter_entry.entry_id}
+    assert dev.config_entry_id == adapter_entry.entry_id
     assert dev.manufacturer == manufacturer
 
     manager.async_remove_scanner(scanner.source)

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -604,7 +604,7 @@ async def test_remove_device(
     # Identifiers and connections are unique per config entry, so the two config
     # entries get separate devices even though they share a connection
     assert device_entry_1.id != device_entry.id
-    assert device_entry.config_entries == {entry_2.entry_id}
+    assert device_entry.config_entry_id == entry_2.entry_id
 
     # Removal is rejected while async_remove_config_entry_device returns False
     response = await _send_remove_device(
@@ -628,9 +628,9 @@ async def test_remove_device(
     assert not device_registry.async_get(device_entry.id)
 
     # The device belonging to the other config entry is untouched
-    assert device_registry.async_get(device_entry_1.id).config_entries == {
-        entry_1.entry_id
-    }
+    assert (
+        device_registry.async_get(device_entry_1.id).config_entry_id == entry_1.entry_id
+    )
 
     # Only the deprecated alias logs a deprecation warning
     assert (_DEPRECATION_WARNING in caplog.text) is deprecated
@@ -698,9 +698,9 @@ async def test_remove_device_fails(
     )
     # Identifiers and connections are unique per config entry, so each config entry
     # gets its own device even though they share a connection
-    assert device_entry_1.config_entries == {entry_1.entry_id}
-    assert device_entry_2.config_entries == {entry_2.entry_id}
-    assert device_entry_3.config_entries == {entry_3.entry_id}
+    assert device_entry_1.config_entry_id == entry_1.entry_id
+    assert device_entry_2.config_entry_id == entry_2.entry_id
+    assert device_entry_3.config_entry_id == entry_3.entry_id
 
     fake_device_id = "abc123"
     assert device_entry_3.id != fake_device_id
@@ -797,7 +797,7 @@ async def test_remove_device_if_integration_removes(
     # Identifiers and connections are unique per config entry, so the two config
     # entries get separate devices even though they share a connection
     assert device_entry_1.id != device_entry.id
-    assert device_entry.config_entries == {entry_2.entry_id}
+    assert device_entry.config_entry_id == entry_2.entry_id
 
     # Removal is rejected while async_remove_config_entry_device returns False
     response = await ws_client.remove_device(device_entry.id)
@@ -817,9 +817,9 @@ async def test_remove_device_if_integration_removes(
     assert not device_registry.async_get(device_entry.id)
 
     # The device belonging to the other config entry is untouched
-    assert device_registry.async_get(device_entry_1.id).config_entries == {
-        entry_1.entry_id
-    }
+    assert (
+        device_registry.async_get(device_entry_1.id).config_entry_id == entry_1.entry_id
+    )
 
 
 @pytest.mark.parametrize(("command", "deprecated"), _REMOVE_DEVICE_COMMANDS)

--- a/tests/components/deconz/test_services.py
+++ b/tests/components/deconz/test_services.py
@@ -364,7 +364,7 @@ async def test_remove_orphaned_entries_service(
             [
                 entry
                 for entry in device_registry.devices
-                if config_entry_setup.entry_id in entry.config_entries
+                if entry.config_entry_id == config_entry_setup.entry_id
             ]
         )
         == 4  # Gateway, light, switch and orphan
@@ -400,7 +400,7 @@ async def test_remove_orphaned_entries_service(
             [
                 entry
                 for entry in device_registry.devices
-                if config_entry_setup.entry_id in entry.config_entries
+                if entry.config_entry_id == config_entry_setup.entry_id
             ]
         )
         == 3  # Gateway, light and switch

--- a/tests/components/derivative/test_init.py
+++ b/tests/components/derivative/test_init.py
@@ -103,7 +103,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert derivative_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert derivative_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != derivative_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, derivative_entity_entry.entity_id)
 
@@ -151,7 +151,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert derivative_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert derivative_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != derivative_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, derivative_entity_entry.entity_id)
 
@@ -174,7 +174,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     # Check that the source device is not removed
     sensor_device = device_registry.async_get(sensor_device.id)
     assert sensor_device is not None
-    assert derivative_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != derivative_config_entry.entry_id
 
     # Check that the derivative config entry is not removed
     assert derivative_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -201,7 +201,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert derivative_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert derivative_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != derivative_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, derivative_entity_entry.entity_id)
 
@@ -224,7 +224,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 
     # Check that the derivative config entry is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert derivative_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != derivative_config_entry.entry_id
 
     # Check that the derivative config entry is not removed
     assert derivative_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -257,9 +257,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert derivative_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert derivative_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != derivative_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert derivative_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != derivative_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, derivative_entity_entry.entity_id)
 
@@ -282,9 +282,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 
     # Check that the derivative config entry is not in any of the devices
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert derivative_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != derivative_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert derivative_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != derivative_config_entry.entry_id
 
     # Check that the derivative config entry is not removed
     assert derivative_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -311,7 +311,7 @@ async def test_async_handle_source_entity_new_entity_id(
     assert derivative_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert derivative_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != derivative_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, derivative_entity_entry.entity_id)
 
@@ -331,7 +331,7 @@ async def test_async_handle_source_entity_new_entity_id(
 
     # Check that the helper config is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert derivative_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != derivative_config_entry.entry_id
 
     # Check that the derivative config entry is not removed
     assert derivative_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -412,7 +412,7 @@ async def test_migration_1_2(
     # Check that the derivative config entry is not on the source device and the
     # derivative entity is linked to the source device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert derivative_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != derivative_config_entry.entry_id
     derivative_entity_entry = entity_registry.async_get(
         "sensor.mock_title_my_derivative"
     )

--- a/tests/components/generic_hygrostat/test_init.py
+++ b/tests/components/generic_hygrostat/test_init.py
@@ -177,7 +177,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_hygrostat_config_entry.entry_id
 
     events = track_entity_registry_actions(
         hass, generic_hygrostat_entity_entry.entity_id
@@ -250,7 +250,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_hygrostat_config_entry.entry_id
 
     events = track_entity_registry_actions(
         hass, generic_hygrostat_entity_entry.entity_id
@@ -276,7 +276,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     # entry is not in the device
     source_device = device_registry.async_get(source_device.id)
     assert source_device is not None
-    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_hygrostat_config_entry.entry_id
 
     # Check that the generic_hygrostat config entry is not removed
     assert (
@@ -332,7 +332,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_hygrostat_config_entry.entry_id
 
     events = track_entity_registry_actions(
         hass, generic_hygrostat_entity_entry.entity_id
@@ -357,7 +357,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 
     # Check that the generic_hygrostat config entry is not in the device
     source_device = device_registry.async_get(source_device.id)
-    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_hygrostat_config_entry.entry_id
 
     # Check that the generic_hygrostat config entry is not removed
     assert (
@@ -408,9 +408,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_hygrostat_config_entry.entry_id
     source_device_2 = device_registry.async_get(source_device_2.id)
-    assert generic_hygrostat_config_entry.entry_id not in source_device_2.config_entries
+    assert source_device_2.config_entry_id != generic_hygrostat_config_entry.entry_id
 
     events = track_entity_registry_actions(
         hass, generic_hygrostat_entity_entry.entity_id
@@ -436,9 +436,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 
     # Check that the generic_hygrostat config entry is not in any of the devices
     source_device = device_registry.async_get(source_device.id)
-    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_hygrostat_config_entry.entry_id
     source_device_2 = device_registry.async_get(source_device_2.id)
-    assert generic_hygrostat_config_entry.entry_id not in source_device_2.config_entries
+    assert source_device_2.config_entry_id != generic_hygrostat_config_entry.entry_id
 
     # Check that the generic_hygrostat config entry is not removed
     assert (
@@ -487,7 +487,7 @@ async def test_async_handle_source_entity_new_entity_id(
     assert generic_hygrostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_hygrostat_config_entry.entry_id
 
     events = track_entity_registry_actions(
         hass, generic_hygrostat_entity_entry.entity_id
@@ -509,7 +509,7 @@ async def test_async_handle_source_entity_new_entity_id(
 
     # Check that the helper config is not in the device
     source_device = device_registry.async_get(source_device.id)
-    assert generic_hygrostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_hygrostat_config_entry.entry_id
 
     # Check that the generic_hygrostat config entry is not removed
     assert (
@@ -556,7 +556,7 @@ async def test_migration_1_1(
     # Check that the helper config entry is not on the source device and the helper
     # entity is linked to the source device
     switch_device = device_registry.async_get(switch_device.id)
-    assert generic_hygrostat_config_entry.entry_id not in switch_device.config_entries
+    assert switch_device.config_entry_id != generic_hygrostat_config_entry.entry_id
     generic_hygrostat_entity_entry = entity_registry.async_get(
         "humidifier.mock_title_my_generic_hygrostat"
     )

--- a/tests/components/generic_thermostat/test_init.py
+++ b/tests/components/generic_thermostat/test_init.py
@@ -181,7 +181,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert generic_thermostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert generic_thermostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_thermostat_config_entry.entry_id
 
     events = track_entity_registry_actions(
         hass, generic_thermostat_entity_entry.entity_id
@@ -255,7 +255,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert generic_thermostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert generic_thermostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_thermostat_config_entry.entry_id
 
     events = track_entity_registry_actions(
         hass, generic_thermostat_entity_entry.entity_id
@@ -281,7 +281,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     # entry is not in the device
     source_device = device_registry.async_get(source_device.id)
     assert source_device is not None
-    assert generic_thermostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_thermostat_config_entry.entry_id
 
     # Check that the generic_thermostat config entry is not removed
     assert (
@@ -338,7 +338,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert generic_thermostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert generic_thermostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_thermostat_config_entry.entry_id
 
     events = track_entity_registry_actions(
         hass, generic_thermostat_entity_entry.entity_id
@@ -363,7 +363,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 
     # Check that the generic_thermostat config entry is not in the device
     source_device = device_registry.async_get(source_device.id)
-    assert generic_thermostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_thermostat_config_entry.entry_id
 
     # Check that the generic_thermostat config entry is not removed
     assert (
@@ -415,11 +415,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert generic_thermostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert generic_thermostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_thermostat_config_entry.entry_id
     source_device_2 = device_registry.async_get(source_device_2.id)
-    assert (
-        generic_thermostat_config_entry.entry_id not in source_device_2.config_entries
-    )
+    assert source_device_2.config_entry_id != generic_thermostat_config_entry.entry_id
 
     events = track_entity_registry_actions(
         hass, generic_thermostat_entity_entry.entity_id
@@ -445,11 +443,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 
     # Check that the generic_thermostat config entry is not in any of the devices
     source_device = device_registry.async_get(source_device.id)
-    assert generic_thermostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_thermostat_config_entry.entry_id
     source_device_2 = device_registry.async_get(source_device_2.id)
-    assert (
-        generic_thermostat_config_entry.entry_id not in source_device_2.config_entries
-    )
+    assert source_device_2.config_entry_id != generic_thermostat_config_entry.entry_id
 
     # Check that the generic_thermostat config entry is not removed
     assert (
@@ -499,7 +495,7 @@ async def test_async_handle_source_entity_new_entity_id(
     assert generic_thermostat_entity_entry.device_id == switch_entity_entry.device_id
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert generic_thermostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_thermostat_config_entry.entry_id
 
     events = track_entity_registry_actions(
         hass, generic_thermostat_entity_entry.entity_id
@@ -521,7 +517,7 @@ async def test_async_handle_source_entity_new_entity_id(
 
     # Check that the helper config is not in the device
     source_device = device_registry.async_get(source_device.id)
-    assert generic_thermostat_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != generic_thermostat_config_entry.entry_id
 
     # Check that the generic_thermostat config entry is not removed
     assert (
@@ -569,7 +565,7 @@ async def test_migration_1_1(
     # Check that the helper config entry is not on the source device and the helper
     # entity is linked to the source device
     switch_device = device_registry.async_get(switch_device.id)
-    assert generic_thermostat_config_entry.entry_id not in switch_device.config_entries
+    assert switch_device.config_entry_id != generic_thermostat_config_entry.entry_id
     generic_thermostat_entity_entry = entity_registry.async_get(
         "climate.mock_title_my_generic_thermostat"
     )

--- a/tests/components/github/test_init.py
+++ b/tests/components/github/test_init.py
@@ -112,7 +112,7 @@ async def test_minor_v1_v2_migration(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={(DOMAIN, "test/repository")},
     )
-    assert device_entry.config_entries_subentries[mock_config_entry.entry_id] == {None}
+    assert device_entry.config_subentry_id is None
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -126,6 +126,4 @@ async def test_minor_v1_v2_migration(
     assert subentry.unique_id == "test/repository"
 
     assert (device_entry := device_registry.async_get(device_entry.id))
-    assert device_entry.config_entries_subentries[mock_config_entry.entry_id] == {
-        subentry.subentry_id
-    }
+    assert device_entry.config_subentry_id == subentry.subentry_id

--- a/tests/components/google_generative_ai_conversation/test_init.py
+++ b/tests/components/google_generative_ai_conversation/test_init.py
@@ -201,10 +201,8 @@ async def test_migration_from_v1(
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert device.id == device_1.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
     subentry = conversation_subentries[1]
 
@@ -224,10 +222,8 @@ async def test_migration_from_v1(
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert device.id == device_2.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
 
 @pytest.mark.parametrize(
@@ -471,12 +467,8 @@ async def test_migration_from_v1_disabled(
         )
         assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
         assert device.id == devices[subentry_data["device"]].id
-        assert device.config_entries == {
-            mock_config_entries[main_config_entry].entry_id
-        }
-        assert device.config_entries_subentries == {
-            mock_config_entries[main_config_entry].entry_id: {subentry.subentry_id}
-        }
+        assert device.config_entry_id == mock_config_entries[main_config_entry].entry_id
+        assert device.config_subentry_id == subentry.subentry_id
         assert device.disabled_by is subentry_data["device_disabled_by"]
 
 
@@ -582,10 +574,8 @@ async def test_migration_from_v1_with_multiple_keys(
             (DOMAIN, list(entry.subentries.values())[0].subentry_id), entry.entry_id
         )
         assert dev is not None
-        assert dev.config_entries == {entry.entry_id}
-        assert dev.config_entries_subentries == {
-            entry.entry_id: {list(entry.subentries.values())[0].subentry_id}
-        }
+        assert dev.config_entry_id == entry.entry_id
+        assert dev.config_subentry_id == list(entry.subentries.values())[0].subentry_id
 
 
 async def test_migration_from_v1_with_same_keys(
@@ -720,10 +710,8 @@ async def test_migration_from_v1_with_same_keys(
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert device.id == device_1.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
     subentry = conversation_subentries[1]
 
@@ -743,10 +731,8 @@ async def test_migration_from_v1_with_same_keys(
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert device.id == device_2.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
 
 @pytest.mark.parametrize(
@@ -924,10 +910,8 @@ async def test_migration_from_v2_1(
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert device.id == device_1.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
     subentry = conversation_subentries[1]
 
@@ -947,10 +931,8 @@ async def test_migration_from_v2_1(
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert device.id == device_2.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
 
 async def test_devices(

--- a/tests/components/history_stats/test_init.py
+++ b/tests/components/history_stats/test_init.py
@@ -133,7 +133,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert history_stats_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert history_stats_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != history_stats_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, history_stats_entity_entry.entity_id)
 
@@ -185,7 +185,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert history_stats_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert history_stats_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != history_stats_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, history_stats_entity_entry.entity_id)
 
@@ -205,7 +205,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     # Check that the source device is not removed
     sensor_device = device_registry.async_get(sensor_device.id)
     assert sensor_device is not None
-    assert history_stats_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != history_stats_config_entry.entry_id
 
     # Check that the history_stats config entry is removed
     assert (
@@ -235,7 +235,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert history_stats_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert history_stats_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != history_stats_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, history_stats_entity_entry.entity_id)
 
@@ -258,7 +258,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 
     # Check that the history_stats config entry is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert history_stats_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != history_stats_config_entry.entry_id
 
     # Check that the history_stats config entry is not removed
     assert history_stats_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -292,9 +292,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert history_stats_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert history_stats_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != history_stats_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert history_stats_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != history_stats_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, history_stats_entity_entry.entity_id)
 
@@ -317,9 +317,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 
     # Check that the history_stats config entry is not in any of the devices
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert history_stats_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != history_stats_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert history_stats_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != history_stats_config_entry.entry_id
 
     # Check that the history_stats config entry is not removed
     assert history_stats_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -347,7 +347,7 @@ async def test_async_handle_source_entity_new_entity_id(
     assert history_stats_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert history_stats_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != history_stats_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, history_stats_entity_entry.entity_id)
 
@@ -367,7 +367,7 @@ async def test_async_handle_source_entity_new_entity_id(
 
     # Check that the helper config is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert history_stats_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != history_stats_config_entry.entry_id
 
     # Check that the history_stats config entry is not removed
     assert history_stats_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -411,7 +411,7 @@ async def test_migration_1_1(
     # Check that the helper config entry is not on the source device and the helper
     # entity is linked to the source device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert history_stats_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != history_stats_config_entry.entry_id
     history_stats_entity_entry = entity_registry.async_get(
         "sensor.mock_title_my_history_stats"
     )

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -142,7 +142,7 @@ async def test_migrate_device_id_no_serial_skip_if_other_owner(
     bridge = device_registry.async_get(bridge.id)
 
     assert bridge.identifiers == variant.before
-    assert bridge.config_entries == {entry.entry_id}
+    assert bridge.config_entry_id == entry.entry_id
 
 
 @pytest.mark.parametrize("variant", DEVICE_MIGRATION_TESTS)

--- a/tests/components/hyperion/test_camera.py
+++ b/tests/components/hyperion/test_camera.py
@@ -198,7 +198,7 @@ async def test_device_info(
         (DOMAIN, device_id), TEST_CONFIG_ENTRY_ID
     )
     assert device
-    assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
+    assert device.config_entry_id == TEST_CONFIG_ENTRY_ID
     assert device.identifiers == {(DOMAIN, device_id)}
     assert device.manufacturer == HYPERION_MANUFACTURER_NAME
     assert device.model == HYPERION_MODEL_NAME

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -803,7 +803,7 @@ async def test_device_info(
         (DOMAIN, device_id), TEST_CONFIG_ENTRY_ID
     )
     assert device
-    assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
+    assert device.config_entry_id == TEST_CONFIG_ENTRY_ID
     assert device.identifiers == {(DOMAIN, device_id)}
     assert device.manufacturer == HYPERION_MANUFACTURER_NAME
     assert device.model == HYPERION_MODEL_NAME

--- a/tests/components/hyperion/test_sensor.py
+++ b/tests/components/hyperion/test_sensor.py
@@ -68,7 +68,7 @@ async def test_device_info(
         (DOMAIN, device_identifer), TEST_CONFIG_ENTRY_ID
     )
     assert device
-    assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
+    assert device.config_entry_id == TEST_CONFIG_ENTRY_ID
     assert device.identifiers == {(DOMAIN, device_identifer)}
     assert device.manufacturer == HYPERION_MANUFACTURER_NAME
     assert device.model == HYPERION_MODEL_NAME

--- a/tests/components/hyperion/test_switch.py
+++ b/tests/components/hyperion/test_switch.py
@@ -172,7 +172,7 @@ async def test_device_info(
         (DOMAIN, device_identifer), TEST_CONFIG_ENTRY_ID
     )
     assert device
-    assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
+    assert device.config_entry_id == TEST_CONFIG_ENTRY_ID
     assert device.identifiers == {(DOMAIN, device_identifer)}
     assert device.manufacturer == HYPERION_MANUFACTURER_NAME
     assert device.model == HYPERION_MODEL_NAME

--- a/tests/components/integration/test_init.py
+++ b/tests/components/integration/test_init.py
@@ -170,11 +170,11 @@ async def test_entry_changed(
             domain, "test", name, suggested_object_id=name, device_id=device_entry.id
         )
 
-    def _get_device_config_entries(entry: er.RegistryEntry) -> set[str]:
+    def _get_device_config_entry_id(entry: er.RegistryEntry) -> str:
         assert entry.device_id
         device = device_registry.async_get(entry.device_id)
         assert device
-        return device.config_entries
+        return device.config_entry_id
 
     # Set up entities, with backing devices and config entries
     input_entry = _create_mock_entity("sensor", "input")
@@ -197,8 +197,8 @@ async def test_entry_changed(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.entry_id not in _get_device_config_entries(input_entry)
-    assert config_entry.entry_id not in _get_device_config_entries(valid_entry)
+    assert _get_device_config_entry_id(input_entry) != config_entry.entry_id
+    assert _get_device_config_entry_id(valid_entry) != config_entry.entry_id
     integration_entity_entry = entity_registry.async_get("sensor.input_my_integration")
     assert integration_entity_entry.device_id == input_entry.device_id
 
@@ -209,8 +209,8 @@ async def test_entry_changed(
     await hass.async_block_till_done()
 
     # Check that the device association has updated
-    assert config_entry.entry_id not in _get_device_config_entries(input_entry)
-    assert config_entry.entry_id not in _get_device_config_entries(valid_entry)
+    assert _get_device_config_entry_id(input_entry) != config_entry.entry_id
+    assert _get_device_config_entry_id(valid_entry) != config_entry.entry_id
     integration_entity_entry = entity_registry.async_get("sensor.input_my_integration")
     assert integration_entity_entry.device_id == valid_entry.device_id
 
@@ -234,7 +234,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert integration_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert integration_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != integration_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, integration_entity_entry.entity_id)
 
@@ -282,7 +282,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert integration_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert integration_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != integration_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, integration_entity_entry.entity_id)
 
@@ -307,7 +307,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
 
     # Check that the integration config entry is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert integration_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != integration_config_entry.entry_id
 
     # Check that the integration config entry is not removed
     assert integration_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -334,7 +334,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert integration_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert integration_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != integration_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, integration_entity_entry.entity_id)
 
@@ -357,7 +357,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 
     # Check that the integration config entry is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert integration_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != integration_config_entry.entry_id
 
     # Check that the integration config entry is not removed
     assert integration_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -390,9 +390,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert integration_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert integration_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != integration_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert integration_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != integration_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, integration_entity_entry.entity_id)
 
@@ -415,9 +415,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 
     # Check that the derivative config entry is not in any of the devices
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert integration_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != integration_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert integration_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != integration_config_entry.entry_id
 
     # Check that the integration config entry is not removed
     assert integration_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -444,7 +444,7 @@ async def test_async_handle_source_entity_new_entity_id(
     assert integration_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert integration_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != integration_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, integration_entity_entry.entity_id)
 
@@ -464,7 +464,7 @@ async def test_async_handle_source_entity_new_entity_id(
 
     # Check that the helper config is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert integration_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != integration_config_entry.entry_id
 
     # Check that the integration config entry is not removed
     assert integration_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -508,7 +508,7 @@ async def test_migration_1_1(
     # Check that the helper config entry is not in the device and the helper entity
     # is linked to the source device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert integration_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != integration_config_entry.entry_id
     integration_entity_entry = entity_registry.async_get(
         "sensor.mock_title_my_integration"
     )

--- a/tests/components/lifx/test_migration.py
+++ b/tests/components/lifx/test_migration.py
@@ -64,7 +64,7 @@ async def test_migration_device_online_end_to_end(
 
         assert migrated_entry is not None
 
-        assert device.config_entries == {migrated_entry.entry_id}
+        assert device.config_entry_id == migrated_entry.entry_id
         assert light_entity_reg.config_entry_id == migrated_entry.entry_id
         assert er.async_entries_for_config_entry(entity_registry, config_entry) == []
 
@@ -198,7 +198,7 @@ async def test_migration_device_online_end_to_end_after_downgrade(
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=20))
         await hass.async_block_till_done()
 
-        assert device.config_entries == {config_entry.entry_id}
+        assert device.config_entry_id == config_entry.entry_id
         assert light_entity_reg.config_entry_id == config_entry.entry_id
         assert er.async_entries_for_config_entry(entity_registry, config_entry) == []
 
@@ -281,7 +281,7 @@ async def test_migration_device_online_end_to_end_ignores_other_devices(
         assert new_entry is not None
         assert legacy_entry is None
 
-        assert device.config_entries == {legacy_config_entry.entry_id}
+        assert device.config_entry_id == legacy_config_entry.entry_id
         assert light_entity_reg.config_entry_id == legacy_config_entry.entry_id
         assert ignored_entity_reg.config_entry_id == other_domain_config_entry.entry_id
         assert garbage_entity_reg.config_entry_id == legacy_config_entry.entry_id

--- a/tests/components/lutron_caseta/test_logbook.py
+++ b/tests/components/lutron_caseta/test_logbook.py
@@ -102,7 +102,7 @@ async def test_humanify_lutron_caseta_button_event_integration_not_loaded(
     await hass.async_block_till_done()
 
     for device in device_registry.devices:
-        if device.config_entries == {config_entry.entry_id}:
+        if device.config_entry_id == config_entry.entry_id:
             dr_device_id = device.id
             break
 

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -248,7 +248,7 @@ async def test_node_diagnostics(
 
     # repeat test with a device id that does not have a node attached
     new_entry = device_registry.async_get_or_create(
-        config_entry_id=list(entry.config_entries)[0],
+        config_entry_id=entry.config_entry_id,
         identifiers={(DOMAIN, "MatterNodeDevice")},
     )
     await ws_client.send_json(
@@ -302,7 +302,7 @@ async def test_ping_node(
 
     # repeat test with a device id that does not have a node attached
     new_entry = device_registry.async_get_or_create(
-        config_entry_id=list(entry.config_entries)[0],
+        config_entry_id=entry.config_entry_id,
         identifiers={(DOMAIN, "MatterNodeDevice")},
     )
     await ws_client.send_json(
@@ -362,7 +362,7 @@ async def test_open_commissioning_window(
 
     # repeat test with a device id that does not have a node attached
     new_entry = device_registry.async_get_or_create(
-        config_entry_id=list(entry.config_entries)[0],
+        config_entry_id=entry.config_entry_id,
         identifiers={(DOMAIN, "MatterNodeDevice")},
     )
     await ws_client.send_json(
@@ -411,7 +411,7 @@ async def test_remove_matter_fabric(
 
     # repeat test with a device id that does not have a node attached
     new_entry = device_registry.async_get_or_create(
-        config_entry_id=list(entry.config_entries)[0],
+        config_entry_id=entry.config_entry_id,
         identifiers={(DOMAIN, "MatterNodeDevice")},
     )
     await ws_client.send_json(
@@ -455,7 +455,7 @@ async def test_interview_node(
 
     # repeat test with a device id that does not have a node attached
     new_entry = device_registry.async_get_or_create(
-        config_entry_id=list(entry.config_entries)[0],
+        config_entry_id=entry.config_entry_id,
         identifiers={(DOMAIN, "MatterNodeDevice")},
     )
     await ws_client.send_json(

--- a/tests/components/mold_indicator/test_init.py
+++ b/tests/components/mold_indicator/test_init.py
@@ -226,7 +226,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     )
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert mold_indicator_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != mold_indicator_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, mold_indicator_entity_entry.entity_id)
 
@@ -289,7 +289,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     )
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert mold_indicator_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != mold_indicator_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, mold_indicator_entity_entry.entity_id)
 
@@ -314,7 +314,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
 
     # Check if the mold_indicator config entry is not in the device
     source_device = device_registry.async_get(source_device.id)
-    assert mold_indicator_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != mold_indicator_config_entry.entry_id
 
     # Check that the mold_indicator config entry is not removed
     assert mold_indicator_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -362,7 +362,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     )
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert mold_indicator_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != mold_indicator_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, mold_indicator_entity_entry.entity_id)
 
@@ -385,7 +385,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 
     # Check that the mold_indicator config entry is not in the device
     source_device = device_registry.async_get(source_device.id)
-    assert mold_indicator_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != mold_indicator_config_entry.entry_id
 
     # Check that the mold_indicator config entry is not removed
     assert mold_indicator_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -431,9 +431,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     )
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert mold_indicator_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != mold_indicator_config_entry.entry_id
     source_device_2 = device_registry.async_get(source_device_2.id)
-    assert mold_indicator_config_entry.entry_id not in source_device_2.config_entries
+    assert source_device_2.config_entry_id != mold_indicator_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, mold_indicator_entity_entry.entity_id)
 
@@ -461,9 +461,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 
     # Check that the mold_indicator config entry is not in any of the devices
     source_device = device_registry.async_get(source_device.id)
-    assert mold_indicator_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != mold_indicator_config_entry.entry_id
     source_device_2 = device_registry.async_get(source_device_2.id)
-    assert mold_indicator_config_entry.entry_id not in source_device_2.config_entries
+    assert source_device_2.config_entry_id != mold_indicator_config_entry.entry_id
 
     # Check that the mold_indicator config entry is not removed
     assert mold_indicator_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -503,7 +503,7 @@ async def test_async_handle_source_entity_new_entity_id(
     )
 
     source_device = device_registry.async_get(source_entity_entry.device_id)
-    assert mold_indicator_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != mold_indicator_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, mold_indicator_entity_entry.entity_id)
 
@@ -523,7 +523,7 @@ async def test_async_handle_source_entity_new_entity_id(
 
     # Check that the helper config is not in the device
     source_device = device_registry.async_get(source_device.id)
-    assert mold_indicator_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != mold_indicator_config_entry.entry_id
 
     # Check that the mold_indicator config entry is not removed
     assert mold_indicator_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -567,7 +567,7 @@ async def test_migration_1_1(
     # Check that the helper config entry is not in the device and the helper entity
     # is linked to the source device
     source_device = device_registry.async_get(indoor_humidity_device.id)
-    assert mold_indicator_config_entry.entry_id not in source_device.config_entries
+    assert source_device.config_entry_id != mold_indicator_config_entry.entry_id
     mold_indicator_entity_entry = entity_registry.async_get(
         "sensor.mock_title_my_mold_indicator"
     )

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -338,7 +338,7 @@ async def test_device_info(
         device_identifier, entry.entry_id
     )
     assert device
-    assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
+    assert device.config_entry_id == TEST_CONFIG_ENTRY_ID
     assert device.identifiers == {device_identifier}
     assert device.manufacturer == MOTIONEYE_MANUFACTURER
     assert device.model == MOTIONEYE_MANUFACTURER

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -2108,7 +2108,7 @@ async def test_cleanup_device_multiple_config_entries(
         connections={("mac", "12:34:56:AB:CD:EF")},
     )
     assert mqtt_device_entry is not None
-    assert mqtt_device_entry.config_entries == {mqtt_config_entry.entry_id}
+    assert mqtt_device_entry.config_entry_id == mqtt_config_entry.entry_id
     assert (
         _get_device_for_config_entry(
             device_registry,
@@ -2137,7 +2137,7 @@ async def test_cleanup_device_multiple_config_entries(
     )
     assert device_entry is not None
     entity_entry = entity_registry.async_get("sensor.mqtt_mqtt_sensor")
-    assert device_entry.config_entries == {config_entry.entry_id}
+    assert device_entry.config_entry_id == config_entry.entry_id
     assert entity_entry is None
 
     # Verify state is removed
@@ -2233,7 +2233,7 @@ async def test_cleanup_device_multiple_config_entries_mqtt(
         connections={("mac", "12:34:56:AB:CD:EF")},
     )
     assert mqtt_device_entry is not None
-    assert mqtt_device_entry.config_entries == {mqtt_config_entry.entry_id}
+    assert mqtt_device_entry.config_entry_id == mqtt_config_entry.entry_id
     assert (
         _get_device_for_config_entry(
             device_registry,
@@ -2262,7 +2262,7 @@ async def test_cleanup_device_multiple_config_entries_mqtt(
     )
     assert device_entry is not None
     entity_entry = entity_registry.async_get("sensor.mqtt_mqtt_sensor")
-    assert device_entry.config_entries == {config_entry.entry_id}
+    assert device_entry.config_entry_id == config_entry.entry_id
     assert entity_entry is None
 
     # Verify state is removed

--- a/tests/components/mqtt/test_repairs.py
+++ b/tests/components/mqtt/test_repairs.py
@@ -89,7 +89,7 @@ async def test_subentry_reconfigure_export_settings(
     device = device_registry.async_get_device_by_identifier(
         (DOMAIN, subentry_id), config_entry.entry_id
     )
-    assert device.config_entries_subentries[config_entry.entry_id] == {subentry_id}
+    assert device.config_subentry_id == subentry_id
     assert device is not None
 
     # assert we entity for all subentry components
@@ -137,7 +137,7 @@ async def test_subentry_reconfigure_export_settings(
     device = device_registry.async_get_device_by_identifier(
         (DOMAIN, subentry_id), config_entry.entry_id
     )
-    assert device.config_entries_subentries[config_entry.entry_id] == {subentry_id}
+    assert device.config_subentry_id == subentry_id
     assert device is not None
 
     # Assert a repair flow was created
@@ -178,5 +178,5 @@ async def test_subentry_reconfigure_export_settings(
     device = device_registry.async_get_device_by_identifier(
         (DOMAIN, subentry_id), config_entry.entry_id
     )
-    assert device.config_entries_subentries[config_entry.entry_id] == {None}
+    assert device.config_subentry_id is None
     assert device is not None

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -650,14 +650,14 @@ async def test_cleanup_tag(
         identifiers={("mqtt", "helloworld")},
     )
     assert device_entry1 is not None
-    assert device_entry1.config_entries == {config_entry.entry_id}
+    assert device_entry1.config_entry_id == config_entry.entry_id
     mqtt_device_entry1 = _get_device_for_config_entry(
         device_registry,
         mqtt_entry.entry_id,
         identifiers={("mqtt", "helloworld")},
     )
     assert mqtt_device_entry1 is not None
-    assert mqtt_device_entry1.config_entries == {mqtt_entry.entry_id}
+    assert mqtt_device_entry1.config_entry_id == mqtt_entry.entry_id
     device_entry2 = device_registry.async_get_device_by_identifier(
         ("mqtt", "hejhopp"), mqtt_entry.entry_id
     )
@@ -680,7 +680,7 @@ async def test_cleanup_tag(
         identifiers={("mqtt", "helloworld")},
     )
     assert mqtt_device_entry1 is not None
-    assert mqtt_device_entry1.config_entries == {mqtt_entry.entry_id}
+    assert mqtt_device_entry1.config_entry_id == mqtt_entry.entry_id
     device_entry2 = device_registry.async_get_device_by_identifier(
         ("mqtt", "hejhopp"), mqtt_entry.entry_id
     )

--- a/tests/components/nest/test_device_trigger.py
+++ b/tests/components/nest/test_device_trigger.py
@@ -211,8 +211,7 @@ async def test_triggers_for_invalid_device_id(
 
     # Create an additional device that does not exist.  Fetching supported
     # triggers for an unknown device will fail.
-    assert len(device_entry.config_entries) == 1
-    config_entry_id = next(iter(device_entry.config_entries))
+    config_entry_id = device_entry.config_entry_id
     device_entry_2 = device_registry.async_get_or_create(
         config_entry_id=config_entry_id, identifiers={(DOMAIN, "some-unknown-nest-id")}
     )

--- a/tests/components/nextdns/test_init.py
+++ b/tests/components/nextdns/test_init.py
@@ -147,9 +147,10 @@ async def test_migrate_entry_v1_to_v2(
         (DOMAIN, "xyz12"), mock_config_entry_v1.entry_id
     )
     assert device is not None
-    assert device.config_entries_subentries == {
-        mock_config_entry_v1.entry_id: {subentry.subentry_id}
-    }
+    assert (device.config_entry_id, device.config_subentry_id) == (
+        mock_config_entry_v1.entry_id,
+        subentry.subentry_id,
+    )
 
     # Verify entity was migrated and linked to subentry
     entity_entry = entity_registry.async_get("sensor.nextdns_xyz12_dns_queries")
@@ -240,13 +241,13 @@ async def test_migrate_entry_v1_to_v2_merge_same_api_key(
         (DOMAIN, "abc11"), entry1.entry_id
     )
     assert device_abc is not None
-    assert entry1.entry_id in device_abc.config_entries
+    assert device_abc.config_entry_id == entry1.entry_id
 
     device_def = device_registry.async_get_device_by_identifier(
         (DOMAIN, "def22"), entry1.entry_id
     )
     assert device_def is not None
-    assert entry1.entry_id in device_def.config_entries
+    assert device_def.config_entry_id == entry1.entry_id
 
     # Verify entities from both entries were migrated to entry1
     entity_entry_1 = entity_registry.async_get("sensor.nextdns_profile_one_dns_queries")

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -225,7 +225,7 @@ async def test_setup_registers_hub_device(
         (DOMAIN, SERIAL), mock_config_entry.entry_id
     )
     assert device is not None
-    assert device.config_entries == {mock_config_entry.entry_id}
+    assert device.config_entry_id == mock_config_entry.entry_id
     assert device.name == "My Eco Hub"
     assert device.manufacturer == "Glen Dimplex Nordic AS"
     assert device.model == "Nobø Ecohub"

--- a/tests/components/ollama/test_init.py
+++ b/tests/components/ollama/test_init.py
@@ -249,10 +249,8 @@ async def test_migration_from_v1(
     )
     assert migrated_device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert migrated_device.id == device.id
-    assert migrated_device.config_entries == {mock_config_entry.entry_id}
-    assert migrated_device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert migrated_device.config_entry_id == mock_config_entry.entry_id
+    assert migrated_device.config_subentry_id == subentry.subentry_id
 
 
 async def test_migration_from_v1_with_multiple_urls(
@@ -359,8 +357,8 @@ async def test_migration_from_v1_with_multiple_urls(
             (DOMAIN, list(entry.subentries.values())[0].subentry_id), entry.entry_id
         )
         assert dev is not None
-        assert dev.config_entries == {entry.entry_id}
-        assert dev.config_entries_subentries == {entry.entry_id: {subentry.subentry_id}}
+        assert dev.config_entry_id == entry.entry_id
+        assert dev.config_subentry_id == subentry.subentry_id
 
 
 async def test_migration_from_v1_with_same_urls(
@@ -462,10 +460,8 @@ async def test_migration_from_v1_with_same_urls(
             (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
         assert dev is not None
-        assert dev.config_entries == {mock_config_entry.entry_id}
-        assert dev.config_entries_subentries == {
-            mock_config_entry.entry_id: {subentry.subentry_id}
-        }
+        assert dev.config_entry_id == mock_config_entry.entry_id
+        assert dev.config_subentry_id == subentry.subentry_id
 
 
 @pytest.mark.parametrize(
@@ -675,12 +671,8 @@ async def test_migration_from_v1_disabled(
         )
         assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
         assert device.id == devices[subentry_data["device"]].id
-        assert device.config_entries == {
-            mock_config_entries[main_config_entry].entry_id
-        }
-        assert device.config_entries_subentries == {
-            mock_config_entries[main_config_entry].entry_id: {subentry.subentry_id}
-        }
+        assert device.config_entry_id == mock_config_entries[main_config_entry].entry_id
+        assert device.config_subentry_id == subentry.subentry_id
         assert device.disabled_by is subentry_data["device_disabled_by"]
 
 
@@ -801,10 +793,8 @@ async def test_migration_from_v2_1(
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert device.id == device_1.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
     subentry = conversation_subentries[1]
 
@@ -822,10 +812,8 @@ async def test_migration_from_v2_1(
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert device.id == device_2.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
 
 async def test_migration_from_v2_2(hass: HomeAssistant) -> None:

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -748,10 +748,8 @@ async def test_migration_from_v1(
     )
     assert migrated_device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert migrated_device.id == device.id
-    assert migrated_device.config_entries == {mock_config_entry.entry_id}
-    assert migrated_device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert migrated_device.config_entry_id == mock_config_entry.entry_id
+    assert migrated_device.config_subentry_id == subentry.subentry_id
 
 
 async def test_migration_from_v1_with_multiple_keys(
@@ -854,8 +852,8 @@ async def test_migration_from_v1_with_multiple_keys(
             (DOMAIN, subentry.subentry_id), entry.entry_id
         )
         assert dev is not None
-        assert dev.config_entries == {entry.entry_id}
-        assert dev.config_entries_subentries == {entry.entry_id: {subentry.subentry_id}}
+        assert dev.config_entry_id == entry.entry_id
+        assert dev.config_subentry_id == subentry.subentry_id
 
 
 async def test_migration_from_v1_with_same_keys(
@@ -975,10 +973,8 @@ async def test_migration_from_v1_with_same_keys(
             (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
         assert dev is not None
-        assert dev.config_entries == {mock_config_entry.entry_id}
-        assert dev.config_entries_subentries == {
-            mock_config_entry.entry_id: {subentry.subentry_id}
-        }
+        assert dev.config_entry_id == mock_config_entry.entry_id
+        assert dev.config_subentry_id == subentry.subentry_id
 
 
 @pytest.mark.parametrize(
@@ -1217,12 +1213,8 @@ async def test_migration_from_v1_disabled(
         )
         assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
         assert device.id == devices[subentry_data["device"]].id
-        assert device.config_entries == {
-            mock_config_entries[main_config_entry].entry_id
-        }
-        assert device.config_entries_subentries == {
-            mock_config_entries[main_config_entry].entry_id: {subentry.subentry_id}
-        }
+        assert device.config_entry_id == mock_config_entries[main_config_entry].entry_id
+        assert device.config_subentry_id == subentry.subentry_id
         assert device.disabled_by is subentry_data["device_disabled_by"]
 
 
@@ -1365,10 +1357,8 @@ async def test_migration_from_v2_1(
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert device.id == device_1.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
     subentry = conversation_subentries[1]
 
@@ -1386,10 +1376,8 @@ async def test_migration_from_v2_1(
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
     assert device.id == device_2.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
 
 @pytest.mark.parametrize(

--- a/tests/components/ping/test_init.py
+++ b/tests/components/ping/test_init.py
@@ -45,5 +45,5 @@ async def test_device_migration(
 
     assert device is not None
     assert device.id == old_device.id
-    assert device.config_entries == {config_entry.entry_id}
+    assert device.config_entry_id == config_entry.entry_id
     assert config_entry.minor_version == 2

--- a/tests/components/scrape/test_init.py
+++ b/tests/components/scrape/test_init.py
@@ -318,12 +318,8 @@ async def test_migrate_from_version_1_to_2(
             unique_id=None,
         ),
     }
-    assert device.config_entries == {"01JZN04ZJ9BQXXGXDS05WS7D6P"}
-    assert device.config_entries_subentries == {
-        "01JZN04ZJ9BQXXGXDS05WS7D6P": {
-            "01JZQ1G63X2DX66GZ9ZTFY9PEH",
-        },
-    }
+    assert device.config_entry_id == "01JZN04ZJ9BQXXGXDS05WS7D6P"
+    assert device.config_subentry_id == "01JZQ1G63X2DX66GZ9ZTFY9PEH"
     assert entity.config_entry_id == config_entry.entry_id
     assert entity.config_subentry_id == "01JZQ1G63X2DX66GZ9ZTFY9PEH"
 

--- a/tests/components/statistics/test_init.py
+++ b/tests/components/statistics/test_init.py
@@ -121,7 +121,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert statistics_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert statistics_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != statistics_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, statistics_entity_entry.entity_id)
 
@@ -170,7 +170,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert statistics_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert statistics_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != statistics_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, statistics_entity_entry.entity_id)
 
@@ -192,7 +192,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
 
     # Check that the statistics config entry is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert statistics_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != statistics_config_entry.entry_id
 
     # Check that the statistics config entry is removed
     assert statistics_config_entry.entry_id not in hass.config_entries.async_entry_ids()
@@ -219,7 +219,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert statistics_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert statistics_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != statistics_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, statistics_entity_entry.entity_id)
 
@@ -242,7 +242,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 
     # Check that the statistics config entry is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert statistics_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != statistics_config_entry.entry_id
 
     # Check that the statistics config entry is not removed
     assert statistics_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -275,9 +275,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert statistics_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert statistics_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != statistics_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert statistics_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != statistics_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, statistics_entity_entry.entity_id)
 
@@ -300,9 +300,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 
     # Check that the history_stats config entry is not in any of the devices
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert statistics_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != statistics_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert statistics_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != statistics_config_entry.entry_id
 
     # Check that the statistics config entry is not removed
     assert statistics_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -329,7 +329,7 @@ async def test_async_handle_source_entity_new_entity_id(
     assert statistics_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert statistics_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != statistics_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, statistics_entity_entry.entity_id)
 
@@ -349,7 +349,7 @@ async def test_async_handle_source_entity_new_entity_id(
 
     # Check that the helper config is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert statistics_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != statistics_config_entry.entry_id
 
     # Check that the statistics config entry is not removed
     assert statistics_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -393,7 +393,7 @@ async def test_migration_1_1(
     # Check that the helper config entry is not in the device and the helper entity
     # is linked to the source device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert statistics_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != statistics_config_entry.entry_id
     statistics_entity_entry = entity_registry.async_get(
         "sensor.mock_title_my_statistics"
     )

--- a/tests/components/sunricher_dali/test_init.py
+++ b/tests/components/sunricher_dali/test_init.py
@@ -164,4 +164,4 @@ async def test_remove_stale_devices(
         (DOMAIN, mock_gateway.gw_sn), mock_config_entry.entry_id
     )
     assert gateway_device is not None
-    assert mock_config_entry.entry_id in gateway_device.config_entries
+    assert gateway_device.config_entry_id == mock_config_entry.entry_id

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -233,7 +233,7 @@ async def test_device_registry_config_entry_1(
     assert entity_entry.device_id == switch_entity_entry.device_id
 
     device_entry = device_registry.async_get(device_entry.id)
-    assert switch_as_x_config_entry.entry_id not in device_entry.config_entries
+    assert device_entry.config_entry_id != switch_as_x_config_entry.entry_id
 
     events = []
 
@@ -255,7 +255,7 @@ async def test_device_registry_config_entry_1(
 
     # Check that the switch_as_x config entry is removed from the device
     device_entry = device_registry.async_get(device_entry.id)
-    assert switch_as_x_config_entry.entry_id not in device_entry.config_entries
+    assert device_entry.config_entry_id != switch_as_x_config_entry.entry_id
 
     # Check that the switch_as_x config entry is removed
     assert (
@@ -315,7 +315,7 @@ async def test_device_registry_config_entry_2(
     assert entity_entry.device_id == switch_entity_entry.device_id
 
     device_entry = device_registry.async_get(device_entry.id)
-    assert switch_as_x_config_entry.entry_id not in device_entry.config_entries
+    assert device_entry.config_entry_id != switch_as_x_config_entry.entry_id
 
     events = []
 
@@ -338,7 +338,7 @@ async def test_device_registry_config_entry_2(
 
     # Check that the switch_as_x config entry is removed from the device
     device_entry = device_registry.async_get(device_entry.id)
-    assert switch_as_x_config_entry.entry_id not in device_entry.config_entries
+    assert device_entry.config_entry_id != switch_as_x_config_entry.entry_id
 
     # Check that the switch_as_x config entry is not removed
     assert switch_as_x_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -400,9 +400,9 @@ async def test_device_registry_config_entry_3(
     assert entity_entry.device_id == switch_entity_entry.device_id
 
     device_entry = device_registry.async_get(device_entry.id)
-    assert switch_as_x_config_entry.entry_id not in device_entry.config_entries
+    assert device_entry.config_entry_id != switch_as_x_config_entry.entry_id
     device_entry_2 = device_registry.async_get(device_entry_2.id)
-    assert switch_as_x_config_entry.entry_id not in device_entry_2.config_entries
+    assert device_entry_2.config_entry_id != switch_as_x_config_entry.entry_id
 
     events = []
 
@@ -425,9 +425,9 @@ async def test_device_registry_config_entry_3(
 
     # Check that the switch_as_x config entry is moved to the other device
     device_entry = device_registry.async_get(device_entry.id)
-    assert switch_as_x_config_entry.entry_id not in device_entry.config_entries
+    assert device_entry.config_entry_id != switch_as_x_config_entry.entry_id
     device_entry_2 = device_registry.async_get(device_entry_2.id)
-    assert switch_as_x_config_entry.entry_id not in device_entry_2.config_entries
+    assert device_entry_2.config_entry_id != switch_as_x_config_entry.entry_id
 
     # Check that the switch_as_x config entry is not removed
     assert switch_as_x_config_entry.entry_id in hass.config_entries.async_entry_ids()

--- a/tests/components/tasmota/test_discovery.py
+++ b/tests/components/tasmota/test_discovery.py
@@ -355,7 +355,7 @@ async def test_device_remove_multiple_config_entries_1(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)},
     )
     assert tasmota_device_entry is not None
-    assert tasmota_device_entry.config_entries == {tasmota_entry.entry_id}
+    assert tasmota_device_entry.config_entry_id == tasmota_entry.entry_id
     mock_device_entry = _get_device_for_config_entry(
         device_registry,
         mock_entry.entry_id,
@@ -385,7 +385,7 @@ async def test_device_remove_multiple_config_entries_1(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)},
     )
     assert device_entry is not None
-    assert device_entry.config_entries == {mock_entry.entry_id}
+    assert device_entry.config_entry_id == mock_entry.entry_id
 
 
 async def test_device_remove_multiple_config_entries_2(
@@ -428,7 +428,7 @@ async def test_device_remove_multiple_config_entries_2(
         connections={(dr.CONNECTION_NETWORK_MAC, mac)},
     )
     assert device_entry is not None
-    assert device_entry.config_entries == {tasmota_entry.entry_id}
+    assert device_entry.config_entry_id == tasmota_entry.entry_id
     assert other_device_entry.id != device_entry.id
 
     # Remove the other (non-Tasmota) device sharing the connection
@@ -446,7 +446,7 @@ async def test_device_remove_multiple_config_entries_2(
         hass.config_entries.async_entries("tasmota")[0].entry_id,
     )
     assert device_entry is not None
-    assert device_entry.config_entries == {tasmota_entry.entry_id}
+    assert device_entry.config_entry_id == tasmota_entry.entry_id
     mqtt_mock.async_publish.assert_not_called()
 
     # Remove the other (non-Tasmota) device

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -446,7 +446,7 @@ async def test_change_device(
     # and that the entities are linked to device 1
     for device_id in (device_id1, device_id2):
         device = device_registry.async_get(device_id=device_id)
-        assert template_config_entry.entry_id not in device.config_entries
+        assert device.config_entry_id != template_config_entry.entry_id
     check_template_entities(template_entity_id, device_id1)
 
     # Change config options to use device 2 and reload the integration
@@ -463,7 +463,7 @@ async def test_change_device(
     # and that the entities are linked to device 2
     for device_id in (device_id1, device_id2):
         device = device_registry.async_get(device_id=device_id)
-        assert template_config_entry.entry_id not in device.config_entries
+        assert device.config_entry_id != template_config_entry.entry_id
     check_template_entities(template_entity_id, device_id2)
 
     # Change the config options to remove the device and reload the integration
@@ -480,7 +480,7 @@ async def test_change_device(
     # and that the entities are not linked to any device
     for device_id in (device_id1, device_id2):
         device = device_registry.async_get(device_id=device_id)
-        assert template_config_entry.entry_id not in device.config_entries
+        assert device.config_entry_id != template_config_entry.entry_id
     check_template_entities(template_entity_id, None)
 
     # Confirm that there is no device with the helper config entry
@@ -727,7 +727,7 @@ async def test_migration_1_1(
     # Check that the helper config entry is not in the device and the helper
     # entity is linked to the source device
     device_entry = device_registry.async_get(device_entry.id)
-    assert template_config_entry.entry_id not in device_entry.config_entries
+    assert device_entry.config_entry_id != template_config_entry.entry_id
     template_entity_entry = entity_registry.async_get("sensor.mock_title_my_template")
     assert template_entity_entry.device_id == device_entry.id
 

--- a/tests/components/threshold/test_init.py
+++ b/tests/components/threshold/test_init.py
@@ -168,11 +168,11 @@ async def test_entry_changed(
             domain, "test", name, suggested_object_id=name, device_id=device_entry.id
         )
 
-    def _get_device_config_entries(entry: er.RegistryEntry) -> set[str]:
+    def _get_device_config_entry_id(entry: er.RegistryEntry) -> str:
         assert entry.device_id
         device = device_registry.async_get(entry.device_id)
         assert device
-        return device.config_entries
+        return device.config_entry_id
 
     # Set up entities, with backing devices and config entries
     run1_entry = _create_mock_entity("sensor", "initial")
@@ -196,8 +196,8 @@ async def test_entry_changed(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.entry_id not in _get_device_config_entries(run1_entry)
-    assert config_entry.entry_id not in _get_device_config_entries(run2_entry)
+    assert _get_device_config_entry_id(run1_entry) != config_entry.entry_id
+    assert _get_device_config_entry_id(run2_entry) != config_entry.entry_id
     threshold_entity_entry = entity_registry.async_get(
         "binary_sensor.initial_my_threshold"
     )
@@ -210,8 +210,8 @@ async def test_entry_changed(
     await hass.async_block_till_done()
 
     # Check that the device association has updated
-    assert config_entry.entry_id not in _get_device_config_entries(run1_entry)
-    assert config_entry.entry_id not in _get_device_config_entries(run2_entry)
+    assert _get_device_config_entry_id(run1_entry) != config_entry.entry_id
+    assert _get_device_config_entry_id(run2_entry) != config_entry.entry_id
     threshold_entity_entry = entity_registry.async_get(
         "binary_sensor.initial_my_threshold"
     )
@@ -237,7 +237,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert threshold_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert threshold_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != threshold_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, threshold_entity_entry.entity_id)
 
@@ -285,7 +285,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert threshold_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert threshold_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != threshold_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, threshold_entity_entry.entity_id)
 
@@ -310,7 +310,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
 
     # Check that the threshold config entry is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert threshold_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != threshold_config_entry.entry_id
 
     # Check that the threshold config entry is not removed
     assert threshold_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -337,7 +337,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert threshold_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert threshold_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != threshold_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, threshold_entity_entry.entity_id)
 
@@ -360,7 +360,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 
     # Check that the threshold config entry is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert threshold_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != threshold_config_entry.entry_id
 
     # Check that the threshold config entry is not removed
     assert threshold_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -393,9 +393,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert threshold_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert threshold_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != threshold_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert threshold_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != threshold_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, threshold_entity_entry.entity_id)
 
@@ -418,9 +418,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 
     # Check that the derivative config entry is not in any of the devices
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert threshold_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != threshold_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert threshold_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != threshold_config_entry.entry_id
 
     # Check that the threshold config entry is not removed
     assert threshold_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -447,7 +447,7 @@ async def test_async_handle_source_entity_new_entity_id(
     assert threshold_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert threshold_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != threshold_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, threshold_entity_entry.entity_id)
 
@@ -467,7 +467,7 @@ async def test_async_handle_source_entity_new_entity_id(
 
     # Check that the helper config is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert threshold_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != threshold_config_entry.entry_id
 
     # Check that the threshold config entry is not removed
     assert threshold_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -509,7 +509,7 @@ async def test_migration_1_1(
     # Check that the helper config entry is not in the device and the helper entity
     # is linked to the source device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert threshold_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != threshold_config_entry.entry_id
     threshold_entity_entry = entity_registry.async_get(
         "binary_sensor.mock_title_my_threshold"
     )

--- a/tests/components/trend/test_init.py
+++ b/tests/components/trend/test_init.py
@@ -151,7 +151,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert trend_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert trend_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != trend_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, trend_entity_entry.entity_id)
 
@@ -198,7 +198,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert trend_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert trend_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != trend_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, trend_entity_entry.entity_id)
 
@@ -220,7 +220,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
 
     # Check that the trend config entry is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert trend_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != trend_config_entry.entry_id
 
     # Check that the trend config entry is removed
     assert trend_config_entry.entry_id not in hass.config_entries.async_entry_ids()
@@ -245,7 +245,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert trend_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert trend_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != trend_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, trend_entity_entry.entity_id)
 
@@ -266,7 +266,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 
     # Check that the trend config entry is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert trend_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != trend_config_entry.entry_id
 
     # Check that the trend config entry is not removed
     assert trend_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -297,9 +297,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert trend_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert trend_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != trend_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert trend_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != trend_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, trend_entity_entry.entity_id)
 
@@ -320,9 +320,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 
     # Check that the trend config entry is not in any of the devices
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert trend_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != trend_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert trend_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != trend_config_entry.entry_id
 
     # Check that the trend config entry is not removed
     assert trend_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -347,7 +347,7 @@ async def test_async_handle_source_entity_new_entity_id(
     assert trend_entity_entry.device_id == sensor_entity_entry.device_id
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert trend_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != trend_config_entry.entry_id
 
     events = track_entity_registry_actions(hass, trend_entity_entry.entity_id)
 
@@ -367,7 +367,7 @@ async def test_async_handle_source_entity_new_entity_id(
 
     # Check that the helper config is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert trend_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != trend_config_entry.entry_id
 
     # Check that the trend config entry is not removed
     assert trend_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -407,7 +407,7 @@ async def test_migration_1_1(
     # Check that the helper config entry is not in the device and the helper entity
     # is linked to the source device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert trend_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != trend_config_entry.entry_id
     trend_entity_entry = entity_registry.async_get("binary_sensor.mock_title_my_trend")
     assert trend_entity_entry.device_id == sensor_entity_entry.device_id
 

--- a/tests/components/utility_meter/test_config_flow.py
+++ b/tests/components/utility_meter/test_config_flow.py
@@ -408,7 +408,7 @@ async def test_change_device_source(
     current_device = device_registry.async_get(
         device_id=current_entity_source.device_id
     )
-    assert utility_meter_config_entry.entry_id not in current_device.config_entries
+    assert current_device.config_entry_id != utility_meter_config_entry.entry_id
 
     # Check that the entities are linked to the expected device
     for (
@@ -442,14 +442,14 @@ async def test_change_device_source(
     previous_device = device_registry.async_get(
         device_id=previous_entity_source.device_id
     )
-    assert utility_meter_config_entry.entry_id not in previous_device.config_entries
+    assert previous_device.config_entry_id != utility_meter_config_entry.entry_id
 
     # Confirm that the configuration entry is not in
     # the source entity 2 (current) device registry
     current_device = device_registry.async_get(
         device_id=current_entity_source.device_id
     )
-    assert utility_meter_config_entry.entry_id not in current_device.config_entries
+    assert current_device.config_entry_id != utility_meter_config_entry.entry_id
 
     # Check that the entities are linked to the expected device
     for (
@@ -483,7 +483,7 @@ async def test_change_device_source(
     previous_device = device_registry.async_get(
         device_id=previous_entity_source.device_id
     )
-    assert utility_meter_config_entry.entry_id not in previous_device.config_entries
+    assert previous_device.config_entry_id != utility_meter_config_entry.entry_id
 
     # Check that the entities are no longer linked to a device
     for (
@@ -525,7 +525,7 @@ async def test_change_device_source(
     current_device = device_registry.async_get(
         device_id=current_entity_source.device_id
     )
-    assert utility_meter_config_entry.entry_id not in current_device.config_entries
+    assert current_device.config_entry_id != utility_meter_config_entry.entry_id
 
     # Check that the entities are linked to the expected device
     for (

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -598,7 +598,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed(
     assert set(events) == expected_entities
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != utility_meter_config_entry.entry_id
 
     # Remove the source device, this removes the source sensor
     with patch(
@@ -669,7 +669,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     assert set(events) == expected_entities
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != utility_meter_config_entry.entry_id
 
     # Remove the source sensor
     with patch(
@@ -693,7 +693,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_shared_d
     # config entry
     sensor_device = device_registry.async_get(sensor_device.id)
     assert sensor_device is not None
-    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != utility_meter_config_entry.entry_id
 
     # Check that the utility_meter config entry is not removed
     assert utility_meter_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -743,7 +743,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
     assert set(events) == expected_entities
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != utility_meter_config_entry.entry_id
 
     # Remove the source sensor from the device
     with patch(
@@ -766,7 +766,7 @@ async def test_async_handle_source_entity_changes_source_entity_removed_from_dev
 
     # Check that the utility_meter config entry is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != utility_meter_config_entry.entry_id
 
     # Check that the utility_meter config entry is not removed
     assert utility_meter_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -822,9 +822,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
     assert set(events) == expected_entities
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != utility_meter_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert utility_meter_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != utility_meter_config_entry.entry_id
 
     # Move the source sensor to another device
     with patch(
@@ -847,9 +847,9 @@ async def test_async_handle_source_entity_changes_source_entity_moved_other_devi
 
     # Check that the derivative config entry is not in any of the devices
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != utility_meter_config_entry.entry_id
     sensor_device_2 = device_registry.async_get(sensor_device_2.id)
-    assert utility_meter_config_entry.entry_id not in sensor_device_2.config_entries
+    assert sensor_device_2.config_entry_id != utility_meter_config_entry.entry_id
 
     # Check that the utility_meter config entry is not removed
     assert utility_meter_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -899,7 +899,7 @@ async def test_async_handle_source_entity_new_entity_id(
     assert set(events) == expected_entities
 
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != utility_meter_config_entry.entry_id
 
     # Change the source entity's entity ID
     with patch(
@@ -917,7 +917,7 @@ async def test_async_handle_source_entity_new_entity_id(
 
     # Check that the helper config is not in the device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != utility_meter_config_entry.entry_id
 
     # Check that the utility_meter config entry is not removed
     assert utility_meter_config_entry.entry_id in hass.config_entries.async_entry_ids()
@@ -979,7 +979,7 @@ async def test_migration_2_1(
     # Check that the helper config entry is not in the device and the helper
     # entities are linked to the source device
     sensor_device = device_registry.async_get(sensor_device.id)
-    assert utility_meter_config_entry.entry_id not in sensor_device.config_entries
+    assert sensor_device.config_entry_id != utility_meter_config_entry.entry_id
     entities = set()
     for (
         utility_meter_entity

--- a/tests/components/velbus/test_init.py
+++ b/tests/components/velbus/test_init.py
@@ -272,7 +272,7 @@ async def test_remove_config_entry_device(
     stale_device_after = device_registry.async_get(stale_device.id)
     assert (
         stale_device_after is None
-        or config_entry.entry_id not in stale_device_after.config_entries
+        or stale_device_after.config_entry_id != config_entry.entry_id
     )
 
 
@@ -305,7 +305,7 @@ async def test_remove_config_entry_device_detaches_subdevices(
 
     sub_device_after = device_registry.async_get(sub_device.id)
     assert sub_device_after is None or (
-        config_entry.entry_id not in sub_device_after.config_entries
+        sub_device_after.config_entry_id != config_entry.entry_id
         and sub_device_after.via_device_id is None
     )
 

--- a/tests/components/waqi/test_init.py
+++ b/tests/components/waqi/test_init.py
@@ -118,10 +118,8 @@ async def test_migration_from_v1(
     )
     assert device.identifiers == {(DOMAIN, "4584")}
     assert device.id == device_1.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
     subentry = list(entry.subentries.values())[1]
     assert subentry.subentry_type == "station"
@@ -140,10 +138,8 @@ async def test_migration_from_v1(
     )
     assert device.identifiers == {(DOMAIN, "4585")}
     assert device.id == device_2.id
-    assert device.config_entries == {mock_config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        mock_config_entry.entry_id: {subentry.subentry_id}
-    }
+    assert device.config_entry_id == mock_config_entry.entry_id
+    assert device.config_subentry_id == subentry.subentry_id
 
 
 @pytest.mark.parametrize(
@@ -346,10 +342,6 @@ async def test_migration_from_v1_disabled(
         )
         assert device.identifiers == {(DOMAIN, subentry.unique_id)}
         assert device.id == devices[subentry_data["device"]].id
-        assert device.config_entries == {
-            mock_config_entries[main_config_entry].entry_id
-        }
-        assert device.config_entries_subentries == {
-            mock_config_entries[main_config_entry].entry_id: {subentry.subentry_id}
-        }
+        assert device.config_entry_id == mock_config_entries[main_config_entry].entry_id
+        assert device.config_subentry_id == subentry.subentry_id
         assert device.disabled_by is subentry_data["device_disabled_by"]

--- a/tests/components/wolflink/test_init.py
+++ b/tests/components/wolflink/test_init.py
@@ -108,7 +108,7 @@ async def test_migration_v1_to_v2(
     migrated_device = device_registry.async_get(device.id)
     assert migrated_device is not None
     assert migrated_device.identifiers == {(DOMAIN, "1234")}
-    assert migrated_device.config_entries == {config_entry.entry_id}
+    assert migrated_device.config_entry_id == config_entry.entry_id
     assert migrated_device.disabled_by is dr.DeviceEntryDisabler.USER
 
     migrated_entity = entity_registry.async_get(entity.entity_id)
@@ -252,7 +252,7 @@ async def test_migration_merges_duplicate_v1_entries(
     # The pre-existing device for 5678 was reattached to the surviving entry.
     device = device_registry.async_get(device_5678.id)
     assert device is not None
-    assert device.config_entries == {surviving.entry_id}
+    assert device.config_entry_id == surviving.entry_id
 
 
 async def test_migration_merge_into_disabled_hub(
@@ -303,7 +303,7 @@ async def test_migration_merge_into_disabled_hub(
     # state now reflects the new owning entry's disabled state.
     migrated_device = device_registry.async_get(device.id)
     assert migrated_device is not None
-    assert migrated_device.config_entries == {hub_entry.entry_id}
+    assert migrated_device.config_entry_id == hub_entry.entry_id
     assert migrated_device.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
 
 

--- a/tests/components/xbox/test_config_flow.py
+++ b/tests/components/xbox/test_config_flow.py
@@ -617,7 +617,7 @@ async def test_unique_id_and_friends_migration(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "2533274838782903")},
     )
-    assert device_friend.config_entries_subentries[config_entry.entry_id] == {None}
+    assert device_friend.config_subentry_id is None
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -640,9 +640,7 @@ async def test_unique_id_and_friends_migration(
     assert device_own.identifiers == {(DOMAIN, "271958441785640")}
 
     assert (device_friend := device_registry.async_get(device_friend.id))
-    assert device_friend.config_entries_subentries[config_entry.entry_id] == {
-        subentries[0].subentry_id
-    }
+    assert device_friend.config_subentry_id == subentries[0].subentry_id
 
 
 @pytest.mark.parametrize(

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1512,19 +1512,15 @@ async def test_device_info_called(
         ("hue", "1234"), config_entry.entry_id
     )
     assert device == snapshot
-    assert device.config_entries == {config_entry.entry_id}
-    assert device.config_entries_subentries == {config_entry.entry_id: {None}}
-    assert device.primary_config_entry == config_entry.entry_id
+    assert device.config_entry_id == config_entry.entry_id
+    assert device.config_subentry_id is None
     assert device.via_device_id == via.id
     device = device_registry.async_get_device_by_identifier(
         ("hue", "efgh"), config_entry.entry_id
     )
     assert device == snapshot
-    assert device.config_entries == {config_entry.entry_id}
-    assert device.config_entries_subentries == {
-        config_entry.entry_id: {"mock-subentry-id-1"}
-    }
-    assert device.primary_config_entry == config_entry.entry_id
+    assert device.config_entry_id == config_entry.entry_id
+    assert device.config_subentry_id == "mock-subentry-id-1"
     assert device.via_device_id == via.id
 
 

--- a/tests/helpers/test_target.py
+++ b/tests/helpers/test_target.py
@@ -1104,7 +1104,7 @@ async def test_target_trickle_down_to_splits(
     split_a = next(
         d
         for d in device_registry.async_get_devices_for_composite_device_id(COMPOSITE_ID)
-        if entry_a.entry_id in d.config_entries
+        if d.config_entry_id == entry_a.entry_id
     )
     child = device_registry.async_get_or_create_child(
         config_entry_id=entry_a.entry_id,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid accessing `DeviceEntry.config_entries` and `DeviceEntry.config_entries_subentries` in tests

### Rationale:

`DeviceEntry.config_entries` and `DeviceEntry.config_entries_subentries` are remnants from the multi config entry device design.
Tests which don't manipulate synthetic composite devices should use `DeviceEntry.config_entry_id` and `DeviceEntry.config_subentry_id`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
