### PR TITLE
Add cleanup of stale devices and client trackers for TP-Link Omada

### DIFF
--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -1,9 +1,10 @@
 """The TP-Link Omada integration."""
 
+import asyncio
+from datetime import datetime, timedelta
 import logging
 
 from tplink_omada_client import OmadaSite
-from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import (
     ConnectionFailed,
     LoginFailed,
@@ -13,14 +14,16 @@ from tplink_omada_client.exceptions import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 
 from .config_flow import CONF_SITE, create_omada_client
 from .const import DOMAIN
 from .controller import OmadaSiteController
+from .coordinator import async_cleanup_client_trackers, async_cleanup_devices
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
@@ -76,13 +79,54 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
 
     site_client = await client.get_site_client(OmadaSite("", entry.data[CONF_SITE]))
     controller = OmadaSiteController(hass, entry, site_client)
-    await controller.initialize_first_refresh()
 
     entry.runtime_data = controller
 
-    _remove_old_devices(hass, entry, controller.devices_coordinator.data)
+    _cleanup_task: asyncio.Task[None] | None = None
+    _first_cleanup_call = True
+
+    async def _async_cleanup_task() -> None:
+        nonlocal _first_cleanup_call
+        if not _first_cleanup_call:
+            # On hourly runs refresh coordinators so cleanup doesn't use stale data.
+            # On the first run data is already fresh from initialize_first_refresh().
+            await controller.devices_coordinator.async_refresh()
+            await controller.known_clients_coordinator.async_refresh()
+        _first_cleanup_call = False
+        await async_cleanup_devices(
+            hass,
+            controller,
+        )
+        await async_cleanup_client_trackers(
+            hass,
+            controller,
+        )
+
+    @callback
+    def _schedule_cleanup(_now: datetime | None = None) -> None:
+        nonlocal _cleanup_task
+        if _cleanup_task is not None and not _cleanup_task.done():
+            return
+        _cleanup_task = entry.async_create_background_task(
+            hass,
+            _async_cleanup_task(),
+            "tplink_omada cleanup",
+        )
+
+    await controller.initialize_first_refresh()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    @callback
+    def _cancel_cleanup() -> None:
+        if _cleanup_task is not None and not _cleanup_task.done():
+            _cleanup_task.cancel()
+
+    _schedule_cleanup()
+    entry.async_on_unload(_cancel_cleanup)
+    entry.async_on_unload(
+        async_track_time_interval(hass, _schedule_cleanup, timedelta(hours=1))
+    )
 
     return True
 
@@ -90,23 +134,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
 async def async_unload_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-
-def _remove_old_devices(
-    hass: HomeAssistant,
-    entry: OmadaConfigEntry,
-    omada_devices: dict[str, OmadaListDevice],
-) -> None:
-    device_registry = dr.async_get(hass)
-
-    for registered_device in dr.async_entries_for_config_entry(
-        device_registry, entry.entry_id
-    ):
-        mac = next(
-            (i[1] for i in registered_device.identifiers if i[0] == DOMAIN), None
-        )
-        if mac and mac not in omada_devices:
-            device_registry.async_remove_device(registered_device.id)
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> bool:

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -87,12 +87,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
 
     async def _async_cleanup_task() -> None:
         nonlocal _first_cleanup_call
-        if not _first_cleanup_call:
-            # On hourly runs refresh coordinators so cleanup doesn't use stale data.
-            # On the first run data is already fresh from initialize_first_refresh().
+        if _first_cleanup_call:
+            # Data is already fresh from initialize_first_refresh().
+            _first_cleanup_call = False
+        elif entry.pref_disable_polling:
+            # Cleanup decisions need fresh data, so skip the run entirely
+            # instead of polling the controller while polling is disabled.
+            return
+        else:
+            # Refresh coordinators so cleanup doesn't use stale data.
             await controller.devices_coordinator.async_refresh()
             await controller.known_clients_coordinator.async_refresh()
-        _first_cleanup_call = False
         await async_cleanup_devices(
             hass,
             controller,

--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -28,6 +28,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import OmadaConfigEntry
+from .const import DOMAIN
 from .controller import OmadaGatewayCoordinator
 from .entity import OmadaDeviceEntity
 
@@ -48,7 +49,11 @@ async def async_setup_entry(
         entities: list[Entity] = []
         gateway = (gateway_coordinator.data or {}).get(device.mac)
         if gateway is None:
-            raise HomeAssistantError(f"Gateway data for {device.mac} is unavailable")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="gateway_unavailable",
+                translation_placeholders={"mac": device.mac},
+            )
 
         entities.extend(
             OmadaGatewayPortBinarySensor(

--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -23,6 +23,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -46,15 +47,17 @@ async def async_setup_entry(
 
         entities: list[Entity] = []
         gateway = (gateway_coordinator.data or {}).get(device.mac)
-        if gateway:
-            entities.extend(
-                OmadaGatewayPortBinarySensor(
-                    gateway_coordinator, gateway, p.port_number, desc
-                )
-                for p in gateway.port_configs
-                for desc in GATEWAY_PORT_SENSORS
-                if desc.exists_func(p)
+        if gateway is None:
+            raise HomeAssistantError(f"Gateway data for {device.mac} is unavailable")
+
+        entities.extend(
+            OmadaGatewayPortBinarySensor(
+                gateway_coordinator, gateway, p.port_number, desc
             )
+            for p in gateway.port_configs
+            for desc in GATEWAY_PORT_SENSORS
+            if desc.exists_func(p)
+        )
         async_add_entities(entities)
 
     await controller.async_register_device_entities(

--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, override
+from typing import override
 
 from tplink_omada_client.definitions import (
     DeviceStatusCategory,
@@ -42,12 +42,10 @@ async def async_setup_entry(
     controller = config_entry.runtime_data
 
     async def _create_gateway_port_entities(device: OmadaListDevice) -> None:
-        gateway_coordinator = controller.gateway_coordinator
-        if TYPE_CHECKING:
-            assert gateway_coordinator is not None
+        gateway_coordinator = await controller.async_get_gateway_coordinator(device.mac)
 
         entities: list[Entity] = []
-        gateway = gateway_coordinator.data.get(device.mac)
+        gateway = (gateway_coordinator.data or {}).get(device.mac)
         if gateway:
             entities.extend(
                 OmadaGatewayPortBinarySensor(

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -134,6 +134,13 @@ class OmadaSiteController:
         for processed in self._device_entity_registrations:
             processed.discard(mac)
 
+        for switch_mac, switch_coordinator in list(
+            self._switch_port_coordinators.items()
+        ):
+            if dr.format_mac(switch_mac) == mac:
+                del self._switch_port_coordinators[switch_mac]
+                await switch_coordinator.async_shutdown()
+
         async with self._gateway_coordinator_lock:
             coordinator = self._gateway_coordinator
             if coordinator is None or dr.format_mac(coordinator.mac) != mac:

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -132,6 +132,20 @@ class OmadaSiteController:
 
         return self._switch_port_coordinators[switch.mac]
 
+    async def async_get_gateway_coordinator(self, mac: str) -> OmadaGatewayCoordinator:
+        """Get the gateway coordinator, creating or replacing it for the given MAC."""
+        coordinator = self._gateway_coordinator
+        if coordinator is None or coordinator.mac != mac:
+            if coordinator is not None:
+                await coordinator.async_shutdown()
+            coordinator = OmadaGatewayCoordinator(
+                self._hass, self._config_entry, self._omada_client, mac
+            )
+            await coordinator.async_refresh()
+            self._gateway_coordinator = coordinator
+
+        return coordinator
+
     @property
     def gateway_coordinator(self) -> OmadaGatewayCoordinator | None:
         """Gets the coordinator for site's gateway, or None if there is no gateway."""

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -1,12 +1,15 @@
 """Controller for sharing Omada API coordinators between platforms."""
 
+import asyncio
 from collections.abc import Awaitable, Callable
+import logging
 from typing import TYPE_CHECKING
 
 from tplink_omada_client import OmadaSiteClient
 from tplink_omada_client.devices import OmadaListDevice, OmadaSwitch
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 
 if TYPE_CHECKING:
@@ -19,6 +22,8 @@ from .coordinator import (
     OmadaKnownClientsCoordinator,
     OmadaSwitchPortCoordinator,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class OmadaSiteController:
@@ -48,6 +53,7 @@ class OmadaSiteController:
             hass, config_entry, omada_client
         )
         self._device_entity_registrations: list[set[str]] = []
+        self._gateway_coordinator_lock = asyncio.Lock()
 
     async def initialize_first_refresh(self) -> None:
         """Initialize the all coordinators, and perform first refresh."""
@@ -79,7 +85,9 @@ class OmadaSiteController:
             entity_callback: Given a discovered Omada device,
                 creates entities for that device.
         """
-        # Track which devices have been processed already
+        # Track which devices have been processed already. Devices are marked
+        # only after successful entity creation so failed registrations retry
+        # on the next device update.
         processed_devices: set[str] = set()
         self._device_entity_registrations.append(processed_devices)
 
@@ -96,8 +104,18 @@ class OmadaSiteController:
                 return
 
             for device in devices_to_process:
+                try:
+                    await entity_callback(device)
+                except HomeAssistantError as ex:
+                    # Leave the device unmarked so registration retries on the
+                    # next device update.
+                    _LOGGER.debug(
+                        "Failed to register entities for device %s: %s",
+                        device.mac,
+                        ex,
+                    )
+                    continue
                 processed_devices.add(dr.format_mac(device.mac))
-                await entity_callback(device)
 
         @callback
         def _handle_devices_update() -> None:
@@ -110,11 +128,18 @@ class OmadaSiteController:
         # Call once on initial setup
         await _async_register_entities()
 
-    def async_mark_device_removed(self, mac: str) -> None:
+    async def async_mark_device_removed(self, mac: str) -> None:
         """Allow entities for a removed device to be re-registered if it reappears."""
         mac = dr.format_mac(mac)
         for processed in self._device_entity_registrations:
             processed.discard(mac)
+
+        async with self._gateway_coordinator_lock:
+            coordinator = self._gateway_coordinator
+            if coordinator is None or dr.format_mac(coordinator.mac) != mac:
+                return
+            self._gateway_coordinator = None
+            await coordinator.async_shutdown()
 
     @property
     def omada_client(self) -> OmadaSiteClient:
@@ -134,17 +159,23 @@ class OmadaSiteController:
 
     async def async_get_gateway_coordinator(self, mac: str) -> OmadaGatewayCoordinator:
         """Get the gateway coordinator, creating or replacing it for the given MAC."""
-        coordinator = self._gateway_coordinator
-        if coordinator is None or coordinator.mac != mac:
-            if coordinator is not None:
-                await coordinator.async_shutdown()
-            coordinator = OmadaGatewayCoordinator(
-                self._hass, self._config_entry, self._omada_client, mac
-            )
-            await coordinator.async_refresh()
-            self._gateway_coordinator = coordinator
+        async with self._gateway_coordinator_lock:
+            coordinator = self._gateway_coordinator
+            if coordinator is None or dr.format_mac(coordinator.mac) != dr.format_mac(
+                mac
+            ):
+                if coordinator is not None:
+                    await coordinator.async_shutdown()
+                coordinator = OmadaGatewayCoordinator(
+                    self._hass, self._config_entry, self._omada_client, mac
+                )
+                self._gateway_coordinator = coordinator
+                await coordinator.async_refresh()
+            elif not coordinator.data:
+                # Retry a previous failed fetch so registration can recover.
+                await coordinator.async_refresh()
 
-        return coordinator
+            return coordinator
 
     @property
     def gateway_coordinator(self) -> OmadaGatewayCoordinator | None:

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -9,7 +9,6 @@ from tplink_omada_client import OmadaSiteClient
 from tplink_omada_client.devices import OmadaListDevice, OmadaSwitch
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 
 if TYPE_CHECKING:
@@ -110,14 +109,12 @@ class OmadaSiteController:
                 processed_devices.add(mac)
                 try:
                     await entity_callback(device)
-                except HomeAssistantError as ex:
+                except Exception:
                     # Release the reservation so registration retries on the
                     # next device update.
                     processed_devices.discard(mac)
-                    _LOGGER.debug(
-                        "Failed to register entities for device %s: %s",
-                        device.mac,
-                        ex,
+                    _LOGGER.exception(
+                        "Failed to register entities for device %s", device.mac
                     )
                     continue
 

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -104,18 +104,22 @@ class OmadaSiteController:
                 return
 
             for device in devices_to_process:
+                mac = dr.format_mac(device.mac)
+                # Reserve the device before awaiting so concurrent
+                # registrations do not process it twice.
+                processed_devices.add(mac)
                 try:
                     await entity_callback(device)
                 except HomeAssistantError as ex:
-                    # Leave the device unmarked so registration retries on the
+                    # Release the reservation so registration retries on the
                     # next device update.
+                    processed_devices.discard(mac)
                     _LOGGER.debug(
                         "Failed to register entities for device %s: %s",
                         device.mac,
                         ex,
                     )
                     continue
-                processed_devices.add(dr.format_mac(device.mac))
 
         @callback
         def _handle_devices_update() -> None:

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -7,6 +7,7 @@ from tplink_omada_client import OmadaSiteClient
 from tplink_omada_client.devices import OmadaListDevice, OmadaSwitch
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 
 if TYPE_CHECKING:
     from . import OmadaConfigEntry
@@ -15,6 +16,7 @@ from .coordinator import (
     OmadaClientsCoordinator,
     OmadaDevicesCoordinator,
     OmadaGatewayCoordinator,
+    OmadaKnownClientsCoordinator,
     OmadaSwitchPortCoordinator,
 )
 
@@ -42,9 +44,14 @@ class OmadaSiteController:
         self._clients_coordinator = OmadaClientsCoordinator(
             hass, config_entry, omada_client
         )
+        self._known_clients_coordinator = OmadaKnownClientsCoordinator(
+            hass, config_entry, omada_client
+        )
+        self._device_entity_registrations: list[set[str]] = []
 
     async def initialize_first_refresh(self) -> None:
         """Initialize the all coordinators, and perform first refresh."""
+        await self._known_clients_coordinator.async_config_entry_first_refresh()
         await self._devices_coordinator.async_config_entry_first_refresh()
 
         devices = self._devices_coordinator.data.values()
@@ -74,20 +81,22 @@ class OmadaSiteController:
         """
         # Track which devices have been processed already
         processed_devices: set[str] = set()
+        self._device_entity_registrations.append(processed_devices)
 
         async def _async_register_entities() -> None:
             """Register entities for devices that match the filter."""
             devices_to_process = [
                 device
                 for device in self._devices_coordinator.data.values()
-                if device_filter(device) and device.mac not in processed_devices
+                if device_filter(device)
+                and dr.format_mac(device.mac) not in processed_devices
             ]
 
             if not devices_to_process:
                 return
 
             for device in devices_to_process:
-                processed_devices.add(device.mac)
+                processed_devices.add(dr.format_mac(device.mac))
                 await entity_callback(device)
 
         @callback
@@ -100,6 +109,12 @@ class OmadaSiteController:
 
         # Call once on initial setup
         await _async_register_entities()
+
+    def async_mark_device_removed(self, mac: str) -> None:
+        """Allow entities for a removed device to be re-registered if it reappears."""
+        mac = dr.format_mac(mac)
+        for processed in self._device_entity_registrations:
+            processed.discard(mac)
 
     @property
     def omada_client(self) -> OmadaSiteClient:
@@ -131,3 +146,8 @@ class OmadaSiteController:
     def clients_coordinator(self) -> OmadaClientsCoordinator:
         """Gets the coordinator for site's clients."""
         return self._clients_coordinator
+
+    @property
+    def known_clients_coordinator(self) -> OmadaKnownClientsCoordinator:
+        """Gets the coordinator for all wireless clients known to the controller."""
+        return self._known_clients_coordinator

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -15,13 +15,16 @@ from tplink_omada_client.devices import (
 )
 from tplink_omada_client.exceptions import OmadaClientException
 
+from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
 
 if TYPE_CHECKING:
     from . import OmadaConfigEntry
+    from .controller import OmadaSiteController
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,6 +33,11 @@ POLL_GATEWAY = 300
 POLL_CLIENTS = 300
 POLL_DEVICES = 300
 POLL_UPGRADE = 60
+
+# Number of consecutive empty device-list updates required before removing
+# device entries, to tolerate transient empty responses from the controller.
+# Device polls run every five minutes, so this is about one hour of emptiness.
+EMPTY_DEVICE_LIMIT = 12
 
 
 class OmadaCoordinator[_T](DataUpdateCoordinator[dict[str, _T]]):
@@ -131,11 +139,17 @@ class OmadaDevicesCoordinator(OmadaCoordinator[OmadaListDevice]):
     ) -> None:
         """Initialize my coordinator."""
         super().__init__(hass, config_entry, omada_client, "DeviceList", POLL_CLIENTS)
+        self.consecutive_empty_updates = 0
 
     @override
     async def poll_update(self) -> dict[str, OmadaListDevice]:
         """Poll the site's current registered Omada devices."""
-        return {d.mac: d for d in await self.omada_client.get_devices()}
+        devices = {d.mac: d for d in await self.omada_client.get_devices()}
+        if devices:
+            self.consecutive_empty_updates = 0
+        else:
+            self.consecutive_empty_updates += 1
+        return devices
 
 
 class OmadaClientsCoordinator(OmadaCoordinator[OmadaWirelessClient]):
@@ -157,6 +171,30 @@ class OmadaClientsCoordinator(OmadaCoordinator[OmadaWirelessClient]):
             c.mac: c
             async for c in self.omada_client.get_connected_clients()
             if isinstance(c, OmadaWirelessClient)
+        }
+
+
+class OmadaKnownClientsCoordinator(OmadaCoordinator[OmadaWirelessClient]):
+    """Coordinator for getting details about all wireless clients known to the controller."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: OmadaConfigEntry,
+        omada_client: OmadaSiteClient,
+    ) -> None:
+        """Initialize my coordinator."""
+        super().__init__(
+            hass, config_entry, omada_client, "KnownClientsList", poll_delay=None
+        )
+
+    @override
+    async def poll_update(self) -> dict[str, OmadaWirelessClient]:
+        """Poll the site's all-time known wireless clients."""
+        return {
+            client.mac: client
+            async for client in self.omada_client.get_known_clients()
+            if isinstance(client, OmadaWirelessClient)
         }
 
 
@@ -224,3 +262,89 @@ class OmadaFirmwareUpdateCoordinator(OmadaCoordinator[FirmwareUpdateStatus]):
         self._config_entry.async_create_background_task(
             self.hass, self.async_request_refresh(), "Omada Firmware Update Refresh"
         )
+
+
+def _unique_id_to_mac(unique_id: str | None) -> str | None:
+    """Extract the client MAC address from a tracker unique ID."""
+    if not unique_id or not unique_id.startswith("scanner_"):
+        return None
+    # The format is scanner_<site_id>_<mac>. Strip the prefix and split from the
+    # right so site_ids that contain underscores are handled correctly.
+    remainder = unique_id.removeprefix("scanner_")
+    site_id, sep, mac = remainder.rpartition("_")
+    if not sep or not site_id or not mac:
+        return None
+    return dr.format_mac(mac)
+
+
+async def async_cleanup_client_trackers(
+    hass: HomeAssistant,
+    controller: OmadaSiteController,
+) -> None:
+    """Remove stale client tracker entities for the Omada integration."""
+    if not controller.known_clients_coordinator.last_update_success:
+        return
+
+    known_clients = controller.known_clients_coordinator.data or {}
+    entity_registry = er.async_get(hass)
+    entry_id = controller.known_clients_coordinator.config_entry.entry_id
+    known_macs = {dr.format_mac(mac) for mac in known_clients}
+
+    for entity in er.async_entries_for_config_entry(entity_registry, entry_id):
+        if entity.domain != DEVICE_TRACKER_DOMAIN:
+            continue
+
+        client_mac = _unique_id_to_mac(entity.unique_id)
+        if client_mac is None:
+            continue
+
+        if (
+            client_mac not in known_macs
+            and entity.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+        ):
+            entity_registry.async_remove(entity.entity_id)
+
+
+async def async_cleanup_devices(
+    hass: HomeAssistant,
+    controller: OmadaSiteController,
+) -> None:
+    """Remove devices from the registry when Omada no longer reports them."""
+    if not controller.devices_coordinator.last_update_success:
+        return
+
+    devices = controller.devices_coordinator.data
+    if not devices:
+        # A successful but empty response is likely a transient controller glitch,
+        # and removal also deletes the device's entities from the registry, so only
+        # clean once the empty list is confirmed over consecutive updates.
+        if (
+            controller.devices_coordinator.consecutive_empty_updates
+            < EMPTY_DEVICE_LIMIT
+        ):
+            return
+
+    device_registry = dr.async_get(hass)
+    entry_id = controller.devices_coordinator.config_entry.entry_id
+    known_devices = {dr.format_mac(mac) for mac in devices}
+
+    for device_entry in dr.async_entries_for_config_entry(device_registry, entry_id):
+        mac = next(
+            (
+                fmt
+                for identifier in device_entry.identifiers
+                if identifier[0] == DOMAIN
+                and len(fmt := dr.format_mac(identifier[1])) == 17
+                and fmt.count(":") == 5
+            ),
+            None,
+        )
+
+        if mac and mac not in known_devices:
+            _LOGGER.debug(
+                "Removing stale Omada device %s from entry %s",
+                mac,
+                entry_id,
+            )
+            controller.async_mark_device_removed(mac)
+            device_registry.async_remove_device(device_entry.id)

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -346,5 +346,5 @@ async def async_cleanup_devices(
                 mac,
                 entry_id,
             )
-            controller.async_mark_device_removed(mac)
+            await controller.async_mark_device_removed(mac)
             device_registry.async_remove_device(device_entry.id)

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -274,7 +274,12 @@ def _unique_id_to_mac(unique_id: str | None) -> str | None:
     site_id, sep, mac = remainder.rpartition("_")
     if not sep or not site_id or not mac:
         return None
-    return dr.format_mac(mac)
+
+    # format_mac returns unrecognized input unchanged, so validate the shape.
+    mac = dr.format_mac(mac)
+    if len(mac) != 17 or mac.count(":") != 5:
+        return None
+    return mac
 
 
 async def async_cleanup_client_trackers(

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -275,12 +275,14 @@ def _unique_id_to_mac(unique_id: str | None) -> str | None:
     if not sep or not site_id or not mac:
         return None
 
-    # format_mac returns unrecognized input unchanged or lowercases without
-    # validating, so require the canonical MAC shape and hex digits.
+    # format_mac lowercases and reformats recognized separators without
+    # validating, so require six octets of exactly two hex digits.
     mac = dr.format_mac(mac)
-    if len(mac) != 17 or mac.count(":") != 5:
-        return None
-    if any(char not in "0123456789abcdef" for char in mac if char != ":"):
+    octets = mac.split(":")
+    if len(octets) != 6 or any(
+        len(octet) != 2 or any(char not in "0123456789abcdef" for char in octet)
+        for octet in octets
+    ):
         return None
     return mac
 

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -275,9 +275,12 @@ def _unique_id_to_mac(unique_id: str | None) -> str | None:
     if not sep or not site_id or not mac:
         return None
 
-    # format_mac returns unrecognized input unchanged, so validate the shape.
+    # format_mac returns unrecognized input unchanged or lowercases without
+    # validating, so require the canonical MAC shape and hex digits.
     mac = dr.format_mac(mac)
     if len(mac) != 17 or mac.count(":") != 5:
+        return None
+    if any(char not in "0123456789abcdef" for char in mac if char != ":"):
         return None
     return mac
 

--- a/homeassistant/components/tplink_omada/device_tracker.py
+++ b/homeassistant/components/tplink_omada/device_tracker.py
@@ -4,8 +4,12 @@ from typing import override
 
 from tplink_omada_client.clients import OmadaWirelessClient
 
-from homeassistant.components.device_tracker import ScannerEntity
+from homeassistant.components.device_tracker import (
+    DOMAIN as DEVICE_TRACKER_DOMAIN,
+    ScannerEntity,
+)
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -26,6 +30,35 @@ async def async_setup_entry(
     controller = config_entry.runtime_data
 
     site_id = config_entry.data[CONF_SITE]
+    known_clients_coordinator = controller.known_clients_coordinator
+
+    def _new_trackers() -> list[OmadaClientScannerEntity]:
+        """Return trackers for known clients without a registry entry."""
+        entity_registry = er.async_get(hass)
+        tracked_ids = {
+            entity.unique_id
+            for entity in er.async_entries_for_config_entry(
+                entity_registry, config_entry.entry_id
+            )
+            if entity.domain == DEVICE_TRACKER_DOMAIN and entity.unique_id is not None
+        }
+        return [
+            OmadaClientScannerEntity(
+                site_id, client.mac, client.name, controller.clients_coordinator
+            )
+            for client in (known_clients_coordinator.data or {}).values()
+            if f"scanner_{site_id}_{client.mac}" not in tracked_ids
+        ]
+
+    @callback
+    def _handle_known_clients_update() -> None:
+        """Add trackers for clients that reappeared on the controller."""
+        if entities := _new_trackers():
+            async_add_entities(entities)
+
+    config_entry.async_on_unload(
+        known_clients_coordinator.async_add_listener(_handle_known_clients_update)
+    )
 
     # Add all known WiFi devices as potentially tracked devices. They will only be
     # tracked if the user enables the entity.
@@ -34,8 +67,7 @@ async def async_setup_entry(
             OmadaClientScannerEntity(
                 site_id, client.mac, client.name, controller.clients_coordinator
             )
-            async for client in controller.omada_client.get_known_clients()
-            if isinstance(client, OmadaWirelessClient)
+            for client in (known_clients_coordinator.data or {}).values()
         ]
     )
 

--- a/homeassistant/components/tplink_omada/quality_scale.yaml
+++ b/homeassistant/components/tplink_omada/quality_scale.yaml
@@ -68,9 +68,7 @@ rules:
   icon-translations: done
   reconfiguration-flow: todo
   repair-issues: todo
-  stale-devices:
-    status: todo
-    comment: Stale devices are auto-deleted at startup, not yet during runtime.
+  stale-devices: done
 
   # Platinum
   async-dependency: done

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -138,6 +138,9 @@
     "firmware_update_rejected": {
       "message": "Firmware update request rejected"
     },
+    "gateway_unavailable": {
+      "message": "Gateway data for device with MAC {mac} is not available."
+    },
     "no_controllers": {
       "message": "No active TP-Link Omada controllers found"
     },

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -97,7 +97,11 @@ async def async_setup_entry(
         gateway_coordinator = await controller.async_get_gateway_coordinator(device.mac)
         gateway = (gateway_coordinator.data or {}).get(device.mac)
         if gateway is None:
-            raise HomeAssistantError(f"Gateway data for {device.mac} is unavailable")
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="gateway_unavailable",
+                translation_placeholders={"mac": device.mac},
+            )
 
         entities.extend(
             OmadaDevicePortSwitchEntity[

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -94,9 +94,9 @@ async def async_setup_entry(
     ) -> None:
         """Create entities for a gateway's ports."""
         entities: list[Entity] = []
-        gateway_coordinator = controller.gateway_coordinator
-        if gateway_coordinator:
-            gateway = gateway_coordinator.data[device.mac]
+        gateway_coordinator = await controller.async_get_gateway_coordinator(device.mac)
+        gateway = (gateway_coordinator.data or {}).get(device.mac)
+        if gateway:
             entities.extend(
                 OmadaDevicePortSwitchEntity[
                     OmadaGatewayCoordinator, OmadaGateway, OmadaGatewayPortStatus

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -96,23 +96,25 @@ async def async_setup_entry(
         entities: list[Entity] = []
         gateway_coordinator = await controller.async_get_gateway_coordinator(device.mac)
         gateway = (gateway_coordinator.data or {}).get(device.mac)
-        if gateway:
-            entities.extend(
-                OmadaDevicePortSwitchEntity[
-                    OmadaGatewayCoordinator, OmadaGateway, OmadaGatewayPortStatus
-                ](gateway_coordinator, gateway, p, str(p.port_number), desc)
-                for p in gateway.port_status
-                for desc in GATEWAY_PORT_STATUS_SWITCHES
-                if desc.exists_func(gateway, p)
-            )
-            entities.extend(
-                OmadaDevicePortSwitchEntity[
-                    OmadaGatewayCoordinator, OmadaGateway, OmadaGatewayPortConfig
-                ](gateway_coordinator, gateway, p, str(p.port_number), desc)
-                for p in gateway.port_configs
-                for desc in GATEWAY_PORT_CONFIG_SWITCHES
-                if desc.exists_func(gateway, p)
-            )
+        if gateway is None:
+            raise HomeAssistantError(f"Gateway data for {device.mac} is unavailable")
+
+        entities.extend(
+            OmadaDevicePortSwitchEntity[
+                OmadaGatewayCoordinator, OmadaGateway, OmadaGatewayPortStatus
+            ](gateway_coordinator, gateway, p, str(p.port_number), desc)
+            for p in gateway.port_status
+            for desc in GATEWAY_PORT_STATUS_SWITCHES
+            if desc.exists_func(gateway, p)
+        )
+        entities.extend(
+            OmadaDevicePortSwitchEntity[
+                OmadaGatewayCoordinator, OmadaGateway, OmadaGatewayPortConfig
+            ](gateway_coordinator, gateway, p, str(p.port_number), desc)
+            for p in gateway.port_configs
+            for desc in GATEWAY_PORT_CONFIG_SWITCHES
+            if desc.exists_func(gateway, p)
+        )
         async_add_entities(entities)
 
     await controller.async_register_device_entities(

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -30,14 +30,15 @@ async def async_setup_entry(
     """Set up switches."""
     controller = config_entry.runtime_data
 
-    devices = controller.devices_coordinator.data
-
     coordinator = OmadaFirmwareUpdateCoordinator(
         hass, config_entry, controller.omada_client, controller.devices_coordinator
     )
 
-    async_add_entities(
-        OmadaDeviceUpdate(coordinator, device) for device in devices.values()
+    async def _async_register_device(device: OmadaListDevice) -> None:
+        async_add_entities([OmadaDeviceUpdate(coordinator, device)])
+
+    await controller.async_register_device_entities(
+        lambda device: True, _async_register_device
     )
     await coordinator.async_request_refresh()
 

--- a/tests/components/tplink_omada/test_device_tracker.py
+++ b/tests/components/tplink_omada/test_device_tracker.py
@@ -16,7 +16,6 @@ from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
-UPDATE_INTERVAL = timedelta(seconds=10)
 POLL_INTERVAL = timedelta(seconds=POLL_CLIENTS + 10)
 
 MOCK_ENTRY_DATA = {
@@ -43,7 +42,7 @@ async def init_integration(
     mock_config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     return mock_config_entry
 
@@ -60,8 +59,9 @@ async def test_device_scanner_created(
 
     updated_entity = entity_registry.async_update_entity(entity_id, disabled_by=None)
     assert not updated_entity.disabled
+    await hass.async_block_till_done(wait_background_tasks=True)
     async_fire_time_changed(hass, utcnow() + POLL_INTERVAL)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     entity = hass.states.get(entity_id)
     assert entity is not None
@@ -81,8 +81,9 @@ async def test_device_scanner_update_to_away_nulls_properties(
 
     updated_entity = entity_registry.async_update_entity(entity_id, disabled_by=None)
     assert not updated_entity.disabled
+    await hass.async_block_till_done(wait_background_tasks=True)
     async_fire_time_changed(hass, utcnow() + POLL_INTERVAL)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     entity = hass.states.get(entity_id)
     await _setup_client_disconnect(
@@ -90,7 +91,7 @@ async def test_device_scanner_update_to_away_nulls_properties(
     )
 
     async_fire_time_changed(hass, utcnow() + (POLL_INTERVAL * 2))
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     entity = hass.states.get(entity_id)
     assert entity is not None

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -502,6 +502,37 @@ async def test_cleanup_recreates_device_when_reappears(
     )
 
 
+async def test_gateway_entities_created_when_gateway_appears_later(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test gateway entities are created when a gateway appears after setup."""
+    gateway_mac = "AA-BB-CC-DD-EE-FF"
+    site_client = mock_omada_client.get_site_client.return_value
+    site_client.get_devices = AsyncMock(
+        side_effect=partial(_get_devices_without, hass, gateway_mac)
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get("binary_sensor.test_router_port_1_lan_status") is None
+    assert hass.states.get("switch.test_router_port_4_internet_connected") is None
+
+    # Gateway appears on the controller — the next interval run registers it
+    devices_data = await async_load_json_array_fixture(hass, "devices.json", DOMAIN)
+    site_client.get_devices = AsyncMock(
+        return_value=[OmadaListDevice(d) for d in devices_data]
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1, seconds=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get("binary_sensor.test_router_port_1_lan_status") is not None
+    assert hass.states.get("switch.test_router_port_4_internet_connected") is not None
+
+
 @pytest.mark.parametrize(
     ("empty_updates", "orphan_removed"),
     [

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -278,6 +278,15 @@ async def test_cleanup_helpers_remove_unknown_clients(
         disabled_by=er.RegistryEntryDisabler.INTEGRATION,
     )
 
+    # Device tracker whose parsed suffix has noncanonical octets — skipped, not removed
+    malformed_octets = entity_registry.async_get_or_create(
+        domain="device_tracker",
+        platform=DOMAIN,
+        unique_id="scanner_Default_0:000:00:00:00:00",
+        config_entry=mock_config_entry,
+        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+    )
+
     await async_cleanup_client_trackers(hass, controller)
 
     assert entity_registry.async_get(unknown_client_entity_1.entity_id) is None
@@ -291,6 +300,7 @@ async def test_cleanup_helpers_remove_unknown_clients(
     assert entity_registry.async_get(malformed_wrong_parts.entity_id) is not None
     assert entity_registry.async_get(malformed_mac.entity_id) is not None
     assert entity_registry.async_get(malformed_hex.entity_id) is not None
+    assert entity_registry.async_get(malformed_octets.entity_id) is not None
 
 
 async def test_cleanup_devices_removes_orphans(

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -260,6 +260,15 @@ async def test_cleanup_helpers_remove_unknown_clients(
         config_entry=mock_config_entry,
     )
 
+    # Device tracker whose parsed suffix is not a MAC — skipped, not removed
+    malformed_mac = entity_registry.async_get_or_create(
+        domain="device_tracker",
+        platform=DOMAIN,
+        unique_id="scanner_Default_not-a-mac",
+        config_entry=mock_config_entry,
+        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+    )
+
     await async_cleanup_client_trackers(hass, controller)
 
     assert entity_registry.async_get(unknown_client_entity_1.entity_id) is None
@@ -271,6 +280,7 @@ async def test_cleanup_helpers_remove_unknown_clients(
     assert entity_registry.async_get(sensor_entity.entity_id) is not None
     assert entity_registry.async_get(malformed_no_prefix.entity_id) is not None
     assert entity_registry.async_get(malformed_wrong_parts.entity_id) is not None
+    assert entity_registry.async_get(malformed_mac.entity_id) is not None
 
 
 async def test_cleanup_devices_removes_orphans(

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -269,6 +269,15 @@ async def test_cleanup_helpers_remove_unknown_clients(
         disabled_by=er.RegistryEntryDisabler.INTEGRATION,
     )
 
+    # Device tracker whose parsed suffix has non-hex octets — skipped, not removed
+    malformed_hex = entity_registry.async_get_or_create(
+        domain="device_tracker",
+        platform=DOMAIN,
+        unique_id="scanner_Default_zz-zz-zz-zz-zz-zz",
+        config_entry=mock_config_entry,
+        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+    )
+
     await async_cleanup_client_trackers(hass, controller)
 
     assert entity_registry.async_get(unknown_client_entity_1.entity_id) is None
@@ -281,6 +290,7 @@ async def test_cleanup_helpers_remove_unknown_clients(
     assert entity_registry.async_get(malformed_no_prefix.entity_id) is not None
     assert entity_registry.async_get(malformed_wrong_parts.entity_id) is not None
     assert entity_registry.async_get(malformed_mac.entity_id) is not None
+    assert entity_registry.async_get(malformed_hex.entity_id) is not None
 
 
 async def test_cleanup_devices_removes_orphans(

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -757,6 +757,26 @@ async def test_cleanup_trackers_on_empty_known_clients(
     assert entity_registry.async_get(tracker.entity_id) is None
 
 
+async def test_cleanup_skipped_when_polling_disabled(
+    hass: HomeAssistant,
+    mock_omada_clients_only_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the hourly cleanup does not poll while polling is disabled."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(mock_config_entry, pref_disable_polling=True)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    site_client = mock_omada_clients_only_client.get_site_client.return_value
+    calls_before = site_client.get_devices.call_count
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1, seconds=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert site_client.get_devices.call_count == calls_before
+
+
 async def test_unload_cancels_cleanup_and_interval(
     hass: HomeAssistant,
     mock_omada_clients_only_client: MagicMock,

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from tplink_omada_client.clients import OmadaWirelessClient
-from tplink_omada_client.devices import OmadaListDevice
+from tplink_omada_client.devices import OmadaGateway, OmadaListDevice
 from tplink_omada_client.exceptions import (
     ConnectionFailed,
     LoginFailed,
@@ -34,6 +34,7 @@ from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
     async_load_json_array_fixture,
+    async_load_json_object_fixture,
 )
 
 MOCK_ENTRY_DATA = {
@@ -531,6 +532,90 @@ async def test_gateway_entities_created_when_gateway_appears_later(
 
     assert hass.states.get("binary_sensor.test_router_port_1_lan_status") is not None
     assert hass.states.get("switch.test_router_port_4_internet_connected") is not None
+
+
+async def test_cleanup_recreates_gateway_when_it_reappears(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a gateway removed by cleanup is re-registered when it returns."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    gateway_mac = "AA-BB-CC-DD-EE-FF"
+    site_client = mock_omada_client.get_site_client.return_value
+    assert hass.states.get("binary_sensor.test_router_port_1_lan_status") is not None
+
+    # Remove the gateway from the controller's device list and clean up
+    site_client.get_devices = AsyncMock(
+        side_effect=partial(_get_devices_without, hass, gateway_mac)
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1, seconds=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, gateway_mac), mock_config_entry.entry_id
+        )
+        is None
+    )
+    assert hass.states.get("binary_sensor.test_router_port_1_lan_status") is None
+
+    # Gateway returns — the next interval run re-registers it with fresh data
+    devices_data = await async_load_json_array_fixture(hass, "devices.json", DOMAIN)
+    site_client.get_devices = AsyncMock(
+        return_value=[OmadaListDevice(d) for d in devices_data]
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=2, seconds=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert hass.states.get("binary_sensor.test_router_port_1_lan_status") is not None
+
+
+async def test_gateway_registration_retries_after_failed_refresh(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test gateway entity registration retries when the initial fetch fails."""
+    gateway_mac = "AA-BB-CC-DD-EE-FF"
+    site_client = mock_omada_client.get_site_client.return_value
+    site_client.get_devices = AsyncMock(
+        side_effect=partial(_get_devices_without, hass, gateway_mac)
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    gateway_data = await async_load_json_object_fixture(
+        hass, "gateway-TL-ER7212PC.json", DOMAIN
+    )
+    gateway = OmadaGateway(gateway_data)
+    gateway_available = False
+
+    async def _get_gateway(mac: str) -> OmadaGateway:
+        if not gateway_available:
+            raise OmadaClientException("Gateway fetch failed")
+        return gateway
+
+    site_client.get_gateway = AsyncMock(side_effect=_get_gateway)
+    devices_data = await async_load_json_array_fixture(hass, "devices.json", DOMAIN)
+    site_client.get_devices = AsyncMock(
+        return_value=[OmadaListDevice(d) for d in devices_data]
+    )
+
+    # The gateway appears but cannot be fetched, so no entities are registered
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1, seconds=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert hass.states.get("binary_sensor.test_router_port_1_lan_status") is None
+
+    # Once the gateway is fetchable, the next run retries registration
+    gateway_available = True
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=2, seconds=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert hass.states.get("binary_sensor.test_router_port_1_lan_status") is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -1,8 +1,14 @@
 """Tests for TP-Link Omada integration init."""
 
-from unittest.mock import MagicMock, patch
+import asyncio
+from collections.abc import AsyncGenerator
+from datetime import timedelta
+from functools import partial
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from tplink_omada_client.clients import OmadaWirelessClient
+from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import (
     ConnectionFailed,
     LoginFailed,
@@ -11,13 +17,24 @@ from tplink_omada_client.exceptions import (
 )
 
 from homeassistant.components.tplink_omada.const import DOMAIN
-from homeassistant.components.tplink_omada.coordinator import OmadaCoordinator
+from homeassistant.components.tplink_omada.controller import OmadaSiteController
+from homeassistant.components.tplink_omada.coordinator import (
+    EMPTY_DEVICE_LIMIT,
+    OmadaCoordinator,
+    async_cleanup_client_trackers,
+    async_cleanup_devices,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.update_coordinator import UpdateFailed
+from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    async_load_json_array_fixture,
+)
 
 MOCK_ENTRY_DATA = {
     "host": "https://fake.omada.host",
@@ -97,12 +114,16 @@ async def test_coordinator_update_failure_is_translated(
     assert err.value.translation_key == "api_error"
 
 
-async def test_missing_devices_removed_at_startup(
+async def test_automatic_missing_device_cleanup(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     mock_omada_client: MagicMock,
 ) -> None:
-    """Test missing devices are removed at startup."""
+    """Test missing devices are removed during initial startup cleanup.
+
+    This validates the cleanup mechanism scheduled immediately on entry setup,
+    which runs as a background task.
+    """
     mock_config_entry = MockConfigEntry(
         title="Test Omada Controller",
         domain=DOMAIN,
@@ -114,7 +135,7 @@ async def test_missing_devices_removed_at_startup(
 
     device_entry = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
-        identifiers={(DOMAIN, "AA:BB:CC:DD:EE:FF")},
+        identifiers={(DOMAIN, "99:99:99:99:99:99")},
         manufacturer="TPLink",
         name="Old Device",
         model="Some old model",
@@ -123,9 +144,522 @@ async def test_missing_devices_removed_at_startup(
     assert device_registry.async_get(device_entry.id) == device_entry
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     assert device_registry.async_get(device_entry.id) is None
+
+
+async def test_automatic_missing_client_cleanup(
+    hass: HomeAssistant,
+    mock_omada_clients_only_client: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test missing client trackers are removed during initial startup cleanup.
+
+    This validates the cleanup mechanism scheduled immediately on entry setup,
+    which runs as a background task.
+    """
+
+    mock_config_entry = MockConfigEntry(
+        title="Test Omada Controller",
+        domain=DOMAIN,
+        data=dict(MOCK_ENTRY_DATA),
+        unique_id="12345",
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    tracker = entity_registry.async_get_or_create(
+        domain="device_tracker",
+        platform=DOMAIN,
+        unique_id="scanner_SiteId_11-11-11-11-11-11",
+        config_entry=mock_config_entry,
+        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+    )
+
+    assert entity_registry.async_get(tracker.entity_id)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entity_registry.async_get(tracker.entity_id) is None
+
+
+async def test_cleanup_helpers_remove_unknown_clients(
+    hass: HomeAssistant,
+    mock_omada_clients_only_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test cleanup helper removes device_tracker entities for unknown clients."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    controller = hass.config_entries.async_get_entry(
+        mock_config_entry.entry_id
+    ).runtime_data
+
+    all_entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+    device_trackers = [e for e in all_entities if e.domain == "device_tracker"]
+    assert device_trackers, "Setup should have created device_tracker entities"
+
+    unknown_client_entity_1 = entity_registry.async_get_or_create(
+        domain="device_tracker",
+        platform=DOMAIN,
+        unique_id="scanner_Default_99-99-99-99-99-99",
+        config_entry=mock_config_entry,
+        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+    )
+
+    unknown_client_entity_2 = entity_registry.async_get_or_create(
+        domain="device_tracker",
+        platform=DOMAIN,
+        unique_id="scanner_Default_88-88-88-88-88-88",
+        config_entry=mock_config_entry,
+        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+    )
+
+    enabled_unknown_client_entity = entity_registry.async_get_or_create(
+        domain="device_tracker",
+        platform=DOMAIN,
+        unique_id="scanner_Default_66-66-66-66-66-66",
+        config_entry=mock_config_entry,
+    )
+
+    already_disabled_entity = entity_registry.async_get_or_create(
+        domain="device_tracker",
+        platform=DOMAIN,
+        unique_id="scanner_Default_77-77-77-77-77-77",
+        config_entry=mock_config_entry,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+
+    sensor_entity = entity_registry.async_get_or_create(
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id="some_sensor",
+        config_entry=mock_config_entry,
+    )
+
+    # Device tracker whose unique_id does not start with "scanner_" — MAC is unparsable
+    malformed_no_prefix = entity_registry.async_get_or_create(
+        domain="device_tracker",
+        platform=DOMAIN,
+        unique_id="tracker_00-11-22-33-44-55",
+        config_entry=mock_config_entry,
+    )
+
+    # Device tracker whose unique_id has only two underscore-separated parts — MAC is unparsable
+    malformed_wrong_parts = entity_registry.async_get_or_create(
+        domain="device_tracker",
+        platform=DOMAIN,
+        unique_id="scanner_notype",
+        config_entry=mock_config_entry,
+    )
+
+    await async_cleanup_client_trackers(hass, controller)
+
+    assert entity_registry.async_get(unknown_client_entity_1.entity_id) is None
+    assert entity_registry.async_get(unknown_client_entity_2.entity_id) is None
+    assert (
+        entity_registry.async_get(enabled_unknown_client_entity.entity_id) is not None
+    )
+    assert entity_registry.async_get(already_disabled_entity.entity_id) is not None
+    assert entity_registry.async_get(sensor_entity.entity_id) is not None
+    assert entity_registry.async_get(malformed_no_prefix.entity_id) is not None
+    assert entity_registry.async_get(malformed_wrong_parts.entity_id) is not None
+
+
+async def test_cleanup_devices_removes_orphans(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test cleanup helper removes orphaned device registry entries."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    controller = hass.config_entries.async_get_entry(
+        mock_config_entry.entry_id
+    ).runtime_data
+
+    orphan = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "99:99:99:99:99:99")},
+        manufacturer="TP-Link",
+        model="Test",
+        name="Orphan",
+    )
+    assert device_registry.async_get(orphan.id)
+
+    await async_cleanup_devices(hass, controller)
+
+    assert device_registry.async_get(orphan.id) is None
+
+
+async def test_cleanup_task_guard_prevents_redundant_tasks(
+    hass: HomeAssistant,
+    mock_omada_clients_only_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test in-flight task guard prevents scheduling a second cleanup concurrently."""
+    cleanup_call_count = 0
+    cleanup_started = asyncio.Event()
+    cleanup_proceed = asyncio.Event()
+
+    async def blocking_cleanup(h: HomeAssistant, c: OmadaSiteController) -> None:
+        nonlocal cleanup_call_count
+        cleanup_call_count += 1
+        cleanup_started.set()
+        await cleanup_proceed.wait()
+
+    with patch(
+        "homeassistant.components.tplink_omada.async_cleanup_devices",
+        new=blocking_cleanup,
+    ):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # With eager_start=True the background task runs synchronously until its
+        # first await, so cleanup_started is set before async_setup_entry returns.
+        assert cleanup_started.is_set()
+
+        # In-flight task guard is now active — the 1-hour interval should be a no-op
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1, seconds=1))
+        await hass.async_block_till_done()
+
+        # Release the first cleanup
+        cleanup_proceed.set()
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    # The second _schedule_cleanup call returned early due to the in-flight task guard
+    assert cleanup_call_count == 1
+
+
+async def _get_known_clients_without(
+    hass: HomeAssistant, excluded_mac: str
+) -> AsyncGenerator[OmadaWirelessClient]:
+    """Yield wireless clients from the known-clients fixture, skipping one MAC."""
+    known_clients_data = await async_load_json_array_fixture(
+        hass, "known-clients.json", DOMAIN
+    )
+    for client in known_clients_data:
+        if client["mac"] != excluded_mac and client["wireless"]:
+            yield OmadaWirelessClient(client)
+
+
+async def _get_no_known_clients() -> AsyncGenerator[OmadaWirelessClient]:
+    """Yield no known clients."""
+    for client in ():
+        yield client
+
+
+async def _get_devices_without(
+    hass: HomeAssistant, excluded_mac: str
+) -> list[OmadaListDevice]:
+    """Return devices from the devices fixture, skipping one MAC."""
+    devices_data = await async_load_json_array_fixture(hass, "devices.json", DOMAIN)
+    return [
+        OmadaListDevice(device)
+        for device in devices_data
+        if device["mac"] != excluded_mac
+    ]
+
+
+async def test_cleanup_runs_hourly(
+    hass: HomeAssistant,
+    mock_omada_clients_only_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a client removed from the controller is cleaned up on the hourly interval."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Client present in the known-clients.json fixture at startup
+    removed_mac = "2C-71-FF-ED-34-83"
+    tracker = entity_registry.async_get_or_create(
+        domain="device_tracker",
+        platform=DOMAIN,
+        unique_id=f"scanner_Default_{removed_mac}",
+        config_entry=mock_config_entry,
+    )
+    assert entity_registry.async_get(tracker.entity_id) is not None
+
+    # Remove the client from the controller's known-clients list
+    site_client = mock_omada_clients_only_client.get_site_client.return_value
+    site_client.get_known_clients.side_effect = partial(
+        _get_known_clients_without, hass, removed_mac
+    )
+
+    # Fire the 1-hour interval to trigger cleanup
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(hours=1, seconds=1),
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert entity_registry.async_get(tracker.entity_id) is None
+
+
+async def test_cleanup_recreates_tracker_when_client_reappears(
+    hass: HomeAssistant,
+    mock_omada_clients_only_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a tracker removed by cleanup is recreated when the client returns."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    removed_mac = "2C-71-FF-ED-34-83"
+    tracker_unique_id = f"scanner_Default_{removed_mac}"
+    site_client = mock_omada_clients_only_client.get_site_client.return_value
+
+    # Remove the client from the controller's known-clients list and clean up
+    site_client.get_known_clients.side_effect = partial(
+        _get_known_clients_without, hass, removed_mac
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1, seconds=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert (
+        entity_registry.async_get_entity_id("device_tracker", DOMAIN, tracker_unique_id)
+        is None
+    )
+
+    # Client returns to the controller — the next interval run recreates the tracker
+    site_client.get_known_clients.side_effect = partial(
+        _get_known_clients_without, hass, ""
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=2, seconds=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert (
+        entity_registry.async_get_entity_id("device_tracker", DOMAIN, tracker_unique_id)
+        is not None
+    )
+
+
+async def test_cleanup_recreates_device_when_reappears(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a device removed by cleanup is re-registered when it returns."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    removed_mac = "54-AF-97-00-00-01"
+    update_unique_id = f"{removed_mac}_firmware"
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, removed_mac), mock_config_entry.entry_id
+    )
+    assert (
+        entity_registry.async_get_entity_id("update", DOMAIN, update_unique_id)
+        is not None
+    )
+
+    site_client = mock_omada_client.get_site_client.return_value
+
+    # Remove the switch from the controller's device list and clean up
+    site_client.get_devices = AsyncMock(
+        side_effect=partial(_get_devices_without, hass, removed_mac)
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1, seconds=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, removed_mac), mock_config_entry.entry_id
+        )
+        is None
+    )
+    assert (
+        entity_registry.async_get_entity_id("update", DOMAIN, update_unique_id) is None
+    )
+
+    # Switch returns to the controller — the next interval run re-registers it
+    devices_data = await async_load_json_array_fixture(hass, "devices.json", DOMAIN)
+    site_client.get_devices = AsyncMock(
+        return_value=[OmadaListDevice(d) for d in devices_data]
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=2, seconds=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, removed_mac), mock_config_entry.entry_id
+    )
+    assert (
+        entity_registry.async_get_entity_id("update", DOMAIN, update_unique_id)
+        is not None
+    )
+
+
+@pytest.mark.parametrize(
+    ("empty_updates", "orphan_removed"),
+    [
+        (1, False),
+        (EMPTY_DEVICE_LIMIT - 1, False),
+        (EMPTY_DEVICE_LIMIT, True),
+    ],
+)
+async def test_cleanup_devices_requires_confirmed_empty_list(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    empty_updates: int,
+    orphan_removed: bool,
+) -> None:
+    """Test device cleanup removes entries only after repeated empty responses."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    controller = hass.config_entries.async_get_entry(
+        mock_config_entry.entry_id
+    ).runtime_data
+
+    orphan = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "99:99:99:99:99:99")},
+        manufacturer="TP-Link",
+        model="Test",
+        name="Orphan",
+    )
+
+    site_client = mock_omada_client.get_site_client.return_value
+    site_client.get_devices = AsyncMock(return_value=[])
+
+    for _ in range(empty_updates):
+        await controller.devices_coordinator.async_refresh()
+        await async_cleanup_devices(hass, controller)
+
+    assert (device_registry.async_get(orphan.id) is None) is orphan_removed
+
+
+async def test_cleanup_devices_empty_count_resets_on_data(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the empty sweep counter resets when devices are reported again."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    controller = hass.config_entries.async_get_entry(
+        mock_config_entry.entry_id
+    ).runtime_data
+
+    switch_mac = "54-AF-97-00-00-01"
+    site_client = mock_omada_client.get_site_client.return_value
+
+    site_client.get_devices = AsyncMock(return_value=[])
+    await controller.devices_coordinator.async_refresh()
+    await async_cleanup_devices(hass, controller)
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, switch_mac), mock_config_entry.entry_id
+    )
+
+    devices_data = await async_load_json_array_fixture(hass, "devices.json", DOMAIN)
+    site_client.get_devices = AsyncMock(
+        return_value=[OmadaListDevice(d) for d in devices_data]
+    )
+    await controller.devices_coordinator.async_refresh()
+    await async_cleanup_devices(hass, controller)
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, switch_mac), mock_config_entry.entry_id
+    )
+
+    site_client.get_devices = AsyncMock(return_value=[])
+    await controller.devices_coordinator.async_refresh()
+    await async_cleanup_devices(hass, controller)
+    await async_cleanup_devices(hass, controller)
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, switch_mac), mock_config_entry.entry_id
+    )
+
+
+async def test_cleanup_trackers_on_empty_known_clients(
+    hass: HomeAssistant,
+    mock_omada_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test tracker cleanup removes integration-disabled trackers on an empty known list."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    controller = hass.config_entries.async_get_entry(
+        mock_config_entry.entry_id
+    ).runtime_data
+
+    tracker = entity_registry.async_get_or_create(
+        domain="device_tracker",
+        platform=DOMAIN,
+        unique_id="scanner_Default_55-55-55-55-55-55",
+        config_entry=mock_config_entry,
+        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+    )
+
+    site_client = mock_omada_client.get_site_client.return_value
+    site_client.get_known_clients.return_value = _get_no_known_clients()
+    await controller.known_clients_coordinator.async_refresh()
+
+    await async_cleanup_client_trackers(hass, controller)
+
+    assert entity_registry.async_get(tracker.entity_id) is None
+
+
+async def test_unload_cancels_cleanup_and_interval(
+    hass: HomeAssistant,
+    mock_omada_clients_only_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test entry unload cancels in-flight cleanup task and removes interval."""
+    cleanup_started = asyncio.Event()
+    cleanup_cancelled = False
+
+    async def blocking_cleanup(h: HomeAssistant, c: OmadaSiteController) -> None:
+        nonlocal cleanup_cancelled
+        cleanup_started.set()
+        try:
+            await asyncio.Event().wait()  # block forever until cancelled
+        except asyncio.CancelledError:
+            cleanup_cancelled = True
+            raise
+
+    with patch(
+        "homeassistant.components.tplink_omada.async_cleanup_devices",
+        new=blocking_cleanup,
+    ):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert cleanup_started.is_set()
+
+        assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert cleanup_cancelled is True
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+    # Firing the interval after unload must not start a new cleanup task
+    cleanup_started.clear()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1, seconds=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert not cleanup_started.is_set()
 
 
 async def test_migrate_entry_v1_to_v2(

--- a/tests/components/tplink_omada/test_update.py
+++ b/tests/components/tplink_omada/test_update.py
@@ -1,16 +1,13 @@
 """Tests for TP-Link Omada update entities."""
 
-from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
 
 from homeassistant.components.tplink_omada.const import DOMAIN
-from homeassistant.components.tplink_omada.coordinator import POLL_DEVICES
 from homeassistant.components.update import (
     ATTR_IN_PROGRESS,
     DOMAIN as UPDATE_DOMAIN,
@@ -20,16 +17,14 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import async_get_platforms
 
 from tests.common import (
     MockConfigEntry,
-    async_fire_time_changed,
     async_load_json_array_fixture,
     snapshot_platform,
 )
 from tests.typing import WebSocketGenerator
-
-POLL_INTERVAL = timedelta(seconds=POLL_DEVICES)
 
 
 async def _rebuild_device_list_with_update(
@@ -77,14 +72,10 @@ async def test_firmware_download_in_progress(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_omada_site_client: MagicMock,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test update entity when firmware download is in progress."""
     entity_id = "update.test_poe_switch_firmware"
-
-    freezer.tick(POLL_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
+    controller = init_integration.runtime_data
 
     # Rebuild device list with fwDownload set to True for the switch
     updated_devices = await _rebuild_device_list_with_update(
@@ -92,10 +83,16 @@ async def test_firmware_download_in_progress(
     )
     mock_omada_site_client.get_devices.return_value = updated_devices
 
-    # Trigger coordinator update
-    freezer.tick(POLL_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
+    # Refresh the devices coordinator so the firmware coordinator
+    # picks up the download state.
+    await controller.devices_coordinator.async_refresh()
+
+    # The firmware refresh is debounced, so a fire-based trigger
+    # would make this test timing-dependent.
+    update_platform = async_get_platforms(hass, DOMAIN)[0]
+    update_entity = update_platform.entities[entity_id]
+    await update_entity.coordinator.async_refresh()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     # Verify update entity shows in progress
     entity = hass.states.get(entity_id)

--- a/tests/components/tplink_omada/test_update.py
+++ b/tests/components/tplink_omada/test_update.py
@@ -1,5 +1,6 @@
 """Tests for TP-Link Omada update entities."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -17,10 +18,12 @@ from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_platform import async_get_platforms
+from homeassistant.helpers.update_coordinator import REQUEST_REFRESH_DEFAULT_COOLDOWN
+from homeassistant.util import dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
+    async_fire_time_changed,
     async_load_json_array_fixture,
     snapshot_platform,
 )
@@ -83,15 +86,15 @@ async def test_firmware_download_in_progress(
     )
     mock_omada_site_client.get_devices.return_value = updated_devices
 
-    # Refresh the devices coordinator so the firmware coordinator
-    # picks up the download state.
+    # Refresh the devices coordinator so the firmware coordinator's
+    # devices listener requests a debounced refresh of the download state.
     await controller.devices_coordinator.async_refresh()
 
-    # The firmware refresh is debounced, so a fire-based trigger
-    # would make this test timing-dependent.
-    update_platform = async_get_platforms(hass, DOMAIN)[0]
-    update_entity = update_platform.entities[entity_id]
-    await update_entity.coordinator.async_refresh()
+    # Advance past the debounce cooldown to run the requested refresh.
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + timedelta(seconds=REQUEST_REFRESH_DEFAULT_COOLDOWN + 1),
+    )
     await hass.async_block_till_done(wait_background_tasks=True)
 
     # Verify update entity shows in progress


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clients removed from the Omada controller leave stale device tracker entities in Home Assistant. This PR adds:

* `async_cleanup_client_trackers`: removes integration-disabled device tracker entities for clients no longer known to the controller, preserving trackers the user has enabled or disabled
* `async_cleanup_devices`: removes device registry entries for infrastructure devices (APs, switches, gateway) no longer present (formerly only on startup), after an empty device list is confirmed over consecutive polls, and re-registers devices that reappear — including their firmware update entities
* `OmadaKnownClientsCoordinator`: caches the known-clients list, avoiding extra API calls on every cleanup run
* Cleanup runs once at startup and every hour thereafter via `async_track_time_interval`

Replaces #168191, which GitHub stopped scheduling CI and mergeability updates for. The content, tests, and resolved review feedback are carried over unchanged.

Satisfies the Gold-tier `stale-devices` quality scale rule.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
