### PR TITLE
2026.9.2

### DIFF
--- a/homeassistant/components/actron_air/manifest.json
+++ b/homeassistant/components/actron_air/manifest.json
@@ -14,5 +14,5 @@
   "iot_class": "cloud_push",
   "loggers": ["actron_neo_api"],
   "quality_scale": "silver",
-  "requirements": ["actron-neo-api==0.5.14"]
+  "requirements": ["actron-neo-api==0.5.16"]
 }

--- a/homeassistant/components/airos/manifest.json
+++ b/homeassistant/components/airos/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "platinum",
-  "requirements": ["airos==0.6.9"]
+  "requirements": ["airos==0.6.12"]
 }

--- a/homeassistant/components/alarmdecoder/manifest.json
+++ b/homeassistant/components/alarmdecoder/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["adext", "alarmdecoder"],
-  "requirements": ["adext==0.4.4"]
+  "requirements": ["adext==0.4.7"]
 }

--- a/homeassistant/components/alexa_devices/select.py
+++ b/homeassistant/components/alexa_devices/select.py
@@ -66,23 +66,25 @@ async def async_setup_entry(
         new_devices = current_devices - known_devices
         if new_devices:
             known_devices.update(new_devices)
-            select_entities = [
-                AmazonSelectEntity(coordinator, serial_num, select_desc)
-                for select_desc in SELECTS
-                for serial_num in new_devices
-                if select_desc.is_available_fn(coordinator.data[serial_num])
-            ]
-            select_service_entites = [
-                AmazonSelectServiceEntity(coordinator, select_desc)
-                for select_desc in SERVICE_SELECTS
-                for serial_num in new_devices
-                if select_desc.is_available_fn(coordinator.data[serial_num])
-            ]
-            async_add_entities(select_entities)
-            async_add_entities(select_service_entites)
+            async_add_entities(
+                [
+                    AmazonSelectEntity(coordinator, serial_num, select_desc)
+                    for select_desc in SELECTS
+                    for serial_num in new_devices
+                    if select_desc.is_available_fn(coordinator.data[serial_num])
+                ]
+            )
 
     _check_device()
     entry.async_on_unload(coordinator.async_add_listener(_check_device))
+
+    # Service entities
+    async_add_entities(
+        [
+            AmazonSelectServiceEntity(coordinator, select_desc)
+            for select_desc in SERVICE_SELECTS
+        ]
+    )
 
 
 class AmazonSelectEntity(AmazonEntity, SelectEntity):

--- a/homeassistant/components/atag/manifest.json
+++ b/homeassistant/components/atag/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["pyatag"],
-  "requirements": ["pyatag==0.3.5.3"]
+  "requirements": ["pyatag==0.3.7.1"]
 }

--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
   "quality_scale": "platinum",
