### PR TITLE
Bound Teslemetry Bluetooth disconnect timeout on unload

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -908,9 +908,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) 
                 try:
                     async with asyncio.timeout(BLE_DISCONNECT_TIMEOUT):
                         await vehicle.api.primary.disconnect()
-                except (BleakError, TeslaFleetError, TimeoutError) as err:
+                except TimeoutError:
                     # Swallowed so one stuck link cannot block the unload, but
                     # warn: a leaked BLE connection can keep the vehicle awake.
+                    LOGGER.warning(
+                        "Bluetooth disconnect for %s timed out after %ss",
+                        vehicle.vin,
+                        BLE_DISCONNECT_TIMEOUT,
+                    )
+                except (BleakError, TeslaFleetError) as err:
                     LOGGER.warning(
                         "Error disconnecting Bluetooth for %s: %s", vehicle.vin, err
                     )

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -907,18 +907,22 @@ async def async_unload_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) 
             if isinstance(vehicle.api, VehicleRouter):
                 try:
                     async with asyncio.timeout(BLE_DISCONNECT_TIMEOUT):
-                        await vehicle.api.primary.disconnect()
+                        try:
+                            await vehicle.api.primary.disconnect()
+                        except (BleakError, TeslaFleetError, TimeoutError) as err:
+                            # Swallowed so one stuck link cannot block the
+                            # unload, but warn: a leaked BLE connection can
+                            # keep the vehicle awake.
+                            LOGGER.warning(
+                                "Error disconnecting Bluetooth for %s: %s",
+                                vehicle.vin,
+                                err,
+                            )
                 except TimeoutError:
-                    # Swallowed so one stuck link cannot block the unload, but
-                    # warn: a leaked BLE connection can keep the vehicle awake.
                     LOGGER.warning(
                         "Bluetooth disconnect for %s timed out after %ss",
                         vehicle.vin,
                         BLE_DISCONNECT_TIMEOUT,
-                    )
-                except (BleakError, TeslaFleetError) as err:
-                    LOGGER.warning(
-                        "Error disconnecting Bluetooth for %s: %s", vehicle.vin, err
                     )
     return unloaded
 

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -59,6 +59,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .const import (
+    BLE_DISCONNECT_TIMEOUT,
     CLIENT_ID,
     CONF_VIN,
     DOMAIN,
@@ -905,7 +906,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) 
         for vehicle in entry.runtime_data.vehicles:
             if isinstance(vehicle.api, VehicleRouter):
                 try:
-                    await vehicle.api.primary.disconnect()
+                    async with asyncio.timeout(BLE_DISCONNECT_TIMEOUT):
+                        await vehicle.api.primary.disconnect()
                 except (BleakError, TeslaFleetError, TimeoutError) as err:
                     # Swallowed so one stuck link cannot block the unload, but
                     # warn: a leaked BLE connection can keep the vehicle awake.

--- a/homeassistant/components/teslemetry/const.py
+++ b/homeassistant/components/teslemetry/const.py
@@ -17,6 +17,7 @@ CONF_VIN = "vin"
 VEHICLE_KEY_FILE = "tesla_vehicle.key"
 BLE_PARENT_KEY = f"{DOMAIN}_ble_parent"
 BLE_PARENT_LOCK_KEY = f"{DOMAIN}_ble_parent_lock"
+BLE_DISCONNECT_TIMEOUT = 10
 
 SUBENTRY_TYPE_ENERGY_SITE = "energy_site"
 CONF_SITE_ID = "site_id"

--- a/homeassistant/components/teslemetry/helpers.py
+++ b/homeassistant/components/teslemetry/helpers.py
@@ -22,7 +22,9 @@ async def async_get_ble_parent(hass: HomeAssistant) -> TeslaBluetooth:
         if existing is not None:
             return existing
         parent = TeslaBluetooth()
-        await parent.get_private_key(hass.config.path(VEHICLE_KEY_FILE))
+        await hass.async_add_executor_job(
+            asyncio.run, parent.get_private_key(hass.config.path(VEHICLE_KEY_FILE))
+        )
         hass.data[BLE_PARENT_KEY] = parent
         return parent
 

--- a/homeassistant/components/teslemetry/helpers.py
+++ b/homeassistant/components/teslemetry/helpers.py
@@ -22,9 +22,7 @@ async def async_get_ble_parent(hass: HomeAssistant) -> TeslaBluetooth:
         if existing is not None:
             return existing
         parent = TeslaBluetooth()
