### PR TITLE
Deprecate DeviceEnty.config_entries

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -381,6 +381,22 @@ def _normalize_connections_validator(
             raise ValueError(f"Invalid mac address format: {value}")
 
 
+def _report_deprecated_config_entries_property(
+    instance: object, name: str, *replacements: str
+) -> None:
+    """Report use of a deprecated multi-config-entry compatibility property."""
+    class_name = type(instance).__name__
+    replacement = " and ".join(f"`{class_name}.{field}`" for field in replacements)
+    report_usage(
+        f"accesses `{class_name}.{name}`, which is deprecated because a device "
+        f"belongs to a single config entry; use {replacement} instead",
+        breaks_in_ha_version="2027.8.0",
+        core_behavior=ReportBehavior.ERROR,
+        core_integration_behavior=ReportBehavior.ERROR,
+        custom_integration_behavior=ReportBehavior.LOG,
+    )
+
+
 @attr.s(frozen=True, slots=True)
 class BaseDeviceEntry:
     """Base class for device registry entries."""
@@ -400,13 +416,27 @@ class BaseDeviceEntry:
     _cache: dict[str, Any] = attr.ib(factory=dict, eq=False, init=False)
 
     @property
+    def _config_entries(self) -> set[str]:
+        """Return the config entries this device belongs to, without reporting."""
+        return {self.config_entry_id}
+
+    @property
+    def _config_entries_subentries(self) -> dict[str, set[str | None]]:
+        """Return the config subentries this device belongs to, without reporting."""
+        return {self.config_entry_id: {self.config_subentry_id}}
+
+    @property
     def config_entries(self) -> set[str]:
         """Return the config entries this device belongs to.
 
         Deprecated compatibility shim: a device now belongs to a single config
-        entry, available as config_entry_id.
+        entry, available as config_entry_id. It can be removed in HA Core 2027.8.
         """
-        return {self.config_entry_id}
+        if not self.is_composite_device:
+            _report_deprecated_config_entries_property(
+                self, "config_entries", "config_entry_id"
+            )
+        return self._config_entries
 
     @property
     def config_entries_subentries(self) -> dict[str, set[str | None]]:
@@ -414,8 +444,16 @@ class BaseDeviceEntry:
 
         Deprecated compatibility shim: a device now belongs to a single config
         entry and subentry, available as config_entry_id and config_subentry_id.
+        It can be removed in HA Core 2027.8.
         """
-        return {self.config_entry_id: {self.config_subentry_id}}
+        if not self.is_composite_device:
+            _report_deprecated_config_entries_property(
+                self,
+                "config_entries_subentries",
+                "config_entry_id",
+                "config_subentry_id",
+            )
+        return self._config_entries_subentries
 
     @property
     def primary_config_entry(self) -> str:
@@ -423,7 +461,12 @@ class BaseDeviceEntry:
 
         Deprecated compatibility shim: a device now belongs to a single config
         entry, available as config_entry_id, which is its primary config entry.
+        It can be removed in HA Core 2027.8.
         """
+        if not self.is_composite_device:
+            _report_deprecated_config_entries_property(
+                self, "primary_config_entry", "config_entry_id"
+            )
         return self.config_entry_id
 
     @property
@@ -511,24 +554,16 @@ class DeviceEntry(BaseDeviceEntry):
 
     @property
     @override
-    def config_entries(self) -> set[str]:
-        """Return the config entries this device belongs to.
-
-        Deprecated compatibility shim: a device now belongs to a single config
-        entry, available as config_entry_id.
-        """
+    def _config_entries(self) -> set[str]:
+        """Return the config entries this device belongs to, without reporting."""
         if self._composite_subentries is not None:
             return set(self._composite_subentries)
         return {self.config_entry_id}
 
     @property
     @override
-    def config_entries_subentries(self) -> dict[str, set[str | None]]:
-        """Return the config subentries this device belongs to.
-
-        Deprecated compatibility shim: a device now belongs to a single config
-        entry and subentry, available as config_entry_id and config_subentry_id.
-        """
+    def _config_entries_subentries(self) -> dict[str, set[str | None]]:
+        """Return the config subentries this device belongs to, without reporting."""
         if self._composite_subentries is not None:
             return {
                 entry_id: set(subentries)
@@ -559,10 +594,10 @@ class DeviceEntry(BaseDeviceEntry):
             # config_entries and config_entries_subentries are deprecated and kept for
             # backwards compatibility, they can be removed in HA Core 2027.8. They use the
             # compatibility properties so a restored composite reports its merged entries.
-            "config_entries": list(self.config_entries),
+            "config_entries": list(self._config_entries),
             "config_entries_subentries": {
                 entry_id: list(subentries)
-                for entry_id, subentries in self.config_entries_subentries.items()
+                for entry_id, subentries in self._config_entries_subentries.items()
             },
             "config_entry_id": self.config_entry_id,
             "config_subentry_id": self.config_subentry_id,
@@ -581,7 +616,8 @@ class DeviceEntry(BaseDeviceEntry):
             "name_by_user": self.name_by_user,
             "name": self.name,
             "parent_device_id": None,
-            "primary_config_entry": self.primary_config_entry,
+            # primary_config_entry is deprecated, it can be removed in HA Core 2027.8.
+            "primary_config_entry": self.config_entry_id,
             "serial_number": self.serial_number,
             "sw_version": self.sw_version,
             "via_device_id": self.via_device_id,
@@ -614,7 +650,9 @@ class DeviceEntry(BaseDeviceEntry):
                 "name_by_user": self.name_by_user,
                 "name": self.name,
                 "has_composite_identifiers": (self.has_composite_identifiers),
-                "primary_config_entry": self.primary_config_entry,
+                # primary_config_entry is deprecated, it can be removed in HA Core
+                # 2027.8.
+                "primary_config_entry": self.config_entry_id,
                 "serial_number": self.serial_number,
                 "sw_version": self.sw_version,
                 "via_device_id": self.via_device_id,
@@ -776,16 +814,24 @@ class DeletedDeviceEntry:
     def config_entries(self) -> set[str]:
         """Return the config entries this device belonged to.
 
-        Deprecated compatibility shim; empty for orphaned deleted devices.
+        Deprecated compatibility shim; empty for orphaned deleted devices. It can be
+        removed in HA Core 2027.8.
         """
+        _report_deprecated_config_entries_property(
+            self, "config_entries", "config_entry_id"
+        )
         return {self.config_entry_id} if self.config_entry_id is not None else set()
 
     @property
     def config_entries_subentries(self) -> dict[str, set[str | None]]:
         """Return the config subentries this device belonged to.
 
-        Deprecated compatibility shim; empty for orphaned deleted devices.
+        Deprecated compatibility shim; empty for orphaned deleted devices. It can be
+        removed in HA Core 2027.8.
         """
+        _report_deprecated_config_entries_property(
+            self, "config_entries_subentries", "config_entry_id", "config_subentry_id"
+        )
         if self.config_entry_id is None:
             return {}
         return {self.config_entry_id: {self.config_subentry_id}}

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -390,7 +390,7 @@ def _report_deprecated_config_entries_property(
     report_usage(
         f"accesses `{class_name}.{name}`, which is deprecated because a device "
         f"belongs to a single config entry; use {replacement} instead",
-        breaks_in_ha_version="2027.8.0",
+        breaks_in_ha_version="2027.10.0",
         core_behavior=ReportBehavior.ERROR,
         core_integration_behavior=ReportBehavior.ERROR,
         custom_integration_behavior=ReportBehavior.LOG,
@@ -430,7 +430,7 @@ class BaseDeviceEntry:
         """Return the config entries this device belongs to.
 
         Deprecated compatibility shim: a device now belongs to a single config
-        entry, available as config_entry_id. It can be removed in HA Core 2027.8.
+        entry, available as config_entry_id. It can be removed in HA Core 2027.10.
         """
         if not self.is_composite_device:
             _report_deprecated_config_entries_property(
@@ -444,7 +444,7 @@ class BaseDeviceEntry:
 
         Deprecated compatibility shim: a device now belongs to a single config
         entry and subentry, available as config_entry_id and config_subentry_id.
-        It can be removed in HA Core 2027.8.
+        It can be removed in HA Core 2027.10.
         """
         if not self.is_composite_device:
             _report_deprecated_config_entries_property(
@@ -461,7 +461,7 @@ class BaseDeviceEntry:
 
         Deprecated compatibility shim: a device now belongs to a single config
         entry, available as config_entry_id, which is its primary config entry.
-        It can be removed in HA Core 2027.8.
+        It can be removed in HA Core 2027.10.
         """
         if not self.is_composite_device:
             _report_deprecated_config_entries_property(
@@ -616,7 +616,7 @@ class DeviceEntry(BaseDeviceEntry):
             "name_by_user": self.name_by_user,
             "name": self.name,
             "parent_device_id": None,
-            # primary_config_entry is deprecated, it can be removed in HA Core 2027.8.
+            # primary_config_entry is deprecated, it can be removed in HA Core 2027.10.
             "primary_config_entry": self.config_entry_id,
             "serial_number": self.serial_number,
             "sw_version": self.sw_version,
@@ -651,7 +651,7 @@ class DeviceEntry(BaseDeviceEntry):
                 "name": self.name,
                 "has_composite_identifiers": (self.has_composite_identifiers),
                 # primary_config_entry is deprecated, it can be removed in HA Core
-                # 2027.8.
+                # 2027.10.
                 "primary_config_entry": self.config_entry_id,
                 "serial_number": self.serial_number,
                 "sw_version": self.sw_version,
@@ -815,7 +815,7 @@ class DeletedDeviceEntry:
         """Return the config entries this device belonged to.
 
         Deprecated compatibility shim; empty for orphaned deleted devices. It can be
-        removed in HA Core 2027.8.
+        removed in HA Core 2027.10.
         """
         _report_deprecated_config_entries_property(
             self, "config_entries", "config_entry_id"
@@ -827,7 +827,7 @@ class DeletedDeviceEntry:
         """Return the config subentries this device belonged to.
 
         Deprecated compatibility shim; empty for orphaned deleted devices. It can be
-        removed in HA Core 2027.8.
+        removed in HA Core 2027.10.
         """
         _report_deprecated_config_entries_property(
             self, "config_entries_subentries", "config_entry_id", "config_subentry_id"

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -49,9 +49,11 @@ def _downgrade_device_registry_deprecation_reports(
     """Keep the deprecated device registry APIs from raising in tests.
 
     async_get_device, async_is_composite_device_id, the config entry parameters and
-    merge_connections/merge_identifiers parameters of async_update_device, and via_device
-    on async_get_or_create are deprecated and raise for core and core integration callers,
-    disable them here so we can run tests without triggering deprecation errors.
+    merge_connections/merge_identifiers parameters of async_update_device, via_device
+    on async_get_or_create, and the config_entries, config_entries_subentries and
+    primary_config_entry properties are deprecated and raise for core and core
+    integration callers, disable them here so we can run tests without triggering
+    deprecation errors.
 
     Tests which use `mock_integration_frame` will not be affected by this fixture, so
     they can test the deprecation.
@@ -8621,6 +8623,155 @@ async def test_single_config_entry_and_compat_properties(
     assert device.primary_config_entry == entry.entry_id
 
 
+_DEPRECATED_CONFIG_ENTRIES_PROPERTIES = [
+    "config_entries",
+    "config_entries_subentries",
+    "primary_config_entry",
+]
+
+
+@pytest.mark.parametrize("property_name", _DEPRECATED_CONFIG_ENTRIES_PROPERTIES)
+@pytest.mark.parametrize(
+    ("integration_frame_path", "expectation", "expected_log"),
+    [
+        pytest.param(
+            "homeassistant/test_core", pytest.raises(RuntimeError), 0, id="core"
+        ),
+        pytest.param(
+            "homeassistant/components/test_integration",
+            pytest.raises(RuntimeError),
+            1,
+            id="core integration",
+        ),
+        pytest.param(
+            "custom_components/test_integration",
+            nullcontext(),
+            1,
+            id="custom integration",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_integration_frame")
+async def test_deprecated_config_entries_properties(
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+    property_name: str,
+    expectation: AbstractContextManager,
+    expected_log: int,
+) -> None:
+    """Test the multi-config-entry compatibility properties are deprecated.
+
+    They log for custom integrations and raise for core and core integrations. Use
+    config_entry_id and config_subentry_id instead.
+    """
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id, identifiers={("test", "1")}
+    )
+
+    what = f"accesses `DeviceEntry.{property_name}`"
+    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()), expectation:
+        getattr(device, property_name)
+
+    assert caplog.text.count(what) == expected_log
+
+
+@pytest.mark.parametrize("property_name", _DEPRECATED_CONFIG_ENTRIES_PROPERTIES)
+@pytest.mark.parametrize(
+    "integration_frame_path",
+    [
+        pytest.param("homeassistant/test_core", id="core"),
+        pytest.param(
+            "homeassistant/components/test_integration", id="core integration"
+        ),
+        pytest.param("custom_components/test_integration", id="custom integration"),
+    ],
+)
+@pytest.mark.usefixtures("mock_integration_frame")
+async def test_deprecated_config_entries_properties_composite_exempt(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+    property_name: str,
+) -> None:
+    """Test a restored composite device is exempt from the deprecation.
+
+    A composite really does span several config entries, so the properties are the
+    correct API for it and reading them must not report, for any caller.
+    """
+    entry_1 = MockConfigEntry(domain="test")
+    entry_1.add_to_hass(hass)
+    entry_2 = MockConfigEntry(domain="test")
+    entry_2.add_to_hass(hass)
+    device_1 = device_registry.async_get_or_create(
+        config_entry_id=entry_1.entry_id, identifiers={("test", "1")}
+    )
+    device_2 = device_registry.async_get_or_create(
+        config_entry_id=entry_2.entry_id, identifiers={("test", "2")}
+    )
+    old_id = "composite00000000000000000000ab"
+    # Simulate a migration split: both devices carry the pre-migration composite id
+    device_registry._devices[device_1.id] = attr.evolve(
+        device_1, composite_device_id=old_id
+    )
+    device_registry._devices[device_2.id] = attr.evolve(
+        device_2, composite_device_id=old_id
+    )
+    composite = device_registry.async_get(old_id)
+    assert composite.is_composite_device is True
+
+    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()):
+        getattr(composite, property_name)
+
+    assert f"DeviceEntry.{property_name}" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "property_name", ["config_entries", "config_entries_subentries"]
+)
+@pytest.mark.parametrize(
+    ("integration_frame_path", "expectation", "expected_log"),
+    [
+        pytest.param(
+            "homeassistant/test_core", pytest.raises(RuntimeError), 0, id="core"
+        ),
+        pytest.param(
+            "homeassistant/components/test_integration",
+            pytest.raises(RuntimeError),
+            1,
+            id="core integration",
+        ),
+        pytest.param(
+            "custom_components/test_integration",
+            nullcontext(),
+            1,
+            id="custom integration",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_integration_frame")
+async def test_deprecated_config_entries_properties_deleted_device(
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+    property_name: str,
+    expectation: AbstractContextManager,
+    expected_log: int,
+) -> None:
+    """Test the compatibility properties are deprecated on a deleted device too."""
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id, identifiers={("test", "1")}
+    )
+    device_registry.async_remove_device(device.id)
+    deleted_device = device_registry._deleted_devices[device.id]
+
+    what = f"accesses `DeletedDeviceEntry.{property_name}`"
+    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()), expectation:
+        getattr(deleted_device, property_name)
+
+    assert caplog.text.count(what) == expected_log
+
+
 async def test_identifiers_unique_per_config_entry(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
@@ -12444,6 +12595,48 @@ async def test_child_device_config_entry_compat_shims(
         mock_config_entry.entry_id: {None}
     }
     assert child_device.primary_config_entry == mock_config_entry.entry_id
+
+
+@pytest.mark.parametrize("property_name", _DEPRECATED_CONFIG_ENTRIES_PROPERTIES)
+@pytest.mark.parametrize(
+    ("integration_frame_path", "expectation", "expected_log"),
+    [
+        pytest.param(
+            "homeassistant/test_core", pytest.raises(RuntimeError), 0, id="core"
+        ),
+        pytest.param(
+            "homeassistant/components/test_integration",
+            pytest.raises(RuntimeError),
+            1,
+            id="core integration",
+        ),
+        pytest.param(
+            "custom_components/test_integration",
+            nullcontext(),
+            1,
+            id="custom integration",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_integration_frame")
+async def test_deprecated_config_entries_properties_child_device(
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+    property_name: str,
+    expectation: AbstractContextManager,
+    expected_log: int,
+) -> None:
+    """Test the compatibility properties are deprecated on a child device too."""
+    _, child_device = _create_parent_and_child(
+        device_registry, mock_config_entry.entry_id
+    )
+
+    what = f"accesses `ChildDeviceEntry.{property_name}`"
+    with patch.object(frame, "_REPORTED_INTEGRATIONS", set()), expectation:
+        getattr(child_device, property_name)
+
+    assert caplog.text.count(what) == expected_log
 
 
 @pytest.mark.usefixtures("hass")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate `DeviceEntry.config_entries`, `DeviceEntry.config_entries_subentries` and `DeviceEntry.primary_config_entry` for concrete devices. The attributes are not deprecated for synthesized composite devices.

Needs https://github.com/home-assistant/core/pull/181945

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