-  "requirements": ["pyenphase==4.0.1"],
+  "requirements": ["pyenphase==4.0.3"],
   "zeroconf": [
     {
       "type": "_enphase-envoy._tcp.local."

--- a/homeassistant/components/esphome/dashboard.py
+++ b/homeassistant/components/esphome/dashboard.py
@@ -61,21 +61,25 @@ class ESPHomeDashboardManager:
         if not (data := self._data) or not (info := data.get("info")):
             return
         if is_hassio(self._hass):
-            from homeassistant.components.hassio import get_addons_info  # noqa: PLC0415
+            from homeassistant.components.hassio import (  # noqa: PLC0415
+                HassioNotReadyError,
+                get_addons_info,
+            )
 
-            # This may raise HassioNotReadyError if Supervisor was unreachable
-            # during setup of the Supervisor integration. That will fail setup
-            # of this integration. However there is no better option at this time
-            # since we need to know if the addon is installed from Supervisor to
-            # correctly setup this integration and we can't raise ConfigEntryNotReady
-            # to trigger a retry from async_setup.
-            addons = get_addons_info(self._hass)
-            if info["addon_slug"] not in addons:
-                # The addon is not installed anymore, but it make come back
-                # so we don't want to remove the dashboard, but for now
-                # we don't want to use it.
-                _LOGGER.debug("Addon %s is no longer installed", info["addon_slug"])
-                return
+            try:
+                addons = get_addons_info(self._hass)
+            except HassioNotReadyError:
+                # Supervisor was unreachable during its own setup, so we cannot
+                # tell if the addon is installed. Restore the dashboard anyway,
+                # a stale one only fails to refresh.
+                _LOGGER.debug("Supervisor is not ready, skipping addon check")
+            else:
+                if info["addon_slug"] not in addons:
+                    # The addon is not installed anymore, but it make come back
+                    # so we don't want to remove the dashboard, but for now
+                    # we don't want to use it.
+                    _LOGGER.debug("Addon %s is no longer installed", info["addon_slug"])
+                    return
 
         await self.async_set_dashboard_info(
             info["addon_slug"], info["host"], info["port"]

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -22,5 +22,5 @@
   "integration_type": "system",
   "preview_features": { "winter_mode": {} },
   "quality_scale": "internal",
-  "requirements": ["home-assistant-frontend==20260826.6"]
+  "requirements": ["home-assistant-frontend==20260826.7"]
 }

--- a/homeassistant/components/go2rtc/server.py
+++ b/homeassistant/components/go2rtc/server.py
@@ -4,6 +4,7 @@ import asyncio
 from collections import deque
 from contextlib import suppress
 import logging
+import re
 from tempfile import NamedTemporaryFile
 
 from aiohttp import ClientSession
@@ -103,6 +104,21 @@ _LOG_LEVEL_MAP = {
     "FTL": logging.ERROR,
     "PNC": logging.ERROR,
 }
+
+
+# go2rtc logs stream urls verbatim, which may embed camera credentials.
+# Upstream strips the url userinfo since AlexxIT/go2rtc#2051, but no release
+# includes it yet (v1.9.14 is the newest). It does not touch query parameters.
+_URL_USERINFO = re.compile(r"://[^/?#\s@]+@")
+_URL_CREDENTIAL_QUERY = re.compile(
+    r"([?&](?:auth|user|password)=)[^&\s]+", re.IGNORECASE
+)
+
+
+def _redact_url_credentials(msg: str) -> str:
+    """Redact credentials from urls in a go2rtc log message."""
+    msg = _URL_USERINFO.sub("://****@", msg)
+    return _URL_CREDENTIAL_QUERY.sub(r"\1****", msg)
 
 
 class Go2RTCServerStartError(HomeAssistantError):
@@ -238,7 +254,7 @@ class Server:
         assert process.stdout is not None
 
         async for line in process.stdout:
-            msg = line[:-1].decode().strip()
+            msg = _redact_url_credentials(line[:-1].decode().strip())
             self._log_buffer.append(msg)
             loglevel = logging.WARNING
             if len(split_msg := msg.split(" ", 2)) == 3:

--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["googleapiclient"],
-  "requirements": ["gcal-sync==9.1.0", "oauth2client==4.1.3", "ical==14.1.1"]
+  "requirements": ["gcal-sync==9.1.1", "oauth2client==4.1.3", "ical==14.1.1"]
 }

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -50,12 +50,14 @@ class HiveFlowHandler(ConfigFlow, domain=DOMAIN):
         # Login to Hive with user data.
         if user_input is not None:
             self.data.update(user_input)
+            username = self.data[CONF_USERNAME].lower()
             self.hive_auth = Auth(
-                username=self.data[CONF_USERNAME], password=self.data[CONF_PASSWORD]
+                username=username,
+                password=self.data[CONF_PASSWORD],
             )
 
             # Get user from existing entry and abort if already setup
-            await self.async_set_unique_id(self.data[CONF_USERNAME])
+            await self.async_set_unique_id(username)
             if self.context["source"] != SOURCE_REAUTH:
                 self._abort_if_unique_id_configured()
 

--- a/homeassistant/components/local_todo/store.py
+++ b/homeassistant/components/local_todo/store.py
@@ -24,7 +24,7 @@ class LocalTodoListStore:
         """Load the calendar from disk."""
         if not self._path.exists():
             return ""
-        return self._path.read_text()
+        return self._path.read_text(encoding="utf-8")
 
     async def async_store(self, ics_content: str) -> None:
         """Persist the calendar to storage."""
@@ -33,4 +33,4 @@ class LocalTodoListStore:
 
     def _store(self, ics_content: str) -> None:
         """Persist the calendar to storage."""
-        self._path.write_text(ics_content)
+        self._path.write_text(ics_content, encoding="utf-8")

--- a/homeassistant/components/local_todo/todo.py
+++ b/homeassistant/components/local_todo/todo.py
@@ -7,6 +7,7 @@ from typing import override
 
 from ical.calendar import Calendar
 from ical.calendar_stream import IcsCalendarStream
+from ical.exceptions import CalendarParseError
 from ical.store import TodoStore
 from ical.todo import Todo, TodoStatus
 
@@ -63,6 +64,16 @@ def _migrate_calendar(calendar: Calendar) -> bool:
     return migrated
 
 
+def _repair_legacy_crlf_newlines(content: str) -> str:
+    r"""Repair ICS content corrupted by CRLF newlines from ical <= 12.1.3.
+
+    In ical <= 12.1.3, TextEncoder escaped \n to \\n but left \r unescaped.
+    When read with Python's universal newlines mode (newline=None), any lone \r
+    before \\n was converted into \n\\n, breaking property line parsing.
+    """
+    return content.replace("\r\\n", "\\n").replace("\n\\n", "\\n").replace("\r", "")
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: LocalTodoConfigEntry,
@@ -70,20 +81,37 @@ async def async_setup_entry(
 ) -> None:
     """Set up the local_todo todo platform."""
 
+    name = config_entry.data[CONF_TODO_LIST_NAME]
     store = config_entry.runtime_data
     ics = await store.async_load()
 
-    with async_pause_setup(hass, SetupPhases.WAIT_IMPORT_PACKAGES):
-        # calendar_from_ics will dynamically load packages
-        # the first time it is called, so we need to do it
-        # in a separate thread to avoid blocking the event loop
-        calendar: Calendar = await hass.async_add_import_executor_job(
-            IcsCalendarStream.calendar_from_ics, ics
+    migrated = False
+    try:
+        with async_pause_setup(hass, SetupPhases.WAIT_IMPORT_PACKAGES):
+            # calendar_from_ics will dynamically load packages
+            # the first time it is called, so we need to do it
+            # in a separate thread to avoid blocking the event loop
+            calendar: Calendar = await hass.async_add_import_executor_job(
+                IcsCalendarStream.calendar_from_ics, ics
+            )
+    except CalendarParseError:
+        # Attempt to repair malformed newlines from ical <= 12.1.3 CRLF bug
+        repaired_ics = _repair_legacy_crlf_newlines(ics)
+        if repaired_ics == ics:
+            raise
+        calendar = await hass.async_add_import_executor_job(
+            IcsCalendarStream.calendar_from_ics, repaired_ics
         )
-    migrated = _migrate_calendar(calendar)
+        _LOGGER.warning(
+            "Repaired malformed iCalendar file for to-do list %s",
+            name,
+        )
+        migrated = True
+
+    if _migrate_calendar(calendar):
+        migrated = True
     calendar.prodid = PRODID
 
-    name = config_entry.data[CONF_TODO_LIST_NAME]
     entity = LocalTodoListEntity(store, calendar, name, unique_id=config_entry.entry_id)
     async_add_entities([entity], True)
 

--- a/homeassistant/components/mcp/config_flow.py
+++ b/homeassistant/components/mcp/config_flow.py
@@ -117,8 +117,15 @@ async def validate_input(
     except vol.Invalid as error:
         raise InvalidUrl from error
     try:
-        async with mcp_client(hass, url, token_manager=token_manager) as session:
-            response = await session.initialize()
+        async with mcp_client(hass, url, token_manager=token_manager) as (
+            _session,
+            response,
+        ):
+            if not response.capabilities.tools:
+                raise MissingCapabilities(
+                    f"MCP Server {url} does not support 'Tools' capability"
+                )
+            return {"title": response.serverInfo.name}
     except httpx.TimeoutException as error:
         _LOGGER.info("Timeout connecting to MCP server: %s", error)
         raise TimeoutConnectError from error
@@ -131,13 +138,6 @@ async def validate_input(
     except httpx.HTTPError as error:
         _LOGGER.info("Cannot connect to MCP server: %s", error)
         raise CannotConnect from error
-
-    if not response.capabilities.tools:
-        raise MissingCapabilities(
-            f"MCP Server {url} does not support 'Tools' capability"
-        )
-
-    return {"title": response.serverInfo.name}
 
 
 class ModelContextProtocolConfigFlow(AbstractOAuth2FlowHandler, domain=DOMAIN):

--- a/homeassistant/components/mcp/coordinator.py
+++ b/homeassistant/components/mcp/coordinator.py
@@ -12,6 +12,7 @@ from mcp import McpError
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
+from mcp.types import InitializeResult
 from probatio import from_openapi
 import voluptuous as vol
 
@@ -65,7 +66,7 @@ async def mcp_client(
     hass: HomeAssistant,
     url: str,
     token_manager: TokenManager | None = None,
-) -> AsyncGenerator[ClientSession]:
+) -> AsyncGenerator[tuple[ClientSession, InitializeResult]]:
     """Create an MCP client.
 
     This is an asynccontext manager that exists to wrap other async context managers
@@ -84,8 +85,8 @@ async def mcp_client(
             ) as (read_stream, write_stream, _),
             ClientSession(read_stream, write_stream) as session,
         ):
-            await session.initialize()
-            yield session
+            result = await session.initialize()
+            yield session, result
     except ExceptionGroup as streamable_err:
         main_error = streamable_err.exceptions[0]
         # Method not Allowed likely means this is not a streamable HTTP server,
@@ -109,8 +110,8 @@ async def mcp_client(
                     ) as streams,
                     ClientSession(*streams) as session,
                 ):
-                    await session.initialize()
-                    yield session
+                    result = await session.initialize()
+                    yield session, result
             except ExceptionGroup as sse_err:
                 _LOGGER.debug("Error creating SSE MCP client: %s", sse_err)
                 raise sse_err.exceptions[0] from sse_err
@@ -149,9 +150,10 @@ class ModelContextProtocolTool(llm.Tool):
         """Call the tool."""
         try:
             async with asyncio.timeout(TIMEOUT):
-                async with mcp_client(
-                    hass, self.server_url, self.token_manager
-                ) as session:
+                async with mcp_client(hass, self.server_url, self.token_manager) as (
+                    session,
+                    _,
+                ):
                     result = await session.call_tool(
                         tool_input.tool_name, tool_input.tool_args
                     )
@@ -219,7 +221,7 @@ class ModelContextProtocolCoordinator(DataUpdateCoordinator[list[llm.Tool]]):
             async with asyncio.timeout(TIMEOUT):
                 async with mcp_client(
                     self.hass, self.config_entry.data[CONF_URL], self.token_manager
-                ) as session:
+                ) as (session, _):
                     result = await session.list_tools()
         except TimeoutError as error:
             _LOGGER.debug("Timeout when listing tools: %s", error)

--- a/homeassistant/components/melcloud_home/coordinator.py
+++ b/homeassistant/components/melcloud_home/coordinator.py
@@ -176,7 +176,7 @@ class MelCloudHomeEnergyCoordinator(DataUpdateCoordinator[dict[str, float | None
         """Fetch energy telemetry for a unit without failing the whole update."""
         try:
             energy = await self.client.get_energy_telemetry(
-                unit_id, from_dt=start_of_month, to_dt=now
+                unit_id, from_dt=start_of_month, to_dt=now, interval="Day"
             )
         except (
             MelCloudHomeAuthenticationError,

--- a/homeassistant/components/midea/climate.py
+++ b/homeassistant/components/midea/climate.py
@@ -251,18 +251,15 @@ class MideaClimate(MideaEntity, ClimateEntity):
         if hvac_mode == HVACMode.OFF:
             self.turn_off()
         else:
-            mode = None
-            if hvac_mode:
-                if hvac_mode not in self.hvac_modes:
-                    raise ServiceValidationError(
-                        translation_domain=DOMAIN,
-                        translation_key="unsupported_hvac_mode",
-                        translation_placeholders={"hvac_mode": hvac_mode},
-                    )
-                mode = self.hvac_modes.index(hvac_mode)
-            self._device.set_target_temperature(
+            if hvac_mode and hvac_mode not in self.hvac_modes:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="unsupported_hvac_mode",
+                    translation_placeholders={"hvac_mode": hvac_mode},
+                )
+            self._device.set_raw_target_temperature(
                 target_temperature=temperature,
-                mode=mode,
+                hvac_mode=hvac_mode,
                 zone=self._zone,
             )
 
@@ -355,31 +352,13 @@ class MideaACClimate(MideaClimate):
     @property
     @override
     def hvac_modes(self) -> list[HVACMode]:
-        """Midea AC Climate hvac modes."""
-        return (
-            [HVACMode.OFF]
-            + (
-                [HVACMode.AUTO]
-                if self._device.capabilities.get("auto_mode", True)
-                else []
-            )
-            + (
-                [HVACMode.COOL]
-                if self._device.capabilities.get("cool_mode", True)
-                else []
-            )
-            + (
-                [HVACMode.DRY]
-                if self._device.capabilities.get("dry_mode", True)
-                else []
-            )
-            + (
-                [HVACMode.HEAT]
-                if self._device.capabilities.get("heat_mode", True)
-                else []
-            )
-            + [HVACMode.FAN_ONLY]
-        )
+        """Midea AC Climate hvac modes.
+
+        The device reports the generic mode names in protocol-index order
+        (``off`` first, ``fan_only`` last), already filtered by its B5
+        capabilities.
+        """
+        return [HVACMode(mode) for mode in self._device.raw_hvac_modes]
 
     @property
     @override
@@ -439,13 +418,7 @@ class MideaACClimate(MideaClimate):
     @override
     def set_swing_mode(self, swing_mode: str) -> None:
         """Midea AC Climate set swing mode."""
-        swing_vertical, swing_horizontal = _SWING_MODE_MAP.get(
-            swing_mode, (False, False)
-        )
-        self._device.set_swing(
-            swing_vertical=swing_vertical,
-            swing_horizontal=swing_horizontal,
-        )
+        self._device.set_raw_swing_mode(swing_mode)
 
 
 class MideaCCClimate(MideaClimate):
@@ -481,16 +454,13 @@ class MideaCCClimate(MideaClimate):
     @override
     def fan_modes(self) -> list[str] | None:
         """Midea CC Climate fan modes."""
-        return self._device.fan_modes
+        return list(self._device.raw_fan_modes)
 
     @property
     @override
     def fan_mode(self) -> str | None:
         """Midea CC Climate fan mode."""
-        fan_mode = self._device.get_attribute(CCAttributes.fan_speed)
-        if not isinstance(fan_mode, str):
-            return None
-        return fan_mode
+        return self._device.raw_fan_mode
 
     @property
     @override
@@ -510,7 +480,7 @@ class MideaCCClimate(MideaClimate):
     @override
     def set_fan_mode(self, fan_mode: str) -> None:
         """Midea CC Climate set fan mode."""
-        self._device.set_attribute(attr=CCAttributes.fan_speed, value=fan_mode)
+        self._device.set_raw_fan_mode(fan_mode)
 
     @override
     def set_swing_mode(self, swing_mode: str) -> None:
@@ -554,10 +524,9 @@ class MideaCFClimate(MideaClimate):
         if hvac_mode == HVACMode.OFF:
             self.turn_off()
         else:
-            target_temperature = self.target_temperature or self.min_temp
-            self._device.set_target_temperature(
-                target_temperature=target_temperature,
-                mode=self._hvac_to_protocol_mode(hvac_mode),
+            self._device.set_raw_target_temperature(
+                target_temperature=self.target_temperature or self.min_temp,
+                hvac_mode=hvac_mode,
             )
 
     @property
@@ -709,7 +678,7 @@ class MideaC3Climate(MideaClimate):
         if hvac_mode == HVACMode.OFF:
             self.turn_off()
         else:
-            self._device.set_mode(self._zone, self._hvac_to_protocol_mode(hvac_mode))
+            self._device.set_raw_hvac_mode(hvac_mode, zone=self._zone)
 
 
 class MideaFBClimate(MideaClimate):

--- a/homeassistant/components/midea/config_flow.py
+++ b/homeassistant/components/midea/config_flow.py
@@ -14,6 +14,7 @@ from midealocal.const import DeviceType, ProtocolVersion
 from midealocal.device import MideaDevice
 from midealocal.devices import device_selector
 from midealocal.discover import discover
+from midealocal.exceptions import MideaCloudError
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -110,6 +111,8 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         self.supports: dict = {}
         self.cloud: MideaCloud | None = None
         self._login_data: dict[str, str] | None = None
+        self._cloud_error: str | None = None
+        self._cloud_error_code: int | None = None
         unsorted = dict(MIDEA_DEVICE_NAMES)
 
         # sort and assign supports
@@ -125,9 +128,32 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         self.preset_cloud_name: str = preset_account["cloud_name"]
 
     def _clear_login_state(self) -> None:
-        """Clear flow-scoped credentials and cloud."""
+        """Clear flow-scoped credentials and cloud.
+
+        The pending cloud error/code are intentionally left in place: this is
+        called right before re-showing a form that still needs to render that
+        error. They are refreshed on the next cloud call (``_check_cloud_login``
+        resets them) or when ``async_step_auto`` re-runs with input.
+        """
         self._login_data = None
         self.cloud = None
+
+    def _reset_cloud_error(self) -> None:
+        """Forget any cloud error carried over from a previous submit."""
+        self._cloud_error = None
+        self._cloud_error_code = None
+
+    def _form_error(self, error: str | None) -> dict[str, Any]:
+        """Build async_show_form error kwargs, adding the cloud error code if known."""
+        if not error:
+            return {"errors": None}
+        result: dict[str, Any] = {"errors": {"base": error}}
+        # only the cloud error slug carries a numeric code to show alongside it
+        if error == self._cloud_error and self._cloud_error_code is not None:
+            result["description_placeholders"] = {
+                "error_code": str(self._cloud_error_code)
+            }
+        return result
 
     def _already_configured(self, device_id: str, ip_address: str) -> bool:
         """Check device from json with device_id or ip address."""
@@ -195,7 +221,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                 cloud_server_options,
                 default_server,
                 user_input=user_input,
-                error="login_failed",
+                error=self._cloud_error or "login_failed",
             )
         # user not login, show login form in UI
         return self._show_login_credentials_form(
@@ -232,7 +258,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="login_credentials",
             data_schema=schema,
-            errors={"base": error} if error else None,
+            **self._form_error(error),
         )
 
     async def async_step_auth_method(
@@ -259,7 +285,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
 
             return await self.async_step_auth_method(
-                error="preset_login_failed",
+                error=self._cloud_error or "preset_login_failed",
             )
 
         return self.async_show_form(
@@ -280,7 +306,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                     ),
                 }
             ),
-            errors={"base": error} if error else None,
+            **self._form_error(error),
         )
 
     async def async_step_list(
@@ -383,8 +409,16 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                 account,
                 password,
             )
+        self._reset_cloud_error()
         # check cloud login after self.cloud exist
-        if await self.cloud.login():
+        try:
+            logged_in = await self.cloud.login()
+        except MideaCloudError as err:
+            LOGGER.debug("Cloud login to %s failed: %s", cloud_name, err)
+            self._cloud_error = err.translation_key
+            self._cloud_error_code = err.code
+            return False
+        if logged_in:
             LOGGER.debug(
                 "Cloud login succeeded for %s",
                 cloud_name,
@@ -408,7 +442,20 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         assert self.cloud is not None
 
         # get device token/key from cloud, plus the well-known default keys
-        keys = await self.cloud.get_cloud_keys(appliance_id)
+        try:
+            keys = await self.cloud.get_cloud_keys(appliance_id)
+        except MideaCloudError as err:
+            # A cloud rejection (e.g. code 3201) is not fatal: a V3 device may
+            # still authenticate with a built-in default key. Remember the error
+            # for display and keep going with the default keys only.
+            LOGGER.debug(
+                "Cloud rejected the token request for device %s: %s",
+                appliance_id,
+                err,
+            )
+            self._cloud_error = err.translation_key
+            self._cloud_error_code = err.code
+            keys = {}
         if default_key:
             keys = {**keys, **(await MideaCloud.get_default_keys())}
         error = "connect_error"
@@ -445,7 +492,10 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         LOGGER.debug(
             "Unable to connect device with all the token/key",
         )
-        return {"error": error}
+        result: dict[str, Any] = {"error": error}
+        if self._cloud_error is not None:
+            result["cloud_error"] = self._cloud_error
+        return result
 
     async def async_step_auto(
         self,
@@ -455,6 +505,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         """Discovery device detail info."""
         # input device exist
         if user_input is not None:
+            self._reset_cloud_error()
             device_id = user_input[CONF_DEVICE]
             device = self.devices[device_id]
             self.found_device = {
@@ -484,6 +535,10 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
 
                 # phase 1, try with user input login data
                 keys = await self._check_key_from_cloud(device_id)
+                # _check_key_from_cloud sets the pending cloud error/code on a
+                # cloud rejection; keep phase 1's in case phase 2 is less specific
+                phase1_error = self._cloud_error
+                phase1_error_code = self._cloud_error_code
 
                 # no available key, continue the phase 2
                 if not keys.get("token") or not keys.get("key"):
@@ -494,10 +549,14 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
 
                     # get key phase 2: reinit cloud with preset account
                     if not await self._check_cloud_login(force_login=True):
+                        # _check_cloud_login clears the pending error; if it only
+                        # returned False (no raise), fall back to phase 1's error.
+                        if not self._cloud_error and phase1_error:
+                            self._cloud_error = phase1_error
+                            self._cloud_error_code = phase1_error_code
+                        error = self._cloud_error or "preset_login_failed"
                         self._clear_login_state()
-                        return await self.async_step_auto(
-                            error="preset_login_failed",
-                        )
+                        return await self.async_step_auto(error=error)
                     # try to get a passed key, without default_key
                     keys = await self._check_key_from_cloud(
                         device_id,
@@ -510,10 +569,12 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                             "Can't get available token from Midea server for device %s",
                             device_id,
                         )
+                        if not self._cloud_error and phase1_error:
+                            self._cloud_error = phase1_error
+                            self._cloud_error_code = phase1_error_code
+                        error = self._cloud_error or "token_unavailable"
                         self._clear_login_state()
-                        return await self.async_step_auto(
-                            error="token_unavailable",
-                        )
+                        return await self.async_step_auto(error=error)
                 # get key pass
                 self.found_device[CONF_TOKEN] = keys["token"]
                 self.found_device[CONF_KEY] = keys["key"]
@@ -537,7 +598,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                     ): vol.In(self.available_device),
                 },
             ),
-            errors={"base": error} if error else None,
+            **self._form_error(error),
         )
 
     def _found_device_to_user_input(self) -> dict[str, Any]:
@@ -676,7 +737,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                 if not result:
                     return self._show_manually_form(
                         user_input,
-                        error="preset_login_failed",
+                        error=self._cloud_error or "preset_login_failed",
                     )
                 # try to get a passed key
                 keys = await self._check_key_from_cloud(int(user_input[CONF_DEVICE_ID]))
@@ -689,7 +750,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                     )
                     return self._show_manually_form(
                         user_input,
-                        error="token_unavailable",
+                        error=keys.get("cloud_error") or "token_unavailable",
                     )
 
                 # set token/key from preset account
@@ -770,5 +831,5 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="manually",
             data_schema=schema,
-            errors={"base": error} if error else None,
+            **self._form_error(error),
         )

--- a/homeassistant/components/midea/manifest.json
+++ b/homeassistant/components/midea/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "loggers": ["midealocal"],
   "quality_scale": "bronze",
-  "requirements": ["midea-local==10.1.0"]
+  "requirements": ["midea-local==11.0.1"]
 }

--- a/homeassistant/components/midea/strings.json
+++ b/homeassistant/components/midea/strings.json
@@ -4,7 +4,13 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
     "error": {
+      "account_locked": "Too many failed sign-in attempts. Wait about five minutes before trying again. (err {error_code})",
+      "cloud_error": "The Midea cloud returned an error. Check the logs for details and try again. (err {error_code})",
+      "cloud_session_expired": "The Midea cloud sign-in session is no longer valid. Try again. (err {error_code})",
       "device_auth_failed": "Could not connect with the provided configuration",
+      "device_not_registered": "This Midea cloud account is not authorized for this device. The device is registered to a different account. (err {error_code})",
+      "invalid_auth": "Invalid authentication (err {error_code})",
+      "invalid_cloud_server": "This account is not registered on the selected cloud server. Choose the server where the account was created. (err {error_code})",
       "invalid_device_id_for_ip": "The device ID does not match the selected IP address",
       "invalid_device_ip": "Could not find a supported device at this IP address",
       "invalid_token": "Token and key must be valid hexadecimal strings",
@@ -14,6 +20,7 @@
       "preset_login_failed": "Could not log in with the preset account",
       "protocol_mismatch": "The protocol does not match the discovered device",
       "token_unavailable": "Could not get a valid token and key from the cloud",
+      "too_many_logged_in_devices": "The Midea cloud account has too many active sign-ins. Sign out of the Midea app on other devices and try again. (err {error_code})",
       "type_mismatch": "The type does not match the discovered device"
     },
     "step": {

--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -126,7 +126,6 @@ class ThermostatEntity(ClimateEntity):
     @override
     async def async_added_to_hass(self) -> None:
         """Run when entity is added to register update signal handler."""
-        self._attr_supported_features = self._get_supported_features()
         self.async_on_remove(
             self._device.add_update_listener(self.async_write_ha_state)
         )
@@ -263,6 +262,12 @@ class ThermostatEntity(ClimateEntity):
         ):
             return FAN_INV_MODES
         return []
+
+    @property
+    @override
+    def supported_features(self) -> ClimateEntityFeature:
+        """Return the bitmap of supported features, computed from current traits."""
+        return self._get_supported_features()
 
     def _get_supported_features(self) -> ClimateEntityFeature:
         """Compute the bitmap of supported features from the current state."""

--- a/homeassistant/components/nibe_heatpump/sensor.py
+++ b/homeassistant/components/nibe_heatpump/sensor.py
@@ -164,6 +164,13 @@ UNIT_DESCRIPTIONS = {
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
     ),
+    "l/min": SensorEntityDescription(
+        key="l/min",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
+    ),
     "m³/h": SensorEntityDescription(
         key="m³/h",
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/homeassistant/components/openhome/__init__.py
+++ b/homeassistant/components/openhome/__init__.py
@@ -2,15 +2,15 @@
 
 import logging
 
-import aiohttp
-from async_upnp_client.client import UpnpError
 from openhomedevice.device import Device
+from openhomedevice.exceptions import OpenhomeError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
@@ -37,11 +37,11 @@ async def async_setup_entry(
     """Set up the configuration config entry."""
     _LOGGER.debug("Setting up config entry: %s", config_entry.unique_id)
 
-    device = await hass.async_add_executor_job(Device, config_entry.data[CONF_HOST])
+    device = Device(config_entry.data[CONF_HOST], session=async_get_clientsession(hass))
 
     try:
         await device.init()
-    except (TimeoutError, aiohttp.ClientError, UpnpError) as exc:
+    except OpenhomeError as exc:
         raise ConfigEntryNotReady from exc
 
     _LOGGER.debug("Initialised device: %s", device.uuid())

--- a/homeassistant/components/openhome/manifest.json
+++ b/homeassistant/components/openhome/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["async_upnp_client", "openhomedevice"],
-  "requirements": ["openhomedevice==2.2.0"],
+  "requirements": ["openhomedevice==2.5"],
   "ssdp": [
     {
       "st": "urn:av-openhome-org:service:Product:1"

--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -5,8 +5,7 @@ import functools
 import logging
 from typing import Any, Concatenate, override
 
-import aiohttp
-from async_upnp_client.client import UpnpError
+from openhomedevice.exceptions import OpenhomeError
 
 from homeassistant.components import media_source
 from homeassistant.components.media_player import (
@@ -58,7 +57,7 @@ type _ReturnFuncType[_T, **_P, _R] = Callable[
 def catch_request_errors[_OpenhomeDeviceT: OpenhomeDevice, **_P, _R]() -> Callable[
     [_FuncType[_OpenhomeDeviceT, _P, _R]], _ReturnFuncType[_OpenhomeDeviceT, _P, _R]
 ]:
-    """Catch TimeoutError, aiohttp.ClientError, UpnpError errors."""
+    """Catch OpenhomeError errors."""
 
     def call_wrapper(
         func: _FuncType[_OpenhomeDeviceT, _P, _R],
@@ -69,11 +68,11 @@ def catch_request_errors[_OpenhomeDeviceT: OpenhomeDevice, **_P, _R]() -> Callab
         async def wrapper(
             self: _OpenhomeDeviceT, *args: _P.args, **kwargs: _P.kwargs
         ) -> _R | None:
-            """Catch TimeoutError, aiohttp.ClientError, UpnpError errors."""
+            """Catch OpenhomeError errors."""
             try:
                 return await func(self, *args, **kwargs)
-            except TimeoutError, aiohttp.ClientError, UpnpError:
-                _LOGGER.error("Error during call %s", func.__name__)
+            except OpenhomeError as err:
+                _LOGGER.error("Error during call %s: %s", func.__name__, err)
             return None
 
         return wrapper
@@ -167,7 +166,9 @@ class OpenhomeDevice(MediaPlayerEntity):
                 self._attr_state = MediaPlayerState.PLAYING
 
             self._attr_available = True
-        except TimeoutError, aiohttp.ClientError, UpnpError:
+        except OpenhomeError as err:
+            if self._attr_available:
+                _LOGGER.warning("Error updating %s: %s", self.entity_id, err)
             self._attr_available = False
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
@@ -261,8 +262,8 @@ class OpenhomeDevice(MediaPlayerEntity):
                 await self._device.invoke_pin(pin)
             else:
                 _LOGGER.error("Pins service not supported")
-        except UpnpError:
-            _LOGGER.error("Error invoking pin %s", pin)
+        except OpenhomeError as err:
+            _LOGGER.error("Error invoking pin %s: %s", pin, err)
 
     # pylint: disable-next=home-assistant-action-swallowed-exception
     @catch_request_errors()

--- a/homeassistant/components/openhome/update.py
+++ b/homeassistant/components/openhome/update.py
@@ -3,8 +3,7 @@
 import logging
 from typing import Any, override
 
-import aiohttp
-from async_upnp_client.client import UpnpError
+from openhomedevice.exceptions import OpenhomeError
 
 from homeassistant.components.update import (
     UpdateDeviceClass,
@@ -92,7 +91,7 @@ class OpenhomeUpdateEntity(UpdateEntity):
         try:
             if self.latest_version:
                 await self._device.update_firmware()
-        except (TimeoutError, aiohttp.ClientError, UpnpError) as err:
+        except OpenhomeError as err:
             raise HomeAssistantError(
                 f"Error updating {self._device.device.friendly_name}: {err}"
             ) from err

--- a/homeassistant/components/portainer/coordinator.py
+++ b/homeassistant/components/portainer/coordinator.py
@@ -23,6 +23,7 @@ from pyportainer import (
 from pyportainer.models.docker import (
     DockerContainer,
     DockerContainerStats,
+    DockerDFType,
     DockerSystemDF,
     DockerVolume,
     DockerVolumeUsageData,
@@ -261,7 +262,9 @@ class PortainerCoordinator(
                     self.portainer.get_containers(endpoint.id),
                     self.portainer.docker_version(endpoint.id),
                     self.portainer.docker_info(endpoint.id),
-                    self.portainer.docker_system_df(endpoint.id, verbose=True),
+                    self.portainer.docker_system_df(
+                        endpoint.id, data_type=DockerDFType.VOLUME, verbose=True
+                    ),
                     self.portainer.get_volumes(endpoint.id),
                 )
 

--- a/homeassistant/components/remember_the_milk/manifest.json
+++ b/homeassistant/components/remember_the_milk/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["aiortm"],
   "quality_scale": "legacy",
-  "requirements": ["aiortm==0.20.0"]
+  "requirements": ["aiortm==0.20.1"]
 }

--- a/homeassistant/components/remote_calendar/client.py
+++ b/homeassistant/components/remote_calendar/client.py
@@ -18,5 +18,5 @@ async def get_calendar(
         url,
         auth=auth,
         follow_redirects=True,
-        timeout=Timeout(5, read=30, write=5, pool=5),
+        timeout=Timeout(5, connect=10, read=30),
     )

--- a/homeassistant/components/remote_calendar/config_flow.py
+++ b/homeassistant/components/remote_calendar/config_flow.py
@@ -71,12 +71,8 @@ class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
                     return await self.async_step_auth()
             if res.status_code == HTTPStatus.FORBIDDEN:
                 errors["base"] = "forbidden"
-                return self.async_show_form(
-                    step_id="user",
-                    data_schema=STEP_USER_DATA_SCHEMA,
-                    errors=errors,
-                )
-            res.raise_for_status()
+            else:
+                res.raise_for_status()
         except TimeoutException as err:
             errors["base"] = "timeout_connect"
             _LOGGER.debug(
@@ -86,18 +82,21 @@ class RemoteCalendarConfigFlow(ConfigFlow, domain=DOMAIN):
             errors["base"] = "cannot_connect"
             _LOGGER.debug("An error occurred: %s", str(err) or type(err).__name__)
         else:
-            try:
-                await parse_calendar(self.hass, res.text)
-            except InvalidIcsException:
-                errors["base"] = "invalid_ics_file"
-            else:
-                return self.async_create_entry(
-                    title=user_input[CONF_CALENDAR_NAME], data=user_input
-                )
+            if not errors:
+                try:
+                    await parse_calendar(self.hass, res.text)
+                except InvalidIcsException:
+                    errors["base"] = "invalid_ics_file"
+                else:
+                    return self.async_create_entry(
+                        title=user_input[CONF_CALENDAR_NAME], data=user_input
+                    )
 
         return self.async_show_form(
             step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA, user_input
+            ),
             errors=errors,
         )
 

--- a/homeassistant/components/remote_calendar/coordinator.py
+++ b/homeassistant/components/remote_calendar/coordinator.py
@@ -80,5 +80,4 @@ class RemoteCalendarDataUpdateCoordinator(DataUpdateCoordinator[Calendar]):
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="unable_to_parse",
-                translation_placeholders={"err": str(err)},
             ) from err

--- a/homeassistant/components/remote_calendar/ics.py
+++ b/homeassistant/components/remote_calendar/ics.py
@@ -39,6 +39,6 @@ async def parse_calendar(hass: HomeAssistant, ics: str) -> Calendar:
     try:
         return await hass.async_add_executor_job(_compat_calendar_from_ics, ics)
     except CalendarParseError as err:
-        _LOGGER.error("Error parsing calendar information: %s", err.message)
+        _LOGGER.error("The remote calendar feed contains invalid data: %s", err.message)
         _LOGGER.debug("Additional calendar error detail: %s", str(err.detailed_error))
         raise InvalidIcsException(err.message) from err

--- a/homeassistant/components/remote_calendar/strings.json
+++ b/homeassistant/components/remote_calendar/strings.json
@@ -9,7 +9,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "forbidden": "The server understood the request but refuses to authorize it.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_ics_file": "There was a problem reading the calendar information. See the error log for additional details.",
+      "invalid_ics_file": "The remote calendar feed contains invalid data. See the error log for additional details.",
       "timeout_connect": "[%key:common::config_flow::error::timeout_connect%]"
     },
     "step": {
@@ -47,7 +47,7 @@
       "message": "Unable to fetch calendar data. See the debug log for additional details."
     },
     "unable_to_parse": {
-      "message": "Unable to parse calendar data: {err}"
+      "message": "The remote calendar feed contains invalid data. See the error log for additional details."
     }
   },
   "title": "Remote Calendar"

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -20,5 +20,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.21.15"]
+  "requirements": ["reolink-aio==0.21.16"]
 }

--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -20,7 +20,7 @@
   "loggers": ["roborock"],
   "quality_scale": "silver",
   "requirements": [
-    "python-roborock==7.2.3",
+    "python-roborock==7.4.1",
     "vacuum-map-parser-roborock==0.1.5"
   ]
 }

--- a/homeassistant/components/roborock/manifest.json
+++ b/homeassistant/components/roborock/manifest.json
@@ -20,7 +20,7 @@
   "loggers": ["roborock"],
   "quality_scale": "silver",
   "requirements": [
-    "python-roborock==7.4.1",
+    "python-roborock==7.4.2",
     "vacuum-map-parser-roborock==0.1.5"
   ]
 }

--- a/homeassistant/components/roomba/sensor.py
+++ b/homeassistant/components/roomba/sensor.py
@@ -149,7 +149,7 @@ async def async_setup_entry(
     roomba = domain_data.roomba
     blid = domain_data.blid
 
-    sensor_list: list[RoombaSensorEntityDescription] = SENSORS
+    sensor_list: list[RoombaSensorEntityDescription] = list(SENSORS)
 
     has_dock: bool = len(roomba_reported_state(roomba).get("dock", {})) > 0
 

--- a/homeassistant/components/satel_integra/client.py
+++ b/homeassistant/components/satel_integra/client.py
@@ -6,6 +6,7 @@ from satel_integra import AsyncSatel
 from satel_integra.exceptions import (
     SatelConnectFailedError,
     SatelConnectionInitializationError,
+    SatelMonitoringStartError,
     SatelPanelBusyError,
 )
 
@@ -107,7 +108,13 @@ class SatelClient:
             output_changed_callback=outputs_update_callback,
         )
 
-        await self.controller.start(enable_monitoring=True)
+        try:
+            await self.controller.start(enable_monitoring=True)
+        except SatelMonitoringStartError as ex:
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="monitoring_start_failed",
+            ) from ex
 
     async def async_close(self) -> None:
         """Close the connection."""

--- a/homeassistant/components/satel_integra/manifest.json
+++ b/homeassistant/components/satel_integra/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "loggers": ["satel_integra"],
   "quality_scale": "bronze",
-  "requirements": ["satel-integra==1.3.1"]
+  "requirements": ["satel-integra==1.4.0"]
 }

--- a/homeassistant/components/satel_integra/manifest.json
+++ b/homeassistant/components/satel_integra/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "loggers": ["satel_integra"],
   "quality_scale": "bronze",
-  "requirements": ["satel-integra==1.4.0"]
+  "requirements": ["satel-integra==1.5.0"]
 }

--- a/homeassistant/components/satel_integra/strings.json
+++ b/homeassistant/components/satel_integra/strings.json
@@ -206,6 +206,9 @@
     "missing_output_access_code": {
       "message": "Cannot control switchable outputs because no user code is configured for this Satel Integra entry. Configure a code in the integration options to enable output control."
     },
+    "monitoring_start_failed": {
+      "message": "Connected to the alarm panel, but the panel did not confirm the request to start sending status updates."
+    },
     "panel_busy": {
       "message": "[%key:component::satel_integra::config::error::panel_busy%]"
     }

--- a/homeassistant/components/sftp_storage/__init__.py
+++ b/homeassistant/components/sftp_storage/__init__.py
@@ -10,9 +10,9 @@ from homeassistant.components.backup import BackupAgentError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 
-from .client import BackupAgentClient
+from .client import BackupAgentClient, SFTPConnectionError
 from .const import (
     CONF_BACKUP_LOCATION,
     CONF_PRIVATE_KEY_FILE,
@@ -55,6 +55,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: SFTPConfigEntry) -> bool
     try:
         client = BackupAgentClient(entry, hass)
         await client.open()
+    except SFTPConnectionError as e:
+        raise ConfigEntryNotReady(str(e)) from e
     except BackupAgentError as e:
         raise ConfigEntryError from e
 

--- a/homeassistant/components/sftp_storage/client.py
+++ b/homeassistant/components/sftp_storage/client.py
@@ -13,7 +13,7 @@ from asyncssh import (
     SSHClientConnectionOptions,
     connect,
 )
-from asyncssh.misc import PermissionDenied
+from asyncssh.misc import Error as SSHError, PermissionDenied
 from asyncssh.sftp import SFTPNoSuchFile, SFTPPermissionDenied
 
 from homeassistant.components.backup import (
@@ -27,6 +27,10 @@ from .const import BUF_SIZE, LOGGER
 
 if TYPE_CHECKING:
     from . import SFTPConfigEntry, SFTPConfigEntryData
+
+
+class SFTPConnectionError(BackupAgentError):
+    """Error raised when the SSH connection could not be established."""
 
 
 def get_client_options(cfg: SFTPConfigEntryData) -> SSHClientConnectionOptions:
@@ -295,11 +299,16 @@ class BackupAgentClient:
                     get_client_options, self.cfg.runtime_data
                 ),
             )
-        except (OSError, PermissionDenied) as e:
+        except PermissionDenied as e:
             raise BackupAgentError(
                 "Failure while attempting to establish SSH"
                 " connection. Please check SSH credentials"
                 " and if changed, re-install the integration"
+            ) from e
+        except (OSError, SSHError) as e:
+            raise SFTPConnectionError(
+                f"Failed to establish SSH connection to"
+                f" {self.cfg.runtime_data.host}: {e}"
             ) from e
 
         # Configure SFTP Client Connection
@@ -310,6 +319,10 @@ class BackupAgentClient:
             raise BackupAgentError(
                 "Failed to create SFTP client."
                 " Re-installing integration might be required"
+            ) from e
+        except (OSError, SSHError) as e:
+            raise SFTPConnectionError(
+                f"Failed to open SFTP session on {self.cfg.runtime_data.host}: {e}"
             ) from e
 
         return self

--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -1,5 +1,6 @@
 """Tesla Fleet integration."""
 
+import asyncio
 from typing import Final
 
 import jwt
@@ -35,6 +36,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 
 from .const import DOMAIN, LOGGER
 from .coordinator import (
+    VEHICLE_FIRST_REFRESH_TIMEOUT,
     TeslaFleetEnergySiteHistoryCoordinator,
     TeslaFleetEnergySiteInfoCoordinator,
     TeslaFleetEnergySiteLiveCoordinator,
@@ -177,7 +179,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
                 hass, entry, api_vehicle, product, Scope.VEHICLE_LOCATION in scopes
             )
 
-            await coordinator.async_config_entry_first_refresh()
+            # A sleeping vehicle can take minutes to answer vehicle_data; bound the
+            # first refresh so setup retries instead of stalling HA's bootstrap.
+            try:
+                async with asyncio.timeout(VEHICLE_FIRST_REFRESH_TIMEOUT):
+                    await coordinator.async_config_entry_first_refresh()
+            except TimeoutError as err:
+                raise ConfigEntryNotReady(
+                    f"Timed out waiting for vehicle {vin} to respond"
+                ) from err
 
             device = DeviceInfo(
                 identifiers={(DOMAIN, vin)},

--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -36,6 +36,11 @@ VEHICLE_WAIT_SECONDS = 900
 VEHICLE_WAIT = timedelta(seconds=VEHICLE_WAIT_SECONDS)
 VEHICLE_STUCK_SECONDS = 1200
 
+# Kept well under Home Assistant's stage-2 setup budget (SLOW_SETUP_MAX_WAIT, 300s)
+# so a sleeping vehicle raises ConfigEntryNotReady and the entry retries instead of
+# being cancelled into a non-retried setup error.
+VEHICLE_FIRST_REFRESH_TIMEOUT = 60
+
 ENERGY_INTERVAL_SECONDS = 60
 ENERGY_INTERVAL = timedelta(seconds=ENERGY_INTERVAL_SECONDS)
 ENERGY_HISTORY_INTERVAL = timedelta(minutes=5)

--- a/homeassistant/components/tesla_fleet/models.py
+++ b/homeassistant/components/tesla_fleet/models.py
@@ -1,7 +1,7 @@
 """The Tesla Fleet integration models."""
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from tesla_fleet_api.const import Scope
 from tesla_fleet_api.tesla import EnergySite, VehicleFleet
@@ -34,7 +34,7 @@ class TeslaFleetVehicleData:
     vin: str
     device: DeviceInfo
     signing: bool
-    wakelock = asyncio.Lock()
+    wakelock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
 @dataclass

--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -263,7 +263,7 @@ def async_device_wan_latency_value_fn(
         # Checked by async_device_wan_latency_supported_fn
         assert target
 
-    return target.get("latency_average", 0)
+    return target.get("latency_average")
 
 
 @callback

--- a/homeassistant/components/usage_prediction/common_control.py
+++ b/homeassistant/components/usage_prediction/common_control.py
@@ -1,15 +1,12 @@
 """Code to generate common control usage patterns."""
 
 from collections import Counter
-from collections.abc import Callable, Sequence
 from datetime import datetime, timedelta
 from functools import cache
 import logging
 from typing import Any, Literal, cast
 
 from sqlalchemy import select
-from sqlalchemy.engine.row import Row
-from sqlalchemy.orm import Session
 
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.db_schema import EventData, Events, EventTypes
@@ -29,6 +26,9 @@ _LOGGER = logging.getLogger(__name__)
 TIME_CATEGORIES = ["morning", "afternoon", "evening", "night"]
 
 RESULTS_TO_INCLUDE = 8
+
+# Rows fetched per round trip while streaming the events query
+QUERY_YIELD_PER = 4096
 
 # List of domains for which we want to track usage
 ALLOWED_DOMAINS = {
@@ -94,83 +94,16 @@ async def async_predict_common_control(
     recorder = get_instance(hass)
     ent_reg = er.async_get(hass)
 
-    # Execute the database operation in the recorder's executor
-    data = await recorder.async_add_executor_job(
-        _fetch_with_session, hass, _fetch_and_process_data, ent_reg, user_id
-    )
-    # Prepare a dictionary to track results
-    results: dict[str, Counter[str]] = {
-        time_cat: Counter() for time_cat in TIME_CATEGORIES
+    allowed_entities = {
+        entity_id
+        for entity_id in hass.states.async_entity_ids(ALLOWED_DOMAINS)
+        if not ((entry := ent_reg.async_get(entity_id)) and entry.hidden)
     }
 
-    allowed_entities = set(hass.states.async_entity_ids(ALLOWED_DOMAINS))
-    hidden_entities: set[str] = set()
-
-    # Keep track of contexts that we processed so that we will only process
-    # the first service call in a context, and not subsequent calls.
-    context_processed: set[bytes] = set()
-    # Execute the query
-    context_id: bytes
-    time_fired_ts: float
-    shared_data: str | None
-    local_time_zone = dt_util.get_default_time_zone()
-    for context_id, time_fired_ts, shared_data in data:
-        # Skip if we have already processed an event that was part of this context
-        if context_id in context_processed:
-            continue
-
-        # Mark this context as processed
-        context_processed.add(context_id)
-
-        # Parse the event data
-        if not time_fired_ts or not shared_data:
-            continue
-
-        try:
-            event_data = json_loads_object(shared_data)
-        except (ValueError, TypeError) as err:
-            _LOGGER.debug("Failed to parse event data: %s", err)
-            continue
-
-        # Empty event data, skipping
-        if not event_data:
-            continue
-
-        service_data = cast(dict[str, Any] | None, event_data.get("service_data"))
-
-        # No service data found, skipping
-        if not service_data:
-            continue
-
-        entity_ids: str | list[str] | None = service_data.get("entity_id")
-
-        # No entity IDs found, skip this event
-        if entity_ids is None:
-            continue
-
-        if not isinstance(entity_ids, list):
-            entity_ids = [entity_ids]
-
-        # Convert to local time for time category determination
-        period = time_category(
-            datetime.fromtimestamp(time_fired_ts, local_time_zone).hour
-        )
-        period_results = results[period]
-
-        # Count entity usage
-        for entity_id in entity_ids:
-            if entity_id not in allowed_entities or entity_id in hidden_entities:
-                continue
-
-            if (
-                entity_id not in period_results
-                and (entry := ent_reg.async_get(entity_id))
-                and entry.hidden
-            ):
-                hidden_entities.add(entity_id)
-                continue
-
-            period_results[entity_id] += 1
+    # Execute the database operation in the recorder's executor
+    results = await recorder.async_add_executor_job(
+        _fetch_and_process_data, hass, user_id, allowed_entities
+    )
 
     return EntityUsagePredictions(
         morning=[
@@ -190,9 +123,13 @@ async def async_predict_common_control(
 
 
 def _fetch_and_process_data(
-    session: Session, ent_reg: er.EntityRegistry, user_id: str
-) -> Sequence[Row[tuple[bytes | None, float | None, str | None]]]:
-    """Fetch and process service call events from the database."""
+    hass: HomeAssistant, user_id: str, allowed_entities: set[str]
+) -> dict[str, Counter[str]]:
+    """Count service call events per entity and time category.
+
+    Rows are streamed and reduced here so only the counters cross the
+    executor boundary; a busy user can have millions of matching events.
+    """
     thirty_days_ago_ts = (dt_util.utcnow() - timedelta(days=30)).timestamp()
     user_id_bytes = uuid_hex_to_bytes_or_none(user_id)
     if not user_id_bytes:
@@ -213,16 +150,69 @@ def _fetch_and_process_data(
         .where(EventTypes.event_type == "call_service")
         .order_by(Events.time_fired_ts)
     )
-    return session.connection().execute(query).all()
 
+    # Prepare a dictionary to track results
+    results: dict[str, Counter[str]] = {
+        time_cat: Counter() for time_cat in TIME_CATEGORIES
+    }
 
-def _fetch_with_session(
-    hass: HomeAssistant,
-    fetch_func: Callable[
-        [Session], Sequence[Row[tuple[bytes | None, float | None, str | None]]]
-    ],
-    *args: object,
-) -> Sequence[Row[tuple[bytes | None, float | None, str | None]]]:
-    """Execute a fetch function with a database session."""
+    # Keep track of contexts that we processed so that we will only process
+    # the first service call in a context, and not subsequent calls.
+    context_processed: set[bytes] = set()
+    local_time_zone = dt_util.get_default_time_zone()
+
+    context_id: bytes
+    time_fired_ts: float
+    shared_data: str | None
     with session_scope(hass=hass, read_only=True) as session:
-        return fetch_func(session, *args)
+        rows = session.connection().execute(query).yield_per(QUERY_YIELD_PER)
+        for context_id, time_fired_ts, shared_data in rows:
+            # Skip if we have already processed an event that was part of this context
+            if context_id in context_processed:
+                continue
+
+            # Mark this context as processed
+            context_processed.add(context_id)
+
+            # Parse the event data
+            if not time_fired_ts or not shared_data:
+                continue
+
+            try:
+                event_data = json_loads_object(shared_data)
+            except (ValueError, TypeError) as err:
+                _LOGGER.debug("Failed to parse event data: %s", err)
+                continue
+
+            # Empty event data, skipping
+            if not event_data:
+                continue
+
+            service_data = cast(dict[str, Any] | None, event_data.get("service_data"))
+
+            # No service data found, skipping
+            if not service_data:
+                continue
+
+            entity_ids: str | list[str] | None = service_data.get("entity_id")
+
+            # No entity IDs found, skip this event
+            if entity_ids is None:
+                continue
+
+            if not isinstance(entity_ids, list):
+                entity_ids = [entity_ids]
+
+            # Convert to local time for time category determination
+            period_results = results[
+                time_category(
+                    datetime.fromtimestamp(time_fired_ts, local_time_zone).hour
+                )
+            ]
+
+            # Count entity usage
+            for entity_id in entity_ids:
+                if entity_id in allowed_entities:
+                    period_results[entity_id] += 1
+
+    return results

--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -11,6 +11,7 @@ from PyViCare.PyViCareOAuthManager import obtain_token_via_basic_auth_pkce
 from PyViCare.PyViCareUtils import (
     PyViCareInvalidConfigurationError,
     PyViCareInvalidCredentialsError,
+    PyViCareRateLimitError,
 )
 
 from homeassistant.components.application_credentials import (
@@ -169,6 +170,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ViCareConfigEntry) -> bo
         PyViCareInvalidCredentialsError,
     ) as err:
         raise ConfigEntryAuthFailed("Authentication failed") from err
+    except PyViCareRateLimitError as err:
+        # The quota recovers on its own.
+        raise ConfigEntryNotReady(
+            f"ViCare API rate limit exceeded, resets at {err.limitResetDate}"
+        ) from err
 
     device_count = len(entry.runtime_data.devices)
     coordinators: list[ViCareCoordinator] = []

--- a/homeassistant/components/vicare/manifest.json
+++ b/homeassistant/components/vicare/manifest.json
@@ -13,5 +13,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["PyViCare"],
-  "requirements": ["PyViCare==2.62.0"]
+  "requirements": ["PyViCare==2.62.1"]
 }

--- a/homeassistant/components/vizio/coordinator.py
+++ b/homeassistant/components/vizio/coordinator.py
@@ -151,10 +151,10 @@ class VizioDeviceCoordinator(DataUpdateCoordinator[VizioDeviceData]):
             update_interval=SCAN_INTERVAL,
         )
         self.device = device
-        # Modern firmware bundles power/input/app state into one endpoint;
+        # Modern TV firmware bundles power/input/app state into one endpoint;
         # firmware without it never gains it, so probe only until the first
-        # URI_NOT_FOUND response.
-        self._use_state_extended = True
+        # URI_NOT_FOUND response. Audio devices do not support this endpoint.
+        self._use_state_extended = device.profile.has_inputs
 
     @override
     async def _async_setup(self) -> None:

--- a/homeassistant/components/vizio/manifest.json
+++ b/homeassistant/components/vizio/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["vizaio"],
-  "requirements": ["vizaio==0.6.1"],
+  "requirements": ["vizaio==0.6.2"],
   "zeroconf": ["_viziocast._tcp.local."]
 }

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -208,12 +208,17 @@ class VizioDevice(VizioEntity, MediaPlayerEntity):
                     else ()
                 ),
             )
-            # find_app_name returns None on a catalog miss; the app_name state
-            # attribute contract expects the UNKNOWN_APP sentinel instead
+            # A catalog miss only warrants the UNKNOWN_APP sentinel on the app
+            # input; HDMI and the like report a config that is never an app.
             if app_name == NO_APP_RUNNING:
                 self._attr_app_name = None
             elif app_name is None:
-                self._attr_app_name = UNKNOWN_APP
+                self._attr_app_name = (
+                    UNKNOWN_APP
+                    if self._current_input is not None
+                    and is_app_input(self._current_input)
+                    else None
+                )
             else:
                 self._attr_app_name = app_name
 

--- a/homeassistant/components/waterfurnace/manifest.json
+++ b/homeassistant/components/waterfurnace/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["waterfurnace"],
   "quality_scale": "bronze",
-  "requirements": ["waterfurnace==1.7.1"]
+  "requirements": ["waterfurnace==1.9.0"]
 }

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -201,6 +201,7 @@ class LgWebOSMediaPlayerEntity(WebOsTvEntity, RestoreEntity, MediaPlayerEntity):
         tv_state = self._client.tv_state
         source_list = self._source_list
         self._source_list = {}
+        self._current_source = None
         conf_sources = self._sources
 
         found_live_tv = False

--- a/homeassistant/components/weheat/application_credentials.py
+++ b/homeassistant/components/weheat/application_credentials.py
@@ -1,11 +1,23 @@
 """application_credentials platform the Weheat integration."""
 
-from homeassistant.components.application_credentials import AuthorizationServer
+from homeassistant.components.application_credentials import ClientCredential
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    LocalOAuth2ImplementationWithPkce,
+)
 
 from .const import OAUTH2_AUTHORIZE, OAUTH2_TOKEN
 
 
-async def async_get_authorization_server(hass: HomeAssistant) -> AuthorizationServer:
-    """Return authorization server."""
-    return AuthorizationServer(authorize_url=OAUTH2_AUTHORIZE, token_url=OAUTH2_TOKEN)
+async def async_get_auth_implementation(
+    hass: HomeAssistant, auth_domain: str, credential: ClientCredential
+) -> LocalOAuth2ImplementationWithPkce:
+    """Return auth implementation with PKCE support."""
+    return LocalOAuth2ImplementationWithPkce(
+        hass,
+        auth_domain,
+        credential.client_id,
+        OAUTH2_AUTHORIZE,
+        OAUTH2_TOKEN,
+        credential.client_secret,
+    )

--- a/homeassistant/components/xbox/strings.json
+++ b/homeassistant/components/xbox/strings.json
@@ -93,7 +93,7 @@
     },
     "sensor": {
       "follower": {
-        "name": "Follower",
+        "name": "Followers",
         "unit_of_measurement": "[%key:component::xbox::entity::sensor::following::unit_of_measurement%]"
       },
       "following": {

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -23,7 +23,7 @@
     "universal_silabs_flasher",
     "serialx"
   ],
-  "requirements": ["zha==2.2.1", "zha-quirks==2.2.1"],
+  "requirements": ["zha==2.2.2", "zha-quirks==2.2.2"],
   "usb": [
     {
       "description": "*2652*",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2026
 MINOR_VERSION: Final = 9
-PATCH_VERSION: Final = "1"
+PATCH_VERSION: Final = "2"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 14, 2)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -40,7 +40,7 @@ habluetooth==6.26.11
 hass-nabucasa==2.7.0
 hassil==3.12.0
 home-assistant-bluetooth==2.0.0
-home-assistant-frontend==20260826.6
+home-assistant-frontend==20260826.7
 home-assistant-intents==2026.8.28
 httpx==0.28.1
 ifaddr==0.2.0

--- a/pylint/plugins/pylint_home_assistant/generated/mdi_icons.py
+++ b/pylint/plugins/pylint_home_assistant/generated/mdi_icons.py
@@ -5,7 +5,7 @@ To update, run python3 -m script.hassfest
 
 from typing import Final
 
-FRONTEND_VERSION: Final[str] = "20260826.6"
+FRONTEND_VERSION: Final[str] = "20260826.7"
 
 MDI_ICONS: Final[set[str]] = {
     "ab-testing",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant"
-version = "2026.9.1"
+version = "2026.9.2"
 license = "Apache-2.0"
 license-files = ["LICENSE*", "homeassistant/backports/LICENSE*"]
 description = "Open-source home automation platform running on Python 3."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -142,7 +142,7 @@ adax==0.4.0
 adb-shell[async]==0.4.4
 
 # homeassistant.components.alarmdecoder
-adext==0.4.4
+adext==0.4.7
 
 # homeassistant.components.adguard
 adguardhome==0.8.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -133,7 +133,7 @@ WSDiscovery==2.1.2
 accuweather==5.1.0
 
 # homeassistant.components.actron_air
-actron-neo-api==0.5.14
+actron-neo-api==0.5.16
 
 # homeassistant.components.adax
 adax==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -495,7 +495,7 @@ airgradient==0.10.0
 airly==1.1.0
 
 # homeassistant.components.airos
-airos==0.6.9
+airos==0.6.12
 
 # homeassistant.components.airpatrol
 airpatrol==0.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3376,7 +3376,7 @@ vilfo-api-client==0.5.0
 visionpluspython==1.1.0
 
 # homeassistant.components.vizio
-vizaio==0.6.1
+vizaio==0.6.2
 
 # homeassistant.components.caldav
 vobject==0.9.9

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1815,7 +1815,7 @@ openai==2.45.0
 openerz-api==0.3.0
 
 # homeassistant.components.openhome
-openhomedevice==2.2.0
+openhomedevice==2.5
 
 # homeassistant.components.openrgb
 openrgb-python==0.3.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3016,7 +3016,7 @@ samsungtvws[async,encrypted]==3.0.5
 sanix==1.0.6
 
 # homeassistant.components.satel_integra
-satel-integra==1.3.1
+satel-integra==1.4.0
 
 # homeassistant.components.screenlogic
 screenlogicpy==0.10.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2956,7 +2956,7 @@ renault-api==0.5.13
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.21.15
+reolink-aio==0.21.16
 
 # homeassistant.components.radio_frequency
 rf-protocols==4.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1611,7 +1611,7 @@ micloud==0.5
 microBeesPy==0.3.5
 
 # homeassistant.components.midea
-midea-local==10.1.0
+midea-local==11.0.1
 
 # homeassistant.components.mill
 mill-local==0.5.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3522,10 +3522,10 @@ zeroconf==0.151.1
 zeversolar==0.3.2
 
 # homeassistant.components.zha
-zha-quirks==2.2.1
+zha-quirks==2.2.2
 
 # homeassistant.components.zha
-zha==2.2.1
+zha==2.2.2
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.19

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1103,7 +1103,7 @@ gatus-api==1.2.0
 gazetteer-matcher==1.1.0
 
 # homeassistant.components.google
-gcal-sync==9.1.0
+gcal-sync==9.1.1
 
 # homeassistant.components.aladdin_connect
 genie-partner-sdk==1.0.11

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3407,7 +3407,7 @@ wallbox==0.9.0
 watchdog==6.0.0
 
 # homeassistant.components.waterfurnace
-waterfurnace==1.7.1
+waterfurnace==1.9.0
 
 # homeassistant.components.watergate
 watergate-local-api==2026.2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -102,7 +102,7 @@ PyTransportNSW==0.1.1
 PyTurboJPEG==1.8.3
 
 # homeassistant.components.vicare
-PyViCare==2.62.0
+PyViCare==2.62.1
 
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.14.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2793,7 +2793,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==7.4.1
+python-roborock==7.4.2
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.47

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2202,7 +2202,7 @@ pyegps==0.2.5
 pyemoncms==0.1.3
 
 # homeassistant.components.enphase_envoy
-pyenphase==4.0.1
+pyenphase==4.0.3
 
 # homeassistant.components.envertech_evt800
 pyenvertechevt800==0.2.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2075,7 +2075,7 @@ pyaprilaire==0.9.1
 pyaqvify==0.0.12
 
 # homeassistant.components.atag
-pyatag==0.3.5.3
+pyatag==0.3.7.1
 
 # homeassistant.components.netatmo
 pyatmo==9.9.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2793,7 +2793,7 @@ python-rabbitair==0.0.8
 python-ripple-api==0.0.3
 
 # homeassistant.components.roborock
-python-roborock==7.2.3
+python-roborock==7.4.1
 
 # homeassistant.components.smarttub
 python-smarttub==0.0.47

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3016,7 +3016,7 @@ samsungtvws[async,encrypted]==3.0.5
 sanix==1.0.6
 
 # homeassistant.components.satel_integra
-satel-integra==1.4.0
+satel-integra==1.5.0
 
 # homeassistant.components.screenlogic
 screenlogicpy==0.10.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -413,7 +413,7 @@ aiorecollect==2023.09.0
 aioridwell==2025.09.0
 
 # homeassistant.components.remember_the_milk
-aiortm==0.20.0
+aiortm==0.20.1
 
 # homeassistant.components.ruckus_unleashed
 aioruckus==0.46.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1303,7 +1303,7 @@ hole==0.9.2
 holidays==0.103
 
 # homeassistant.components.frontend
-home-assistant-frontend==20260826.6
+home-assistant-frontend==20260826.7
 
 # homeassistant.components.conversation
 home-assistant-intents==2026.8.28

--- a/tests/components/alexa_devices/test_select.py
+++ b/tests/components/alexa_devices/test_select.py
@@ -108,6 +108,7 @@ async def test_offline_device(
 
 async def test_service_select_option(
     hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
     mock_amazon_devices_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
@@ -118,6 +119,9 @@ async def test_service_select_option(
     }
 
     await setup_integration(hass, mock_config_entry)
+
+    # A single account-wide entity is created regardless of the number of devices
+    assert "does not generate unique IDs" not in caplog.text
 
     assert (state := hass.states.get(ENTITY_ID_2))
     assert state.state == TEST_DEVICE_1.account_name

--- a/tests/components/atag/test_climate.py
+++ b/tests/components/atag/test_climate.py
@@ -98,7 +98,7 @@ async def test_update_failed(
     """Test data is not destroyed on update failure."""
     entry = await init_integration(hass, aioclient_mock)
     await async_setup_component(hass, HA_DOMAIN, {})
-    assert hass.states.get(CLIMATE_ID).state == HVACMode.HEAT
+    assert hass.states.get(CLIMATE_ID).state == HVACMode.AUTO
     coordinator = entry.runtime_data
     with patch("pyatag.AtagOne.update", side_effect=TimeoutError) as updater:
         await coordinator.async_refresh()

--- a/tests/components/esphome/test_dashboard.py
+++ b/tests/components/esphome/test_dashboard.py
@@ -7,6 +7,7 @@ from aioesphomeapi import APIClient, DeviceInfo, InvalidEncryptionKeyAPIError
 import pytest
 
 from homeassistant.components.esphome import CONF_NOISE_PSK, DOMAIN, dashboard
+from homeassistant.components.hassio import HassioNotReadyError
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -108,6 +109,35 @@ async def test_restore_dashboard_storage_skipped_if_addon_uninstalled(
         await hass.async_block_till_done()
         assert "test-slug is no longer installed" in caplog.text
         assert not mock_dashboard_api.called
+
+
+@pytest.mark.usefixtures("hassio_stubs")
+async def test_restore_dashboard_storage_if_supervisor_not_ready(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Restore the dashboard, without failing setup, if Supervisor is not ready."""
+    hass_storage[dashboard.STORAGE_KEY] = {
+        "version": dashboard.STORAGE_VERSION,
+        "minor_version": dashboard.STORAGE_VERSION,
+        "key": dashboard.STORAGE_KEY,
+        "data": {"info": {"addon_slug": "test-slug", "host": "new-host", "port": 6052}},
+    }
+    with (
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI"
+        ) as mock_dashboard_api,
+        patch(
+            "homeassistant.components.esphome.dashboard.is_hassio", return_value=True
+        ),
+        patch(
+            "homeassistant.components.hassio.get_addons_info",
+            side_effect=HassioNotReadyError,
+        ),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+        assert mock_dashboard_api.mock_calls[0][1][0] == "http://new-host:6052"
 
 
 async def test_setup_dashboard_fails(

--- a/tests/components/go2rtc/test_server.py
+++ b/tests/components/go2rtc/test_server.py
@@ -425,3 +425,48 @@ async def test_server_restart_error(
     assert "Unexpected error when restarting go2rtc server" in caplog.text
 
     await server.stop()
+
+
+@pytest.mark.parametrize(
+    ("server_stdout", "expected_stdout"),
+    [
+        (
+            [
+                "09:00:03.467 INF [api] listen addr=127.0.0.1:1984",
+                "10:27:02.622 WRN producer.go:170 >"
+                ' error="read tcp 192.168.1.96:42550->192.168.1.145:554: i/o timeout"'
+                " url=rtsp://admin:hunter2@192.168.1.145:554/Preview_01_sub",
+                "10:27:02.623 WRN [streams] url=http://192.168.1.145/snapshot"
+                "?auth=token&channel=0&user=admin&password=hunter2",
+                "10:27:02.624 WRN [streams] url=http://camera.local"
+                "?user=alice@example.com",
+            ],
+            [
+                "10:27:02.622 WRN producer.go:170 >"
+                ' error="read tcp 192.168.1.96:42550->192.168.1.145:554: i/o timeout"'
+                " url=rtsp://****@192.168.1.145:554/Preview_01_sub",
+                "10:27:02.623 WRN [streams] url=http://192.168.1.145/snapshot"
+                "?auth=****&channel=0&user=****&password=****",
+                "10:27:02.624 WRN [streams] url=http://camera.local?user=****",
+            ],
+        )
+    ],
+)
+@pytest.mark.usefixtures("mock_tempfile", "rest_client")
+async def test_credentials_redacted_from_server_output(
+    hass: HomeAssistant,
+    mock_create_subprocess: MagicMock,
+    server: Server,
+    caplog: pytest.LogCaptureFixture,
+    expected_stdout: list[str],
+) -> None:
+    """Test credentials in urls are redacted from the logged server output."""
+    await server.start()
+    await hass.async_block_till_done()
+
+    assert_server_output_logged(expected_stdout, caplog, logging.WARNING)
+    assert "hunter2" not in caplog.text
+    assert "token" not in caplog.text
+    assert "alice@example.com" not in caplog.text
+
+    await server.stop()

--- a/tests/components/hive/test_config_flow.py
+++ b/tests/components/hive/test_config_flow.py
@@ -1,8 +1,9 @@
 """Test the Hive config flow."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from apyhiveapi.helper import hive_exceptions
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.hive.const import CONF_CODE, CONF_DEVICE_NAME, DOMAIN
@@ -25,8 +26,13 @@ MFA_RESEND_CODE = "0000"
 MFA_INVALID_CODE = "HIVE"
 
 
-async def test_user_flow(hass: HomeAssistant) -> None:
-    """Test the user flow."""
+@pytest.mark.parametrize(
+    "username",
+    [USERNAME, USERNAME.upper()],
+    ids=["lowercase", "uppercase"],
+)
+async def test_user_flow(hass: HomeAssistant, username: str) -> None:
+    """Test the user flow normalizes the username for Hive auth."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -35,31 +41,31 @@ async def test_user_flow(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
     with (
+        patch("homeassistant.components.hive.config_flow.Auth") as mock_auth,
         patch(
-            "homeassistant.components.hive.config_flow.Auth.login",
+            "homeassistant.components.hive.async_setup_entry",
+            return_value=True,
+        ) as mock_setup_entry,
+    ):
+        mock_auth.return_value.login = AsyncMock(
             return_value={
                 "ChallengeName": "SUCCESS",
                 "AuthenticationResult": {
                     "RefreshToken": "mock-refresh-token",
                     "AccessToken": "mock-access-token",
                 },
-            },
-        ),
-        patch(
-            "homeassistant.components.hive.async_setup_entry",
-            return_value=True,
-        ) as mock_setup_entry,
-    ):
+            }
+        )
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {CONF_USERNAME: USERNAME, CONF_PASSWORD: PASSWORD},
+            {CONF_USERNAME: username, CONF_PASSWORD: PASSWORD},
         )
         await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == USERNAME
+    assert result["title"] == username
     assert result["data"] == {
-        CONF_USERNAME: USERNAME,
+        CONF_USERNAME: username,
         CONF_PASSWORD: PASSWORD,
         "tokens": {
             "AuthenticationResult": {
@@ -69,9 +75,10 @@ async def test_user_flow(hass: HomeAssistant) -> None:
             "ChallengeName": "SUCCESS",
         },
     }
-
+    assert mock_auth.call_args.kwargs["username"] == username.lower()
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert hass.config_entries.async_entries(DOMAIN)[0].unique_id == username.lower()
 
 
 async def test_user_flow_with_no_2fa(hass: HomeAssistant) -> None:
@@ -734,7 +741,7 @@ async def test_abort_if_existing_entry(hass: HomeAssistant) -> None:
         DOMAIN,
         context={"source": config_entries.SOURCE_USER},
         data={
-            CONF_USERNAME: USERNAME,
+            CONF_USERNAME: USERNAME.upper(),
             CONF_PASSWORD: PASSWORD,
         },
     )

--- a/tests/components/local_todo/conftest.py
+++ b/tests/components/local_todo/conftest.py
@@ -55,7 +55,9 @@ class FakeStore(LocalTodoListStore):
     def _mock_exists(self) -> bool:
         return self._mock_path.read_text.return_value is not None
 
-    def _mock_write_text(self, content: str) -> None:
+    def _mock_write_text(self, content: str, encoding: str | None = None) -> None:
+        if encoding is None:
+            content.encode("ascii")
         self._mock_path.read_text.return_value = content
 
 

--- a/tests/components/local_todo/test_todo.py
+++ b/tests/components/local_todo/test_todo.py
@@ -23,8 +23,9 @@ from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from .conftest import TEST_ENTITY
+from .conftest import TEST_ENTITY, TODO_NAME
 
+from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
 
 type WsGetItemsType = Callable[[], Coroutine[Any, Any, list[dict[str, str]]]]
@@ -877,3 +878,219 @@ async def test_reset_item_via_update(
     state = hass.states.get(TEST_ENTITY)
     assert state
     assert state.state == "1"
+
+
+@pytest.mark.parametrize(
+    ("ics_content", "expected_description"),
+    [
+        pytest.param(
+            (
+                "BEGIN:VCALENDAR\n"
+                "PRODID:-//homeassistant.io//local_todo 2.0//EN\n"
+                "VERSION:2.0\n"
+                "BEGIN:VTODO\n"
+                "DTSTAMP:20260205T183141Z\n"
+                "UID:077cb7f2-6c89-11ee-b2a9-0242ac110002\n"
+                "CREATED:20260205T183141Z\n"
+                "SEQUENCE:0\n"
+                "STATUS:NEEDS-ACTION\n"
+                "SUMMARY:Notizen\n"
+                "DESCRIPTION:Einkaufsliste\n\\nMilch\n\\nBrot\n"
+                "END:VTODO\n"
+                "END:VCALENDAR\n"
+            ),
+            "Einkaufsliste\nMilch\nBrot",
+            id="universal_newlines",
+        ),
+        pytest.param(
+            (
+                "BEGIN:VCALENDAR\r\n"
+                "PRODID:-//homeassistant.io//local_todo 2.0//EN\r\n"
+                "VERSION:2.0\r\n"
+                "BEGIN:VTODO\r\n"
+                "DTSTAMP:20260205T183141Z\r\n"
+                "UID:077cb7f2-6c89-11ee-b2a9-0242ac110002\r\n"
+                "CREATED:20260205T183141Z\r\n"
+                "SEQUENCE:0\r\n"
+                "STATUS:NEEDS-ACTION\r\n"
+                "SUMMARY:Notizen\r\n"
+                "DESCRIPTION:Einkaufsliste\r\\nMilch\r\\nBrot\r\n"
+                "END:VTODO\r\n"
+                "END:VCALENDAR\r\n"
+            ),
+            "Einkaufsliste\nMilch\nBrot",
+            id="raw_crlf",
+        ),
+        pytest.param(
+            (
+                "BEGIN:VCALENDAR\n"
+                "PRODID:-//homeassistant.io//local_todo 2.0//EN\n"
+                "VERSION:2.0\n"
+                "BEGIN:VTODO\n"
+                "DTSTAMP:20260205T183141Z\n"
+                "UID:077cb7f2-6c89-11ee-b2a9-0242ac110002\n"
+                "CREATED:20260205T183141Z\n"
+                "SEQUENCE:0\n"
+                "STATUS:NEEDS-ACTION\n"
+                "SUMMARY:Notizen\n"
+                "DESCRIPTION:Line 1\n\\n\n\\nLine 2\n"
+                "END:VTODO\n"
+                "END:VCALENDAR\n"
+            ),
+            "Line 1\n\nLine 2",
+            id="consecutive_newlines",
+        ),
+    ],
+)
+async def test_repair_legacy_crlf_on_setup(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    ws_get_items: WsGetItemsType,
+    caplog: pytest.LogCaptureFixture,
+    expected_description: str,
+) -> None:
+    """Test repairing malformed ICS content from ical <= 12.1.3 CRLF bug on setup."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        f"Repaired malformed iCalendar file for to-do list {TODO_NAME}" in caplog.text
+    )
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state is not None
+    assert state.state == "1"
+
+    items = await ws_get_items()
+    assert len(items) == 1
+    assert items[0]["summary"] == "Notizen"
+    assert items[0]["description"] == expected_description
+
+    # Verify that the file was re-saved cleanly to storage without any invalid lines
+    store = config_entry.runtime_data
+    re_saved = store._mock_path.read_text.return_value
+    assert "\r" not in re_saved
+    assert "\n\\n" not in re_saved
+
+
+@pytest.mark.parametrize(
+    "ics_content",
+    [
+        (
+            "BEGIN:VCALENDAR\n"
+            "PRODID:-//homeassistant.io//local_todo 1.0//EN\n"
+            "VERSION:2.0\n"
+            "BEGIN:VTODO\n"
+            "DTSTAMP:20231024T014011\n"
+            "UID:077cb7f2-6c89-11ee-b2a9-0242ac110002\n"
+            "CREATED:20231017T010348\n"
+            "SEQUENCE:1\n"
+            "STATUS:NEEDS-ACTION\n"
+            "SUMMARY:Task\n"
+            "DESCRIPTION:Line 1\n\\nLine 2\n"
+            "DUE:20231023\n"
+            "END:VTODO\n"
+            "END:VCALENDAR\n"
+        )
+    ],
+)
+async def test_repair_and_migrate_legacy_due_date(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    ws_get_items: WsGetItemsType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that repaired legacy 1.0 calendars also undergo due date migration."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        f"Repaired malformed iCalendar file for to-do list {TODO_NAME}" in caplog.text
+    )
+
+    items = await ws_get_items()
+    assert len(items) == 1
+    assert items[0]["description"] == "Line 1\nLine 2"
+    assert items[0]["due"] == "2023-10-23"
+
+    store = config_entry.runtime_data
+    re_saved = store._mock_path.read_text.return_value
+    assert "PRODID:-//homeassistant.io//local_todo 2.0//EN" in re_saved
+    assert "DUE;VALUE=DATE:20231024" in re_saved
+
+
+async def test_description_newlines_preserved(
+    hass: HomeAssistant,
+    setup_integration: None,
+    config_entry: MockConfigEntry,
+    ws_get_items: WsGetItemsType,
+) -> None:
+    """Test that newlines in descriptions are preserved through service calls and reload."""
+    description = "Line 1\nLine 2\n\nLine 3"
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.ADD_ITEM,
+        {
+            ATTR_ITEM: "Item 1",
+            ATTR_DESCRIPTION: description,
+        },
+        target={ATTR_ENTITY_ID: TEST_ENTITY},
+        blocking=True,
+    )
+
+    items = await ws_get_items()
+    assert len(items) == 1
+    assert items[0]["description"] == description
+
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.UPDATE_ITEM,
+        {
+            ATTR_ITEM: items[0]["uid"],
+            ATTR_DESCRIPTION: f"Updated\n{description}",
+        },
+        target={ATTR_ENTITY_ID: TEST_ENTITY},
+        blocking=True,
+    )
+
+    items = await ws_get_items()
+    assert len(items) == 1
+    assert items[0]["description"] == f"Updated\n{description}"
+
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    items = await ws_get_items()
+    assert len(items) == 1
+    assert items[0]["description"] == f"Updated\n{description}"
+
+
+async def test_crlf_description_preserved_on_reload(
+    hass: HomeAssistant,
+    setup_integration: None,
+    config_entry: MockConfigEntry,
+    ws_get_items: WsGetItemsType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that items added with CRLF descriptions are saved cleanly and load on reload."""
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.ADD_ITEM,
+        {
+            ATTR_ITEM: "Item CRLF",
+            ATTR_DESCRIPTION: "Line 1\r\nLine 2\r\n\r\nLine 3",
+        },
+        target={ATTR_ENTITY_ID: TEST_ENTITY},
+        blocking=True,
+    )
+
+    # After reload from storage, newlines are preserved as LF and no repair warning is logged
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    items = await ws_get_items()
+    assert len(items) == 1
+    assert items[0]["description"] == "Line 1\nLine 2\n\nLine 3"
+    assert "Repaired malformed iCalendar file" not in caplog.text

--- a/tests/components/local_todo/test_todo.py
+++ b/tests/components/local_todo/test_todo.py
@@ -98,6 +98,10 @@ EXPECTED_ADD_ITEM = {
         ),
         ({ATTR_DESCRIPTION: ""}, {**EXPECTED_ADD_ITEM, "description": ""}),
         ({ATTR_DESCRIPTION: None}, EXPECTED_ADD_ITEM),
+        (
+            {ATTR_ITEM: "测试主卧清扫"},
+            {**EXPECTED_ADD_ITEM, "summary": "测试主卧清扫"},
+        ),
     ],
 )
 async def test_add_item(

--- a/tests/components/mcp/test_config_flow.py
+++ b/tests/components/mcp/test_config_flow.py
@@ -119,6 +119,7 @@ async def test_form(
     assert result["result"].unique_id is None
 
     assert len(mock_setup_entry.mock_calls) == 1
+    mock_mcp_client.return_value.initialize.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/components/midea/conftest.py
+++ b/tests/components/midea/conftest.py
@@ -46,11 +46,12 @@ class DummyDevice:
         self.subtype = TEST_SUBTYPE
         self.available = False
         self.attributes = attributes or {}
-        self.capabilities: dict[str, Any] = {}
         self._callbacks: list[Callable] = []
         self.calls: list[tuple] = []
         self.temperature_step = 1
-        self.fan_modes = ["Low", "Medium", "High", "Auto"]
+        self.raw_hvac_modes = ["off", "auto", "cool", "dry", "heat", "fan_only"]
+        self.raw_fan_modes = ["low", "medium", "high", "auto"]
+        self.raw_fan_mode: str | None = "high"
         self.modes = [
             "Auto",
             "ECO",
@@ -88,17 +89,21 @@ class DummyDevice:
         self.notify_update({attr: value})
         self.calls.append(("set_attribute", attr, value))
 
-    def set_target_temperature(self, **kwargs: Any) -> None:
+    def set_raw_target_temperature(self, **kwargs: Any) -> None:
         """Record set target temperature call."""
-        self.calls.append(("set_target_temperature", kwargs))
+        self.calls.append(("set_raw_target_temperature", kwargs))
 
-    def set_swing(self, **kwargs: Any) -> None:
-        """Record set swing call."""
-        self.calls.append(("set_swing", kwargs))
+    def set_raw_swing_mode(self, swing_mode: str) -> None:
+        """Record set swing mode call."""
+        self.calls.append(("set_raw_swing_mode", swing_mode))
 
-    def set_mode(self, zone: int, mode: int) -> None:
-        """Record set mode call."""
-        self.calls.append(("set_mode", zone, mode))
+    def set_raw_fan_mode(self, fan_mode: str) -> None:
+        """Record set fan mode call."""
+        self.calls.append(("set_raw_fan_mode", fan_mode))
+
+    def set_raw_hvac_mode(self, hvac_mode: str, zone: int | None = None) -> None:
+        """Record set hvac mode call."""
+        self.calls.append(("set_raw_hvac_mode", hvac_mode, zone))
 
     def start_work(self) -> None:
         """Record start_work call."""

--- a/tests/components/midea/snapshots/test_climate.ambr
+++ b/tests/components/midea/snapshots/test_climate.ambr
@@ -275,10 +275,10 @@
     'area_id': None,
     'capabilities': dict({
       <ClimateEntityCapabilityAttribute.FAN_MODES: 'fan_modes'>: list([
-        'Low',
-        'Medium',
-        'High',
-        'Auto',
+        'low',
+        'medium',
+        'high',
+        'auto',
       ]),
       <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
         <HVACMode.OFF: 'off'>,
@@ -335,12 +335,12 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <ClimateEntityStateAttribute.CURRENT_TEMPERATURE: 'current_temperature'>: None,
-      <ClimateEntityStateAttribute.FAN_MODE: 'fan_mode'>: 'High',
+      <ClimateEntityStateAttribute.FAN_MODE: 'fan_mode'>: 'high',
       <ClimateEntityCapabilityAttribute.FAN_MODES: 'fan_modes'>: list([
-        'Low',
-        'Medium',
-        'High',
-        'Auto',
+        'low',
+        'medium',
+        'high',
+        'auto',
       ]),
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'MDV Wi-Fi Controller',
       <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([

--- a/tests/components/midea/test_climate.py
+++ b/tests/components/midea/test_climate.py
@@ -147,8 +147,12 @@ async def test_midea_ac_climate_setup_and_services(
         {ATTR_TEMPERATURE: 23.1, "hvac_mode": HVACMode.COOL},
         [
             (
-                "set_target_temperature",
-                {"target_temperature": 23.1, "mode": 2, "zone": None},
+                "set_raw_target_temperature",
+                {
+                    "target_temperature": 23.1,
+                    "hvac_mode": HVACMode.COOL,
+                    "zone": None,
+                },
             )
         ],
         device,
@@ -174,7 +178,7 @@ async def test_midea_ac_climate_setup_and_services(
         entity_entry.entity_id,
         SERVICE_SET_SWING_MODE,
         {ATTR_SWING_MODE: SWING_VERTICAL},
-        [("set_swing", {"swing_vertical": True, "swing_horizontal": False})],
+        [("set_raw_swing_mode", SWING_VERTICAL)],
         device,
     )
     await _assert_service_calls(
@@ -260,7 +264,6 @@ async def test_midea_cc_climate_setup_and_services(
         attributes={
             CCAttributes.power: True,
             CCAttributes.mode: 5,
-            CCAttributes.fan_speed: "High",
             CCAttributes.temperature_precision: 0.5,
             CCAttributes.swing: True,
         },
@@ -272,7 +275,7 @@ async def test_midea_cc_climate_setup_and_services(
     state = hass.states.get(entity_entry.entity_id)
     assert state is not None
     assert state.state == HVACMode.AUTO
-    assert state.attributes[ATTR_FAN_MODE] == "High"
+    assert state.attributes[ATTR_FAN_MODE] == "high"
     assert state.attributes[ATTR_HVAC_MODES] == [
         HVACMode.OFF,
         HVACMode.FAN_ONLY,
@@ -289,8 +292,8 @@ async def test_midea_cc_climate_setup_and_services(
         hass,
         entity_entry.entity_id,
         SERVICE_SET_FAN_MODE,
-        {ATTR_FAN_MODE: "Low"},
-        [("set_attribute", CCAttributes.fan_speed, "Low")],
+        {ATTR_FAN_MODE: "low"},
+        [("set_raw_fan_mode", "low")],
         device,
     )
     await _assert_service_calls(
@@ -352,8 +355,8 @@ async def test_midea_cf_climate_setup_and_services(
         {"hvac_mode": HVACMode.HEAT},
         [
             (
-                "set_target_temperature",
-                {"target_temperature": 20.0, "mode": 3},
+                "set_raw_target_temperature",
+                {"target_temperature": 20.0, "hvac_mode": HVACMode.HEAT},
             )
         ],
         device,
@@ -408,8 +411,12 @@ async def test_midea_c3_climate_setup_and_services(
         {ATTR_TEMPERATURE: 21.4, "hvac_mode": HVACMode.COOL},
         [
             (
-                "set_target_temperature",
-                {"target_temperature": 21.4, "mode": 2, "zone": 0},
+                "set_raw_target_temperature",
+                {
+                    "target_temperature": 21.4,
+                    "hvac_mode": HVACMode.COOL,
+                    "zone": 0,
+                },
             )
         ],
         device,
@@ -427,7 +434,7 @@ async def test_midea_c3_climate_setup_and_services(
         zone1.entity_id,
         SERVICE_SET_HVAC_MODE,
         {"hvac_mode": HVACMode.HEAT},
-        [("set_mode", 0, 3)],
+        [("set_raw_hvac_mode", HVACMode.HEAT, 0)],
         device,
     )
 
@@ -597,8 +604,8 @@ async def test_ac_set_temperature_without_hvac_mode(
         {ATTR_TEMPERATURE: 23.0},
         [
             (
-                "set_target_temperature",
-                {"target_temperature": 23.0, "mode": None, "zone": None},
+                "set_raw_target_temperature",
+                {"target_temperature": 23.0, "hvac_mode": None, "zone": None},
             )
         ],
         device,
@@ -1133,8 +1140,8 @@ async def test_cf_set_hvac_mode_falls_back_to_min_temp(
         {"hvac_mode": HVACMode.HEAT},
         [
             (
-                "set_target_temperature",
-                {"target_temperature": 16.0, "mode": 3},
+                "set_raw_target_temperature",
+                {"target_temperature": 16.0, "hvac_mode": HVACMode.HEAT},
             )
         ],
         device,
@@ -1193,8 +1200,12 @@ async def test_fb_set_temperature_with_heat_mode_turns_on_when_off(
         [
             ("set_attribute", FBAttributes.power, True),
             (
-                "set_target_temperature",
-                {"target_temperature": 25.0, "mode": 1, "zone": None},
+                "set_raw_target_temperature",
+                {
+                    "target_temperature": 25.0,
+                    "hvac_mode": HVACMode.HEAT,
+                    "zone": None,
+                },
             ),
         ],
         device,
@@ -1258,11 +1269,11 @@ async def test_cc_fan_and_swing_invalid_types_return_none(
         attributes={
             CCAttributes.power: True,
             CCAttributes.mode: 5,
-            CCAttributes.fan_speed: 1,
             CCAttributes.temperature_precision: 0.5,
             CCAttributes.swing: "on",
         },
     )
+    device.raw_fan_mode = None
     config_entry = mock_config_entry(device)
     await setup_integration(hass, config_entry, device)
     entity_entry = entity_entries(hass, config_entry)[f"{TEST_DEVICE_ID}_climate"]
@@ -1302,8 +1313,12 @@ async def test_c3_zone2_service_calls_address_zone_two(
         {ATTR_TEMPERATURE: 24.0, "hvac_mode": HVACMode.COOL},
         [
             (
-                "set_target_temperature",
-                {"target_temperature": 24.0, "mode": 2, "zone": 1},
+                "set_raw_target_temperature",
+                {
+                    "target_temperature": 24.0,
+                    "hvac_mode": HVACMode.COOL,
+                    "zone": 1,
+                },
             )
         ],
         device,
@@ -1313,7 +1328,7 @@ async def test_c3_zone2_service_calls_address_zone_two(
         zone2.entity_id,
         SERVICE_SET_HVAC_MODE,
         {"hvac_mode": HVACMode.HEAT},
-        [("set_mode", 1, 3)],
+        [("set_raw_hvac_mode", HVACMode.HEAT, 1)],
         device,
     )
     await _assert_service_calls(
@@ -1402,7 +1417,6 @@ async def test_fb_invalid_attribute_types_return_none(
                 attributes={
                     CCAttributes.power: True,
                     CCAttributes.mode: 5,
-                    CCAttributes.fan_speed: "High",
                     CCAttributes.temperature_precision: 0.5,
                     CCAttributes.swing: True,
                 },

--- a/tests/components/midea/test_config_flow.py
+++ b/tests/components/midea/test_config_flow.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from midealocal.const import DeviceType, ProtocolVersion
 from midealocal.device import MideaDevice
+from midealocal.exceptions import CloudLoginError, MideaCloudError, NoDeviceRegistered
 import pytest
 
 from homeassistant.components.midea.config_flow import (
@@ -164,6 +165,7 @@ async def test_manual_flow_duplicate_unique_id(hass: HomeAssistant) -> None:
         "connect_return",
         "cloud_login_return",
         "cloud_keys_return",
+        "cloud_keys_side_effect",
         "default_keys_return",
         "pre_input",
         "expected_error",
@@ -175,6 +177,7 @@ async def test_manual_flow_duplicate_unique_id(hass: HomeAssistant) -> None:
             None,
             True,
             {},
+            None,
             {},
             None,
             "invalid_token",
@@ -186,6 +189,7 @@ async def test_manual_flow_duplicate_unique_id(hass: HomeAssistant) -> None:
             None,
             True,
             {},
+            None,
             {},
             None,
             "invalid_device_ip",
@@ -197,6 +201,7 @@ async def test_manual_flow_duplicate_unique_id(hass: HomeAssistant) -> None:
             None,
             True,
             {},
+            None,
             {},
             None,
             "invalid_device_id_for_ip",
@@ -214,6 +219,7 @@ async def test_manual_flow_duplicate_unique_id(hass: HomeAssistant) -> None:
             None,
             True,
             {},
+            None,
             {},
             None,
             "ip_address_mismatch",
@@ -231,6 +237,7 @@ async def test_manual_flow_duplicate_unique_id(hass: HomeAssistant) -> None:
             None,
             True,
             {},
+            None,
             {},
             None,
             "protocol_mismatch",
@@ -247,6 +254,7 @@ async def test_manual_flow_duplicate_unique_id(hass: HomeAssistant) -> None:
             None,
             True,
             {},
+            None,
             {},
             None,
             "type_mismatch",
@@ -258,6 +266,7 @@ async def test_manual_flow_duplicate_unique_id(hass: HomeAssistant) -> None:
             False,
             True,
             {},
+            None,
             {},
             None,
             "device_auth_failed",
@@ -269,6 +278,7 @@ async def test_manual_flow_duplicate_unique_id(hass: HomeAssistant) -> None:
             None,
             False,
             {},
+            None,
             {},
             None,
             "preset_login_failed",
@@ -280,10 +290,23 @@ async def test_manual_flow_duplicate_unique_id(hass: HomeAssistant) -> None:
             None,
             True,
             {},
+            None,
             {},
             None,
             "token_unavailable",
             id="no_token_from_cloud",
+        ),
+        pytest.param(
+            {**EXTENDED_DATA, CONF_TOKEN: "", CONF_KEY: ""},
+            {TEST_DEVICE_ID: {**BASE_DATA, CONF_TYPE: TEST_TYPE}},
+            None,
+            True,
+            {},
+            NoDeviceRegistered(3201, "no permission"),
+            {},
+            None,
+            "device_not_registered",
+            id="cloud_rejects_token_request",
         ),
     ],
 )
@@ -294,6 +317,7 @@ async def test_manual_step_errors(
     connect_return: bool | None,
     cloud_login_return: bool,
     cloud_keys_return: dict[str, dict[str, str]],
+    cloud_keys_side_effect: Exception | None,
     default_keys_return: dict[str, dict[str, str]],
     pre_input: dict[str, object] | None,
     expected_error: str,
@@ -318,7 +342,9 @@ async def test_manual_step_errors(
 
     cloud = MagicMock()
     cloud.login = AsyncMock(return_value=cloud_login_return)
-    cloud.get_cloud_keys = AsyncMock(return_value=cloud_keys_return)
+    cloud.get_cloud_keys = AsyncMock(
+        return_value=cloud_keys_return, side_effect=cloud_keys_side_effect
+    )
 
     with (
         patch(
@@ -695,6 +721,150 @@ async def test_auto_flow_v3_preset_phase1_default_key_success(
     assert result["data"][CONF_DEVICE_ID] == TEST_DEVICE_ID
     assert result["data"][CONF_TOKEN] == TEST_TOKEN
     assert result["data"][CONF_KEY] == TEST_KEY
+
+
+async def test_auto_flow_v3_default_key_success_after_cloud_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test a cloud rejection still lets a device connect with a built-in key.
+
+    ``get_cloud_keys`` now raises for known failure codes; that must not skip
+    the established well-known default-key fallback.
+    """
+    mock_devices = {TEST_DEVICE_ID: {**BASE_DATA, CONF_TYPE: TEST_TYPE}}
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    flow_id = result["flow_id"]
+
+    await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={"next_step_id": "search"},
+    )
+    with patch(
+        "homeassistant.components.midea.config_flow.discover",
+        return_value=mock_devices,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            user_input={CONF_IP_ADDRESS: "auto"},
+        )
+    assert result["step_id"] == "auto"
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={CONF_DEVICE: TEST_DEVICE_ID},
+    )
+    assert result["step_id"] == "auth_method"
+
+    cloud = MagicMock()
+    cloud.login = AsyncMock(return_value=True)
+    cloud.get_device_info = AsyncMock(return_value=None)
+    cloud.get_cloud_keys = AsyncMock(
+        side_effect=NoDeviceRegistered(3201, "no permission")
+    )
+
+    dm = MagicMock()
+    dm.connect.return_value = True
+
+    with (
+        patch(
+            "homeassistant.components.midea.config_flow.async_get_clientsession",
+            return_value=object(),
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.get_midea_cloud",
+            return_value=cloud,
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.MideaCloud.get_default_keys",
+            AsyncMock(return_value={"builtin": {"token": TEST_TOKEN, "key": TEST_KEY}}),
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.device_selector",
+            return_value=dm,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            user_input={"login_mode": LOGIN_MODE_PRESET},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_TOKEN] == TEST_TOKEN
+    assert result["data"][CONF_KEY] == TEST_KEY
+
+
+async def test_auto_flow_phase2_login_false_keeps_phase1_cloud_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test a specific phase-1 cloud error survives a plain phase-2 login failure.
+
+    Phase 1 raises ``NoDeviceRegistered`` (3201); phase 2's preset login only
+    returns ``False`` (no exception), which resets the pending error - the flow
+    must still report the actionable 3201 error, not ``preset_login_failed``.
+    """
+    mock_devices = {TEST_DEVICE_ID: {**BASE_DATA, CONF_TYPE: TEST_TYPE}}
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    flow_id = result["flow_id"]
+
+    await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={"next_step_id": "search"},
+    )
+    with patch(
+        "homeassistant.components.midea.config_flow.discover",
+        return_value=mock_devices,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            user_input={CONF_IP_ADDRESS: "auto"},
+        )
+    assert result["step_id"] == "auto"
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={CONF_DEVICE: TEST_DEVICE_ID},
+    )
+    assert result["step_id"] == "auth_method"
+
+    cloud = MagicMock()
+    # phase 1 login succeeds, phase 2 (force_login) login just returns False
+    cloud.login = AsyncMock(side_effect=[True, False])
+    cloud.get_device_info = AsyncMock(return_value=None)
+    cloud.get_cloud_keys = AsyncMock(
+        side_effect=NoDeviceRegistered(3201, "no permission")
+    )
+
+    with (
+        patch(
+            "homeassistant.components.midea.config_flow.async_get_clientsession",
+            return_value=object(),
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.get_midea_cloud",
+            return_value=cloud,
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.MideaCloud.get_default_keys",
+            AsyncMock(return_value={}),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            user_input={"login_mode": LOGIN_MODE_PRESET},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "auto"
+    assert result["errors"] == {"base": "device_not_registered"}
+    assert result["description_placeholders"] == {"error_code": "3201"}
 
 
 async def test_auto_flow_v3_token_retrieval_exhausted(hass: HomeAssistant) -> None:
@@ -1246,6 +1416,191 @@ async def test_login_credentials_step_login_failed_sets_error(
     data_schema = result["data_schema"].schema
     assert get_schema_suggested_value(data_schema, CONF_ACCOUNT) == "user"
     assert get_schema_suggested_value(data_schema, CONF_SERVER) == DEFAULT_CLOUD
+
+
+@pytest.mark.parametrize(
+    ("login_error", "expected_error", "expected_code"),
+    [
+        (CloudLoginError(7610, "locked"), "account_locked", "7610"),
+        (MideaCloudError(9999, "system error"), "cloud_error", "9999"),
+    ],
+    ids=["specific_login_error", "generic_cloud_error"],
+)
+async def test_login_credentials_step_maps_cloud_error(
+    hass: HomeAssistant,
+    login_error: MideaCloudError,
+    expected_error: str,
+    expected_code: str,
+) -> None:
+    """Test a cloud error raised by login() surfaces its translation_key and code.
+
+    The exhaustive code-to-slug matrix is covered in the midea-local library
+    tests; here we only check the config flow forwards ``err.translation_key``
+    and the numeric code.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    flow_id = result["flow_id"]
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={"next_step_id": "search"},
+    )
+    with patch(
+        "homeassistant.components.midea.config_flow.discover",
+        return_value=DISCOVERY_RESULT,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            user_input={CONF_IP_ADDRESS: "auto"},
+        )
+    assert result["step_id"] == "auto"
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={CONF_DEVICE: TEST_DEVICE_ID},
+    )
+    assert result["step_id"] == "auth_method"
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={"login_mode": LOGIN_MODE_ACCOUNT},
+    )
+    assert result["step_id"] == "login_credentials"
+
+    cloud = MagicMock()
+    cloud.login = AsyncMock(side_effect=login_error)
+
+    with (
+        patch(
+            "homeassistant.components.midea.config_flow.MideaCloud.get_cloud_servers",
+            AsyncMock(return_value={1: DEFAULT_CLOUD}),
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.async_get_clientsession",
+            return_value=object(),
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.get_midea_cloud",
+            return_value=cloud,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            user_input={
+                CONF_SERVER: DEFAULT_CLOUD,
+                CONF_ACCOUNT: "user",
+                CONF_PASSWORD: "pass",
+            },
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "login_credentials"
+    assert result["errors"] == {"base": expected_error}
+    assert result["description_placeholders"] == {"error_code": expected_code}
+
+
+@pytest.mark.parametrize(
+    (
+        "login_side_effect",
+        "cloud_keys_side_effect",
+        "expected_step",
+        "expected_error",
+        "expected_code",
+    ),
+    [
+        pytest.param(
+            CloudLoginError(7610, "locked"),
+            None,
+            "auth_method",
+            "account_locked",
+            "7610",
+            id="preset_login_rejected",
+        ),
+        pytest.param(
+            None,
+            [NoDeviceRegistered(3201, "no permission"), {}],
+            "auto",
+            "device_not_registered",
+            "3201",
+            id="device_bound_to_other_account",
+        ),
+    ],
+)
+async def test_auto_flow_preset_auth_maps_cloud_error(
+    hass: HomeAssistant,
+    login_side_effect: MideaCloudError | None,
+    cloud_keys_side_effect: list[object] | None,
+    expected_step: str,
+    expected_error: str,
+    expected_code: str,
+) -> None:
+    """Test cloud API errors on the preset auth path surface a specific message.
+
+    Either the preset login itself is rejected (stays on auth_method), or the
+    login succeeds but the cloud refuses to issue a token/key for the device
+    (falls back to the auto step).
+    """
+    mock_devices = {TEST_DEVICE_ID: {**BASE_DATA, CONF_TYPE: TEST_TYPE}}
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    flow_id = result["flow_id"]
+
+    await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={"next_step_id": "search"},
+    )
+    with patch(
+        "homeassistant.components.midea.config_flow.discover",
+        return_value=mock_devices,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            user_input={CONF_IP_ADDRESS: "auto"},
+        )
+    assert result["step_id"] == "auto"
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={CONF_DEVICE: TEST_DEVICE_ID},
+    )
+    assert result["step_id"] == "auth_method"
+
+    cloud = MagicMock()
+    cloud.login = AsyncMock(return_value=True, side_effect=login_side_effect)
+    cloud.get_device_info = AsyncMock(return_value=None)
+    cloud.get_cloud_keys = AsyncMock(
+        return_value={}, side_effect=cloud_keys_side_effect
+    )
+
+    with (
+        patch(
+            "homeassistant.components.midea.config_flow.async_get_clientsession",
+            return_value=object(),
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.get_midea_cloud",
+            return_value=cloud,
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.MideaCloud.get_default_keys",
+            AsyncMock(return_value={}),
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            user_input={"login_mode": LOGIN_MODE_PRESET},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == expected_step
+    assert result["errors"] == {"base": expected_error}
+    assert result["description_placeholders"] == {"error_code": expected_code}
 
 
 async def test_login_credentials_step_recovers_after_failed_login(

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -1372,6 +1372,55 @@ async def test_thermostat_fan_empty(
     assert ATTR_FAN_MODES not in thermostat.attributes
 
 
+async def test_thermostat_fan_becomes_supported_after_update(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    create_device: CreateDevice,
+    create_event: CreateEvent,
+) -> None:
+    """Test that supported_features is recomputed once the fan trait reports a mode.
+
+    The fan trait can be present at startup without a timer_mode value yet
+    populated (e.g. before the initial full state has propagated). Regression
+    test for supported_features being frozen at entity setup rather than
+    reflecting the live device state.
+    """
+    create_device.create(
+        {
+            "sdm.devices.traits.Fan": {},
+            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
+                "mode": "OFF",
+            },
+        }
+    )
+    await setup_platform()
+
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert ATTR_FAN_MODE not in thermostat.attributes
+    assert ATTR_FAN_MODES not in thermostat.attributes
+    assert not (
+        thermostat.attributes[ATTR_SUPPORTED_FEATURES] & ClimateEntityFeature.FAN_MODE
+    )
+
+    # The fan trait later reports a real timer_mode value
+    await create_event(
+        {
+            "sdm.devices.traits.Fan": {"timerMode": "OFF"},
+        }
+    )
+
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert (
+        thermostat.attributes[ATTR_SUPPORTED_FEATURES] & ClimateEntityFeature.FAN_MODE
+    )
+    assert thermostat.attributes[ATTR_FAN_MODE] == FAN_OFF
+    assert thermostat.attributes[ATTR_FAN_MODES] == [FAN_ON, FAN_OFF]
+
+
 async def test_thermostat_invalid_fan_mode(
     hass: HomeAssistant,
     setup_platform: PlatformSetup,

--- a/tests/components/openhome/test_init.py
+++ b/tests/components/openhome/test_init.py
@@ -1,0 +1,32 @@
+"""Tests for the Openhome integration setup."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.openhome.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from tests.common import MockConfigEntry
+
+HOST = "http://localhost"
+
+
+async def test_device_uses_shared_session(hass: HomeAssistant) -> None:
+    """Test the device is given Home Assistant's shared aiohttp session."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: HOST}, unique_id="uuid")
+    entry.add_to_hass(hass)
+
+    with (
+        patch("homeassistant.components.openhome.PLATFORMS", []),
+        patch("homeassistant.components.openhome.Device", MagicMock()) as mock_device,
+    ):
+        mock_device.return_value.init = AsyncMock()
+        mock_device.return_value.uuid = MagicMock(return_value="uuid")
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    mock_device.assert_called_once_with(HOST, session=async_get_clientsession(hass))

--- a/tests/components/remote_calendar/test_config_flow.py
+++ b/tests/components/remote_calendar/test_config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from . import setup_integration
 from .conftest import CALENDAR_NAME, CALENDER_URL
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, get_schema_suggested_value
 
 
 @respx.mock
@@ -77,6 +77,61 @@ async def test_form_import_webcal(hass: HomeAssistant, ics_content: str) -> None
     }
 
 
+@respx.mock
+async def test_form_import_webcal_error(hass: HomeAssistant, ics_content: str) -> None:
+    """Test webcal URL error re-displays form with suggested values."""
+    respx.get(CALENDER_URL).mock(side_effect=HTTPError("Connection failed"))
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_CALENDAR_NAME: CALENDAR_NAME,
+            CONF_URL: "webcal://some.calendar.com/calendar.ics",
+            CONF_VERIFY_SSL: False,
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_CALENDAR_NAME)
+        == CALENDAR_NAME
+    )
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_URL)
+        == CALENDER_URL
+    )
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_VERIFY_SSL)
+        is False
+    )
+
+    respx.get(CALENDER_URL).mock(
+        return_value=Response(
+            status_code=200,
+            text=ics_content,
+        )
+    )
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_CALENDAR_NAME: CALENDAR_NAME,
+            CONF_URL: CALENDER_URL,
+            CONF_VERIFY_SSL: False,
+        },
+    )
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert result3["title"] == CALENDAR_NAME
+    assert result3["data"] == {
+        CONF_CALENDAR_NAME: CALENDAR_NAME,
+        CONF_URL: CALENDER_URL,
+        CONF_VERIFY_SSL: False,
+    }
+
+
 @pytest.mark.parametrize(
     ("side_effect", "base_error"),
     [
@@ -108,6 +163,14 @@ async def test_form_invalid_url(
     )
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": base_error}
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_CALENDAR_NAME)
+        == CALENDAR_NAME
+    )
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_URL)
+        == "invalid-url.com"
+    )
     respx.get(CALENDER_URL).mock(
         return_value=Response(
             status_code=200,
@@ -167,6 +230,11 @@ async def test_unsupported_inputs(
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": "cannot_connect"}
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_CALENDAR_NAME)
+        == CALENDAR_NAME
+    )
+    assert get_schema_suggested_value(result2["data_schema"].schema, CONF_URL) == url
     assert log_message in caplog.text
     ## It's not possible to test a successful config flow because,
     ## we need to mock httpx.get here and then the exception isn't
@@ -204,6 +272,14 @@ async def test_form_http_status_error(
     )
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": error}
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_CALENDAR_NAME)
+        == CALENDAR_NAME
+    )
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_URL)
+        == CALENDER_URL
+    )
     respx.get(CALENDER_URL).mock(
         return_value=Response(
             status_code=200,
@@ -252,6 +328,18 @@ async def test_no_valid_calendar(hass: HomeAssistant, ics_content: str) -> None:
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {"base": "invalid_ics_file"}
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_CALENDAR_NAME)
+        == CALENDAR_NAME
+    )
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_URL)
+        == CALENDER_URL
+    )
+    assert (
+        get_schema_suggested_value(result2["data_schema"].schema, CONF_VERIFY_SSL)
+        is True
+    )
     respx.get(CALENDER_URL).mock(
         return_value=Response(
             status_code=200,

--- a/tests/components/remote_calendar/test_init.py
+++ b/tests/components/remote_calendar/test_init.py
@@ -85,6 +85,7 @@ async def test_update_failed(
 async def test_calendar_parse_error(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test CalendarParseError using respx."""
     respx.get(CALENDER_URL).mock(
@@ -92,6 +93,7 @@ async def test_calendar_parse_error(
     )
     await setup_integration(hass, config_entry)
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert "The remote calendar feed contains invalid data:" in caplog.text
 
 
 @respx.mock

--- a/tests/components/roomba/test_sensor.py
+++ b/tests/components/roomba/test_sensor.py
@@ -1,15 +1,41 @@
 """Tests for IRobotEntity usage in Roomba sensor platform."""
 
+import copy
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.const import Platform
+from homeassistant.components.roomba.const import CONF_BLID, CONF_CONTINUOUS, DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import CONF_DELAY, CONF_HOST, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry, snapshot_platform
+
+
+def _config_entry(blid: str) -> MockConfigEntry:
+    """Return a config entry for an additional robot."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.0.30",
+            CONF_BLID: blid,
+            CONF_PASSWORD: "pass123",
+        },
+        options={CONF_CONTINUOUS: True, CONF_DELAY: 10},
+        unique_id=blid,
+    )
+
+
+def _dock_tank_level_entities(hass: HomeAssistant) -> list[str]:
+    """Return every dock tank level entity currently set up."""
+    return sorted(
+        entity_id
+        for entity_id in hass.states.async_entity_ids(SENSOR_DOMAIN)
+        if "dock_tank_level" in entity_id
+    )
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -27,3 +53,53 @@ async def test_entities(
         await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_two_docked_robots_do_not_collide(
+    hass: HomeAssistant,
+    mock_roomba: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a second docked robot does not produce a duplicate dock sensor.
+
+    The dock sensors used to be appended to the module level SENSORS list, so
+    setting up a second docked robot appended them twice. The duplicate is
+    dropped by the entity platform, so the surviving entity count still looks
+    correct and only the logged error reveals the problem.
+    """
+    with patch("homeassistant.components.roomba.PLATFORMS", [Platform.SENSOR]):
+        for blid in ("blid_first", "blid_second"):
+            config_entry = _config_entry(blid)
+            config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+    assert "does not generate unique IDs" not in caplog.text
+    assert len(_dock_tank_level_entities(hass)) == 2
+
+
+async def test_robot_without_dock_has_no_dock_sensor(
+    hass: HomeAssistant,
+    mock_roomba: AsyncMock,
+) -> None:
+    """Test a robot without a dock does not get a dock sensor.
+
+    A robot reporting no dock used to inherit one when it was set up after a
+    robot that did have one.
+    """
+    docked_state = copy.deepcopy(mock_roomba.master_state)
+    dockless_state = copy.deepcopy(mock_roomba.master_state)
+    dockless_state["state"]["reported"]["dock"] = {}
+
+    with patch("homeassistant.components.roomba.PLATFORMS", [Platform.SENSOR]):
+        for blid, state in (
+            ("blid_docked", docked_state),
+            ("blid_dockless", dockless_state),
+        ):
+            mock_roomba.master_state = state
+            config_entry = _config_entry(blid)
+            config_entry.add_to_hass(hass)
+            await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+    assert len(_dock_tank_level_entities(hass)) == 1

--- a/tests/components/satel_integra/test_init.py
+++ b/tests/components/satel_integra/test_init.py
@@ -7,6 +7,7 @@ import pytest
 from satel_integra import (
     SatelConnectFailedError,
     SatelConnectionInitializationError,
+    SatelMonitoringStartError,
     SatelPanelBusyError,
 )
 from syrupy.assertion import SnapshotAssertion
@@ -243,3 +244,21 @@ async def test_setup_exceptions(
     mock_satel.connect.side_effect = exception
     await setup_integration(hass, mock_config_entry)
     assert mock_config_entry.state is expected_state
+
+
+async def test_monitoring_start_error(
+    hass: HomeAssistant,
+    mock_satel: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup is retried when monitoring fails to start."""
+    mock_satel.start.side_effect = SatelMonitoringStartError
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.reason == (
+        "Connected to the alarm panel, but the panel did not confirm the request to start sending status updates"
+    )
+    mock_satel.start.assert_awaited_once_with(enable_monitoring=True)
+    mock_satel.read_panel_info.assert_not_awaited()

--- a/tests/components/sftp_storage/test_init.py
+++ b/tests/components/sftp_storage/test_init.py
@@ -3,7 +3,8 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from asyncssh.sftp import SFTPPermissionDenied
+from asyncssh.misc import ChannelOpenError, ConnectionLost, PermissionDenied
+from asyncssh.sftp import SFTPConnectionLost, SFTPPermissionDenied
 import pytest
 
 from homeassistant.components.sftp_storage import SFTPConfigEntryData
@@ -73,15 +74,61 @@ async def test_setup_error(
     assert entries[0].state is ConfigEntryState.SETUP_ERROR
 
 
-async def test_setup_unexpected_error(
+@pytest.mark.parametrize(
+    "connect_error",
+    [OSError("Error message"), ConnectionLost("Connection lost")],
+    ids=["oserror", "connection_lost"],
+)
+async def test_setup_connection_error_is_retried(
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    caplog: pytest.LogCaptureFixture,
+    connect_error: Exception,
+) -> None:
+    """Test that a connection failure leaves the entry in a retrying state."""
+    with patch(
+        "homeassistant.components.sftp_storage.client.connect",
+        side_effect=connect_error,
+    ):
+        await setup_integration()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].state is ConfigEntryState.SETUP_RETRY
+    assert "Failed to establish SSH connection to" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "sftp_error",
+    [ChannelOpenError(1, "Channel open failed"), SFTPConnectionLost("Connection lost")],
+    ids=["channel_open_error", "sftp_connection_lost"],
+)
+async def test_setup_sftp_session_error_is_retried(
+    mock_ssh_connection: SSHClientConnectionMock,
+    hass: HomeAssistant,
+    setup_integration: ComponentSetup,
+    caplog: pytest.LogCaptureFixture,
+    sftp_error: Exception,
+) -> None:
+    """Test that losing the session after connecting is also retried."""
+    mock_ssh_connection._sftp._mock_chdir.side_effect = sftp_error
+    await setup_integration()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].state is ConfigEntryState.SETUP_RETRY
+    assert "Failed to open SFTP session on" in caplog.text
+
+
+async def test_setup_invalid_credentials(
     hass: HomeAssistant,
     setup_integration: ComponentSetup,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test setup error."""
+    """Test that rejected credentials are not retried."""
     with patch(
         "homeassistant.components.sftp_storage.client.connect",
-        side_effect=OSError("Error message"),
+        side_effect=PermissionDenied("Permission denied"),
     ):
         await setup_integration()
 

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -1,5 +1,6 @@
 """Test the Tesla Fleet init."""
 
+import asyncio
 from copy import deepcopy
 from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
@@ -94,6 +95,26 @@ async def test_init_error(
     mock_products.side_effect = side_effect
     await setup_platform(hass, normal_config_entry)
     assert normal_config_entry.state is state
+
+
+async def test_vehicle_first_refresh_timeout(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+    mock_vehicle_data: AsyncMock,
+) -> None:
+    """Test a slow first vehicle refresh retries instead of blocking setup."""
+    never = asyncio.Event()
+
+    async def _hang(*args: object, **kwargs: object) -> None:
+        await never.wait()
+
+    mock_vehicle_data.side_effect = _hang
+
+    with patch("homeassistant.components.tesla_fleet.VEHICLE_FIRST_REFRESH_TIMEOUT", 0):
+        await setup_platform(hass, normal_config_entry)
+
+    assert normal_config_entry.state is ConfigEntryState.SETUP_RETRY
+    never.set()
 
 
 async def test_oauth_refresh_expired(

--- a/tests/components/tesla_fleet/test_models.py
+++ b/tests/components/tesla_fleet/test_models.py
@@ -1,0 +1,20 @@
+"""Test the Tesla Fleet models."""
+
+from unittest.mock import Mock
+
+from homeassistant.components.tesla_fleet.models import TeslaFleetVehicleData
+
+
+def test_wakelock_is_per_instance() -> None:
+    """Each vehicle must get its own wakelock, not a lock shared across the account."""
+    kwargs = {
+        "api": Mock(),
+        "coordinator": Mock(),
+        "vin": "VIN",
+        "device": Mock(),
+        "signing": False,
+    }
+    a = TeslaFleetVehicleData(**kwargs)
+    b = TeslaFleetVehicleData(**kwargs)
+
+    assert a.wakelock is not b.wakelock

--- a/tests/components/unifi/snapshots/test_sensor.ambr
+++ b/tests/components/unifi/snapshots/test_sensor.ambr
@@ -812,7 +812,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': 'unknown',
   })
 # ---
 # name: test_entity_and_device_data[wlan_payload0-device_payload0-client_payload0-config_entry_options0][sensor.mock_name_cloudflare_wan_latency-entry]
@@ -928,7 +928,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': 'unknown',
   })
 # ---
 # name: test_entity_and_device_data[wlan_payload0-device_payload0-client_payload0-config_entry_options0][sensor.mock_name_google_wan_latency-entry]
@@ -1044,7 +1044,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '0',
+    'state': 'unknown',
   })
 # ---
 # name: test_entity_and_device_data[wlan_payload0-device_payload0-client_payload0-config_entry_options0][sensor.mock_name_microsoft_wan_latency-entry]

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1710,14 +1710,22 @@ async def test_device_uptime(
     ],
 )
 @pytest.mark.parametrize(
-    ("monitor_id", "state", "updated_state", "index_to_update"),
+    ("monitor_id", "state", "index_to_update", "monitor_update", "updated_state"),
     [
-        # Microsoft
-        ("microsoft_wan", "56", "20", 0),
-        # Google
-        ("google_wan", "53", "90", 1),
-        # Cloudflare
-        ("cloudflare_wan", "30", "80", 2),
+        pytest.param(
+            "microsoft_wan", "56", 0, {"latency_average": 20}, "20", id="microsoft"
+        ),
+        pytest.param("google_wan", "53", 1, {"latency_average": 90}, "90", id="google"),
+        pytest.param(
+            "cloudflare_wan", "30", 2, {"latency_average": 80}, "80", id="cloudflare"
+        ),
+        pytest.param(
+            "microsoft_wan", "56", 0, {}, STATE_UNKNOWN, id="microsoft_no_response"
+        ),
+        pytest.param("google_wan", "53", 1, {}, STATE_UNKNOWN, id="google_no_response"),
+        pytest.param(
+            "cloudflare_wan", "30", 2, {}, STATE_UNKNOWN, id="cloudflare_no_response"
+        ),
     ],
 )
 @pytest.mark.usefixtures("config_entry_setup")
@@ -1728,8 +1736,9 @@ async def test_wan_monitor_latency(
     device_payload: list[dict[str, Any]],
     monitor_id: str,
     state: str,
-    updated_state: str,
     index_to_update: int,
+    monitor_update: dict[str, Any],
+    updated_state: str,
 ) -> None:
     """Verify that wan latency sensors are working as expected."""
     entity_id = f"sensor.mock_name_{monitor_id}_latency"
@@ -1757,14 +1766,14 @@ async def test_wan_monitor_latency(
     # Verify sensor state
     assert hass.states.get(entity_id).state == state
 
-    # Verify state update
-    device = device_payload[0]
-    device["uptime_stats"]["WAN"]["monitors"][index_to_update]["latency_average"] = (
-        updated_state
-    )
-
+    # Update state
+    device = deepcopy(device_payload[0])
+    monitor = device["uptime_stats"]["WAN"]["monitors"][index_to_update]
+    monitor.pop("latency_average")
+    monitor.update(monitor_update)
     mock_websocket_message(message=MessageKey.DEVICE, data=device)
 
+    # Verify state update
     assert hass.states.get(entity_id).state == updated_state
 
 

--- a/tests/components/usage_prediction/test_common_control.py
+++ b/tests/components/usage_prediction/test_common_control.py
@@ -1,5 +1,6 @@
 """Test the common control usage prediction."""
 
+from typing import Any
 from unittest.mock import patch
 import uuid
 
@@ -408,3 +409,83 @@ async def test_different_users_separated(hass: HomeAssistant) -> None:
         evening=[],
         night=["light.user2_light"],
     )
+
+
+@pytest.mark.usefixtures("recorder_mock")
+@pytest.mark.parametrize(
+    "event_data",
+    [
+        pytest.param({}, id="no_event_data"),
+        pytest.param({"domain": "light", "service": "turn_on"}, id="no_service_data"),
+        pytest.param(
+            {
+                "domain": "light",
+                "service": "turn_on",
+                "service_data": {"brightness": 255},
+            },
+            id="no_entity_id",
+        ),
+    ],
+)
+async def test_events_without_entity_ids_ignored(
+    hass: HomeAssistant, event_data: dict[str, Any]
+) -> None:
+    """Test that service call events without entity IDs are skipped."""
+    user_id = str(uuid.uuid4())
+
+    hass.states.async_set("light.kitchen", "off")
+
+    with freeze_time("2023-07-01 10:00:00"):
+        hass.bus.async_fire(
+            EVENT_CALL_SERVICE, event_data, context=Context(user_id=user_id)
+        )
+        await hass.async_block_till_done()
+
+    await async_wait_recording_done(hass)
+
+    with freeze_time("2023-07-02 10:00:00"):
+        results = await async_predict_common_control(hass, user_id)
+
+    assert results == EntityUsagePredictions()
+
+
+@pytest.mark.usefixtures("recorder_mock")
+@pytest.mark.parametrize(
+    "json_loads_kwargs",
+    [
+        pytest.param({"side_effect": ValueError("bad json")}, id="invalid_json"),
+        pytest.param({"return_value": {}}, id="empty_object"),
+    ],
+)
+async def test_unusable_event_data_ignored(
+    hass: HomeAssistant, json_loads_kwargs: dict[str, Any]
+) -> None:
+    """Test that events whose stored data cannot be used are skipped."""
+    user_id = str(uuid.uuid4())
+
+    hass.states.async_set("light.kitchen", "off")
+
+    with freeze_time("2023-07-01 10:00:00"):
+        hass.bus.async_fire(
+            EVENT_CALL_SERVICE,
+            {
+                "domain": "light",
+                "service": "turn_on",
+                "service_data": {"entity_id": "light.kitchen"},
+            },
+            context=Context(user_id=user_id),
+        )
+        await hass.async_block_till_done()
+
+    await async_wait_recording_done(hass)
+
+    with (
+        freeze_time("2023-07-02 10:00:00"),
+        patch(
+            "homeassistant.components.usage_prediction.common_control.json_loads_object",
+            **json_loads_kwargs,
+        ),
+    ):
+        results = await async_predict_common_control(hass, user_id)
+
+    assert results == EntityUsagePredictions()

--- a/tests/components/vicare/test_init.py
+++ b/tests/components/vicare/test_init.py
@@ -11,6 +11,7 @@ from PyViCare.PyViCareUtils import (
     PyViCareInvalidConfigurationError,
     PyViCareInvalidCredentialsError,
     PyViCareInvalidDataError,
+    PyViCareRateLimitError,
 )
 
 from homeassistant.components.vicare.const import DOMAIN
@@ -327,6 +328,42 @@ async def test_setup_entry_invalid_credentials(
         await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_setup_entry_rate_limited(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test setup retries when the daily API quota is spent."""
+    mock_config_entry.add_to_hass(hass)
+
+    rate_limit_error = PyViCareRateLimitError(
+        {
+            "extendedPayload": {
+                "name": "development portal",
+                "requestCountLimit": 1450,
+                "limitReset": 1757376004000,
+            }
+        }
+    )
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow.OAuth2Session.async_ensure_token_valid",
+        ),
+        patch(
+            f"{MODULE}._setup_vicare_api",
+            side_effect=rate_limit_error,
+        ) as setup_api,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    setup_api.assert_called_once()
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    # SETUP_RETRY alone would also match an unrelated ConfigEntryNotReady.
+    assert "rate limit" in mock_config_entry.reason
+    assert str(rate_limit_error.limitResetDate) in mock_config_entry.reason
 
 
 async def test_setup_entry_invalid_configuration(

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -13,6 +13,7 @@ from vizaio import (
     VizioConnectionError,
     VizioNotFoundError,
 )
+from vizaio.profiles import SOUNDBAR_PROFILE
 
 from homeassistant.components.media_player import (
     DOMAIN as MEDIA_PLAYER_DOMAIN,
@@ -224,6 +225,23 @@ async def test_state_extended_polling(
     mock_vizio.get_power_state.assert_not_called()
     mock_vizio.get_current_input.assert_not_called()
     mock_vizio.get_current_app_config.assert_not_called()
+
+
+@pytest.mark.usefixtures("vizio_connect")
+async def test_soundbar_does_not_poll_state_extended(
+    hass: HomeAssistant,
+    mock_speaker_config_entry: MockConfigEntry,
+    mock_vizio: AsyncMock,
+) -> None:
+    """Test soundbars use the unauthenticated power endpoint."""
+    mock_vizio.profile = SOUNDBAR_PROFILE
+    mock_vizio.get_state_extended.side_effect = VizioAuthError("token required")
+
+    await setup_integration(hass, mock_speaker_config_entry)
+
+    mock_vizio.get_state_extended.assert_not_called()
+    mock_vizio.get_power_state.assert_called_once()
+    assert not hass.config_entries.flow.async_progress_by_handler(DOMAIN)
 
 
 @pytest.mark.usefixtures("vizio_connect")

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -855,14 +855,45 @@ async def test_apps_update(
                 assert len(apps) == len(APP_RECORDS)
 
 
+@pytest.mark.parametrize(
+    ("entry_data", "app_config", "expected_app_name"),
+    [
+        pytest.param(
+            MOCK_USER_VALID_TV_CONFIG,
+            UNKNOWN_APP_CONFIG_OBJ,
+            None,
+            id="unknown_config_hides_app_name",
+        ),
+        pytest.param(
+            MOCK_TV_WITH_ADDITIONAL_APPS_CONFIG,
+            CUSTOM_CONFIG_OBJ,
+            ADDITIONAL_APP_CONFIG["name"],
+            id="additional_config_keeps_mapped_name",
+        ),
+    ],
+)
 @pytest.mark.usefixtures("vizio_connect", "vizio_update_with_apps_on_input")
 async def test_vizio_update_with_apps_on_input(
-    hass: HomeAssistant, mock_tv_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    entry_data: dict[str, Any],
+    app_config: AppConfig,
+    expected_app_name: str | None,
 ) -> None:
-    """Test a vizio TV with apps that is on a TV input."""
-    await setup_integration(hass, mock_tv_config_entry)
+    """Test a vizio TV with apps that is on a TV input.
+
+    The device reports an app config even on HDMI. An unrecognized one must
+    not surface as the unknown-app sentinel, while a name mapped through
+    additional_configs is deliberate user configuration and is kept.
+    """
+    config_entry = MockConfigEntry(domain=DOMAIN, data=entry_data, unique_id=UNIQUE_ID)
+    with patch(
+        "homeassistant.components.vizio.Vizio.get_current_app_config",
+        return_value=app_config,
+    ):
+        await setup_integration(hass, config_entry)
     attr = _get_attr_and_assert_base_attr(hass, MediaPlayerDeviceClass.TV, STATE_ON)
-    # app ID should not be in the attributes
+    assert attr[ATTR_INPUT_SOURCE] == CURRENT_INPUT
+    assert attr.get("app_name") == expected_app_name
     assert "app_id" not in attr
 
 

--- a/tests/components/webostv/__init__.py
+++ b/tests/components/webostv/__init__.py
@@ -1,5 +1,7 @@
 """Tests for the LG webOS TV integration."""
 
+from typing import Any
+
 from homeassistant.components.webostv.const import DOMAIN
 from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST
 from homeassistant.core import HomeAssistant
@@ -10,7 +12,9 @@ from tests.common import MockConfigEntry
 
 
 async def setup_webostv(
-    hass: HomeAssistant, unique_id: str | None = FAKE_UUID
+    hass: HomeAssistant,
+    unique_id: str | None = FAKE_UUID,
+    options: dict[str, Any] | None = None,
 ) -> MockConfigEntry:
     """Initialize webostv and media_player for tests."""
     entry = MockConfigEntry(
@@ -19,6 +23,7 @@ async def setup_webostv(
             CONF_HOST: HOST,
             CONF_CLIENT_SECRET: CLIENT_KEY,
         },
+        options=options or {},
         title=TV_NAME,
         unique_id=unique_id,
     )

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -28,6 +28,7 @@ from homeassistant.components.media_player import (
 from homeassistant.components.webostv.const import (
     ATTR_PAYLOAD,
     ATTR_SOUND_OUTPUT,
+    CONF_SOURCES,
     DOMAIN,
     LIVE_TV_APP_ID,
     WebOsTvCommandError,
@@ -535,6 +536,38 @@ async def test_update_sources_live_tv_find(hass: HomeAssistant, client) -> None:
 
     assert "Live TV" in sources
     assert len(sources) == 1
+
+
+async def test_source_unlisted_current_app(hass: HomeAssistant, client) -> None:
+    """Test source is cleared when the current app is not in the lists."""
+    await setup_webostv(hass)
+    await client.mock_state_update()
+
+    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE] == "Live TV"
+
+    # home screen and screen saver are not in the apps or inputs lists
+    client.tv_state.current_app_id = "com.webos.app.home"
+    await client.mock_state_update()
+
+    attributes = hass.states.get(ENTITY_ID).attributes
+    assert ATTR_INPUT_SOURCE not in attributes
+    assert attributes[ATTR_INPUT_SOURCE_LIST] == ["Input01", "Input02", "Live TV"]
+
+
+async def test_source_cleared_with_filtered_out_sources(
+    hass: HomeAssistant, client
+) -> None:
+    """Test source is cleared when configured sources match nothing."""
+    client.tv_state.inputs = {}
+    await setup_webostv(hass, options={CONF_SOURCES: ["Netflix"]})
+    await client.mock_state_update()
+
+    assert hass.states.get(ENTITY_ID).attributes[ATTR_INPUT_SOURCE] == "Live TV"
+
+    client.tv_state.current_app_id = "com.webos.app.home"
+    await client.mock_state_update()
+
+    assert ATTR_INPUT_SOURCE not in hass.states.get(ENTITY_ID).attributes
 
 
 async def test_client_disconnected(

--- a/tests/components/weheat/test_config_flow.py
+++ b/tests/components/weheat/test_config_flow.py
@@ -4,11 +4,13 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from weheat.exceptions import ApiException
+from yarl import URL
 
 from homeassistant.components.weheat.const import (
     DOMAIN,
     ENTRY_TITLE,
     OAUTH2_AUTHORIZE,
+    OAUTH2_SCOPES,
     OAUTH2_TOKEN,
 )
 from homeassistant.config_entries import SOURCE_USER, ConfigFlowResult
@@ -57,6 +59,10 @@ async def test_full_flow(
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert len(mock_setup_entry.mock_calls) == 1
     assert len(mock_weheat.mock_calls) == 1
+
+    token_request_data = aioclient_mock.mock_calls[-1][2]
+    assert token_request_data["grant_type"] == "authorization_code"
+    assert token_request_data["code_verifier"]
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["result"].unique_id == USER_UUID_1
@@ -189,12 +195,17 @@ async def handle_oauth(
         },
     )
 
-    assert result["url"] == (
-        f"{OAUTH2_AUTHORIZE}?response_type=code&client_id={CLIENT_ID}"
-        "&redirect_uri=https://example.com/auth/external/callback"
-        f"&state={state}"
-        "&scope=openid+offline_access"
+    result_url = URL(result["url"])
+    assert f"{result_url.origin()}{result_url.path}" == OAUTH2_AUTHORIZE
+    assert result_url.query["response_type"] == "code"
+    assert result_url.query["client_id"] == CLIENT_ID
+    assert (
+        result_url.query["redirect_uri"] == "https://example.com/auth/external/callback"
     )
+    assert result_url.query["state"] == state
+    assert result_url.query["scope"] == " ".join(OAUTH2_SCOPES)
+    assert result_url.query["code_challenge"]
+    assert result_url.query["code_challenge_method"] == "S256"
 
     client = await hass_client_no_auth()
     resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")

--- a/tests/components/xbox/snapshots/test_sensor.ambr
+++ b/tests/components/xbox/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_sensors[sensor.erics273_follower-entry]
+# name: test_sensors[sensor.erics273_followers-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -15,7 +15,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.erics273_follower',
+    'entity_id': 'sensor.erics273_followers',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -23,12 +23,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Follower',
+    'object_id_base': 'Followers',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Follower',
+    'original_name': 'Followers',
     'platform': 'xbox',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -38,15 +38,15 @@
     'unit_of_measurement': 'people',
   })
 # ---
-# name: test_sensors[sensor.erics273_follower-state]
+# name: test_sensors[sensor.erics273_followers-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'erics273 Follower',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'erics273 Followers',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'people',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.erics273_follower',
+    'entity_id': 'sensor.erics273_followers',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -487,7 +487,7 @@
     'state': 'Last seen 17h ago: Home',
   })
 # ---
-# name: test_sensors[sensor.gsr_ae_follower-entry]
+# name: test_sensors[sensor.gsr_ae_followers-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -503,7 +503,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.gsr_ae_follower',
+    'entity_id': 'sensor.gsr_ae_followers',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -511,12 +511,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Follower',
+    'object_id_base': 'Followers',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Follower',
+    'original_name': 'Followers',
     'platform': 'xbox',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -526,15 +526,15 @@
     'unit_of_measurement': 'people',
   })
 # ---
-# name: test_sensors[sensor.gsr_ae_follower-state]
+# name: test_sensors[sensor.gsr_ae_followers-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'GSR Ae Follower',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'GSR Ae Followers',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'people',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.gsr_ae_follower',
+    'entity_id': 'sensor.gsr_ae_followers',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -976,7 +976,7 @@
     'state': 'Last seen 49m ago: Xbox App',
   })
 # ---
-# name: test_sensors[sensor.ikken_hissatsuu_follower-entry]
+# name: test_sensors[sensor.ikken_hissatsuu_followers-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -992,7 +992,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.ikken_hissatsuu_follower',
+    'entity_id': 'sensor.ikken_hissatsuu_followers',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1000,12 +1000,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Follower',
+    'object_id_base': 'Followers',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Follower',
+    'original_name': 'Followers',
     'platform': 'xbox',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1015,15 +1015,15 @@
     'unit_of_measurement': 'people',
   })
 # ---
-# name: test_sensors[sensor.ikken_hissatsuu_follower-state]
+# name: test_sensors[sensor.ikken_hissatsuu_followers-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Ikken Hissatsuu Follower',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Ikken Hissatsuu Followers',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'people',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.ikken_hissatsuu_follower',
+    'entity_id': 'sensor.ikken_hissatsuu_followers',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,


### PR DESCRIPTION
- Normalize Hive auth username before login ([@Oluwatobi-Mustapha] - [#168827]) ([hive docs])
- Don't mutate the module level Roomba SENSORS list ([@jasondillingham] - [#181107]) ([roomba docs])
- Fix Openhome players becoming unavailable between polls ([@bazwilliams] - [#181238]) ([openhome docs]) (dependency)
- Clear webostv source when the current app is not in the source list ([@darkrain-nl] - [#181381]) ([webostv docs])
- Bump adext to 0.4.7 ([@Chang-Jin-Lee] - [#181384]) ([alarmdecoder docs]) (dependency)
- Bump midea-local to 11.0.1 ([@chemelli74] - [#181405]) ([midea docs]) (dependency)
- Drop the unknown-app sentinel from vizio app_name on non-app inputs ([@raman325] - [#181417]) ([vizio docs])
- Add l/min unit mapping to nibe_heatpump sensors ([@frankkopp] - [#181433]) ([nibe_heatpump docs])
- Bump airos to 0.6.12 ([@CoMPaTech] - [#181473]) ([airos docs]) (dependency)
- Bump gcal-sync to 9.1.1 ([@allenporter] - [#181499]) ([google docs]) (dependency)
- Add volume filter DF Portainer ([@erwindouna] - [#181510]) ([portainer docs])
- Bump satel_integra to 1.4.0 ([@Tommatheussen] - [#180960]) ([satel_integra docs]) (dependency)
- Bump satel-integra to 1.5.0 ([@Tommatheussen] - [#181523]) ([satel_integra docs]) (dependency)
- Bump aiortm to 0.20.1 ([@MartinHjelmare] - [#181524]) ([remember_the_milk docs]) (dependency)
- Fix unique_id for service entities in Alexa Devices ([@chemelli74] - [#181526]) ([alexa_devices docs])
- Handle monitoring failure for Satel Integra ([@Tommatheussen] - [#181548]) ([satel_integra docs])
- Fix Vizio soundbars requiring authentication ([@raman325] - [#181556]) ([vizio docs])
- Bump vizaio to 0.6.2 ([@raman325] - [#181562]) ([vizio docs]) (dependency)
- Improve error messages in remote_calendar ([@allenporter] - [#181571]) ([remote_calendar docs])
- Update local_todo to explicitly specify UTF-8 encoding for ICS storage ([@allenporter] - [#181578]) ([local_todo docs])
- Repair local_todo malformed ICS files with CRLF newlines on setup ([@allenporter] - [#181581]) ([local_todo docs])
- Redact credentials from go2rtc server log output ([@balloob] - [#181583]) ([go2rtc docs])
- Fix MCP client double initialize in config flow ([@allenporter] - [#181594]) ([mcp docs])
- Increase HTTP timeout in remote_calendar ([@allenporter] - [#181599]) ([remote_calendar docs])
- Bound Tesla Fleet vehicle first refresh with a timeout ([@Bre77] - [#181606]) ([tesla_fleet docs])
- Bump ZHA to 2.2.2, zha-quirks to 2.2.2 ([@TheJulianJES] - [#181610]) ([zha docs]) (dependency)
- Retry ViCare setup when the API quota is spent ([@lackas] - [#181629]) ([vicare docs])
- Bump actron-neo-api to 0.5.16 ([@kclif9] - [#181639]) ([actron_air docs])
- Rename Xbox follower sensor name to 'Followers' ([@neyzm] - [#181654]) ([xbox docs])
- Fix shared wakelock across Tesla Fleet vehicles ([@Bre77] - [#181658]) ([tesla_fleet docs])
- Nest climate: recompute supported_features from live device traits ([@rqi14] - [#181660]) ([nest docs])
- Bump waterfurnace to 1.9.0 ([@sdague] - [#181746]) ([waterfurnace docs]) (dependency)
- Bump python-roborock to 7.4.1 ([@piitaya] - [#181754]) ([roborock docs]) (dependency)
- Retry sftp_storage setup when the SSH connection fails ([@lackas] - [#181769]) ([sftp_storage docs])
- Stream usage prediction events instead of loading them into memory ([@balloob] - [#181770]) ([usage_prediction docs])
- Bump pyatag to 0.3.7.1 ([@JamieMagee] - [#181796]) ([atag docs]) (dependency)
- Do not fail esphome setup when Supervisor is not ready ([@balloob] - [#181805]) ([esphome docs])
- Report UniFi WAN latency as unknown when a monitor is unresponsive ([@sdelmas] - [#181809]) ([unifi docs])
- Bump PyViCare to 2.62.1 ([@lackas] - [#181830]) ([vicare docs]) (dependency)
- Bump reolink_aio to 0.21.16 ([@starkillerOG] - [#181861]) ([reolink docs]) (dependency)
- Use PKCE for Weheat OAuth2 authorization ([@barryvdh] - [#181881]) ([weheat docs])
- Bump python-roborock to 7.4.2 ([@allenporter] - [#181907]) ([roborock docs]) (dependency)
- Preserve form values on error in Remote Calendar config flow ([@allenporter] - [#181908]) ([remote_calendar docs])
- Fix MELCloud Home energy interval ([@erwindouna] - [#181937]) ([melcloud_home docs])
- bump pyenphase to 4.0.3 ([@catsmanac] - [#181940]) ([enphase_envoy docs]) (dependency)
- Update frontend to 20260826.7 ([@bramkragten] - [#181950]) ([frontend docs]) (dependency)

[#168827]: https://github.com/home-assistant/core/pull/168827
[#180960]: https://github.com/home-assistant/core/pull/180960
[#181088]: https://github.com/home-assistant/core/pull/181088
[#181107]: https://github.com/home-assistant/core/pull/181107
[#181238]: https://github.com/home-assistant/core/pull/181238
[#181370]: https://github.com/home-assistant/core/pull/181370
[#181381]: https://github.com/home-assistant/core/pull/181381
[#181384]: https://github.com/home-assistant/core/pull/181384
[#181405]: https://github.com/home-assistant/core/pull/181405
[#181417]: https://github.com/home-assistant/core/pull/181417
[#181433]: https://github.com/home-assistant/core/pull/181433
[#181473]: https://github.com/home-assistant/core/pull/181473
[#181499]: https://github.com/home-assistant/core/pull/181499
[#181510]: https://github.com/home-assistant/core/pull/181510
[#181523]: https://github.com/home-assistant/core/pull/181523
[#181524]: https://github.com/home-assistant/core/pull/181524
[#181526]: https://github.com/home-assistant/core/pull/181526
[#181548]: https://github.com/home-assistant/core/pull/181548
[#181556]: https://github.com/home-assistant/core/pull/181556
[#181562]: https://github.com/home-assistant/core/pull/181562
[#181571]: https://github.com/home-assistant/core/pull/181571
[#181578]: https://github.com/home-assistant/core/pull/181578
[#181581]: https://github.com/home-assistant/core/pull/181581
[#181583]: https://github.com/home-assistant/core/pull/181583
[#181594]: https://github.com/home-assistant/core/pull/181594
[#181599]: https://github.com/home-assistant/core/pull/181599
[#181606]: https://github.com/home-assistant/core/pull/181606
[#181610]: https://github.com/home-assistant/core/pull/181610
[#181629]: https://github.com/home-assistant/core/pull/181629
[#181639]: https://github.com/home-assistant/core/pull/181639
[#181654]: https://github.com/home-assistant/core/pull/181654
[#181658]: https://github.com/home-assistant/core/pull/181658
[#181660]: https://github.com/home-assistant/core/pull/181660
[#181746]: https://github.com/home-assistant/core/pull/181746
[#181754]: https://github.com/home-assistant/core/pull/181754
[#181769]: https://github.com/home-assistant/core/pull/181769
[#181770]: https://github.com/home-assistant/core/pull/181770
[#181796]: https://github.com/home-assistant/core/pull/181796
[#181805]: https://github.com/home-assistant/core/pull/181805
[#181809]: https://github.com/home-assistant/core/pull/181809
[#181830]: https://github.com/home-assistant/core/pull/181830
[#181861]: https://github.com/home-assistant/core/pull/181861
[#181881]: https://github.com/home-assistant/core/pull/181881
[#181907]: https://github.com/home-assistant/core/pull/181907
[#181908]: https://github.com/home-assistant/core/pull/181908
[#181937]: https://github.com/home-assistant/core/pull/181937
[#181940]: https://github.com/home-assistant/core/pull/181940
[#181950]: https://github.com/home-assistant/core/pull/181950
[@Bre77]: https://github.com/Bre77
[@Chang-Jin-Lee]: https://github.com/Chang-Jin-Lee
[@CoMPaTech]: https://github.com/CoMPaTech
[@JamieMagee]: https://github.com/JamieMagee
[@MartinHjelmare]: https://github.com/MartinHjelmare
[@Oluwatobi-Mustapha]: https://github.com/Oluwatobi-Mustapha
[@TheJulianJES]: https://github.com/TheJulianJES
[@Tommatheussen]: https://github.com/Tommatheussen
[@allenporter]: https://github.com/allenporter
[@balloob]: https://github.com/balloob
[@barryvdh]: https://github.com/barryvdh
[@bazwilliams]: https://github.com/bazwilliams
[@bramkragten]: https://github.com/bramkragten
[@catsmanac]: https://github.com/catsmanac
[@chemelli74]: https://github.com/chemelli74
[@darkrain-nl]: https://github.com/darkrain-nl
[@erwindouna]: https://github.com/erwindouna
[@frankkopp]: https://github.com/frankkopp
[@frenck]: https://github.com/frenck
[@jasondillingham]: https://github.com/jasondillingham
[@kclif9]: https://github.com/kclif9
[@lackas]: https://github.com/lackas
[@neyzm]: https://github.com/neyzm
[@piitaya]: https://github.com/piitaya
[@raman325]: https://github.com/raman325
[@rqi14]: https://github.com/rqi14
[@sdague]: https://github.com/sdague
[@sdelmas]: https://github.com/sdelmas
[@starkillerOG]: https://github.com/starkillerOG
[abode docs]: https://www.home-assistant.io/integrations/abode/
[actron_air docs]: https://www.home-assistant.io/integrations/actron_air/
[airos docs]: https://www.home-assistant.io/integrations/airos/
[alarmdecoder docs]: https://www.home-assistant.io/integrations/alarmdecoder/
[alexa_devices docs]: https://www.home-assistant.io/integrations/alexa_devices/
[atag docs]: https://www.home-assistant.io/integrations/atag/
[enphase_envoy docs]: https://www.home-assistant.io/integrations/enphase_envoy/
[esphome docs]: https://www.home-assistant.io/integrations/esphome/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[go2rtc docs]: https://www.home-assistant.io/integrations/go2rtc/
[google docs]: https://www.home-assistant.io/integrations/google/
[hive docs]: https://www.home-assistant.io/integrations/hive/
[local_todo docs]: https://www.home-assistant.io/integrations/local_todo/
[mcp docs]: https://www.home-assistant.io/integrations/mcp/
[melcloud_home docs]: https://www.home-assistant.io/integrations/melcloud_home/
[midea docs]: https://www.home-assistant.io/integrations/midea/
[nest docs]: https://www.home-assistant.io/integrations/nest/
[nibe_heatpump docs]: https://www.home-assistant.io/integrations/nibe_heatpump/
[openhome docs]: https://www.home-assistant.io/integrations/openhome/
[portainer docs]: https://www.home-assistant.io/integrations/portainer/
[remember_the_milk docs]: https://www.home-assistant.io/integrations/remember_the_milk/
[remote_calendar docs]: https://www.home-assistant.io/integrations/remote_calendar/
[reolink docs]: https://www.home-assistant.io/integrations/reolink/
[roborock docs]: https://www.home-assistant.io/integrations/roborock/
[roomba docs]: https://www.home-assistant.io/integrations/roomba/
[satel_integra docs]: https://www.home-assistant.io/integrations/satel_integra/
[sftp_storage docs]: https://www.home-assistant.io/integrations/sftp_storage/
[tesla_fleet docs]: https://www.home-assistant.io/integrations/tesla_fleet/
[unifi docs]: https://www.home-assistant.io/integrations/unifi/
[usage_prediction docs]: https://www.home-assistant.io/integrations/usage_prediction/
[vicare docs]: https://www.home-assistant.io/integrations/vicare/
[vizio docs]: https://www.home-assistant.io/integrations/vizio/
[waterfurnace docs]: https://www.home-assistant.io/integrations/waterfurnace/
[webostv docs]: https://www.home-assistant.io/integrations/webostv/
[weheat docs]: https://www.home-assistant.io/integrations/weheat/
[xbox docs]: https://www.home-assistant.io/integrations/xbox/
[zha docs]: https://www.home-assistant.io/integrations/zha/