-        await hass.async_add_executor_job(
-            asyncio.run, parent.get_private_key(hass.config.path(VEHICLE_KEY_FILE))
-        )
+        await parent.get_private_key(hass.config.path(VEHICLE_KEY_FILE))
         hass.data[BLE_PARENT_KEY] = parent
         return parent
 

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from copy import deepcopy
 import logging
 import time
@@ -2306,6 +2306,42 @@ async def test_unload_never_connected_bluetooth(hass: HomeAssistant) -> None:
     bluetooth_vehicle.disconnect.assert_awaited_once()
 
 
+async def test_unload_disconnect_timeout(hass: HomeAssistant) -> None:
+    """A hung Bluetooth disconnect cannot block unload past the timeout."""
+    entry = _entry_with_ble()
+    entry.add_to_hass(hass)
+    bluetooth_vehicle = AsyncMock()
+
+    async def _hang(*args: object, **kwargs: object) -> None:
+        await asyncio.sleep(999)
+
+    bluetooth_vehicle.disconnect = AsyncMock(side_effect=_hang)
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry.async_ble_device_from_address",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.components.teslemetry.helpers.TeslaBluetooth"
+        ) as mock_parent,
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+        patch("homeassistant.components.teslemetry.BLE_DISCONNECT_TIMEOUT", 0),
+    ):
+        mock_parent.return_value.get_private_key = AsyncMock()
+        mock_parent.return_value.vehicles.createBluetooth.return_value = (
+            bluetooth_vehicle
+        )
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert isinstance(entry.runtime_data.vehicles[0].api, VehicleRouter)
+
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    bluetooth_vehicle.disconnect.assert_awaited_once()
+
+
 async def test_ble_parent_shared_and_cached(hass: HomeAssistant) -> None:
     """The BLE parent (holding the private key) is created once and reused."""
     with patch(
@@ -2337,6 +2373,34 @@ async def test_ble_parent_concurrent_first_init(hass: HomeAssistant) -> None:
     assert all(parent is parents[0] for parent in parents)
     mock_parent.assert_called_once()
     mock_parent.return_value.get_private_key.assert_awaited_once()
+
+
+async def test_ble_parent_key_load_runs_off_event_loop(hass: HomeAssistant) -> None:
+    """Loading the private key cannot stall the event loop, even if it blocks."""
+    heartbeats = 0
+
+    async def _heartbeat() -> None:
+        nonlocal heartbeats
+        while True:
+            await asyncio.sleep(0.01)
+            heartbeats += 1
+
+    async def _blocking_get_private_key(path: str) -> None:
+        time.sleep(0.2)  # noqa: ASYNC251 - simulates the library's synchronous work
+
+    with patch(
+        "homeassistant.components.teslemetry.helpers.TeslaBluetooth"
+    ) as mock_parent:
+        mock_parent.return_value.get_private_key = AsyncMock(
+            side_effect=_blocking_get_private_key
+        )
+        heartbeat_task = hass.async_create_task(_heartbeat())
+        await async_get_ble_parent(hass)
+        heartbeat_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await heartbeat_task
+
+    assert heartbeats >= 1
 
 
 async def test_router_does_not_fail_over_on_unconfirmed() -> None:

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager
 from copy import deepcopy
 import logging
 import time
@@ -2373,34 +2373,6 @@ async def test_ble_parent_concurrent_first_init(hass: HomeAssistant) -> None:
     assert all(parent is parents[0] for parent in parents)
     mock_parent.assert_called_once()
     mock_parent.return_value.get_private_key.assert_awaited_once()
-
-
-async def test_ble_parent_key_load_runs_off_event_loop(hass: HomeAssistant) -> None:
-    """Loading the private key cannot stall the event loop, even if it blocks."""
-    heartbeats = 0
-
-    async def _heartbeat() -> None:
-        nonlocal heartbeats
-        while True:
-            await asyncio.sleep(0.01)
-            heartbeats += 1
-
-    async def _blocking_get_private_key(path: str) -> None:
-        time.sleep(0.2)  # noqa: ASYNC251 - simulates the library's synchronous work
-
-    with patch(
-        "homeassistant.components.teslemetry.helpers.TeslaBluetooth"
-    ) as mock_parent:
-        mock_parent.return_value.get_private_key = AsyncMock(
-            side_effect=_blocking_get_private_key
-        )
-        heartbeat_task = hass.async_create_task(_heartbeat())
-        await async_get_ble_parent(hass)
-        heartbeat_task.cancel()
-        with suppress(asyncio.CancelledError):
-            await heartbeat_task
-
-    assert heartbeats >= 1
 
 
 async def test_router_does_not_fail_over_on_unconfirmed() -> None:

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -2313,9 +2313,10 @@ async def test_unload_disconnect_timeout(
     entry = _entry_with_ble()
     entry.add_to_hass(hass)
     bluetooth_vehicle = AsyncMock()
+    never_set = asyncio.Event()
 
     async def _hang(*args: object, **kwargs: object) -> None:
-        await asyncio.sleep(999)
+        await never_set.wait()
 
     bluetooth_vehicle.disconnect = AsyncMock(side_effect=_hang)
 
@@ -2337,7 +2338,6 @@ async def test_unload_disconnect_timeout(
         )
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-        assert isinstance(entry.runtime_data.vehicles[0].api, VehicleRouter)
 
         assert await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
@@ -2372,7 +2372,6 @@ async def test_unload_disconnect_instant_timeout(
         )
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-        assert isinstance(entry.runtime_data.vehicles[0].api, VehicleRouter)
 
         assert await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -2346,6 +2346,43 @@ async def test_unload_disconnect_timeout(
     assert "timed out after 0s" in caplog.text
 
 
+async def test_unload_disconnect_instant_timeout(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A TimeoutError raised by disconnect() itself is not mistaken for the deadline."""
+    entry = _entry_with_ble()
+    entry.add_to_hass(hass)
+    bluetooth_vehicle = AsyncMock()
+    bluetooth_vehicle.disconnect = AsyncMock(side_effect=TimeoutError("device busy"))
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry.async_ble_device_from_address",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "homeassistant.components.teslemetry.helpers.TeslaBluetooth"
+        ) as mock_parent,
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+        caplog.at_level(logging.WARNING),
+    ):
+        mock_parent.return_value.get_private_key = AsyncMock()
+        mock_parent.return_value.vehicles.createBluetooth.return_value = (
+            bluetooth_vehicle
+        )
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert isinstance(entry.runtime_data.vehicles[0].api, VehicleRouter)
+
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    bluetooth_vehicle.disconnect.assert_awaited_once()
+    assert "Error disconnecting Bluetooth for" in caplog.text
+    assert "device busy" in caplog.text
+    assert "timed out after" not in caplog.text
+
+
 async def test_ble_parent_shared_and_cached(hass: HomeAssistant) -> None:
     """The BLE parent (holding the private key) is created once and reused."""
     with patch(

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -2306,7 +2306,9 @@ async def test_unload_never_connected_bluetooth(hass: HomeAssistant) -> None:
     bluetooth_vehicle.disconnect.assert_awaited_once()
 
 
-async def test_unload_disconnect_timeout(hass: HomeAssistant) -> None:
+async def test_unload_disconnect_timeout(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """A hung Bluetooth disconnect cannot block unload past the timeout."""
     entry = _entry_with_ble()
     entry.add_to_hass(hass)
@@ -2327,6 +2329,7 @@ async def test_unload_disconnect_timeout(hass: HomeAssistant) -> None:
         ) as mock_parent,
         patch("homeassistant.components.teslemetry.PLATFORMS", []),
         patch("homeassistant.components.teslemetry.BLE_DISCONNECT_TIMEOUT", 0),
+        caplog.at_level(logging.WARNING),
     ):
         mock_parent.return_value.get_private_key = AsyncMock()
         mock_parent.return_value.vehicles.createBluetooth.return_value = (
@@ -2340,6 +2343,7 @@ async def test_unload_disconnect_timeout(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     bluetooth_vehicle.disconnect.assert_awaited_once()
+    assert "timed out after 0s" in caplog.text
 
 
 async def test_ble_parent_shared_and_cached(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A failed Bluetooth adapter can make `vehicle.api.primary.disconnect()` hang during `async_unload_entry`, leaving the config entry stuck in `UNLOAD_IN_PROGRESS` until Home Assistant restarts, so wrapping it in `asyncio.timeout()` bounds the wait and lets the existing exception handling proceed with unload once the timeout fires.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
