### PR TITLE
Support PKCE S256 in OAuth server

### DIFF
--- a/homeassistant/auth/models.py
+++ b/homeassistant/auth/models.py
@@ -28,6 +28,8 @@ class AuthFlowContext(FlowContext, total=False):
 
     ip_address: IPv4Address | IPv6Address
     redirect_uri: str
+    code_challenge: str
+    code_challenge_method: str
 
 
 class AuthFlowResult(FlowResult[AuthFlowContext, tuple[str, str]], total=False):

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -124,11 +124,15 @@ as part of a config flow.
 """
 
 import asyncio
+import base64
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timedelta
+import hashlib
+import hmac
 from http import HTTPStatus
 from logging import getLogger
-from typing import Any, cast
+from typing import Any, Protocol, cast
 import uuid
 
 from aiohttp import web
@@ -162,8 +166,31 @@ from . import indieauth, login_flow, mfa_setup_flow
 
 DOMAIN = "auth"
 
-type StoreResultType = Callable[[str, Credentials], str]
-type RetrieveResultType = Callable[[str, str], Credentials | None]
+
+@dataclass(slots=True)
+class AuthCodeEntry:
+    """Entry stored in the auth code store."""
+
+    created: datetime
+    credentials: Credentials
+    code_challenge: str | None = None
+    code_challenge_method: str | None = None
+
+
+class StoreResultType(Protocol):
+    """Protocol for storing auth flow results."""
+
+    def __call__(
+        self,
+        client_id: str,
+        result: Credentials,
+        code_challenge: str | None = None,
+        code_challenge_method: str | None = None,
+    ) -> str:
+        """Store flow result and return a code to retrieve it."""
+
+
+type RetrieveResultType = Callable[[str, str], AuthCodeEntry | None]
 DATA_STORE: HassKey[StoreResultType] = HassKey(DOMAIN)
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
@@ -231,6 +258,19 @@ class RevokeTokenView(HomeAssistantView):
         return web.Response(status=HTTPStatus.OK)
 
 
+def _verify_code_verifier(code_verifier: str, code_challenge: str) -> bool:
+    """Verify code_verifier against code_challenge per RFC 7636 (S256)."""
+    if not 43 <= len(code_verifier) <= 128:
+        return False
+    try:
+        ascii_verifier = code_verifier.encode("ascii")
+    except UnicodeEncodeError:
+        return False
+    hashed = hashlib.sha256(ascii_verifier).digest()
+    computed_challenge = base64.urlsafe_b64encode(hashed).decode("ascii").rstrip("=")
+    return hmac.compare_digest(computed_challenge, code_challenge)
+
+
 class TokenView(HomeAssistantView):
     """View to issue tokens."""
 
@@ -290,14 +330,43 @@ class TokenView(HomeAssistantView):
                 status_code=HTTPStatus.BAD_REQUEST,
             )
 
-        credential = self._retrieve_auth(client_id, code)
+        entry = self._retrieve_auth(client_id, code)
 
-        if credential is None or not isinstance(credential, Credentials):
+        if entry is None:
             return self.json(
                 {"error": "invalid_request", "error_description": "Invalid code"},
                 status_code=HTTPStatus.BAD_REQUEST,
             )
 
+        if entry.code_challenge is not None:
+            if not (code_verifier := data.get("code_verifier")):
+                return self.json(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "Code verifier required",
+                    },
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            if not _verify_code_verifier(code_verifier, entry.code_challenge):
+                return self.json(
+                    {
+                        "error": "invalid_grant",
+                        "error_description": "Invalid code verifier",
+                    },
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+        elif "code_verifier" in data:
+            return self.json(
+                {
+                    "error": "invalid_request",
+                    "error_description": (
+                        "Code verifier provided but no code challenge was present"
+                    ),
+                },
+                status_code=HTTPStatus.BAD_REQUEST,
+            )
+
+        credential = entry.credentials
         user = await hass.auth.async_get_or_create_user(credential)
 
         if user_access_error := async_user_not_allowed_do_auth(hass, user):
@@ -421,12 +490,12 @@ class LinkUserView(HomeAssistantView):
         hass = request.app[KEY_HASS]
         user: User = request["hass_user"]
 
-        credentials = self._retrieve_credentials(data["client_id"], data["code"])
+        entry = self._retrieve_credentials(data["client_id"], data["code"])
 
-        if credentials is None:
+        if entry is None:
             return self.json_message("Invalid code", status_code=HTTPStatus.BAD_REQUEST)
 
-        linked_user = await hass.auth.async_get_user_by_credentials(credentials)
+        linked_user = await hass.auth.async_get_user_by_credentials(entry.credentials)
         if linked_user != user and linked_user is not None:
             return self.json_message(
                 "Credential already linked", status_code=HTTPStatus.BAD_REQUEST
@@ -434,44 +503,51 @@ class LinkUserView(HomeAssistantView):
 
         # No-op if credential is already linked to the user it will be linked to
         if linked_user != user:
-            await hass.auth.async_link_user(user, credentials)
+            await hass.auth.async_link_user(user, entry.credentials)
         return self.json_message("User linked")
 
 
 @callback
 def _create_auth_code_store() -> tuple[StoreResultType, RetrieveResultType]:
     """Create an in memory store."""
-    temp_results: dict[tuple[str, str], tuple[datetime, Credentials]] = {}
+    temp_results: dict[tuple[str, str], AuthCodeEntry] = {}
 
     @callback
-    def store_result(client_id: str, result: Credentials) -> str:
+    def store_result(
+        client_id: str,
+        result: Credentials,
+        code_challenge: str | None = None,
+        code_challenge_method: str | None = None,
+    ) -> str:
         """Store flow result and return a code to retrieve it."""
         if not isinstance(result, Credentials):
             raise TypeError("result has to be a Credentials instance")
 
         code = uuid.uuid4().hex
-        temp_results[(client_id, code)] = (
-            dt_util.utcnow(),
-            result,
+        temp_results[(client_id, code)] = AuthCodeEntry(
+            created=dt_util.utcnow(),
+            credentials=result,
+            code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method,
         )
         return code
 
     @callback
-    def retrieve_result(client_id: str, code: str) -> Credentials | None:
+    def retrieve_result(client_id: str, code: str) -> AuthCodeEntry | None:
         """Retrieve flow result."""
         key = (client_id, code)
 
         if key not in temp_results:
             return None
 
-        created, result = temp_results.pop(key)
+        entry = temp_results.pop(key)
 
         # OAuth 4.2.1
         # The authorization code MUST expire shortly after it is issued to
         # mitigate the risk of leaks.  A maximum authorization code lifetime of
         # 10 minutes is RECOMMENDED.
-        if dt_util.utcnow() - created < timedelta(minutes=10):
-            return result
+        if dt_util.utcnow() - entry.created < timedelta(minutes=10):
+            return entry
 
         return None
 

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -14,7 +14,8 @@ Exchange the authorization code retrieved from the login flow for tokens.
 {
     "client_id": "https://hassbian.local:8123/",
     "grant_type": "authorization_code",
-    "code": "411ee2f916e648d691e937ae9344681e"
+    "code": "411ee2f916e648d691e937ae9344681e",
+    "code_verifier": "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
 }
 
 Return value will be the access and refresh tokens. The access token will have
@@ -132,6 +133,7 @@ import hashlib
 import hmac
 from http import HTTPStatus
 from logging import getLogger
+import re
 from typing import Any, Protocol, cast
 import uuid
 
@@ -258,15 +260,15 @@ class RevokeTokenView(HomeAssistantView):
         return web.Response(status=HTTPStatus.OK)
 
 
+# RFC 7636 4.1: code_verifier is 43-128 unreserved characters.
+_CODE_VERIFIER_RE = re.compile(r"^[A-Za-z0-9._~-]{43,128}\Z")
+
+
 def _verify_code_verifier(code_verifier: str, code_challenge: str) -> bool:
     """Verify code_verifier against code_challenge per RFC 7636 (S256)."""
-    if not 43 <= len(code_verifier) <= 128:
+    if not _CODE_VERIFIER_RE.match(code_verifier):
         return False
-    try:
-        ascii_verifier = code_verifier.encode("ascii")
-    except UnicodeEncodeError:
-        return False
-    hashed = hashlib.sha256(ascii_verifier).digest()
+    hashed = hashlib.sha256(code_verifier.encode("ascii")).digest()
     computed_challenge = base64.urlsafe_b64encode(hashed).decode("ascii").rstrip("=")
     return hmac.compare_digest(computed_challenge, code_challenge)
 

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -64,7 +64,6 @@ an authorization code.
 }
 """
 
