### PR TITLE
Add Management LLM API and system log tool

### DIFF
--- a/homeassistant/components/llm/__init__.py
+++ b/homeassistant/components/llm/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.integration_platform import LazyIntegrationPlatforms
 from homeassistant.helpers.llm import (
     API,
     LLM_API_ASSIST,
+    LLM_API_MANAGEMENT,
     APIInstance,
     LLMContext,
     Tool,
@@ -62,6 +63,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass, DOMAIN, _process_llm_tools_platform
     )
     async_register_api(hass, AssistAPI(hass))
+    async_register_api(hass, ManagementAPI(hass))
     async_setup_ws_api(hass)
     return True
 
@@ -132,6 +134,31 @@ class AssistAPI(API):
             hass=hass,
             id=LLM_API_ASSIST,
             name="Assist",
+        )
+
+    @override
+    async def async_get_api_instance(self, llm_context: LLMContext) -> APIInstance:
+        """Return the instance of the API."""
+        llm_tools = await async_get_tools(self.hass, llm_context, self.id)
+
+        return APIInstance(
+            api=self,
+            api_prompt=llm_tools.prompt or "",
+            llm_context=llm_context,
+            tools=llm_tools.tools,
+            custom_serializer=selector_serializer,
+        )
+
+
+class ManagementAPI(API):
+    """API exposing Management API to LLMs."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Init the class."""
+        super().__init__(
+            hass=hass,
+            id=LLM_API_MANAGEMENT,
+            name="Management",
         )
 
     @override

--- a/homeassistant/components/llm/__init__.py
+++ b/homeassistant/components/llm/__init__.py
@@ -5,6 +5,7 @@ import logging
 from typing import Protocol, override
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.frame import ReportBehavior, report_usage
 from homeassistant.helpers.integration_platform import LazyIntegrationPlatforms
@@ -168,30 +169,27 @@ class ManagementAPI(API):
             hass=hass,
             id=LLM_API_MANAGEMENT,
             name="Management",
+            requires_admin=True,
         )
 
     @override
     async def async_get_api_instance(self, llm_context: LLMContext) -> APIInstance:
         """Return the instance of the API."""
