### PR TITLE
Make Wyoming STT duplex for early exit

### DIFF
--- a/homeassistant/components/wyoming/stt.py
+++ b/homeassistant/components/wyoming/stt.py
@@ -1,5 +1,6 @@
 """Support for Wyoming speech-to-text services."""
 
+import asyncio
 from collections.abc import AsyncIterable
 import logging
 from typing import override
@@ -19,6 +20,42 @@ from .error import WyomingError, error_event_message
 from .models import WyomingConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def _async_upload_audio(
+    client: AsyncTcpClient, stream: AsyncIterable[bytes]
+) -> None:
+    """Upload an audio stream to a Wyoming service."""
+    async for audio_bytes in stream:
+        chunk = AudioChunk(
+            rate=SAMPLE_RATE,
+            width=SAMPLE_WIDTH,
+            channels=SAMPLE_CHANNELS,
+            audio=audio_bytes,
+        )
+        await client.write_event(chunk.event())
+
+    await client.write_event(AudioStop().event())
+
+
+async def _async_receive_result(client: AsyncTcpClient) -> stt.SpeechResult:
+    """Receive a transcription result from a Wyoming service."""
+    while True:
+        event = await client.read_event()
+        if event is None:
+            _LOGGER.debug("Connection lost")
+            return stt.SpeechResult(None, stt.SpeechResultState.ERROR)
+
+        if Error.is_type(event.type):
+            _LOGGER.error(error_event_message(Error.from_event(event)))
+            return stt.SpeechResult(None, stt.SpeechResultState.ERROR)
+
+        if Transcript.is_type(event.type):
+            transcript = Transcript.from_event(event)
+            return stt.SpeechResult(
+                transcript.text,
+                stt.SpeechResultState.SUCCESS,
+            )
 
 
 async def async_setup_entry(
@@ -53,6 +90,11 @@ class WyomingSttProvider(stt.SpeechToTextEntity):
                 model_languages.update(asr_model.languages)
 
         self._supported_languages = list(model_languages)
+        self._audio_processing = stt.SpeechAudioProcessing(
+            requires_external_vad=asr_service.requires_external_vad,
+            prefers_auto_gain_enabled=asr_service.prefers_auto_gain_enabled,
+            prefers_noise_reduction_enabled=asr_service.prefers_noise_reduction_enabled,
+        )
         self._attr_name = asr_service.name
         self._attr_unique_id = f"{config_entry.entry_id}-stt"  # pylint: disable=home-assistant-entity-unique-id-redundant-platform
 
@@ -92,6 +134,12 @@ class WyomingSttProvider(stt.SpeechToTextEntity):
         """Return a list of supported channels."""
         return [stt.AudioChannels.CHANNEL_MONO]
 
+    @property
+    @override
+    def audio_processing(self) -> stt.SpeechAudioProcessing:
+        """Return required/preferred input audio processing settings."""
+        return self._audio_processing
+
     @override
     async def async_process_audio_stream(
         self, metadata: stt.SpeechMetadata, stream: AsyncIterable[bytes]
@@ -111,38 +159,39 @@ class WyomingSttProvider(stt.SpeechToTextEntity):
                     ).event(),
                 )
 