-from collections.abc import Callable
 from http import HTTPStatus
 from ipaddress import ip_address
 from typing import TYPE_CHECKING, Any, cast
@@ -75,7 +74,7 @@ import voluptuous as vol
 
 from homeassistant import data_entry_flow
 from homeassistant.auth import AuthManagerFlowManager, InvalidAuthError
-from homeassistant.auth.models import AuthFlowContext, AuthFlowResult, Credentials
+from homeassistant.auth.models import AuthFlowContext, AuthFlowResult
 from homeassistant.components import onboarding
 from homeassistant.components.http import KEY_HASS
 from homeassistant.components.http.auth import async_user_not_allowed_do_auth
@@ -105,9 +104,7 @@ if TYPE_CHECKING:
 
 
 @callback
-def async_setup(
-    hass: HomeAssistant, store_result: Callable[[str, Credentials], str]
-) -> None:
+def async_setup(hass: HomeAssistant, store_result: StoreResultType) -> None:
     """Component to allow users to login."""
     hass.http.register_view(WellKnownOAuthInfoView)
     hass.http.register_view(WellKnownProtectedResourceView)
@@ -143,6 +140,7 @@ class WellKnownOAuthInfoView(HomeAssistantView):
             # This flag advertises that support
             # (draft-ietf-oauth-client-id-metadata-document).
             "client_id_metadata_document_supported": True,