-        tools: list[Tool] = []
-        prompt = ""
-
         if (
-            llm_context.context
-            and llm_context.context.user_id
-            and (
+            not llm_context.context
+            or not llm_context.context.user_id
+            or not (
                 user := await self.hass.auth.async_get_user(llm_context.context.user_id)
             )
-            and user.is_admin
+            or not user.is_admin
         ):
-            llm_tools = await async_get_tools(self.hass, llm_context, self.id)
-            tools = llm_tools.tools
-            prompt = llm_tools.prompt or ""
+            raise Unauthorized(context=llm_context.context)
 
+        llm_tools = await async_get_tools(self.hass, llm_context, self.id)
         return APIInstance(
             api=self,
-            api_prompt=prompt,
+            api_prompt=llm_tools.prompt or "",
             llm_context=llm_context,
-            tools=tools,
+            tools=llm_tools.tools,
             custom_serializer=selector_serializer,
         )

--- a/homeassistant/components/llm/__init__.py
+++ b/homeassistant/components/llm/__init__.py
@@ -5,7 +5,6 @@ import logging
 from typing import Protocol, override
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.frame import ReportBehavior, report_usage
 from homeassistant.helpers.integration_platform import LazyIntegrationPlatforms
@@ -175,16 +174,6 @@ class ManagementAPI(API):
     @override
     async def async_get_api_instance(self, llm_context: LLMContext) -> APIInstance:
         """Return the instance of the API."""
-        if (
-            not llm_context.context
-            or not llm_context.context.user_id
-            or not (
-                user := await self.hass.auth.async_get_user(llm_context.context.user_id)
-            )
-            or not user.is_admin
-        ):
-            raise Unauthorized(context=llm_context.context)
-
         llm_tools = await async_get_tools(self.hass, llm_context, self.id)
         return APIInstance(
             api=self,

--- a/homeassistant/components/llm/__init__.py
+++ b/homeassistant/components/llm/__init__.py
@@ -126,7 +126,11 @@ def _async_report_unprefixed_tools(
 
 
 class AssistAPI(API):
-    """API exposing Assist API to LLMs."""
+    """API exposing Assist API to LLMs.
+
+    The assist API controls and reads entities exposed by the user to an assistant.
+    Its scope is bounded by entity exposure.
+    """
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Init the class."""
@@ -151,7 +155,12 @@ class AssistAPI(API):
 
 
 class ManagementAPI(API):
-    """API exposing Management API to LLMs."""
+    """API exposing Management API to LLMs.
+
+    The management API manages Home Assistant itself (e.g. registries, system logs,
+    automations, and config entries). It is not bounded by entity exposure and is
+    restricted to admin users.
+    """
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Init the class."""
@@ -164,12 +173,25 @@ class ManagementAPI(API):
     @override
     async def async_get_api_instance(self, llm_context: LLMContext) -> APIInstance:
         """Return the instance of the API."""
-        llm_tools = await async_get_tools(self.hass, llm_context, self.id)
+        tools: list[Tool] = []
+        prompt = ""
+
+        if (
+            llm_context.context
+            and llm_context.context.user_id
+            and (
+                user := await self.hass.auth.async_get_user(llm_context.context.user_id)
+            )
+            and user.is_admin
+        ):
+            llm_tools = await async_get_tools(self.hass, llm_context, self.id)
+            tools = llm_tools.tools
+            prompt = llm_tools.prompt or ""
 
         return APIInstance(
             api=self,
-            api_prompt=llm_tools.prompt or "",
+            api_prompt=prompt,
             llm_context=llm_context,
-            tools=llm_tools.tools,
+            tools=tools,
             custom_serializer=selector_serializer,
         )

--- a/homeassistant/components/llm/websocket_api.py
+++ b/homeassistant/components/llm/websocket_api.py
@@ -30,5 +30,14 @@ def websocket_list_apis(
     """
     connection.send_result(
         msg["id"],
-        {"apis": [{"id": api.id, "name": api.name} for api in async_get_apis(hass)]},
+        {
+            "apis": [
+                {
+                    "id": api.id,
+                    "name": api.name,
+                    "requires_admin": api.requires_admin,
+                }
+                for api in async_get_apis(hass)
+            ]
+        },
     )

--- a/homeassistant/components/system_log/llm.py
+++ b/homeassistant/components/system_log/llm.py
@@ -14,22 +14,22 @@ from homeassistant.util.json import JsonObjectType
 
 from . import DOMAIN, LogErrorHandler
 
-LOG_LEVELS = ["error", "warning", "critical"]
-DEFAULT_LIMIT = 25
+_LOG_LEVELS = ["error", "warning", "critical"]
+_DEFAULT_LIMIT = 25
 
 
 def _filter_log_entries(
     log_entries: list[dict[str, Any]],
     level: str | None = None,
     logger: str | None = None,
-    limit: int = DEFAULT_LIMIT,
+    limit: int = _DEFAULT_LIMIT,
 ) -> list[dict[str, Any]]:
     """Filter and limit raw log entries."""
     predicates: list[Callable[[dict[str, Any]], bool]] = []
 
     if level:
-        level_upper = level.upper()
-        predicates.append(lambda entry: entry["level"].upper() == level_upper)
+        level_lower = level.lower()
+        predicates.append(lambda entry: entry["level"].lower() == level_lower)
 
     if logger:
         logger_lower = logger.strip().lower()
@@ -83,7 +83,7 @@ class SystemLogGetEntriesTool(Tool):
             vol.Optional(
                 "level",
                 description="Filter by log level. Allowed values: 'error', 'warning', 'critical'.",
-            ): vol.All(cv.string, vol.Lower, vol.In(LOG_LEVELS)),
+            ): vol.All(cv.string, vol.Lower, vol.In(_LOG_LEVELS)),
             vol.Optional(
                 "logger",
                 description=(
@@ -93,8 +93,8 @@ class SystemLogGetEntriesTool(Tool):
             ): cv.string,
             vol.Optional(
                 "limit",
-                description=f"Maximum number of log entries to return (default: {DEFAULT_LIMIT}, max: 50).",
-                default=DEFAULT_LIMIT,
+                description=f"Maximum number of log entries to return (default: {_DEFAULT_LIMIT}, max: 50).",
+                default=_DEFAULT_LIMIT,
             ): vol.All(vol.Coerce(int), vol.Range(min=1, max=50)),
             vol.Optional(
                 "include_traceback",

--- a/homeassistant/components/system_log/llm.py
+++ b/homeassistant/components/system_log/llm.py
@@ -28,8 +28,7 @@ def _filter_log_entries(
     predicates: list[Callable[[dict[str, Any]], bool]] = []
 
     if level:
-        level_lower = level.lower()
-        predicates.append(lambda entry: entry["level"].lower() == level_lower)
+        predicates.append(lambda entry: entry["level"].lower() == level)
 
     if logger:
         logger_lower = logger.strip().lower()

--- a/homeassistant/components/system_log/llm.py
+++ b/homeassistant/components/system_log/llm.py
@@ -1,0 +1,135 @@
+"""LLM tools for the system_log integration."""
+
+from typing import override
+
+import voluptuous as vol
+
+from homeassistant.components.llm import LLMTools
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.llm import LLM_API_MANAGEMENT, LLMContext, Tool, ToolInput
+from homeassistant.util import dt as dt_util
+from homeassistant.util.json import JsonObjectType, JsonValueType
+
+from . import DOMAIN, LogErrorHandler
+
+
+class SystemLogGetEntriesTool(Tool):
+    """LLM Tool allowing querying the system log."""
+
+    name = "system_log__get_entries"
+    description = (
+        "Retrieve recent system log errors and warnings from Home Assistant. "
+        "Can filter by log level, domain or logger name, and choose whether "
+        "to include full exception tracebacks."
+    )
+    parameters = vol.Schema(
+        {
+            vol.Optional(
+                "level",
+                description="Filter by log level (e.g. 'error', 'warning', 'critical'). Case-insensitive.",
+            ): cv.string,
+            vol.Optional(
+                "logger",
+                description=(
+                    "Filter by integration domain or logger name (case-insensitive "
+                    "substring match, e.g. 'zwave_js', 'hue', 'automation')."
+                ),
+            ): cv.string,
+            vol.Optional(
+                "limit",
+                description="Maximum number of log entries to return (default: 10, max: 50).",
+                default=10,
+            ): vol.All(vol.Coerce(int), vol.Range(min=1, max=50)),
+            vol.Optional(
+                "include_traceback",
+                description=(
+                    "Whether to include full Python exception stack traces in the "
+                    "returned entries (default: false)."
+                ),
+                default=False,
+            ): cv.boolean,
+        }
+    )
+
+    @override
+    async def async_call(
+        self, hass: HomeAssistant, tool_input: ToolInput, llm_context: LLMContext
+    ) -> JsonObjectType:
+        """Query the system log."""
+        if llm_context.context and llm_context.context.user_id:
+            user = await hass.auth.async_get_user(llm_context.context.user_id)
+            if user is None or not user.is_admin:
+                return {
+                    "success": False,
+                    "error": "Unauthorized: Admin access is required to view system logs.",
+                }
+
+        handler: LogErrorHandler | None = hass.data.get(DOMAIN)
+        if handler is None:
+            return {
+                "success": False,
+                "error": "System log integration is not loaded.",
+            }
+
+        args = self.parameters(tool_input.tool_args)
+        raw_entries = handler.records.to_list()
+
+        if level_filter := args.get("level"):
+            normalized_level = level_filter.strip().upper()
+            raw_entries = [
+                entry
+                for entry in raw_entries
+                if entry["level"].upper() == normalized_level
+            ]
+
+        if logger_filter := args.get("logger"):
+            normalized_logger = logger_filter.strip().lower()
+            raw_entries = [
+                entry
+                for entry in raw_entries
+                if normalized_logger in entry["name"].lower()
+                or (
+                    isinstance(entry["source"], (tuple, list))
+                    and normalized_logger in str(entry["source"][0]).lower()
+                )
+            ]
+
+        limit: int = args["limit"]
+        raw_entries = raw_entries[:limit]
+
+        include_traceback: bool = args["include_traceback"]
+        entries: list[JsonValueType] = []
+        for entry in raw_entries:
+            entry_dict: JsonObjectType = {
+                "name": entry["name"],
+                "message": list(entry["message"]),
+                "level": entry["level"],
+                "source": list(entry["source"])
+                if isinstance(entry["source"], (tuple, list))
+                else entry["source"],
+                "count": entry["count"],
+                "timestamp": dt_util.utc_from_timestamp(entry["timestamp"]).isoformat(),
+                "first_occurred": dt_util.utc_from_timestamp(
+                    entry["first_occurred"]
+                ).isoformat(),
+            }
+            if include_traceback and entry.get("exception"):
+                entry_dict["exception"] = entry["exception"]
+            entries.append(entry_dict)
+
+        return {
+            "success": True,
+            "result": entries,
+        }
+
+
+@callback
+def async_get_tools(
+    hass: HomeAssistant, llm_context: LLMContext, api_id: str
+) -> LLMTools | None:
+    """Return the system log LLM tools for the management API."""
+    if api_id != LLM_API_MANAGEMENT:
+        return None
+
+    return LLMTools(tools=[SystemLogGetEntriesTool()])

--- a/homeassistant/components/system_log/llm.py
+++ b/homeassistant/components/system_log/llm.py
@@ -1,6 +1,7 @@
 """LLM tools for the system_log integration."""
 
-from typing import override
+from collections.abc import Callable
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -9,9 +10,63 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.llm import LLM_API_MANAGEMENT, LLMContext, Tool, ToolInput
 from homeassistant.util import dt as dt_util
-from homeassistant.util.json import JsonObjectType, JsonValueType
+from homeassistant.util.json import JsonObjectType
 
 from . import DOMAIN, LogErrorHandler
+
+LOG_LEVELS = ["error", "warning", "critical"]
+DEFAULT_LIMIT = 25
+
+
+def _filter_log_entries(
+    log_entries: list[dict[str, Any]],
+    level: str | None = None,
+    logger: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+) -> list[dict[str, Any]]:
+    """Filter and limit raw log entries."""
+    predicates: list[Callable[[dict[str, Any]], bool]] = []
+
+    if level:
+        level_upper = level.upper()
+        predicates.append(lambda entry: entry["level"].upper() == level_upper)
+
+    if logger:
+        logger_lower = logger.strip().lower()
+        predicates.append(
+            lambda entry: (
+                logger_lower in entry["name"].lower()
+                or logger_lower in str(entry["source"][0]).lower()
+            )
+        )
+
+    if predicates:
+        log_entries = [
+            entry
+            for entry in log_entries
+            if all(predicate(entry) for predicate in predicates)
+        ]
+
+    return log_entries[:limit]
+
+
+def _format_entry(entry: dict[str, Any], include_traceback: bool) -> JsonObjectType:
+    """Format a single raw log entry for LLM consumption."""
+    source = entry["source"]
+    entry_dict: JsonObjectType = {
+        "name": entry["name"],
+        "message": list(entry["message"]),
+        "level": entry["level"],
+        "source": list(source) if isinstance(source, (tuple, list)) else source,
+        "count": entry["count"],
+        "timestamp": dt_util.utc_from_timestamp(entry["timestamp"]).isoformat(),
+        "first_occurred": dt_util.utc_from_timestamp(
+            entry["first_occurred"]
+        ).isoformat(),
+    }
+    if include_traceback and (exception := entry.get("exception")):
+        entry_dict["exception"] = exception
+    return entry_dict
 
 
 class SystemLogGetEntriesTool(Tool):
@@ -27,8 +82,8 @@ class SystemLogGetEntriesTool(Tool):
         {
             vol.Optional(
                 "level",
-                description="Filter by log level (e.g. 'error', 'warning', 'critical'). Case-insensitive.",
-            ): cv.string,
+                description="Filter by log level. Allowed values: 'error', 'warning', 'critical'.",
+            ): vol.All(cv.string, vol.Lower, vol.In(LOG_LEVELS)),
             vol.Optional(
                 "logger",
                 description=(
@@ -38,8 +93,8 @@ class SystemLogGetEntriesTool(Tool):
             ): cv.string,
             vol.Optional(
                 "limit",
-                description="Maximum number of log entries to return (default: 10, max: 50).",
-                default=10,
+                description=f"Maximum number of log entries to return (default: {DEFAULT_LIMIT}, max: 50).",
+                default=DEFAULT_LIMIT,
             ): vol.All(vol.Coerce(int), vol.Range(min=1, max=50)),
             vol.Optional(
                 "include_traceback",
@@ -57,14 +112,6 @@ class SystemLogGetEntriesTool(Tool):
         self, hass: HomeAssistant, tool_input: ToolInput, llm_context: LLMContext
     ) -> JsonObjectType:
         """Query the system log."""
-        if llm_context.context and llm_context.context.user_id:
-            user = await hass.auth.async_get_user(llm_context.context.user_id)
-            if user is None or not user.is_admin:
-                return {
-                    "success": False,
-                    "error": "Unauthorized: Admin access is required to view system logs.",
-                }
-
         handler: LogErrorHandler | None = hass.data.get(DOMAIN)
         if handler is None:
             return {
@@ -73,54 +120,18 @@ class SystemLogGetEntriesTool(Tool):
             }
 
         args = self.parameters(tool_input.tool_args)
-        raw_entries = handler.records.to_list()
-
-        if level_filter := args.get("level"):
-            normalized_level = level_filter.strip().upper()
-            raw_entries = [
-                entry
-                for entry in raw_entries
-                if entry["level"].upper() == normalized_level
-            ]
-
-        if logger_filter := args.get("logger"):
-            normalized_logger = logger_filter.strip().lower()
-            raw_entries = [
-                entry
-                for entry in raw_entries
-                if normalized_logger in entry["name"].lower()
-                or (
-                    isinstance(entry["source"], (tuple, list))
-                    and normalized_logger in str(entry["source"][0]).lower()
-                )
-            ]
-
-        limit: int = args["limit"]
-        raw_entries = raw_entries[:limit]
-
+        filtered_entries = _filter_log_entries(
+            handler.records.to_list(),
+            level=args.get("level"),
+            logger=args.get("logger"),
+            limit=args["limit"],
+        )
         include_traceback: bool = args["include_traceback"]
-        entries: list[JsonValueType] = []
-        for entry in raw_entries:
-            entry_dict: JsonObjectType = {
-                "name": entry["name"],
-                "message": list(entry["message"]),
-                "level": entry["level"],
-                "source": list(entry["source"])
-                if isinstance(entry["source"], (tuple, list))
-                else entry["source"],
-                "count": entry["count"],
-                "timestamp": dt_util.utc_from_timestamp(entry["timestamp"]).isoformat(),
-                "first_occurred": dt_util.utc_from_timestamp(
-                    entry["first_occurred"]
-                ).isoformat(),
-            }
-            if include_traceback and entry.get("exception"):
-                entry_dict["exception"] = entry["exception"]
-            entries.append(entry_dict)
-
         return {
             "success": True,
-            "result": entries,
+            "result": [
+                _format_entry(entry, include_traceback) for entry in filtered_entries
+            ],
         }
 
 

--- a/homeassistant/components/system_log/llm.py
+++ b/homeassistant/components/system_log/llm.py
@@ -74,8 +74,9 @@ class SystemLogGetEntriesTool(Tool):
     name = "system_log__get_entries"
     description = (
         "Retrieve recent system log errors and warnings from Home Assistant. "
-        "Can filter by log level, domain or logger name, and choose whether "
-        "to include full exception tracebacks."
+        "This inspects the in-memory system log, which only records WARNING, ERROR, "
+        "and CRITICAL events (not DEBUG or INFO). Can filter by log level, integration "
+        "or logger name, and choose whether to include full exception tracebacks."
     )
     parameters = vol.Schema(
         {

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     EVENT_SERVICE_REMOVED,
 )
 from homeassistant.core import Context, Event, HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.json import JsonObjectType
 from homeassistant.util.ulid import ulid_now
@@ -115,6 +115,14 @@ async def async_get_api(
         api = apis[api_id[0]]
     else:
         api = MergedAPI([apis[key] for key in api_id])
+
+    if api.requires_admin and (
+        not llm_context.context
+        or not llm_context.context.user_id
+        or not (user := await hass.auth.async_get_user(llm_context.context.user_id))
+        or not user.is_admin
+    ):
+        raise Unauthorized(context=llm_context.context)
 
     return await api.async_get_api_instance(llm_context)
 

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -41,6 +41,7 @@ APIS_CACHE: HassKey[dict[str, API]] = HassKey("llm_apis")
 
 
 LLM_API_ASSIST = "assist"
+LLM_API_MANAGEMENT = "management"
 
 DATE_TIME_PROMPT = (
     'Current time is {{ now().strftime("%H:%M:%S") }}. '

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -214,6 +214,7 @@ class API(ABC):
     hass: HomeAssistant
     id: str
     name: str
+    requires_admin: bool = False
 
     @abstractmethod
     async def async_get_api_instance(self, llm_context: LLMContext) -> APIInstance:
@@ -357,6 +358,7 @@ class MergedAPI(API):
             hass=hass,
             id="|".join(unicode_slug.slugify(api.id) for api in llm_apis),
             name="Merged LLM API",
+            requires_admin=any(api.requires_admin for api in llm_apis),
         )
         self.llm_apis = llm_apis
 

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -129,7 +129,11 @@ async def async_get_api(
 
 @callback
 def async_get_apis(hass: HomeAssistant) -> list[API]:
-    """Get all the LLM APIs."""
+    """Get all registered LLM APIs.
+
+    This is intended for discovery (e.g. config flows and UI listing).
+    To obtain an API instance with permission checks applied, use `async_get_api`.
+    """
     return list(_async_get_apis(hass).values())
 
 
@@ -226,7 +230,11 @@ class API(ABC):
 
     @abstractmethod
     async def async_get_api_instance(self, llm_context: LLMContext) -> APIInstance:
-        """Return the instance of the API."""
+        """Return the instance of the API.
+
+        This is used internally by `async_get_api`. Callers should use `async_get_api`
+        rather than calling this directly to ensure permission checks are enforced.
+        """
         raise NotImplementedError
 
 

--- a/tests/components/llm/test_init.py
+++ b/tests/components/llm/test_init.py
@@ -6,12 +6,12 @@ from unittest.mock import Mock, patch
 import pytest
 
 from homeassistant.components.llm import DATA_PLATFORMS, LLMTools, async_get_tools
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import frame, llm
 from homeassistant.setup import async_setup_component
 from homeassistant.util.json import JsonObjectType
 
-from tests.common import mock_platform
+from tests.common import MockUser, mock_platform
 
 
 class _StubTool(llm.Tool):
@@ -204,8 +204,8 @@ async def test_get_tools_prefixed_tool_names_not_reported(
     assert "not prefixed with 'test__'" not in caplog.text
 
 
-async def test_management_api(hass: HomeAssistant, llm_context: llm.LLMContext) -> None:
-    """Test that ManagementAPI is registered and retrieves management tools."""
+async def test_management_api(hass: HomeAssistant, hass_admin_user: MockUser) -> None:
+    """Test that ManagementAPI is registered and retrieves management tools for admin."""
     tool = _StubTool("test__mgmt_tool")
     _mock_tools_platform(hass, "test", LLMTools(tools=[tool], prompt="mgmt prompt"))
 
@@ -216,11 +216,59 @@ async def test_management_api(hass: HomeAssistant, llm_context: llm.LLMContext) 
     assert llm.LLM_API_MANAGEMENT in apis
     assert apis[llm.LLM_API_MANAGEMENT].name == "Management"
 
+    admin_context = llm.LLMContext(
+        platform="test",
+        context=Context(user_id=hass_admin_user.id),
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
     api_instance = await apis[llm.LLM_API_MANAGEMENT].async_get_api_instance(
-        llm_context
+        admin_context
     )
     assert api_instance.api_prompt == "mgmt prompt"
     assert [t.name for t in api_instance.tools] == [
         "llm__GetDateTime",
         "test__mgmt_tool",
     ]
+
+
+async def test_management_api_denied_for_non_admin(
+    hass: HomeAssistant, hass_read_only_user: MockUser
+) -> None:
+    """Test that ManagementAPI returns empty tools for non-admin user."""
+    tool = _StubTool("test__mgmt_tool")
+    _mock_tools_platform(hass, "test", LLMTools(tools=[tool], prompt="mgmt prompt"))
+
+    assert await async_setup_component(hass, "llm", {})
+
+    apis = {api.id: api for api in llm.async_get_apis(hass)}
+    non_admin_context = llm.LLMContext(
+        platform="test",
+        context=Context(user_id=hass_read_only_user.id),
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+    api_instance = await apis[llm.LLM_API_MANAGEMENT].async_get_api_instance(
+        non_admin_context
+    )
+    assert api_instance.api_prompt == ""
+    assert api_instance.tools == []
+
+
+async def test_management_api_denied_without_user(
+    hass: HomeAssistant, llm_context: llm.LLMContext
+) -> None:
+    """Test that ManagementAPI returns empty tools when no user is in context."""
+    tool = _StubTool("test__mgmt_tool")
+    _mock_tools_platform(hass, "test", LLMTools(tools=[tool], prompt="mgmt prompt"))
+
+    assert await async_setup_component(hass, "llm", {})
+
+    apis = {api.id: api for api in llm.async_get_apis(hass)}
+    api_instance = await apis[llm.LLM_API_MANAGEMENT].async_get_api_instance(
+        llm_context
+    )
+    assert api_instance.api_prompt == ""
+    assert api_instance.tools == []

--- a/tests/components/llm/test_init.py
+++ b/tests/components/llm/test_init.py
@@ -202,3 +202,25 @@ async def test_get_tools_prefixed_tool_names_not_reported(
         await async_get_tools(hass, llm_context, "assist")
 
     assert "not prefixed with 'test__'" not in caplog.text
+
+
+async def test_management_api(hass: HomeAssistant, llm_context: llm.LLMContext) -> None:
+    """Test that ManagementAPI is registered and retrieves management tools."""
+    tool = _StubTool("test__mgmt_tool")
+    _mock_tools_platform(hass, "test", LLMTools(tools=[tool], prompt="mgmt prompt"))
+
+    assert await async_setup_component(hass, "llm", {})
+
+    apis = {api.id: api for api in llm.async_get_apis(hass)}
+    assert llm.LLM_API_ASSIST in apis
+    assert llm.LLM_API_MANAGEMENT in apis
+    assert apis[llm.LLM_API_MANAGEMENT].name == "Management"
+
+    api_instance = await apis[llm.LLM_API_MANAGEMENT].async_get_api_instance(
+        llm_context
+    )
+    assert api_instance.api_prompt == "mgmt prompt"
+    assert [t.name for t in api_instance.tools] == [
+        "llm__GetDateTime",
+        "test__mgmt_tool",
+    ]

--- a/tests/components/llm/test_init.py
+++ b/tests/components/llm/test_init.py
@@ -212,11 +212,6 @@ async def test_management_api(hass: HomeAssistant, hass_admin_user: MockUser) ->
 
     assert await async_setup_component(hass, "llm", {})
 
-    apis = {api.id: api for api in llm.async_get_apis(hass)}
-    assert llm.LLM_API_ASSIST in apis
-    assert llm.LLM_API_MANAGEMENT in apis
-    assert apis[llm.LLM_API_MANAGEMENT].name == "Management"
-
     admin_context = llm.LLMContext(
         platform="test",
         context=Context(user_id=hass_admin_user.id),
@@ -224,9 +219,7 @@ async def test_management_api(hass: HomeAssistant, hass_admin_user: MockUser) ->
         assistant="conversation",
         device_id=None,
     )
-    api_instance = await apis[llm.LLM_API_MANAGEMENT].async_get_api_instance(
-        admin_context
-    )
+    api_instance = await llm.async_get_api(hass, llm.LLM_API_MANAGEMENT, admin_context)
     assert api_instance.api_prompt == "mgmt prompt"
     assert [t.name for t in api_instance.tools] == [
         "llm__GetDateTime",

--- a/tests/components/llm/test_init.py
+++ b/tests/components/llm/test_init.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant.components.llm import DATA_PLATFORMS, LLMTools, async_get_tools
 from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import frame, llm
 from homeassistant.setup import async_setup_component
 from homeassistant.util.json import JsonObjectType
@@ -236,7 +237,7 @@ async def test_management_api(hass: HomeAssistant, hass_admin_user: MockUser) ->
 async def test_management_api_denied_for_non_admin(
     hass: HomeAssistant, hass_read_only_user: MockUser
 ) -> None:
-    """Test that ManagementAPI returns empty tools for non-admin user."""
+    """Test that ManagementAPI raises Unauthorized for non-admin user."""
     tool = _StubTool("test__mgmt_tool")
     _mock_tools_platform(hass, "test", LLMTools(tools=[tool], prompt="mgmt prompt"))
 
@@ -250,25 +251,19 @@ async def test_management_api_denied_for_non_admin(
         assistant="conversation",
         device_id=None,
     )
-    api_instance = await apis[llm.LLM_API_MANAGEMENT].async_get_api_instance(
-        non_admin_context
-    )
-    assert api_instance.api_prompt == ""
-    assert api_instance.tools == []
+    with pytest.raises(Unauthorized):
+        await apis[llm.LLM_API_MANAGEMENT].async_get_api_instance(non_admin_context)
 
 
 async def test_management_api_denied_without_user(
     hass: HomeAssistant, llm_context: llm.LLMContext
 ) -> None:
-    """Test that ManagementAPI returns empty tools when no user is in context."""
+    """Test that ManagementAPI raises Unauthorized when no user is in context."""
     tool = _StubTool("test__mgmt_tool")
     _mock_tools_platform(hass, "test", LLMTools(tools=[tool], prompt="mgmt prompt"))
 
     assert await async_setup_component(hass, "llm", {})
 
     apis = {api.id: api for api in llm.async_get_apis(hass)}
-    api_instance = await apis[llm.LLM_API_MANAGEMENT].async_get_api_instance(
-        llm_context
-    )
-    assert api_instance.api_prompt == ""
-    assert api_instance.tools == []
+    with pytest.raises(Unauthorized):
+        await apis[llm.LLM_API_MANAGEMENT].async_get_api_instance(llm_context)

--- a/tests/components/llm/test_init.py
+++ b/tests/components/llm/test_init.py
@@ -243,7 +243,6 @@ async def test_management_api_denied_for_non_admin(
 
     assert await async_setup_component(hass, "llm", {})
 
-    apis = {api.id: api for api in llm.async_get_apis(hass)}
     non_admin_context = llm.LLMContext(
         platform="test",
         context=Context(user_id=hass_read_only_user.id),
@@ -252,7 +251,7 @@ async def test_management_api_denied_for_non_admin(
         device_id=None,
     )
     with pytest.raises(Unauthorized):
-        await apis[llm.LLM_API_MANAGEMENT].async_get_api_instance(non_admin_context)
+        await llm.async_get_api(hass, llm.LLM_API_MANAGEMENT, non_admin_context)
 
 
 async def test_management_api_denied_without_user(
@@ -264,6 +263,5 @@ async def test_management_api_denied_without_user(
 
     assert await async_setup_component(hass, "llm", {})
 
-    apis = {api.id: api for api in llm.async_get_apis(hass)}
     with pytest.raises(Unauthorized):
-        await apis[llm.LLM_API_MANAGEMENT].async_get_api_instance(llm_context)
+        await llm.async_get_api(hass, llm.LLM_API_MANAGEMENT, llm_context)

--- a/tests/components/llm/test_websocket_api.py
+++ b/tests/components/llm/test_websocket_api.py
@@ -1,5 +1,7 @@
 """Tests for the LLM integration websocket API."""
 
+from typing import Any
+
 import pytest
 
 from homeassistant.core import HomeAssistant
@@ -33,17 +35,17 @@ async def setup_llm(hass: HomeAssistant) -> None:
         pytest.param(
             [],
             [
-                {"id": "assist", "name": "Assist"},
-                {"id": "management", "name": "Management"},
+                {"id": "assist", "name": "Assist", "requires_admin": False},
+                {"id": "management", "name": "Management", "requires_admin": True},
             ],
             id="default_apis",
         ),
         pytest.param(
             [("test-api", "Test API")],
             [
-                {"id": "assist", "name": "Assist"},
-                {"id": "management", "name": "Management"},
-                {"id": "test-api", "name": "Test API"},
+                {"id": "assist", "name": "Assist", "requires_admin": False},
+                {"id": "management", "name": "Management", "requires_admin": True},
+                {"id": "test-api", "name": "Test API", "requires_admin": False},
             ],
             id="registered_api",
         ),
@@ -53,7 +55,7 @@ async def test_list_apis(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     registered_apis: list[tuple[str, str]],
-    expected_apis: list[dict[str, str]],
+    expected_apis: list[dict[str, Any]],
 ) -> None:
     """Test listing the registered LLM APIs."""
     for api_id, name in registered_apis:

--- a/tests/components/llm/test_websocket_api.py
+++ b/tests/components/llm/test_websocket_api.py
@@ -30,11 +30,19 @@ async def setup_llm(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("registered_apis", "expected_apis"),
     [
-        pytest.param([], [{"id": "assist", "name": "Assist"}], id="assist_only"),
+        pytest.param(
+            [],
+            [
+                {"id": "assist", "name": "Assist"},
+                {"id": "management", "name": "Management"},
+            ],
+            id="default_apis",
+        ),
         pytest.param(
             [("test-api", "Test API")],
             [
                 {"id": "assist", "name": "Assist"},
+                {"id": "management", "name": "Management"},
                 {"id": "test-api", "name": "Test API"},
             ],
             id="registered_api",

--- a/tests/components/system_log/test_llm.py
+++ b/tests/components/system_log/test_llm.py
@@ -1,0 +1,255 @@
+"""Tests for system_log LLM tools."""
+
+import logging
+
+import pytest
+
+from homeassistant.components import system_log
+from homeassistant.components.system_log.llm import (
+    SystemLogGetEntriesTool,
+    async_get_tools,
+)
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import llm
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockUser
+
+_LOGGER = logging.getLogger("test_system_log_llm")
+_OTHER_LOGGER = logging.getLogger("custom_integration")
+
+
+@pytest.fixture
+def llm_context() -> llm.LLMContext:
+    """Return an LLM context."""
+    return llm.LLMContext(
+        platform="test",
+        context=None,
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+
+
+async def test_async_get_tools(
+    hass: HomeAssistant, llm_context: llm.LLMContext
+) -> None:
+    """Test async_get_tools returns tools only for management API."""
+    assert async_get_tools(hass, llm_context, llm.LLM_API_ASSIST) is None
+
+    management_tools = async_get_tools(hass, llm_context, llm.LLM_API_MANAGEMENT)
+    assert management_tools is not None
+    assert len(management_tools.tools) == 1
+    assert management_tools.tools[0].name == "system_log__get_entries"
+    assert management_tools.prompt is None
+
+
+async def test_system_log_not_loaded(
+    hass: HomeAssistant, llm_context: llm.LLMContext
+) -> None:
+    """Test tool error when system_log is not loaded in hass.data."""
+    tool = SystemLogGetEntriesTool()
+    tool_input = llm.ToolInput(tool_name=tool.name, tool_args={})
+    result = await tool.async_call(hass, tool_input, llm_context)
+
+    assert result == {
+        "success": False,
+        "error": "System log integration is not loaded.",
+    }
+
+
+async def test_unauthorized_non_admin_user(
+    hass: HomeAssistant, hass_read_only_user: MockUser
+) -> None:
+    """Test tool error when called by a non-admin user."""
+    assert await async_setup_component(hass, system_log.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    user_context = Context(user_id=hass_read_only_user.id)
+    context_with_user = llm.LLMContext(
+        platform="test",
+        context=user_context,
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+
+    tool = SystemLogGetEntriesTool()
+    tool_input = llm.ToolInput(tool_name=tool.name, tool_args={})
+    result = await tool.async_call(hass, tool_input, context_with_user)
+
+    assert result == {
+        "success": False,
+        "error": "Unauthorized: Admin access is required to view system logs.",
+    }
+
+
+async def test_get_entries_default(
+    hass: HomeAssistant, llm_context: llm.LLMContext
+) -> None:
+    """Test retrieving entries with default arguments."""
+    assert await async_setup_component(hass, system_log.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    _LOGGER.error("Test error message")
+    _LOGGER.warning("Test warning message")
+
+    tool = SystemLogGetEntriesTool()
+    tool_input = llm.ToolInput(tool_name=tool.name, tool_args={})
+    result = await tool.async_call(hass, tool_input, llm_context)
+
+    assert result["success"] is True
+    entries = result["result"]
+    assert len(entries) == 2
+
+    # Most recent entry first
+    assert entries[0]["level"] == "WARNING"
+    assert entries[0]["message"] == ["Test warning message"]
+    assert entries[0]["name"] == "test_system_log_llm"
+    assert "exception" not in entries[0]
+    assert "timestamp" in entries[0]
+    assert "first_occurred" in entries[0]
+    assert entries[0]["count"] == 1
+
+    assert entries[1]["level"] == "ERROR"
+    assert entries[1]["message"] == ["Test error message"]
+    assert "exception" not in entries[1]
+
+
+async def test_get_entries_with_traceback(
+    hass: HomeAssistant, llm_context: llm.LLMContext
+) -> None:
+    """Test retrieving entries with exception traceback included."""
+    assert await async_setup_component(hass, system_log.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    def _raise_error() -> None:
+        raise ValueError("Something went wrong")
+
+    try:
+        _raise_error()
+    except ValueError:
+        _LOGGER.exception("Caught an exception")
+
+    tool = SystemLogGetEntriesTool()
+    tool_input_no_tb = llm.ToolInput(
+        tool_name=tool.name, tool_args={"include_traceback": False}
+    )
+    result_no_tb = await tool.async_call(hass, tool_input_no_tb, llm_context)
+    assert result_no_tb["success"] is True
+    assert "exception" not in result_no_tb["result"][0]
+
+    tool_input_tb = llm.ToolInput(
+        tool_name=tool.name, tool_args={"include_traceback": True}
+    )
+    result_tb = await tool.async_call(hass, tool_input_tb, llm_context)
+    assert result_tb["success"] is True
+    assert "ValueError: Something went wrong" in result_tb["result"][0]["exception"]
+
+
+@pytest.mark.parametrize(
+    ("filter_level", "expected_count", "expected_level"),
+    [
+        pytest.param("error", 1, "ERROR", id="filter_error"),
+        pytest.param("WARNING", 1, "WARNING", id="filter_warning_uppercase"),
+        pytest.param("critical", 0, None, id="filter_no_match"),
+    ],
+)
+async def test_filter_by_level(
+    hass: HomeAssistant,
+    llm_context: llm.LLMContext,
+    filter_level: str,
+    expected_count: int,
+    expected_level: str | None,
+) -> None:
+    """Test filtering entries by level."""
+    assert await async_setup_component(hass, system_log.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    _LOGGER.error("An error occurred")
+    _LOGGER.warning("A warning occurred")
+
+    tool = SystemLogGetEntriesTool()
+    tool_input = llm.ToolInput(tool_name=tool.name, tool_args={"level": filter_level})
+    result = await tool.async_call(hass, tool_input, llm_context)
+
+    assert result["success"] is True
+    assert len(result["result"]) == expected_count
+    if expected_level:
+        assert result["result"][0]["level"] == expected_level
+
+
+@pytest.mark.parametrize(
+    ("logger_query", "expected_count", "expected_name"),
+    [
+        pytest.param("test_system", 1, "test_system_log_llm", id="match_test_logger"),
+        pytest.param(
+            "custom_integration", 1, "custom_integration", id="match_custom_logger"
+        ),
+        pytest.param("nonexistent", 0, None, id="no_match"),
+    ],
+)
+async def test_filter_by_logger(
+    hass: HomeAssistant,
+    llm_context: llm.LLMContext,
+    logger_query: str,
+    expected_count: int,
+    expected_name: str | None,
+) -> None:
+    """Test filtering entries by logger name."""
+    assert await async_setup_component(hass, system_log.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    _LOGGER.error("Error from primary logger")
+    _OTHER_LOGGER.error("Error from other logger")
+
+    tool = SystemLogGetEntriesTool()
+    tool_input = llm.ToolInput(tool_name=tool.name, tool_args={"logger": logger_query})
+    result = await tool.async_call(hass, tool_input, llm_context)
+
+    assert result["success"] is True
+    assert len(result["result"]) == expected_count
+    if expected_name:
+        assert result["result"][0]["name"] == expected_name
+
+
+async def test_limit(hass: HomeAssistant, llm_context: llm.LLMContext) -> None:
+    """Test limiting the number of returned entries."""
+    assert await async_setup_component(hass, system_log.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    for i in range(5):
+        logging.getLogger(f"test_logger_{i}").error("Error message %d", i)
+
+    tool = SystemLogGetEntriesTool()
+    tool_input = llm.ToolInput(tool_name=tool.name, tool_args={"limit": 2})
+    result = await tool.async_call(hass, tool_input, llm_context)
+
+    assert result["success"] is True
+    assert len(result["result"]) == 2
+
+
+async def test_admin_user_allowed(
+    hass: HomeAssistant, hass_admin_user: MockUser
+) -> None:
+    """Test tool success when called by an admin user."""
+    assert await async_setup_component(hass, system_log.DOMAIN, {})
+    await hass.async_block_till_done()
+
+    _LOGGER.error("Sample error")
+
+    user_context = Context(user_id=hass_admin_user.id)
+    context_with_admin = llm.LLMContext(
+        platform="test",
+        context=user_context,
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+
+    tool = SystemLogGetEntriesTool()
+    tool_input = llm.ToolInput(tool_name=tool.name, tool_args={})
+    result = await tool.async_call(hass, tool_input, context_with_admin)
+
+    assert result["success"] is True
+    assert len(result["result"]) == 1

--- a/tests/components/system_log/test_llm.py
+++ b/tests/components/system_log/test_llm.py
@@ -155,6 +155,11 @@ async def test_filter_by_level(
         pytest.param(
             "custom_integration", ["custom_integration"], id="match_custom_logger"
         ),
+        pytest.param(
+            "test_llm",
+            ["custom_integration", "test_system_log_llm"],
+            id="match_source_path",
+        ),
         pytest.param("nonexistent", [], id="no_match"),
     ],
 )

--- a/tests/components/system_log/test_llm.py
+++ b/tests/components/system_log/test_llm.py
@@ -120,19 +120,18 @@ async def test_get_entries_with_traceback(
 
 
 @pytest.mark.parametrize(
-    ("filter_level", "expected_count", "expected_level"),
+    ("filter_level", "expected_levels"),
     [
-        pytest.param("error", 1, "ERROR", id="filter_error"),
-        pytest.param("WARNING", 1, "WARNING", id="filter_warning_uppercase"),
-        pytest.param("critical", 0, None, id="filter_no_match"),
+        pytest.param("error", ["ERROR"], id="filter_error"),
+        pytest.param("WARNING", ["WARNING"], id="filter_warning_uppercase"),
+        pytest.param("critical", [], id="filter_no_match"),
     ],
 )
 async def test_filter_by_level(
     hass: HomeAssistant,
     llm_context: llm.LLMContext,
     filter_level: str,
-    expected_count: int,
-    expected_level: str | None,
+    expected_levels: list[str],
 ) -> None:
     """Test filtering entries by level."""
     assert await async_setup_component(hass, system_log.DOMAIN, {})
@@ -146,27 +145,24 @@ async def test_filter_by_level(
     result = await tool.async_call(hass, tool_input, llm_context)
 
     assert result["success"] is True
-    assert len(result["result"]) == expected_count
-    if expected_level:
-        assert result["result"][0]["level"] == expected_level
+    assert [entry["level"] for entry in result["result"]] == expected_levels
 
 
 @pytest.mark.parametrize(
-    ("logger_query", "expected_count", "expected_name"),
+    ("logger_query", "expected_names"),
     [
-        pytest.param("test_system", 1, "test_system_log_llm", id="match_test_logger"),
+        pytest.param("test_system", ["test_system_log_llm"], id="match_test_logger"),
         pytest.param(
-            "custom_integration", 1, "custom_integration", id="match_custom_logger"
+            "custom_integration", ["custom_integration"], id="match_custom_logger"
         ),
-        pytest.param("nonexistent", 0, None, id="no_match"),
+        pytest.param("nonexistent", [], id="no_match"),
     ],
 )
 async def test_filter_by_logger(
     hass: HomeAssistant,
     llm_context: llm.LLMContext,
     logger_query: str,
-    expected_count: int,
-    expected_name: str | None,
+    expected_names: list[str],
 ) -> None:
     """Test filtering entries by logger name."""
     assert await async_setup_component(hass, system_log.DOMAIN, {})
@@ -180,9 +176,7 @@ async def test_filter_by_logger(
     result = await tool.async_call(hass, tool_input, llm_context)
 
     assert result["success"] is True
-    assert len(result["result"]) == expected_count
-    if expected_name:
-        assert result["result"][0]["name"] == expected_name
+    assert [entry["name"] for entry in result["result"]] == expected_names
 
 
 async def test_limit(hass: HomeAssistant, llm_context: llm.LLMContext) -> None:

--- a/tests/components/system_log/test_llm.py
+++ b/tests/components/system_log/test_llm.py
@@ -9,11 +9,9 @@ from homeassistant.components.system_log.llm import (
     SystemLogGetEntriesTool,
     async_get_tools,
 )
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import llm
 from homeassistant.setup import async_setup_component
-
-from tests.common import MockUser
 
 _LOGGER = logging.getLogger("test_system_log_llm")
 _OTHER_LOGGER = logging.getLogger("custom_integration")
@@ -55,32 +53,6 @@ async def test_system_log_not_loaded(
     assert result == {
         "success": False,
         "error": "System log integration is not loaded.",
-    }
-
-
-async def test_unauthorized_non_admin_user(
-    hass: HomeAssistant, hass_read_only_user: MockUser
-) -> None:
-    """Test tool error when called by a non-admin user."""
-    assert await async_setup_component(hass, system_log.DOMAIN, {})
-    await hass.async_block_till_done()
-
-    user_context = Context(user_id=hass_read_only_user.id)
-    context_with_user = llm.LLMContext(
-        platform="test",
-        context=user_context,
-        language="*",
-        assistant="conversation",
-        device_id=None,
-    )
-
-    tool = SystemLogGetEntriesTool()
-    tool_input = llm.ToolInput(tool_name=tool.name, tool_args={})
-    result = await tool.async_call(hass, tool_input, context_with_user)
-
-    assert result == {
-        "success": False,
-        "error": "Unauthorized: Admin access is required to view system logs.",
     }
 
 
@@ -227,29 +199,3 @@ async def test_limit(hass: HomeAssistant, llm_context: llm.LLMContext) -> None:
 
     assert result["success"] is True
     assert len(result["result"]) == 2
-
-
-async def test_admin_user_allowed(
-    hass: HomeAssistant, hass_admin_user: MockUser
-) -> None:
-    """Test tool success when called by an admin user."""
-    assert await async_setup_component(hass, system_log.DOMAIN, {})
-    await hass.async_block_till_done()
-
-    _LOGGER.error("Sample error")
-
-    user_context = Context(user_id=hass_admin_user.id)
-    context_with_admin = llm.LLMContext(
-        platform="test",
-        context=user_context,
-        language="*",
-        assistant="conversation",
-        device_id=None,
-    )
-
-    tool = SystemLogGetEntriesTool()
-    tool_input = llm.ToolInput(tool_name=tool.name, tool_args={})
-    result = await tool.async_call(hass, tool_input, context_with_admin)
-
-    assert result["success"] is True
-    assert len(result["result"]) == 1

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -25,7 +25,7 @@ from homeassistant.helpers import (
 from homeassistant.setup import async_setup_component
 from homeassistant.util.json import JsonObjectType
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, MockUser
 
 
 @pytest.fixture(autouse=True)
@@ -130,6 +130,60 @@ async def test_multiple_apis(hass: HomeAssistant, llm_context: llm.LLMContext) -
         assert await llm.async_get_api(hass, "test-1", llm_context)
 
     assert await llm.async_get_api(hass, "test-2", llm_context)
+
+
+async def test_get_api_requires_admin(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    hass_read_only_user: MockUser,
+) -> None:
+    """Test async_get_api enforces requires_admin."""
+    admin_api = MyAPI(hass=hass, id="admin-api", name="Admin API", requires_admin=True)
+    user_api = MyAPI(hass=hass, id="user-api", name="User API", requires_admin=False)
+    llm.async_register_api(hass, admin_api)
+    llm.async_register_api(hass, user_api)
+
+    admin_context = llm.LLMContext(
+        platform="test",
+        context=Context(user_id=hass_admin_user.id),
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+    read_only_context = llm.LLMContext(
+        platform="test",
+        context=Context(user_id=hass_read_only_user.id),
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+    no_user_context = llm.LLMContext(
+        platform="test",
+        context=None,
+        language="*",
+        assistant="conversation",
+        device_id=None,
+    )
+
+    # Allowed for user API regardless of user
+    assert await llm.async_get_api(hass, "user-api", read_only_context)
+    assert await llm.async_get_api(hass, "user-api", no_user_context)
+
+    # Allowed for admin API with admin user
+    assert await llm.async_get_api(hass, "admin-api", admin_context)
+
+    # Denied for admin API without admin user
+    with pytest.raises(llm.Unauthorized):
+        await llm.async_get_api(hass, "admin-api", read_only_context)
+
+    with pytest.raises(llm.Unauthorized):
+        await llm.async_get_api(hass, "admin-api", no_user_context)
+
+    # Merged API requiring admin also enforces check
+    assert await llm.async_get_api(hass, ["user-api", "admin-api"], admin_context)
+
+    with pytest.raises(llm.Unauthorized):
+        await llm.async_get_api(hass, ["user-api", "admin-api"], read_only_context)
 
 
 async def test_call_tool_no_existing(

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -1304,6 +1304,7 @@ async def test_merged_api(hass: HomeAssistant, llm_context: llm.LLMContext) -> N
 
     instance = await llm.async_get_api(hass, ["api-1", "api-2"], llm_context)
     assert instance.api.id == "api-1|api-2"
+    assert instance.api.requires_admin is False
 
     assert (
         instance.api_prompt


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

This PR introduces the **Management LLM API** (`management`) and adds a `system_log__get_entries` tool for LLM agents to query the in-memory system log.

Related Architecture Discussion: https://github.com/home-assistant/architecture/discussions/1476

This PR should not be merged until the above architecture discussion is approved.

This is an initial proposal of the management API which is a separate control plane for Home Assistant itself, different from the Assist API for controlling devices. The system log entries tool is an initial small scoped debugging tool proof of concept. (In the future related tools such as enabling debug logs for an integration or fetching portions of the error log could be additional related follow up tools for each of those respective integration domains)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/discussions/1476
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr