### PR TITLE
Fix thumbnails of Kodi PVR channels

### DIFF
--- a/homeassistant/components/kodi/browse_media.py
+++ b/homeassistant/components/kodi/browse_media.py
@@ -351,12 +351,27 @@ async def get_media_info(media_library, search_id, search_type):
             title = season["seasondetails"]["label"]
 
     elif search_type == MediaType.CHANNEL:
-        media = await media_library.get_channels(
-            channel_group_id="alltv",
-            properties=["thumbnail", "channeltype", "channel", "broadcastnow"],
+        # A channel is asked for by id when its thumbnail is fetched through the
+        # media player proxy, the route an external client takes. There is no
+        # call for a single channel, so it is picked out of the list; the EPG
+        # that the listing needs is then not worth fetching.
+        channel_properties = ["thumbnail"]
+        if not search_id:
+            channel_properties += ["channeltype", "channel", "broadcastnow"]
+
+        channels = await media_library.get_channels(
+            channel_group_id="alltv", properties=channel_properties
         )
-        media = media.get("channels")
+        media = channels.get("channels")
 
         title = "Channels"
+
+        if search_id:
+            channel = next(
+                (item for item in media or [] if str(item["channelid"]) == search_id),
+                None,
+            )
+            if channel:
+                thumbnail = media_library.thumbnail_url(channel["thumbnail"])
 
     return thumbnail, title, media

--- a/homeassistant/components/kodi/browse_media.py
+++ b/homeassistant/components/kodi/browse_media.py
@@ -372,6 +372,6 @@ async def get_media_info(media_library, search_id, search_type):
                 None,
             )
             if channel:
-                thumbnail = media_library.thumbnail_url(channel["thumbnail"])
+                thumbnail = media_library.thumbnail_url(channel.get("thumbnail"))
 
     return thumbnail, title, media

