### PR TITLE
Bump dependency 0.4.3

### DIFF
--- a/homeassistant/components/imeon_inverter/config_flow.py
+++ b/homeassistant/components/imeon_inverter/config_flow.py
@@ -9,6 +9,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_MODEL_NUMBER,
     ATTR_UPNP_SERIAL,
@@ -38,7 +39,7 @@ class ImeonInverterConfigFlow(ConfigFlow, domain=DOMAIN):
             # User have to provide the hostname if device is not discovered
             host = self._host or user_input[CONF_HOST]
 
-            async with Inverter(host) as client:
+            async with Inverter(host, async_get_clientsession(self.hass)) as client:
                 try:
                     # Check connection
                     if await client.login(

--- a/homeassistant/components/imeon_inverter/coordinator.py
+++ b/homeassistant/components/imeon_inverter/coordinator.py
@@ -11,6 +11,7 @@ from imeon_inverter_api.inverter import Inverter
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import TIMEOUT
@@ -47,7 +48,7 @@ class InverterCoordinator(DataUpdateCoordinator[dict[str, str | float | int]]):
             config_entry=entry,
         )
 
-        self._api = Inverter(entry.data[CONF_HOST])
+        self._api = Inverter(entry.data[CONF_HOST], async_get_clientsession(hass))
 
     @property
     def api(self) -> Inverter:

--- a/homeassistant/components/imeon_inverter/manifest.json
+++ b/homeassistant/components/imeon_inverter/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["imeon_inverter_api==0.4.0"],
+  "requirements": ["imeon_inverter_api==0.4.3"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:Basic:1",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1384,7 +1384,7 @@ igloohome-api==0.1.1
 ihcsdk==2.8.12
 
 # homeassistant.components.imeon_inverter
-imeon_inverter_api==0.4.0
+imeon_inverter_api==0.4.3
 
 # homeassistant.components.imgw_pib
 imgw_pib==2.5.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request updates the imeon_inverter_api to the version 0.4.3.
The main change is to use the ClientSession helper in order to let Home Assistant manage the connection lifecycle instead of the client library.

Release notes: https://github.com/Imeon-Inverters-for-Home-Assistant/inverter-api/releases/tag/0.4.3
Diff: https://github.com/Imeon-Inverters-for-Home-Assistant/inverter-api/compare/0.4.0...0.4.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #176872
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