-                async for audio_bytes in stream:
-                    chunk = AudioChunk(
-                        rate=SAMPLE_RATE,
-                        width=SAMPLE_WIDTH,
-                        channels=SAMPLE_CHANNELS,
-                        audio=audio_bytes,
+                upload_task = asyncio.create_task(_async_upload_audio(client, stream))
+                receive_task = asyncio.create_task(_async_receive_result(client))
+                tasks = (upload_task, receive_task)
+                try:
+                    done, _ = await asyncio.wait(
+                        tasks, return_when=asyncio.FIRST_COMPLETED
                     )
-                    await client.write_event(chunk.event())
 
-                # End audio stream
-                await client.write_event(AudioStop().event())
+                    if upload_task in done:
+                        upload_task.result()
 
-                while True:
-                    event = await client.read_event()
-                    if event is None:
-                        _LOGGER.debug("Connection lost")
-                        return stt.SpeechResult(None, stt.SpeechResultState.ERROR)
+                    if receive_task in done:
+                        return receive_task.result()
 
-                    if Error.is_type(event.type):
-                        _LOGGER.error(error_event_message(Error.from_event(event)))
-                        return stt.SpeechResult(None, stt.SpeechResultState.ERROR)
+                    return await receive_task
+                finally:
+                    current_task = asyncio.current_task()
+                    was_cancelled = (
+                        current_task is not None and current_task.cancelling()
+                    )
+                    for task in tasks:
+                        if not task.done():
+                            task.cancel()
 
-                    if Transcript.is_type(event.type):
-                        transcript = Transcript.from_event(event)
-                        text = transcript.text
-                        break
+                    await asyncio.gather(*tasks, return_exceptions=True)
+
+                    if not was_cancelled:
+                        for task in tasks:
+                            if not task.cancelled() and (
+                                task_exception := task.exception()
+                            ):
+                                raise task_exception
 
         except OSError, WyomingError:
             _LOGGER.exception("Error processing audio stream")
             return stt.SpeechResult(None, stt.SpeechResultState.ERROR)
-
-        return stt.SpeechResult(
-            text,
-            stt.SpeechResultState.SUCCESS,
-        )

--- a/homeassistant/components/wyoming/stt.py
+++ b/homeassistant/components/wyoming/stt.py
@@ -1,9 +1,9 @@
 """Support for Wyoming speech-to-text services."""
 
 import asyncio
-from collections.abc import AsyncIterable
+from collections.abc import AsyncIterable, AsyncIterator
 import logging
-from typing import override
+from typing import Protocol, override, runtime_checkable
 
 from wyoming.asr import Transcribe, Transcript
 from wyoming.audio import AudioChunk, AudioStart, AudioStop
@@ -22,20 +22,33 @@ from .models import WyomingConfigEntry
 _LOGGER = logging.getLogger(__name__)
 
 
+@runtime_checkable
+class _ClosableAsyncIterator(Protocol):
+    """Async iterator that can be closed."""
+
+    async def aclose(self) -> None:
+        """Close the iterator."""
+
+
 async def _async_upload_audio(
     client: AsyncTcpClient, stream: AsyncIterable[bytes]
 ) -> None:
     """Upload an audio stream to a Wyoming service."""
-    async for audio_bytes in stream:
-        chunk = AudioChunk(
-            rate=SAMPLE_RATE,
-            width=SAMPLE_WIDTH,
-            channels=SAMPLE_CHANNELS,
-            audio=audio_bytes,
-        )
-        await client.write_event(chunk.event())
+    stream_iterator: AsyncIterator[bytes] = aiter(stream)
+    try:
+        async for audio_bytes in stream_iterator:
+            chunk = AudioChunk(
+                rate=SAMPLE_RATE,
+                width=SAMPLE_WIDTH,
+                channels=SAMPLE_CHANNELS,
+                audio=audio_bytes,
+            )
+            await client.write_event(chunk.event())
 
-    await client.write_event(AudioStop().event())
+        await client.write_event(AudioStop().event())
+    finally:
+        if isinstance(stream_iterator, _ClosableAsyncIterator):
+            await stream_iterator.aclose()
 
 
 async def _async_receive_result(client: AsyncTcpClient) -> stt.SpeechResult:
@@ -167,30 +180,17 @@ class WyomingSttProvider(stt.SpeechToTextEntity):
                         tasks, return_when=asyncio.FIRST_COMPLETED
                     )
 
-                    if upload_task in done:
-                        upload_task.result()
-
                     if receive_task in done:
                         return receive_task.result()
 
+                    upload_task.result()
                     return await receive_task
                 finally:
-                    current_task = asyncio.current_task()
-                    was_cancelled = (
-                        current_task is not None and current_task.cancelling()
-                    )
                     for task in tasks:
                         if not task.done():
                             task.cancel()
 
                     await asyncio.gather(*tasks, return_exceptions=True)
-
-                    if not was_cancelled:
-                        for task in tasks:
-                            if not task.cancelled() and (
-                                task_exception := task.exception()
-                            ):
-                                raise task_exception
 
         except OSError, WyomingError:
             _LOGGER.exception("Error processing audio stream")

--- a/tests/components/wyoming/snapshots/test_stt.ambr
+++ b/tests/components/wyoming/snapshots/test_stt.ambr
@@ -25,7 +25,7 @@
         'timestamp': None,
         'width': 2,
       }),
-      'payload': 'chunk1',
+      'payload': b'chunk1',
       'type': 'audio-chunk',
     }),
     dict({
@@ -35,7 +35,7 @@
         'timestamp': None,
         'width': 2,
       }),