--- a/tests/components/kodi/test_browse_media.py
+++ b/tests/components/kodi/test_browse_media.py
@@ -1,0 +1,88 @@
+"""Tests for the Kodi media browser."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.kodi.browse_media import get_media_info
+from homeassistant.components.media_player import MediaType
+
+CHANNELS = {
+    "channels": [
+        {
+            "channelid": 917,
+            "label": "Das Erste HD",
+            "thumbnail": "image://pvrchannel_tv%40das_erste/",
+        },
+        {
+            "channelid": 902,
+            "label": "ZDF HD",
+            "thumbnail": "image://pvrchannel_tv%40zdf/",
+        },
+    ]
+}
+
+
+def create_media_library() -> MagicMock:
+    """Return a Kodi library that answers with two TV channels."""
+    library = MagicMock()
+    library.get_channels = AsyncMock(return_value=CHANNELS)
+    library.thumbnail_url = MagicMock(
+        side_effect=lambda thumbnail: f"http://1.1.1.1:8080/image/{thumbnail}"
+    )
+    return library
+
+
+async def test_channel_folder_lists_the_channels() -> None:
+    """The folder itself is listed and has no thumbnail of its own."""
+    library = create_media_library()
+
+    thumbnail, title, media = await get_media_info(library, "", MediaType.CHANNEL)
+
+    assert title == "Channels"
+    assert media == CHANNELS["channels"]
+    assert thumbnail is None
+
+
+async def test_channel_asked_for_by_id_carries_its_thumbnail() -> None:
+    """A single channel returns the image the media player proxy serves.
+
+    An external client fetches a browse thumbnail over
+    /api/media_player_proxy/<entity>/browse_media/channel/<id>, which asks the
+    integration for the image by id. Without this the view answers 404.
+    """
+    library = create_media_library()
+
+    thumbnail, _, _ = await get_media_info(library, "902", MediaType.CHANNEL)
+
+    assert thumbnail == "http://1.1.1.1:8080/image/image://pvrchannel_tv%40zdf/"
+
+
+async def test_channel_no_longer_in_the_group_has_no_thumbnail() -> None:
+    """An id that is not in the list leaves the thumbnail unset."""
+    library = create_media_library()
+
+    thumbnail, _, _ = await get_media_info(library, "123", MediaType.CHANNEL)
+
+    assert thumbnail is None
+
+
+async def test_channel_listing_asks_for_the_epg() -> None:
+    """The listing needs what it shows: the current broadcast."""
+    library = create_media_library()
+
+    await get_media_info(library, "", MediaType.CHANNEL)
+
+    assert library.get_channels.call_args.kwargs["properties"] == [
+        "thumbnail",
+        "channeltype",
+        "channel",
+        "broadcastnow",
+    ]
+
+
+async def test_single_channel_asks_for_no_more_than_the_thumbnail() -> None:
+    """One image needs no EPG for a hundred and fifty channels."""
+    library = create_media_library()
+
+    await get_media_info(library, "902", MediaType.CHANNEL)
+
+    assert library.get_channels.call_args.kwargs["properties"] == ["thumbnail"]

--- a/tests/components/kodi/test_browse_media.py
+++ b/tests/components/kodi/test_browse_media.py
@@ -17,6 +17,10 @@ CHANNELS = {
             "label": "ZDF HD",
             "thumbnail": "image://pvrchannel_tv%40zdf/",
         },
+        {
+            "channelid": 850,
+            "label": "3sat HD",
+        },
     ]
 }
 
@@ -26,7 +30,9 @@ def create_media_library() -> MagicMock:
     library = MagicMock()
     library.get_channels = AsyncMock(return_value=CHANNELS)
     library.thumbnail_url = MagicMock(
-        side_effect=lambda thumbnail: f"http://1.1.1.1:8080/image/{thumbnail}"
+        side_effect=lambda thumbnail: (
+            f"http://1.1.1.1:8080/image/{thumbnail}" if thumbnail else None
+        )
     )
     return library
 
@@ -54,6 +60,15 @@ async def test_channel_asked_for_by_id_carries_its_thumbnail() -> None:
     thumbnail, _, _ = await get_media_info(library, "902", MediaType.CHANNEL)
 
     assert thumbnail == "http://1.1.1.1:8080/image/image://pvrchannel_tv%40zdf/"
+
+
+async def test_channel_without_a_thumbnail_has_no_picture() -> None:
+    """Kodi does not promise a thumbnail for every channel."""
+    library = create_media_library()
+
+    thumbnail, _, _ = await get_media_info(library, "850", MediaType.CHANNEL)
+
+    assert thumbnail is None
 
 
 async def test_channel_no_longer_in_the_group_has_no_thumbnail() -> None:

--- a/tests/components/kodi/test_browse_media.py
+++ b/tests/components/kodi/test_browse_media.py
@@ -26,7 +26,7 @@ CHANNELS = {
 
 
 def create_media_library() -> MagicMock:
-    """Return a Kodi library that answers with two TV channels."""
+    """Return a Kodi library that answers with the TV channels above."""
     library = MagicMock()
     library.get_channels = AsyncMock(return_value=CHANNELS)
     library.thumbnail_url = MagicMock(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Thumbnails for PVR channels never load in the media browser when Home Assistant
serves an **external** client: `/api/media_player_proxy/<entity>/browse_media/channel/<id>`
answers 404 for every channel, while movies, TV shows, seasons, albums and
artists work.

`async_browse_media()` hands out Kodi's own image URL for an internal request
and the proxy URL otherwise:

```python
is_internal = is_internal_request(self.hass)

async def _get_thumbnail_url(...):
    if is_internal:
        return self._kodi.thumbnail_url(thumbnail_url)
    return self.get_browse_image_url(...)
```

The proxy route ends in `async_get_browse_image()`, which asks
`get_media_info()` for the picture by id. Every type that can be asked for by
id looks the item up and sets a thumbnail - except `MediaType.CHANNEL`, whose
branch only lists the channel group and returns `thumbnail = None`. The view
turns that into a 404. This is why the failure is invisible at home and shows
up over an external or cloud URL only.

This change picks the requested channel out of the list that branch already
fetches (`PVR.GetChannels`; the library has no per-channel call) and runs its
thumbnail through `thumbnail_url()`, as the other branches do. When a single
channel is asked for, only the `thumbnail` property is requested: serving one
image does not need the EPG the listing shows, and a browser page asks for many
images at once.

Episodes have the same symptom for the same reason - `get_media_info()` has no
episode branch at all. They are not fixed here: the proxy URL carries only the
`episodeid`, and PyKodi offers `get_episodes(tv_show_id, season_id)` but no
per-id lookup, so that needs a library addition first.

Measured against a real library, each thumbnail taken from the
`media_player/browse_media` reply and fetched over the external URL: `movie`
200, `tvshow` 200, `season` 200, `album` 200, `artist` 200 - `channel` 404,
`episode` 404. With this change the channel thumbnail serves the logo
(PNG 400x240), the same picture the internal path delivers straight from Kodi.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #113574 (closed as stale; diagnosed there as an EPG naming problem - the EPG suffix in `item_payload()` only changes the item title)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