+            "code_challenge_methods_supported": ["S256"],
             "response_types_supported": ["code"],
             "service_documentation": (
                 "https://developers.home-assistant.io/docs/auth_api"
@@ -307,7 +305,7 @@ class LoginFlowBaseView(HomeAssistantView):
             return self.json_message("Invalid redirect URI", HTTPStatus.FORBIDDEN)
 
         result.pop("data")
-        result.pop("context")
+        context = result.pop("context")
 
         result_obj = result.pop("result")
 
@@ -323,7 +321,12 @@ class LoginFlowBaseView(HomeAssistantView):
 
         process_success_login(request)
         # We overwrite the Credentials object with the string code to retrieve it.
-        result["result"] = self._store_result(client_id, result_obj)  # type: ignore[typeddict-item]
+        result["result"] = self._store_result(
+            client_id,
+            result_obj,
+            code_challenge=context.get("code_challenge"),
+            code_challenge_method=context.get("code_challenge_method"),
+        )  # type: ignore[typeddict-item]
 
         return self.json(result)
 
@@ -346,6 +349,10 @@ class LoginFlowIndexView(LoginFlowBaseView):
                     [vol.Any(str, None)], vol.Length(2, 2), vol.Coerce(tuple)
                 ),
                 vol.Required("redirect_uri"): str,
+                vol.Optional("code_challenge"): vol.All(
+                    str, vol.Length(min=43, max=128)
+                ),
+                vol.Optional("code_challenge_method"): vol.In(["S256"]),
                 vol.Optional(
                     "type", default="authorize"
                 ): str,  # not used, kept for backwards compatibility
@@ -361,15 +368,32 @@ class LoginFlowIndexView(LoginFlowBaseView):
         if not indieauth.verify_client_id(client_id):
             return self.json_message("Invalid client id", HTTPStatus.BAD_REQUEST)
 
+        code_challenge = data.get("code_challenge")
+        code_challenge_method = data.get("code_challenge_method")
+        if code_challenge_method is not None and not code_challenge:
+            return self.json_message(
+                "code_challenge required when code_challenge_method is provided",
+                HTTPStatus.BAD_REQUEST,
+            )
+        if code_challenge and not code_challenge_method:
+            return self.json_message(
+                "Transform algorithm not supported", HTTPStatus.BAD_REQUEST
+            )
+
         handler: tuple[str, str] = tuple(data["handler"])
+
+        flow_context = AuthFlowContext(
+            ip_address=ip_address(request.remote),  # type: ignore[arg-type]
+            redirect_uri=redirect_uri,
+        )
+        if code_challenge and code_challenge_method:
+            flow_context["code_challenge"] = code_challenge
+            flow_context["code_challenge_method"] = code_challenge_method
 
         try:
             result = await self._flow_mgr.async_init(
                 handler,
-                context=AuthFlowContext(
-                    ip_address=ip_address(request.remote),  # type: ignore[arg-type]
-                    redirect_uri=redirect_uri,
-                ),
+                context=flow_context,
             )
         except data_entry_flow.UnknownHandler:
             return self.json_message("Invalid handler specified", HTTPStatus.NOT_FOUND)

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -22,13 +22,18 @@ Pass in parameter 'client_id' and 'redirect_url' validate by indieauth.
 Pass in parameter 'handler' to specify the auth provider to use. Auth providers
 are identified by type and id.
 
