### PR TITLE
Preserve float precision in Powerwall charge sensor

### DIFF
--- a/homeassistant/components/powerwall/sensor.py
+++ b/homeassistant/components/powerwall/sensor.py
@@ -286,6 +286,7 @@ class PowerWallChargeSensor(PowerWallEntity, SensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_suggested_display_precision = 0
 
     @property
     @override
@@ -295,9 +296,9 @@ class PowerWallChargeSensor(PowerWallEntity, SensorEntity):
 
     @property
     @override
-    def native_value(self) -> int:
+    def native_value(self) -> float:
         """Get the current value in percentage."""
-        return round(self.data.charge)
+        return self.data.charge
 
 
 class PowerWallEnergySensor(PowerWallEntity, SensorEntity):

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -113,7 +113,7 @@ async def test_sensors(hass: HomeAssistant, device_registry: dr.DeviceRegistry) 
     assert float(hass.states.get("sensor.mysite_solar_import").state) == 28.2
 
     state = hass.states.get("sensor.mysite_charge")
-    assert state.state == "47"
+    assert state.state == "47.34587394586"
     expected_attributes = {
         "unit_of_measurement": PERCENTAGE,
         "friendly_name": "MySite Charge",

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -114,6 +114,9 @@ async def test_sensors(hass: HomeAssistant, device_registry: dr.DeviceRegistry) 
 
     state = hass.states.get("sensor.mysite_charge")
     assert state.state == "47.34587394586"
+    entity_entry = er.async_get(hass).async_get("sensor.mysite_charge")
+    assert entity_entry is not None
+    assert entity_entry.options["sensor"]["suggested_display_precision"] == 0
     expected_attributes = {
         "unit_of_measurement": PERCENTAGE,
         "friendly_name": "MySite Charge",

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -32,7 +32,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_sensors(hass: HomeAssistant, device_registry: dr.DeviceRegistry) -> None:
+async def test_sensors(hass: HomeAssistant, device_registry: dr.DeviceRegistry, entity_registry: er.EntityRegistry) -> None:
     """Test creation of the sensors."""
 
     mock_powerwall = await _mock_powerwall_with_fixtures(hass)
@@ -114,7 +114,7 @@ async def test_sensors(hass: HomeAssistant, device_registry: dr.DeviceRegistry) 
 
     state = hass.states.get("sensor.mysite_charge")
     assert state.state == "47.34587394586"
-    entity_entry = er.async_get(hass).async_get("sensor.mysite_charge")
+    entity_entry = entity_registry.async_get("sensor.mysite_charge")
     assert entity_entry is not None
     assert entity_entry.options["sensor"]["suggested_display_precision"] == 0
     expected_attributes = {

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -32,7 +32,11 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_sensors(hass: HomeAssistant, device_registry: dr.DeviceRegistry, entity_registry: er.EntityRegistry) -> None:
+async def test_sensors(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
     """Test creation of the sensors."""
 
     mock_powerwall = await _mock_powerwall_with_fixtures(hass)


### PR DESCRIPTION
## Proposed change

The charge sensor rounded the Powerwall's float SoC to an integer. Return the raw float instead. `suggested_display_precision=0` keeps the whole-number display, decimals are opt-in.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes 
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
