### PR TITLE
Remove unused broken player fixture in squeezebox tests

### DIFF
--- a/tests/components/squeezebox/conftest.py
+++ b/tests/components/squeezebox/conftest.py
@@ -333,12 +333,6 @@ async def mock_async_browse(
 
 
 @pytest.fixture
-def player() -> MagicMock:
-    """Return a mock player."""
-    return mock_pysqueezebox_player()
-
-
-@pytest.fixture
 def player_factory() -> MagicMock:
     """Return a factory for creating mock players."""
     return mock_pysqueezebox_player


### PR DESCRIPTION
## Proposed change

The `player` fixture in `tests/components/squeezebox/conftest.py` is broken and unused:

```python
@pytest.fixture
def player() -> MagicMock:
    """Return a mock player."""
    return mock_pysqueezebox_player()   # called with no arguments


def mock_pysqueezebox_player(uuid: str) -> MagicMock:
    """Mock a Lyrion Media Server player."""
    assert uuid
    ...
```

`mock_pysqueezebox_player` requires a `uuid` argument (and immediately `assert uuid`), but the
`player` fixture calls it with none. Any test requesting this fixture would fail with
`TypeError: mock_pysqueezebox_player() missing 1 required positional argument: 'uuid'`.

It has been like this since it was introduced in #125378, and no test ever requests the `player`
fixture — the tests instead use `player_factory`, which returns the `mock_pysqueezebox_player`
callable to be invoked with a `uuid`. So the fixture is dead code that would crash if it were
ever used.

This PR removes the unused, broken fixture. `player_factory` and `mock_pysqueezebox_player` are
untouched.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  Thanks for contributing!
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