+Pass in optional parameters 'code_challenge' and 'code_challenge_method' for
+PKCE (RFC 7636). The only supported method is 'S256'.
+
 The default 'type' is 'authorize'.
 
 {
     "client_id": "https://hassbian.local:8123/",
     "handler": ["local_provider", null],
     "redirect_url": "https://hassbian.local:8123/",
-    "type': "authorize"
+    "type': "authorize",
+    "code_challenge": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+    "code_challenge_method": "S256"
 }
 
 Return value will be a step in a data entry flow. See the docs for data entry
@@ -349,10 +354,9 @@ class LoginFlowIndexView(LoginFlowBaseView):
                     [vol.Any(str, None)], vol.Length(2, 2), vol.Coerce(tuple)
                 ),
                 vol.Required("redirect_uri"): str,
-                vol.Optional("code_challenge"): vol.All(
-                    str, vol.Length(min=43, max=128)
-                ),
-                vol.Optional("code_challenge_method"): vol.In(["S256"]),
+                # S256 challenges are always 43 unpadded base64url characters.
+                vol.Optional("code_challenge"): vol.Match(r"^[A-Za-z0-9_-]{43}\Z"),
+                vol.Optional("code_challenge_method"): str,
                 vol.Optional(
                     "type", default="authorize"
                 ): str,  # not used, kept for backwards compatibility
@@ -375,7 +379,8 @@ class LoginFlowIndexView(LoginFlowBaseView):
                 "code_challenge required when code_challenge_method is provided",
                 HTTPStatus.BAD_REQUEST,
             )
-        if code_challenge and not code_challenge_method:
+        # RFC 7636 4.3: the method defaults to "plain", which is not supported.
+        if code_challenge is not None and code_challenge_method != "S256":
             return self.json_message(
                 "Transform algorithm not supported", HTTPStatus.BAD_REQUEST
             )

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -3,8 +3,10 @@
 from datetime import timedelta
 from http import HTTPStatus
 import logging
+from typing import Any
 from unittest.mock import patch
 
+from aiohttp.test_utils import TestClient
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -769,21 +771,19 @@ RFC7636_VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
 RFC7636_CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
 
 
-async def test_auth_code_pkce_success(
-    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
-) -> None:
-    """Test login flow and token exchange with PKCE S256."""
-    client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
-    resp = await client.post(
-        "/auth/login_flow",
-        json={
-            "client_id": CLIENT_ID,
-            "handler": ["insecure_example", None],
-            "redirect_uri": CLIENT_REDIRECT_URI,
-            "code_challenge": RFC7636_CHALLENGE,
-            "code_challenge_method": "S256",
-        },
-    )
+async def _async_login_for_code(
+    client: TestClient, code_challenge: str | None = None
+) -> str:
+    """Run the login flow and return the authorization code."""
+    payload: dict[str, Any] = {
+        "client_id": CLIENT_ID,
+        "handler": ["insecure_example", None],
+        "redirect_uri": CLIENT_REDIRECT_URI,
+    }
+    if code_challenge is not None:
+        payload["code_challenge"] = code_challenge
+        payload["code_challenge_method"] = "S256"
+    resp = await client.post("/auth/login_flow", json=payload)
     assert resp.status == HTTPStatus.OK
     step = await resp.json()
 
@@ -797,9 +797,16 @@ async def test_auth_code_pkce_success(
     )
     assert resp.status == HTTPStatus.OK
     step = await resp.json()
-    code = step["result"]
+    return step["result"]
 