-      'payload': 'chunk2',
+      'payload': b'chunk2',
       'type': 'audio-chunk',
     }),
     dict({

--- a/tests/components/wyoming/test_stt.py
+++ b/tests/components/wyoming/test_stt.py
@@ -111,7 +111,19 @@ async def test_early_transcript_stops_audio_stream(
     entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
     assert entity is not None
 
+    audio_write_started = asyncio.Event()
     stream_closed = asyncio.Event()
+
+    class EarlyTranscriptClient(MockAsyncTcpClient):
+        async def write_event(self, event: Event) -> None:
+            await super().write_event(event)
+            if AudioChunk.is_type(event.type):
+                audio_write_started.set()
+                await asyncio.Event().wait()
+
+        async def read_event(self) -> Event | None:
+            await audio_write_started.wait()
+            return await super().read_event()
 
     async def audio_stream() -> AsyncGenerator[bytes]:
         try:
@@ -120,7 +132,7 @@ async def test_early_transcript_stops_audio_stream(
         finally:
             stream_closed.set()
 
-    mock_client = MockAsyncTcpClient([Transcript(text="Hello world").event()])
+    mock_client = EarlyTranscriptClient([Transcript(text="Hello world").event()])
     with patch(
         "homeassistant.components.wyoming.stt.AsyncTcpClient",
         mock_client,
@@ -133,6 +145,38 @@ async def test_early_transcript_stops_audio_stream(
     assert stream_closed.is_set()
     assert any(AudioChunk.is_type(event.type) for event in mock_client.written)
     assert not any(AudioStop.is_type(event.type) for event in mock_client.written)
+
+
+@pytest.mark.usefixtures("init_wyoming_stt")
+async def test_early_transcript_preserved_after_upload_error(
+    hass: HomeAssistant, metadata: stt.SpeechMetadata
+) -> None:
+    """Test an upload error does not replace a completed transcript."""
+    entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
+    assert entity is not None
+
+    async def audio_stream() -> AsyncGenerator[bytes]:
+        yield b"chunk1"
+
+    mock_client = MockAsyncTcpClient([Transcript(text="Hello world").event()])
+    original_write_event = mock_client.write_event
+
+    async def write_event(event: Event) -> None:
+        await original_write_event(event)
+        if AudioChunk.is_type(event.type):
+            raise OSError("Connection closed")
+
+    with (
+        patch(
+            "homeassistant.components.wyoming.stt.AsyncTcpClient",
+            mock_client,
+        ),
+        patch.object(mock_client, "write_event", side_effect=write_event),
+    ):
+        result = await entity.async_process_audio_stream(metadata, audio_stream())
+
+    assert result.result == stt.SpeechResultState.SUCCESS
+    assert result.text == "Hello world"
 
 
 @pytest.mark.usefixtures("init_wyoming_stt")

--- a/tests/components/wyoming/test_stt.py
+++ b/tests/components/wyoming/test_stt.py
@@ -1,19 +1,26 @@
 """Test stt."""
 
+import asyncio
+from collections.abc import AsyncGenerator
+from dataclasses import replace
 from unittest.mock import patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
 from wyoming.asr import Transcript
+from wyoming.audio import AudioChunk, AudioStop
 from wyoming.error import Error
+from wyoming.event import Event
 
 from homeassistant.components import stt
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import MockAsyncTcpClient
+from . import STT_INFO, MockAsyncTcpClient
 
 
-async def test_support(hass: HomeAssistant, init_wyoming_stt) -> None:
+@pytest.mark.usefixtures("init_wyoming_stt")
+async def test_support(hass: HomeAssistant) -> None:
     """Test supported properties."""
     state = hass.states.get("stt.test_asr")
     assert state is not None
@@ -27,22 +34,67 @@ async def test_support(hass: HomeAssistant, init_wyoming_stt) -> None:
     assert entity.supported_bit_rates == [stt.AudioBitRates.BITRATE_16]
     assert entity.supported_sample_rates == [stt.AudioSampleRates.SAMPLERATE_16000]
     assert entity.supported_channels == [stt.AudioChannels.CHANNEL_MONO]
+    assert entity.audio_processing == stt.SpeechAudioProcessing(
+        requires_external_vad=True,
+        prefers_auto_gain_enabled=True,
+        prefers_noise_reduction_enabled=True,
+    )
 
 
+async def test_audio_processing(
+    hass: HomeAssistant, stt_config_entry: ConfigEntry
+) -> None:
+    """Test advertised audio processing properties."""
+    asr_program = replace(
+        STT_INFO.asr[0],
+        requires_external_vad=False,
+        prefers_auto_gain_enabled=False,
+        prefers_noise_reduction_enabled=False,
+    )
+    with patch(
+        "homeassistant.components.wyoming.data.load_wyoming_info",
+        return_value=replace(STT_INFO, asr=[asr_program]),
+    ):
+        await hass.config_entries.async_setup(stt_config_entry.entry_id)
+
+    entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
+    assert entity is not None
+    assert entity.audio_processing == stt.SpeechAudioProcessing(
+        requires_external_vad=False,
+        prefers_auto_gain_enabled=False,
+        prefers_noise_reduction_enabled=False,
+    )
+
+
+@pytest.mark.usefixtures("init_wyoming_stt")
 async def test_streaming_audio(
-    hass: HomeAssistant, init_wyoming_stt, metadata, snapshot: SnapshotAssertion
+    hass: HomeAssistant,
+    metadata: stt.SpeechMetadata,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test streaming audio."""
     entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
     assert entity is not None
 
-    async def audio_stream():
-        yield "chunk1"
-        yield "chunk2"
+    class AudioStopTranscriptClient(MockAsyncTcpClient):
+        async def write_event(self, event: Event) -> None:
+            await super().write_event(event)
+            if AudioStop.is_type(event.type):
+                self.responses.append(Transcript(text="Hello world").event())
 
+        async def read_event(self) -> Event | None:
+            while not self.responses:
+                await asyncio.sleep(0)
+            return await super().read_event()
+
+    async def audio_stream() -> AsyncGenerator[bytes]:
+        yield b"chunk1"
+        yield b"chunk2"
+
+    mock_client = AudioStopTranscriptClient([])
     with patch(
         "homeassistant.components.wyoming.stt.AsyncTcpClient",
-        MockAsyncTcpClient([Transcript(text="Hello world").event()]),
+        mock_client,
     ) as mock_client:
         result = await entity.async_process_audio_stream(metadata, audio_stream())
 
@@ -51,15 +103,54 @@ async def test_streaming_audio(
     assert mock_client.written == snapshot
 
 
+@pytest.mark.usefixtures("init_wyoming_stt")
+async def test_early_transcript_stops_audio_stream(
+    hass: HomeAssistant, metadata: stt.SpeechMetadata
+) -> None:
+    """Test an early transcript stops the source audio stream."""
+    entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
+    assert entity is not None
+
+    stream_closed = asyncio.Event()
+
+    async def audio_stream() -> AsyncGenerator[bytes]:
+        try:
+            yield b"chunk1"
+            await asyncio.Event().wait()
+        finally:
+            stream_closed.set()
+
+    mock_client = MockAsyncTcpClient([Transcript(text="Hello world").event()])
+    with patch(
+        "homeassistant.components.wyoming.stt.AsyncTcpClient",
+        mock_client,
+    ):
+        async with asyncio.timeout(1):
+            result = await entity.async_process_audio_stream(metadata, audio_stream())
+
+    assert result.result == stt.SpeechResultState.SUCCESS
+    assert result.text == "Hello world"
+    assert stream_closed.is_set()
+    assert any(AudioChunk.is_type(event.type) for event in mock_client.written)
+    assert not any(AudioStop.is_type(event.type) for event in mock_client.written)
+
+
+@pytest.mark.usefixtures("init_wyoming_stt")
 async def test_streaming_audio_connection_lost(
-    hass: HomeAssistant, init_wyoming_stt, metadata
+    hass: HomeAssistant, metadata: stt.SpeechMetadata
 ) -> None:
     """Test streaming audio and losing connection."""
     entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
     assert entity is not None
 
-    async def audio_stream():
-        yield "chunk1"
+    stream_closed = asyncio.Event()
+
+    async def audio_stream() -> AsyncGenerator[bytes]:
+        try:
+            yield b"chunk1"
+            await asyncio.Event().wait()
+        finally:
+            stream_closed.set()
 
     with patch(
         "homeassistant.components.wyoming.stt.AsyncTcpClient",
@@ -69,6 +160,7 @@ async def test_streaming_audio_connection_lost(
 
     assert result.result == stt.SpeechResultState.ERROR
     assert result.text is None
+    assert stream_closed.is_set()
 
 
 @pytest.mark.usefixtures("init_wyoming_stt")
@@ -94,8 +186,14 @@ async def test_streaming_audio_error_event(
     entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
     assert entity is not None
 
-    async def audio_stream():
-        yield "chunk1"
+    stream_closed = asyncio.Event()
+
+    async def audio_stream() -> AsyncGenerator[bytes]:
+        try:
+            yield b"chunk1"
+            await asyncio.Event().wait()
+        finally:
+            stream_closed.set()
 
     with patch(
         "homeassistant.components.wyoming.stt.AsyncTcpClient",
@@ -105,18 +203,20 @@ async def test_streaming_audio_error_event(
 
     assert result.result == stt.SpeechResultState.ERROR
     assert result.text is None
+    assert stream_closed.is_set()
     assert expected_message in caplog.text
 
 
+@pytest.mark.usefixtures("init_wyoming_stt")
 async def test_streaming_audio_oserror(
-    hass: HomeAssistant, init_wyoming_stt, metadata
+    hass: HomeAssistant, metadata: stt.SpeechMetadata
 ) -> None:
     """Test streaming audio and error raising."""
     entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
     assert entity is not None
 
-    async def audio_stream():
-        yield "chunk1"
+    async def audio_stream() -> AsyncGenerator[bytes]:
+        yield b"chunk1"
 
     mock_client = MockAsyncTcpClient([Transcript(text="Hello world").event()])
 
@@ -131,3 +231,94 @@ async def test_streaming_audio_oserror(
 
     assert result.result == stt.SpeechResultState.ERROR
     assert result.text is None
+
+
+@pytest.mark.usefixtures("init_wyoming_stt")
+async def test_streaming_audio_source_error(
+    hass: HomeAssistant, metadata: stt.SpeechMetadata
+) -> None:
+    """Test an audio source error is propagated and stops receiving."""
+    entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
+    assert entity is not None
+
+    receive_started = asyncio.Event()
+    receive_cancelled = asyncio.Event()
+
+    async def audio_stream() -> AsyncGenerator[bytes]:
+        yield b"chunk1"
+        await receive_started.wait()
+        raise RuntimeError("Boom!")
+
+    async def read_event() -> None:
+        try:
+            receive_started.set()
+            await asyncio.Event().wait()
+        finally:
+            receive_cancelled.set()
+
+    mock_client = MockAsyncTcpClient([])
+    with (
+        patch(
+            "homeassistant.components.wyoming.stt.AsyncTcpClient",
+            mock_client,
+        ),
+        patch.object(mock_client, "read_event", side_effect=read_event),
+        pytest.raises(RuntimeError, match="Boom!"),
+    ):
+        await entity.async_process_audio_stream(metadata, audio_stream())
+
+    assert receive_cancelled.is_set()
+
+
+@pytest.mark.usefixtures("init_wyoming_stt")
+async def test_streaming_audio_cancellation(
+    hass: HomeAssistant, metadata: stt.SpeechMetadata
+) -> None:
+    """Test cancellation stops both upload and receive tasks."""
+    entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")
+    assert entity is not None
+
+    audio_sent = asyncio.Event()
+    stream_closed = asyncio.Event()
+    receive_cancelled = asyncio.Event()
+
+    async def audio_stream() -> AsyncGenerator[bytes]:
+        try:
+            yield b"chunk1"
+            await asyncio.Event().wait()
+        finally:
+            stream_closed.set()
+
+    mock_client = MockAsyncTcpClient([])
+    original_write_event = mock_client.write_event
+
+    async def write_event(event: Event) -> None:
+        await original_write_event(event)
+        if AudioChunk.is_type(event.type):
+            audio_sent.set()
+
+    async def read_event() -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            receive_cancelled.set()
+
+    with (
+        patch(
+            "homeassistant.components.wyoming.stt.AsyncTcpClient",
+            mock_client,
+        ),
+        patch.object(mock_client, "write_event", side_effect=write_event),
+        patch.object(mock_client, "read_event", side_effect=read_event),
+    ):
+        async with asyncio.timeout(1):
+            process_task = asyncio.create_task(
+                entity.async_process_audio_stream(metadata, audio_stream())
+            )
+            await audio_sent.wait()
+            process_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await process_task
+
+    assert stream_closed.is_set()
+    assert receive_cancelled.is_set()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If an Wyoming speech-to-text app does its own VAD and returns a transcript early, HA could hang or delay further processing of the voice command. This PR makes HA listen for transcript (and error, etc.) events while streaming audio.

Some small test clean up is also included.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