-    # Exchange code for tokens with code_verifier
+
+async def test_auth_code_pkce_success(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
+    """Test login flow and token exchange with PKCE S256."""
+    client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
+    code = await _async_login_for_code(client, RFC7636_CHALLENGE)
+
     resp = await client.post(
         "/auth/token",
         data={
@@ -819,30 +826,7 @@ async def test_auth_code_pkce_missing_code_verifier(
 ) -> None:
     """Test token exchange fails when code_verifier is missing for PKCE code."""
     client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
-    resp = await client.post(
-        "/auth/login_flow",
-        json={
-            "client_id": CLIENT_ID,
-            "handler": ["insecure_example", None],
-            "redirect_uri": CLIENT_REDIRECT_URI,
-            "code_challenge": RFC7636_CHALLENGE,
-            "code_challenge_method": "S256",
-        },
-    )
-    assert resp.status == HTTPStatus.OK
-    step = await resp.json()
-
-    resp = await client.post(
-        f"/auth/login_flow/{step['flow_id']}",
-        json={
-            "client_id": CLIENT_ID,
-            "username": "test-user",
-            "password": "test-pass",
-        },
-    )
-    assert resp.status == HTTPStatus.OK
-    step = await resp.json()
-    code = step["result"]
+    code = await _async_login_for_code(client, RFC7636_CHALLENGE)
 
     resp = await client.post(
         "/auth/token",
@@ -875,30 +859,7 @@ async def test_auth_code_pkce_invalid_code_verifier(
 ) -> None:
     """Test token exchange fails when code_verifier is invalid."""
     client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
-    resp = await client.post(
-        "/auth/login_flow",
-        json={
-            "client_id": CLIENT_ID,
-            "handler": ["insecure_example", None],
-            "redirect_uri": CLIENT_REDIRECT_URI,
-            "code_challenge": RFC7636_CHALLENGE,
-            "code_challenge_method": "S256",
-        },
-    )
-    assert resp.status == HTTPStatus.OK
-    step = await resp.json()
-
-    resp = await client.post(
-        f"/auth/login_flow/{step['flow_id']}",
-        json={
-            "client_id": CLIENT_ID,
-            "username": "test-user",
-            "password": "test-pass",
-        },
-    )
-    assert resp.status == HTTPStatus.OK
-    step = await resp.json()
-    code = step["result"]
+    code = await _async_login_for_code(client, RFC7636_CHALLENGE)
 
     resp = await client.post(
         "/auth/token",
@@ -920,30 +881,8 @@ async def test_auth_code_without_challenge_succeeds(
 ) -> None:
     """Test token exchange succeeds when flow was started without code_challenge and no verifier sent."""
     client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
-    resp = await client.post(
-        "/auth/login_flow",
-        json={
-            "client_id": CLIENT_ID,
-            "handler": ["insecure_example", None],
-            "redirect_uri": CLIENT_REDIRECT_URI,
-        },
-    )
-    assert resp.status == HTTPStatus.OK
-    step = await resp.json()
+    code = await _async_login_for_code(client)
 
-    resp = await client.post(
-        f"/auth/login_flow/{step['flow_id']}",
-        json={
-            "client_id": CLIENT_ID,
-            "username": "test-user",
-            "password": "test-pass",
-        },
-    )
-    assert resp.status == HTTPStatus.OK
-    step = await resp.json()
-    code = step["result"]
-
-    # Exchange without code_verifier succeeds
     resp = await client.post(
         "/auth/token",
         data={
@@ -962,30 +901,8 @@ async def test_auth_code_unexpected_verifier_rejected(
 ) -> None:
     """Test token exchange fails when client sends code_verifier but no code_challenge was registered."""
     client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
-    resp = await client.post(
-        "/auth/login_flow",
-        json={
-            "client_id": CLIENT_ID,
-            "handler": ["insecure_example", None],
-            "redirect_uri": CLIENT_REDIRECT_URI,
-        },
-    )
-    assert resp.status == HTTPStatus.OK
-    step = await resp.json()
+    code = await _async_login_for_code(client)
 
-    resp = await client.post(
-        f"/auth/login_flow/{step['flow_id']}",
-        json={
-            "client_id": CLIENT_ID,
-            "username": "test-user",
-            "password": "test-pass",
-        },
-    )
-    assert resp.status == HTTPStatus.OK
-    step = await resp.json()
-    code = step["result"]
-
-    # Exchange with code_verifier when no challenge was registered should fail
     resp = await client.post(
         "/auth/token",
         data={
@@ -999,62 +916,3 @@ async def test_auth_code_unexpected_verifier_rejected(
     result = await resp.json()
     assert result["error"] == "invalid_request"
     assert "no code challenge was present" in result["error_description"]
-
-
-@pytest.mark.parametrize(
-    ("payload", "expected_message"),
-    [
-        (
-            {
-                "code_challenge_method": "S256",
-            },
-            "code_challenge required when code_challenge_method is provided",
-        ),
-        (
-            {
-                "code_challenge": RFC7636_CHALLENGE,
-            },
-            "Transform algorithm not supported",
-        ),
-        (
-            {
-                "code_challenge": RFC7636_CHALLENGE,
-                "code_challenge_method": "plain",
-            },
-            "Message format incorrect",
-        ),
-        (
-            {
-                "code_challenge": "short",
-                "code_challenge_method": "S256",
-            },
-            "Message format incorrect",
-        ),
-    ],
-    ids=[
-        "method_without_challenge",
-        "challenge_without_method",
-        "unsupported_plain_method",
-        "challenge_too_short",
-    ],
-)
-async def test_login_flow_pkce_validation(
-    hass: HomeAssistant,
-    aiohttp_client: ClientSessionGenerator,
-    payload: dict[str, str],
-    expected_message: str,
-) -> None:
-    """Test PKCE parameter validation in login_flow."""
-    client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
-    resp = await client.post(
-        "/auth/login_flow",
-        json={
-            "client_id": CLIENT_ID,
-            "handler": ["insecure_example", None],
-            "redirect_uri": CLIENT_REDIRECT_URI,
-            **payload,
-        },
-    )
-    assert resp.status == HTTPStatus.BAD_REQUEST
-    result = await resp.json()
-    assert expected_message in result["message"]

--- a/tests/components/auth/test_init.py
+++ b/tests/components/auth/test_init.py
@@ -189,7 +189,9 @@ def test_auth_code_store_expiration(
     code = store(client_id, mock_credential)
 
     freezer.move_to(now + timedelta(minutes=9, seconds=59))
-    assert retrieve(client_id, code) == mock_credential
+    entry = retrieve(client_id, code)
+    assert entry is not None
+    assert entry.credentials == mock_credential
 
 
 def test_auth_code_store_requires_credentials(mock_credential) -> None:
@@ -761,3 +763,298 @@ async def test_ws_refresh_token_set_expiry_error(
         "code": "invalid_token_id",
         "message": "Received invalid token",
     }
+
+
+RFC7636_VERIFIER = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+RFC7636_CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+
+async def test_auth_code_pkce_success(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
+    """Test login flow and token exchange with PKCE S256."""
+    client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
+    resp = await client.post(
+        "/auth/login_flow",
+        json={
+            "client_id": CLIENT_ID,
+            "handler": ["insecure_example", None],
+            "redirect_uri": CLIENT_REDIRECT_URI,
+            "code_challenge": RFC7636_CHALLENGE,
+            "code_challenge_method": "S256",
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    step = await resp.json()
+
+    resp = await client.post(
+        f"/auth/login_flow/{step['flow_id']}",
+        json={
+            "client_id": CLIENT_ID,
+            "username": "test-user",
+            "password": "test-pass",
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    step = await resp.json()
+    code = step["result"]
+
+    # Exchange code for tokens with code_verifier
+    resp = await client.post(
+        "/auth/token",
+        data={
+            "client_id": CLIENT_ID,
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": RFC7636_VERIFIER,
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    tokens = await resp.json()
+    assert hass.auth.async_validate_access_token(tokens["access_token"]) is not None
+
+
+async def test_auth_code_pkce_missing_code_verifier(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
+    """Test token exchange fails when code_verifier is missing for PKCE code."""
+    client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
+    resp = await client.post(
+        "/auth/login_flow",
+        json={
+            "client_id": CLIENT_ID,
+            "handler": ["insecure_example", None],
+            "redirect_uri": CLIENT_REDIRECT_URI,
+            "code_challenge": RFC7636_CHALLENGE,
+            "code_challenge_method": "S256",
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    step = await resp.json()
+
+    resp = await client.post(
+        f"/auth/login_flow/{step['flow_id']}",
+        json={
+            "client_id": CLIENT_ID,
+            "username": "test-user",
+            "password": "test-pass",
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    step = await resp.json()
+    code = step["result"]
+
+    resp = await client.post(
+        "/auth/token",
+        data={
+            "client_id": CLIENT_ID,
+            "grant_type": "authorization_code",
+            "code": code,
+        },
+    )
+    assert resp.status == HTTPStatus.BAD_REQUEST
+    result = await resp.json()
+    assert result["error"] == "invalid_request"
+    assert result["error_description"] == "Code verifier required"
+
+
+@pytest.mark.parametrize(
+    "invalid_verifier",
+    [
+        "wrong_verifier_123456789012345678901234567890123",  # valid length, wrong content
+        "short",  # < 43 chars
+        "a" * 129,  # > 128 chars
+        "non_ascii_verifier_with_unicode_characters_✓_123456",  # non-ascii
+    ],
+    ids=["wrong", "too_short", "too_long", "non_ascii"],
+)
+async def test_auth_code_pkce_invalid_code_verifier(
+    hass: HomeAssistant,
+    aiohttp_client: ClientSessionGenerator,
+    invalid_verifier: str,
+) -> None:
+    """Test token exchange fails when code_verifier is invalid."""
+    client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
+    resp = await client.post(
+        "/auth/login_flow",
+        json={
+            "client_id": CLIENT_ID,
+            "handler": ["insecure_example", None],
+            "redirect_uri": CLIENT_REDIRECT_URI,
+            "code_challenge": RFC7636_CHALLENGE,
+            "code_challenge_method": "S256",
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    step = await resp.json()
+
+    resp = await client.post(
+        f"/auth/login_flow/{step['flow_id']}",
+        json={
+            "client_id": CLIENT_ID,
+            "username": "test-user",
+            "password": "test-pass",
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    step = await resp.json()
+    code = step["result"]
+
+    resp = await client.post(
+        "/auth/token",
+        data={
+            "client_id": CLIENT_ID,
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": invalid_verifier,
+        },
+    )
+    assert resp.status == HTTPStatus.BAD_REQUEST
+    result = await resp.json()
+    assert result["error"] == "invalid_grant"
+    assert result["error_description"] == "Invalid code verifier"
+
+
+async def test_auth_code_without_challenge_succeeds(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
+    """Test token exchange succeeds when flow was started without code_challenge and no verifier sent."""
+    client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
+    resp = await client.post(
+        "/auth/login_flow",
+        json={
+            "client_id": CLIENT_ID,
+            "handler": ["insecure_example", None],
+            "redirect_uri": CLIENT_REDIRECT_URI,
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    step = await resp.json()
+
+    resp = await client.post(
+        f"/auth/login_flow/{step['flow_id']}",
+        json={
+            "client_id": CLIENT_ID,
+            "username": "test-user",
+            "password": "test-pass",
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    step = await resp.json()
+    code = step["result"]
+
+    # Exchange without code_verifier succeeds
+    resp = await client.post(
+        "/auth/token",
+        data={
+            "client_id": CLIENT_ID,
+            "grant_type": "authorization_code",
+            "code": code,
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    tokens = await resp.json()
+    assert hass.auth.async_validate_access_token(tokens["access_token"]) is not None
+
+
+async def test_auth_code_unexpected_verifier_rejected(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator
+) -> None:
+    """Test token exchange fails when client sends code_verifier but no code_challenge was registered."""
+    client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
+    resp = await client.post(
+        "/auth/login_flow",
+        json={
+            "client_id": CLIENT_ID,
+            "handler": ["insecure_example", None],
+            "redirect_uri": CLIENT_REDIRECT_URI,
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    step = await resp.json()
+
+    resp = await client.post(
+        f"/auth/login_flow/{step['flow_id']}",
+        json={
+            "client_id": CLIENT_ID,
+            "username": "test-user",
+            "password": "test-pass",
+        },
+    )
+    assert resp.status == HTTPStatus.OK
+    step = await resp.json()
+    code = step["result"]
+
+    # Exchange with code_verifier when no challenge was registered should fail
+    resp = await client.post(
+        "/auth/token",
+        data={
+            "client_id": CLIENT_ID,
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": RFC7636_VERIFIER,
+        },
+    )
+    assert resp.status == HTTPStatus.BAD_REQUEST
+    result = await resp.json()
+    assert result["error"] == "invalid_request"
+    assert "no code challenge was present" in result["error_description"]
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_message"),
+    [
+        (
+            {
+                "code_challenge_method": "S256",
+            },
+            "code_challenge required when code_challenge_method is provided",
+        ),
+        (
+            {
+                "code_challenge": RFC7636_CHALLENGE,
+            },
+            "Transform algorithm not supported",
+        ),
+        (
+            {
+                "code_challenge": RFC7636_CHALLENGE,
+                "code_challenge_method": "plain",
+            },
+            "Message format incorrect",
+        ),
+        (
+            {
+                "code_challenge": "short",
+                "code_challenge_method": "S256",
+            },
+            "Message format incorrect",
+        ),
+    ],
+    ids=[
+        "method_without_challenge",
+        "challenge_without_method",
+        "unsupported_plain_method",
+        "challenge_too_short",
+    ],
+)
+async def test_login_flow_pkce_validation(
+    hass: HomeAssistant,
+    aiohttp_client: ClientSessionGenerator,
+    payload: dict[str, str],
+    expected_message: str,
+) -> None:
+    """Test PKCE parameter validation in login_flow."""
+    client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
+    resp = await client.post(
+        "/auth/login_flow",
+        json={
+            "client_id": CLIENT_ID,
+            "handler": ["insecure_example", None],
+            "redirect_uri": CLIENT_REDIRECT_URI,
+            **payload,
+        },
+    )
+    assert resp.status == HTTPStatus.BAD_REQUEST
+    result = await resp.json()
+    assert expected_message in result["message"]

--- a/tests/components/auth/test_login_flow.py
+++ b/tests/components/auth/test_login_flow.py
@@ -497,3 +497,70 @@ async def test_well_known_protected_resource_no_url(
         "/.well-known/oauth-protected-resource",
     )
     assert resp.status == 404
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_message"),
+    [
+        (
+            {
+                "code_challenge_method": "S256",
+            },
+            "code_challenge required when code_challenge_method is provided",
+        ),
+        (
+            {
+                "code_challenge": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+            },
+            "Transform algorithm not supported",
+        ),
+        (
+            {
+                "code_challenge": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+                "code_challenge_method": "plain",
+            },
+            "Transform algorithm not supported",
+        ),
+        (
+            {
+                "code_challenge": "short",
+                "code_challenge_method": "S256",
+            },
+            "Message format incorrect",
+        ),
+        (
+            {
+                "code_challenge": "a" * 43 + "=",
+                "code_challenge_method": "S256",
+            },
+            "Message format incorrect",
+        ),
+    ],
+    ids=[
+        "method_without_challenge",
+        "challenge_without_method",
+        "unsupported_plain_method",
+        "challenge_too_short",
+        "challenge_padded",
+    ],
+)
+async def test_login_flow_pkce_validation(
+    hass: HomeAssistant,
+    aiohttp_client: ClientSessionGenerator,
+    payload: dict[str, str],
+    expected_message: str,
+) -> None:
+    """Test PKCE parameter validation in login_flow."""
+    client = await async_setup_auth(hass, aiohttp_client, setup_api=True)
+    resp = await client.post(
+        "/auth/login_flow",
+        json={
+            "client_id": CLIENT_ID,
+            "handler": ["insecure_example", None],
+            "redirect_uri": CLIENT_REDIRECT_URI,
+            **payload,
+        },
+    )
+    assert resp.status == HTTPStatus.BAD_REQUEST
+    result = await resp.json()
+    assert expected_message in result["message"]

--- a/tests/components/auth/test_login_flow.py
+++ b/tests/components/auth/test_login_flow.py
@@ -426,6 +426,7 @@ async def test_well_known_auth_info(
         "token_endpoint": f"{expected_url_prefix}/auth/token",
         "revocation_endpoint": f"{expected_url_prefix}/auth/revoke",
         "client_id_metadata_document_supported": True,
+        "code_challenge_methods_supported": ["S256"],
         "response_types_supported": ["code"],
         "service_documentation": "https://developers.home-assistant.io/docs/auth_api",
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for Proof Key for Code Exchange (PKCE) with the `S256` transform algorithm (RFC 7636) to Home Assistant Core's OAuth 2.0 authorization server, and advertise support in OAuth 2.0 Authorization Server Metadata (RFC 8414).

Architecture discussion: https://github.com/home-assistant/architecture/discussions/1469

This PR should not be merged until (a) the architecture discussion is approved and (b) frontend support PR is referenced this PR and approved.

The primary motivation behind this PR is to allow Home Assistant MCP Server to support the requirements from the MCP spec, required by Chat GPT MCP Client and potentially others in the future.

Background & Implementation:
- Advertises `"code_challenge_methods_supported": ["S256"]` at `/.well-known/oauth-authorization-server`.
- Accepts `code_challenge` (length 43–128) and `code_challenge_method: "S256"` in `/auth/login_flow`.
- Stores `code_challenge` and `code_challenge_method` in the internal `AuthCodeEntry`.
- In `/auth/token`, verifies `code_verifier` against `code_challenge` using constant-time comparison (`hmac.compare_digest`).
- Implements BCP 240 / RFC 9700 downgrade defense by rejecting unexpected `code_verifier` when no challenge was registered.
- Returns OAuth error responses per RFC 7636 (`invalid_request` for missing verifier, `invalid_grant` for incorrect verifier).
- Preserves full backwards compatibility for existing flows that do not use PKCE.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181542
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
