### PR TITLE
motioneye: support motionEye 0.44 session authentication

### DIFF
--- a/homeassistant/components/motioneye/__init__.py
+++ b/homeassistant/components/motioneye/__init__.py
@@ -1,7 +1,8 @@
 """The motionEye integration."""
 
+from base64 import urlsafe_b64encode
 from collections.abc import Callable
-import contextlib
+from datetime import timedelta
 from http import HTTPStatus
 import json
 import logging
@@ -14,7 +15,6 @@ from motioneye_client.client import (
     MotionEyeClient,
     MotionEyeClientError,
     MotionEyeClientInvalidAuthError,
-    MotionEyeClientPathError,
 )
 from motioneye_client.const import (
     KEY_CAMERAS,
@@ -34,6 +34,7 @@ from motioneye_client.const import (
 )
 
 from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
+from homeassistant.components.http.auth import async_sign_path
 from homeassistant.components.media_source import URI_SCHEME
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -475,23 +476,15 @@ def _get_media_event_data(
             f"{URI_SCHEME}{DOMAIN}/{config_entry_id}#{device.id}#{kind}#{file_path}"
         ),
     }
-    url = get_media_url(
-        client,
-        camera_id,
-        file_path,
-        kind == "images",
+    encoded_path = urlsafe_b64encode(file_path.encode("utf-8")).decode("ascii")
+    proxy_path = (
+        f"/api/motioneye/media/{config_entry_id}/{camera_id}/"
+        f"{kind}/0/{encoded_path}"
     )
-    if url:
-        output[EVENT_FILE_URL] = url
+    output[EVENT_FILE_URL] = async_sign_path(
+        hass,
+        proxy_path,
+        timedelta(minutes=5),
+        use_content_user=True,
+    )
     return output
-
-
-def get_media_url(
-    client: MotionEyeClient, camera_id: int, path: str, image: bool
-) -> str | None:
-    """Get the URL for a motionEye media item."""
-    with contextlib.suppress(MotionEyeClientPathError):
-        if image:
-            return client.get_image_url(camera_id, path)
-        return client.get_movie_url(camera_id, path)
-    return None

--- a/homeassistant/components/motioneye/__init__.py
+++ b/homeassistant/components/motioneye/__init__.py
@@ -478,8 +478,7 @@ def _get_media_event_data(
     }
     encoded_path = urlsafe_b64encode(file_path.encode("utf-8")).decode("ascii")
     proxy_path = (
-        f"/api/motioneye/media/{config_entry_id}/{camera_id}/"
-        f"{kind}/0/{encoded_path}"
+        f"/api/motioneye/media/{config_entry_id}/{camera_id}/{kind}/0/{encoded_path}"
     )
     output[EVENT_FILE_URL] = async_sign_path(
         hass,

--- a/homeassistant/components/motioneye/camera.py
+++ b/homeassistant/components/motioneye/camera.py
@@ -255,6 +255,15 @@ class MotionEyeMjpegCamera(MotionEyeEntity, MjpegCamera):
         """Return the camera motion detection status."""
         return self._motion_detection_enabled
 
+    @override
+    async def async_camera_image(
+        self, width: int | None = None, height: int | None = None
+    ) -> bytes | None:
+        """Return a still image using the authenticated motionEye client."""
+        if not self._camera:
+            return None
+        return await self._client.async_get_camera_snapshot(self._camera_id)
+
     async def async_set_text_overlay(
         self,
         left_text: str | None = None,

--- a/homeassistant/components/motioneye/camera.py
+++ b/homeassistant/components/motioneye/camera.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping
 from contextlib import suppress
-from typing import Any, override
+from typing import Any, cast, override
 
 import aiohttp
 from jinja2 import Template
@@ -262,7 +262,7 @@ class MotionEyeMjpegCamera(MotionEyeEntity, MjpegCamera):
         """Return a still image using the authenticated motionEye client."""
         if not self._camera:
             return None
-        return await self._client.async_get_camera_snapshot(self._camera_id)
+        return await cast(Any, self._client).async_get_camera_snapshot(self._camera_id)
 
     async def async_set_text_overlay(
         self,

--- a/homeassistant/components/motioneye/camera.py
+++ b/homeassistant/components/motioneye/camera.py
@@ -195,8 +195,16 @@ class MotionEyeMjpegCamera(MotionEyeEntity, MjpegCamera):
 
         return {
             CONF_NAME: None,
-            CONF_USERNAME: self._surveillance_username if auth is not None else None,
-            CONF_PASSWORD: self._surveillance_password if auth is not None else "",
+            CONF_USERNAME: (
+                camera.get("streaming_username", self._surveillance_username)
+                if auth is not None
+                else None
+            ),
+            CONF_PASSWORD: (
+                camera.get("streaming_password", self._surveillance_password)
+                if auth is not None
+                else ""
+            ),
             CONF_MJPEG_URL: streaming_url or "",
             CONF_STILL_IMAGE_URL: self._client.get_camera_snapshot_url(camera),
             CONF_AUTHENTICATION: auth,

--- a/homeassistant/components/motioneye/manifest.json
+++ b/homeassistant/components/motioneye/manifest.json
@@ -19,6 +19,6 @@
     "motioneye_client"
   ],
   "requirements": [
-    "motioneye-client @ git+https://github.com/mkrawcz1/motioneye-client.git@857d1058d1465d57c96d06fbd3ac55462b2fff7e"
+    "motioneye-client==0.3.14"
   ]
 }

--- a/homeassistant/components/motioneye/manifest.json
+++ b/homeassistant/components/motioneye/manifest.json
@@ -1,13 +1,24 @@
 {
   "domain": "motioneye",
   "name": "motionEye",
-  "after_dependencies": ["media_source"],
-  "codeowners": ["@dermotduffy"],
+  "after_dependencies": [
+    "media_source"
+  ],
+  "codeowners": [
+    "@dermotduffy"
+  ],
   "config_flow": true,
-  "dependencies": ["http", "webhook"],
+  "dependencies": [
+    "http",
+    "webhook"
+  ],
   "documentation": "https://www.home-assistant.io/integrations/motioneye",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "loggers": ["motioneye_client"],
-  "requirements": ["motioneye-client==0.3.14"]
+  "loggers": [
+    "motioneye_client"
+  ],
+  "requirements": [
+    "motioneye-client @ git+https://github.com/mkrawcz1/motioneye-client.git@857d1058d1465d57c96d06fbd3ac55462b2fff7e"
+  ]
 }

--- a/homeassistant/components/motioneye/manifest.json
+++ b/homeassistant/components/motioneye/manifest.json
@@ -1,24 +1,13 @@
 {
   "domain": "motioneye",
   "name": "motionEye",
-  "after_dependencies": [
-    "media_source"
-  ],
-  "codeowners": [
-    "@dermotduffy"
-  ],
+  "after_dependencies": ["media_source"],
+  "codeowners": ["@dermotduffy"],
   "config_flow": true,
-  "dependencies": [
-    "http",
-    "webhook"
-  ],
+  "dependencies": ["http", "webhook"],
   "documentation": "https://www.home-assistant.io/integrations/motioneye",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "loggers": [
-    "motioneye_client"
-  ],
-  "requirements": [
-    "motioneye-client==0.3.14"
-  ]
+  "loggers": ["motioneye_client"],
+  "requirements": ["motioneye-client==0.3.14"]
 }

--- a/homeassistant/components/motioneye/media_source.py
+++ b/homeassistant/components/motioneye/media_source.py
@@ -4,7 +4,7 @@ from base64 import urlsafe_b64decode, urlsafe_b64encode
 from datetime import timedelta
 import logging
 from pathlib import PurePath
-from typing import cast, override
+from typing import Any, cast, override
 
 from aiohttp import web
 from motioneye_client.const import KEY_MEDIA_LIST, KEY_MIME_TYPE, KEY_PATH
@@ -97,10 +97,10 @@ class MotionEyeMediaProxyView(HomeAssistantView):
         try:
             media_path = urlsafe_b64decode(path.encode("ascii")).decode("utf-8")
             camera = int(camera_id)
-        except (ValueError, UnicodeDecodeError):
+        except ValueError, UnicodeDecodeError:
             return web.Response(status=400)
 
-        data = await entry.runtime_data.client.async_get_media(
+        data = await cast(Any, entry.runtime_data.client).async_get_media(
             camera,
             media_path,
             image=kind == "images",

--- a/homeassistant/components/motioneye/media_source.py
+++ b/homeassistant/components/motioneye/media_source.py
@@ -40,9 +40,7 @@ MEDIA_CLASS_MAP = {
 
 _LOGGER = logging.getLogger(__name__)
 
-MEDIA_PROXY_URL = (
-    "/api/motioneye/media/{config_id}/{camera_id}/{kind}/{preview}/{path}"
-)
+MEDIA_PROXY_URL = "/api/motioneye/media/{config_id}/{camera_id}/{kind}/{preview}/{path}"
 
 
 def _encode_media_path(path: str) -> str:

--- a/homeassistant/components/motioneye/media_source.py
+++ b/homeassistant/components/motioneye/media_source.py
@@ -1,11 +1,16 @@
 """motionEye Media Source Implementation."""
 
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from datetime import timedelta
 import logging
 from pathlib import PurePath
 from typing import cast, override
 
+from aiohttp import web
 from motioneye_client.const import KEY_MEDIA_LIST, KEY_MIME_TYPE, KEY_PATH
 
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.http.auth import async_sign_path
 from homeassistant.components.media_player import MediaClass, MediaType
 from homeassistant.components.media_source import (
     BrowseMediaSource,
@@ -19,7 +24,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 
-from . import get_media_url, split_motioneye_device_identifier
+from . import split_motioneye_device_identifier
 from .const import DOMAIN
 from .coordinator import MotionEyeConfigEntry
 
@@ -35,6 +40,77 @@ MEDIA_CLASS_MAP = {
 
 _LOGGER = logging.getLogger(__name__)
 
+MEDIA_PROXY_URL = (
+    "/api/motioneye/media/{config_id}/{camera_id}/{kind}/{preview}/{path}"
+)
+
+
+def _encode_media_path(path: str) -> str:
+    """Encode a motionEye media path for use in a Home Assistant proxy URL."""
+    return urlsafe_b64encode(path.encode("utf-8")).decode("ascii")
+
+
+def _build_media_proxy_path(
+    config_id: str,
+    camera_id: int,
+    kind: str,
+    path: str,
+    *,
+    preview: bool,
+) -> str:
+    """Build an authenticated Home Assistant proxy path for motionEye media."""
+    return MEDIA_PROXY_URL.format(
+        config_id=config_id,
+        camera_id=camera_id,
+        kind=kind,
+        preview="1" if preview else "0",
+        path=_encode_media_path(path),
+    )
+
+
+class MotionEyeMediaProxyView(HomeAssistantView):
+    """Proxy saved motionEye media through Home Assistant."""
+
+    requires_auth = True
+    url = MEDIA_PROXY_URL
+    name = "api:motioneye_media"
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the proxy."""
+        self.hass = hass
+
+    async def get(
+        self,
+        request: web.Request,
+        config_id: str,
+        camera_id: str,
+        kind: str,
+        preview: str,
+        path: str,
+    ) -> web.Response:
+        """Return saved media fetched with the authenticated motionEye session."""
+        entry = self.hass.config_entries.async_get_entry(config_id)
+        if not entry or entry.state is not ConfigEntryState.LOADED:
+            return web.Response(status=404)
+
+        if kind not in MIME_TYPE_MAP:
+            return web.Response(status=400)
+
+        try:
+            media_path = urlsafe_b64decode(path.encode("ascii")).decode("utf-8")
+            camera = int(camera_id)
+        except (ValueError, UnicodeDecodeError):
+            return web.Response(status=400)
+
+        data = await entry.runtime_data.client.async_get_media(
+            camera,
+            media_path,
+            image=kind == "images",
+            preview=preview == "1",
+        )
+
+        return web.Response(body=data, content_type=MIME_TYPE_MAP[kind])
+
 
 # Hierarchy:
 #
@@ -46,6 +122,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_get_media_source(hass: HomeAssistant) -> MotionEyeMediaSource:
     """Set up motionEye media source."""
+    hass.http.register_view(MotionEyeMediaProxyView(hass))
     return MotionEyeMediaSource(hass)
 
 
@@ -73,15 +150,21 @@ class MotionEyeMediaSource(MediaSource):
         device = self._get_device_or_raise(device_id)
         self._verify_kind_or_raise(kind)
 
-        url = get_media_url(
-            config.runtime_data.client,
-            self._get_camera_id_or_raise(config, device),
-            self._get_path_or_raise(path),
-            kind == "images",
+        camera_id = self._get_camera_id_or_raise(config, device)
+        media_path = self._get_path_or_raise(path)
+        proxy_path = _build_media_proxy_path(
+            config.entry_id,
+            camera_id,
+            kind,
+            media_path,
+            preview=False,
         )
-        if not url:
-            raise Unresolvable(f"Could not resolve media item: {item.identifier}")
-
+        url = async_sign_path(
+            self.hass,
+            proxy_path,
+            timedelta(minutes=5),
+            use_content_user=True,
+        )
         return PlayMedia(url, MIME_TYPE_MAP[kind])
 
     @callback
@@ -312,14 +395,19 @@ class MotionEyeMediaSource(MediaSource):
 
                 # Child is a media file.
                 if len(parts) + 1 == len(parts_media):
-                    if kind == "movies":
-                        thumbnail_url = client.get_movie_url(
-                            camera_id, full_child_path, preview=True
-                        )
-                    else:
-                        thumbnail_url = client.get_image_url(
-                            camera_id, full_child_path, preview=True
-                        )
+                    thumbnail_path = _build_media_proxy_path(
+                        config.entry_id,
+                        camera_id,
+                        kind,
+                        full_child_path,
+                        preview=True,
+                    )
+                    thumbnail_url = async_sign_path(
+                        self.hass,
+                        thumbnail_path,
+                        timedelta(minutes=5),
+                        use_content_user=True,
+                    )
 
                     base.children.append(
                         BrowseMediaSource(

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -227,46 +227,17 @@ async def test_unload_camera(hass: HomeAssistant) -> None:
     assert client.async_client_close.called
 
 
-async def test_get_still_image_from_camera(
-    aiohttp_server: Callable[[], TestServer], hass: HomeAssistant
-) -> None:
+async def test_get_still_image_from_camera(hass: HomeAssistant) -> None:
     """Test getting a still image."""
 
-    image_handler = AsyncMock(return_value=web.Response(body=""))
-
-    app = web.Application()
-    app.add_routes(
-        [
-            web.get(
-                "/foo",
-                image_handler,
-            )
-        ]
-    )
-
-    server = await aiohttp_server(app)
     client = create_mock_motioneye_client()
-    client.get_camera_snapshot_url = Mock(
-        return_value=f"http://127.0.0.1:{server.port}/foo"
-    )
-    config_entry = create_mock_motioneye_config_entry(
-        hass,
-        data={
-            CONF_URL: f"http://127.0.0.1:{server.port}",
-            CONF_SURVEILLANCE_USERNAME: TEST_SURVEILLANCE_USERNAME,
-        },
-    )
-
-    await setup_mock_motioneye_config_entry(
-        hass, config_entry=config_entry, client=client
-    )
+    client.async_get_camera_snapshot = AsyncMock(return_value=b"image")
+    await setup_mock_motioneye_config_entry(hass, client=client)
     await hass.async_block_till_done()
 
-    # It won't actually get a stream from the dummy handler, so just catch
-    # the expected exception, then verify the right handler was called.
-    with pytest.raises(HomeAssistantError):
-        await async_get_image(hass, TEST_CAMERA_ENTITY_ID, timeout=1)
-    assert image_handler.called
+    image = await async_get_image(hass, TEST_CAMERA_ENTITY_ID, timeout=1)
+    assert image.content == b"image"
+    client.async_get_camera_snapshot.assert_awaited_once_with(TEST_CAMERA_ID)
 
 
 async def test_get_stream_from_camera(

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -41,7 +41,6 @@ from homeassistant.components.motioneye.const import (
 )
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID, CONF_ACTION, CONF_URL
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util
 from homeassistant.util.aiohttp import MockRequest

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -31,6 +31,7 @@ from homeassistant.components.camera import async_get_image, async_get_mjpeg_str
 from homeassistant.components.motioneye import get_motioneye_device_identifier
 from homeassistant.components.motioneye.const import (
     CONF_STREAM_URL_TEMPLATE,
+    CONF_SURVEILLANCE_PASSWORD,
     CONF_SURVEILLANCE_USERNAME,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
@@ -244,7 +245,9 @@ async def test_get_stream_from_camera(
 ) -> None:
     """Test getting a stream."""
 
-    stream_handler = AsyncMock(return_value=web.Response(body=""))
+    async def stream_handler(request: web.Request) -> web.Response:
+        assert request.headers["Authorization"] == "Basic Y2FtZXJhX3VzZXI6Y2FtZXJhX3Bhc3N3b3Jk"
+        return web.Response(body="")
 
     app = web.Application()
     app.add_routes([web.get("/", stream_handler)])
@@ -260,9 +263,12 @@ async def test_get_stream_from_camera(
             CONF_URL: f"http://127.0.0.1:{stream_server.port}",
             # The port won't be used as the client is a mock.
             CONF_SURVEILLANCE_USERNAME: TEST_SURVEILLANCE_USERNAME,
+            CONF_SURVEILLANCE_PASSWORD: "global_password",
         },
     )
     cameras = copy.deepcopy(TEST_CAMERAS)
+    cameras[KEY_CAMERAS][0]["streaming_username"] = "camera_user"
+    cameras[KEY_CAMERAS][0]["streaming_password"] = "camera_password"
     client.async_get_cameras = AsyncMock(return_value=cameras)
     await setup_mock_motioneye_config_entry(
         hass, config_entry=config_entry, client=client

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -293,10 +293,7 @@ async def test_get_stream_from_camera_falls_back_to_surveillance_credentials(
     async def stream_handler(request: web.Request) -> web.Response:
         nonlocal stream_called
         stream_called = True
-        assert (
-            request.headers["Authorization"]
-            == "Basic dXNlcjpwYXNzd29yZA=="
-        )
+        assert request.headers["Authorization"] == "Basic dXNlcjpwYXNzd29yZA=="
         return web.Response(body="")
 
     app = web.Application()
@@ -327,9 +324,7 @@ async def test_get_stream_from_camera_falls_back_to_surveillance_credentials(
     )
     await hass.async_block_till_done()
 
-    await async_get_mjpeg_stream(
-        hass, MockRequest(b"", "test"), TEST_CAMERA_ENTITY_ID
-    )
+    await async_get_mjpeg_stream(hass, MockRequest(b"", "test"), TEST_CAMERA_ENTITY_ID)
     assert stream_called
 
 async def test_state_attributes(hass: HomeAssistant) -> None:

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -245,9 +245,12 @@ async def test_get_stream_from_camera(
 ) -> None:
     """Test getting a stream."""
 
-    async def stream_handler(request: web.Request) -> web.Response:
-        assert request.headers["Authorization"] == "Basic Y2FtZXJhX3VzZXI6Y2FtZXJhX3Bhc3N3b3Jk"
-        return web.Response(body="")
+async def stream_handler(request: web.Request) -> web.Response:
+    assert (
+        request.headers["Authorization"]
+        == "Basic Y2FtZXJhX3VzZXI6Y2FtZXJhX3Bhc3N3b3Jk"
+    )
+    return web.Response(body="")
 
     app = web.Application()
     app.add_routes([web.get("/", stream_handler)])

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -284,6 +284,53 @@ async def test_get_stream_from_camera(
     await async_get_mjpeg_stream(hass, MockRequest(b"", "test"), TEST_CAMERA_ENTITY_ID)
     assert stream_called
 
+async def test_get_stream_from_camera_falls_back_to_surveillance_credentials(
+    aiohttp_server: Callable[[], TestServer], hass: HomeAssistant
+) -> None:
+    """Test stream auth falls back to global surveillance credentials."""
+    stream_called = False
+
+    async def stream_handler(request: web.Request) -> web.Response:
+        nonlocal stream_called
+        stream_called = True
+        assert (
+            request.headers["Authorization"]
+            == "Basic dXNlcjpwYXNzd29yZA=="
+        )
+        return web.Response(body="")
+
+    app = web.Application()
+    app.add_routes([web.get("/", stream_handler)])
+    stream_server = await aiohttp_server(app)
+
+    client = create_mock_motioneye_client()
+    client.get_camera_stream_url = Mock(
+        return_value=f"http://127.0.0.1:{stream_server.port}/"
+    )
+
+    config_entry = create_mock_motioneye_config_entry(
+        hass,
+        data={
+            CONF_URL: f"http://127.0.0.1:{stream_server.port}",
+            CONF_SURVEILLANCE_USERNAME: "user",
+            CONF_SURVEILLANCE_PASSWORD: "password",
+        },
+    )
+
+    cameras = copy.deepcopy(TEST_CAMERAS)
+    cameras[KEY_CAMERAS][0].pop("streaming_username", None)
+    cameras[KEY_CAMERAS][0].pop("streaming_password", None)
+    client.async_get_cameras = AsyncMock(return_value=cameras)
+
+    await setup_mock_motioneye_config_entry(
+        hass, config_entry=config_entry, client=client
+    )
+    await hass.async_block_till_done()
+
+    await async_get_mjpeg_stream(
+        hass, MockRequest(b"", "test"), TEST_CAMERA_ENTITY_ID
+    )
+    assert stream_called
 
 async def test_state_attributes(hass: HomeAssistant) -> None:
     """Test state attributes are set correctly."""

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -244,13 +244,16 @@ async def test_get_stream_from_camera(
     aiohttp_server: Callable[[], TestServer], hass: HomeAssistant
 ) -> None:
     """Test getting a stream."""
+    stream_called = False
 
-async def stream_handler(request: web.Request) -> web.Response:
-    assert (
-        request.headers["Authorization"]
-        == "Basic Y2FtZXJhX3VzZXI6Y2FtZXJhX3Bhc3N3b3Jk"
-    )
-    return web.Response(body="")
+    async def stream_handler(request: web.Request) -> web.Response:
+        nonlocal stream_called
+        stream_called = True
+        assert (
+            request.headers["Authorization"]
+            == "Basic Y2FtZXJhX3VzZXI6Y2FtZXJhX3Bhc3N3b3Jk"
+        )
+        return web.Response(body="")
 
     app = web.Application()
     app.add_routes([web.get("/", stream_handler)])
@@ -279,7 +282,7 @@ async def stream_handler(request: web.Request) -> web.Response:
     await hass.async_block_till_done()
 
     await async_get_mjpeg_stream(hass, MockRequest(b"", "test"), TEST_CAMERA_ENTITY_ID)
-    assert stream_handler.called
+    assert stream_called
 
 
 async def test_state_attributes(hass: HomeAssistant) -> None:

--- a/tests/components/motioneye/test_camera.py
+++ b/tests/components/motioneye/test_camera.py
@@ -284,6 +284,7 @@ async def test_get_stream_from_camera(
     await async_get_mjpeg_stream(hass, MockRequest(b"", "test"), TEST_CAMERA_ENTITY_ID)
     assert stream_called
 
+
 async def test_get_stream_from_camera_falls_back_to_surveillance_credentials(
     aiohttp_server: Callable[[], TestServer], hass: HomeAssistant
 ) -> None:
@@ -326,6 +327,7 @@ async def test_get_stream_from_camera_falls_back_to_surveillance_credentials(
 
     await async_get_mjpeg_stream(hass, MockRequest(b"", "test"), TEST_CAMERA_ENTITY_ID)
     assert stream_called
+
 
 async def test_state_attributes(hass: HomeAssistant) -> None:
     """Test state attributes are set correctly."""

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -394,6 +394,7 @@ async def test_media_proxy_image(
     client = create_mock_motioneye_client()
     client.async_get_media = AsyncMock(return_value=b"image")
     config = await setup_mock_motioneye_config_entry(hass, client=client)
+    await async_get_media_source(hass)
 
     client_session = await hass_client()
     response = await client_session.get(

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -1,7 +1,7 @@
 """Test Local Media Source."""
 
 import logging
-from unittest.mock import AsyncMock, Mock, call, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from motioneye_client.client import MotionEyeClientPathError
 import pytest
@@ -21,7 +21,6 @@ from homeassistant.setup import async_setup_component
 
 from . import (
     TEST_CAMERA_DEVICE_IDENTIFIER,
-    TEST_CAMERA_ID,
     TEST_CONFIG_ENTRY_ID,
     create_mock_motioneye_client,
     setup_mock_motioneye_config_entry,

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -1,7 +1,7 @@
 """Test Local Media Source."""
 
 import logging
-from unittest.mock import AsyncMock, Mock, call
+from unittest.mock import AsyncMock, Mock, call, patch
 
 from motioneye_client.client import MotionEyeClientPathError
 import pytest
@@ -71,6 +71,16 @@ TEST_IMAGES = {
 
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture(autouse=True)
+def mock_sign_path() -> None:
+    """Return a deterministic signed media proxy URL."""
+    with patch(
+        "homeassistant.components.motioneye.media_source.async_sign_path",
+        return_value="http://signed",
+    ):
+        yield
 
 
 @pytest.fixture(autouse=True)
@@ -250,8 +260,7 @@ async def test_async_browse_media_success(
         "not_shown": 0,
     }
 
-    client.get_movie_url = Mock(return_value="http://movie")
-    media = await async_browse_media(
+        media = await async_browse_media(
         hass,
         f"{URI_SCHEME}{DOMAIN}/{config.entry_id}#{device.id}#movies#/2021-04-25",
     )
@@ -283,7 +292,7 @@ async def test_async_browse_media_success(
                 "can_expand": False,
                 "can_search": False,
                 "search_media_classes": None,
-                "thumbnail": "http://movie",
+                "thumbnail": "http://signed",
                 "children_media_class": None,
             },
             {
@@ -299,7 +308,7 @@ async def test_async_browse_media_success(
                 "can_expand": False,
                 "can_search": False,
                 "search_media_classes": None,
-                "thumbnail": "http://movie",
+                "thumbnail": "http://signed",
                 "children_media_class": None,
             },
             {
@@ -315,7 +324,7 @@ async def test_async_browse_media_success(
                 "can_expand": False,
                 "can_search": False,
                 "search_media_classes": None,
-                "thumbnail": "http://movie",
+                "thumbnail": "http://signed",
                 "children_media_class": None,
             },
         ],
@@ -337,8 +346,7 @@ async def test_async_browse_media_images_success(
     )
 
     client.async_get_images = AsyncMock(return_value=TEST_IMAGES)
-    client.get_image_url = Mock(return_value="http://image")
-
+    
     media = await async_browse_media(
         hass,
         f"{URI_SCHEME}{DOMAIN}/{config.entry_id}#{device.id}#images#/2021-04-12",
@@ -371,7 +379,7 @@ async def test_async_browse_media_images_success(
                 "can_expand": False,
                 "can_search": False,
                 "search_media_classes": None,
-                "thumbnail": "http://image",
+                "thumbnail": "http://signed",
                 "children_media_class": None,
             }
         ],
@@ -394,24 +402,20 @@ async def test_async_resolve_media_success(
     )
 
     # Test successful resolve for a movie.
-    client.get_movie_url = Mock(return_value="http://movie-url")
     media = await async_resolve_media(
         hass,
         f"{URI_SCHEME}{DOMAIN}/{TEST_CONFIG_ENTRY_ID}#{device.id}#movies#/foo.mp4",
         None,
     )
-    assert media == PlayMedia(url="http://movie-url", mime_type="video/mp4")
-    assert client.get_movie_url.call_args == call(TEST_CAMERA_ID, "/foo.mp4")
+    assert media == PlayMedia(url="http://signed", mime_type="video/mp4")
 
     # Test successful resolve for an image.
-    client.get_image_url = Mock(return_value="http://image-url")
     media = await async_resolve_media(
         hass,
         f"{URI_SCHEME}{DOMAIN}/{TEST_CONFIG_ENTRY_ID}#{device.id}#images#/foo.jpg",
         None,
     )
-    assert media == PlayMedia(url="http://image-url", mime_type="image/jpeg")
-    assert client.get_image_url.call_args == call(TEST_CAMERA_ID, "/foo.jpg")
+    assert media == PlayMedia(url="http://signed", mime_type="image/jpeg")
 
 
 async def test_async_resolve_media_failure(

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -14,6 +14,7 @@ from homeassistant.components.media_source import (
     async_resolve_media,
 )
 from homeassistant.components.motioneye.const import DOMAIN
+from homeassistant.components.motioneye.media_source import async_get_media_source
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -385,6 +385,27 @@ async def test_async_browse_media_images_success(
     }
 
 
+
+async def test_media_proxy_image(
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
+) -> None:
+    """Test fetching saved image media through the Home Assistant proxy."""
+    client = create_mock_motioneye_client()
+    client.async_get_media = AsyncMock(return_value=b"image")
+    config = await setup_mock_motioneye_config_entry(hass, client=client)
+
+    response = await hass_client().get(
+        f"/api/motioneye/media/{config.entry_id}/1/images/0/L2Zvby5qcGc="
+    )
+
+    assert response.status == 200
+    assert response.content_type == "image/jpeg"
+    assert await response.read() == b"image"
+    client.async_get_media.assert_awaited_once_with(
+        1, "/foo.jpg", image=True, preview=False
+    )
+
+
 async def test_async_resolve_media_success(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -1,7 +1,7 @@
 """Test Local Media Source."""
 
 import logging
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -260,7 +260,7 @@ async def test_async_browse_media_success(
         "not_shown": 0,
     }
 
-        media = await async_browse_media(
+    media = await async_browse_media(
         hass,
         f"{URI_SCHEME}{DOMAIN}/{config.entry_id}#{device.id}#movies#/2021-04-25",
     )
@@ -346,7 +346,7 @@ async def test_async_browse_media_images_success(
     )
 
     client.async_get_images = AsyncMock(return_value=TEST_IMAGES)
-    
+
     media = await async_browse_media(
         hass,
         f"{URI_SCHEME}{DOMAIN}/{config.entry_id}#{device.id}#images#/2021-04-12",

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -395,7 +395,8 @@ async def test_media_proxy_image(
     client.async_get_media = AsyncMock(return_value=b"image")
     config = await setup_mock_motioneye_config_entry(hass, client=client)
 
-    response = await hass_client().get(
+    client_session = await hass_client()
+    response = await client_session.get(
         f"/api/motioneye/media/{config.entry_id}/1/images/0/L2Zvby5qcGc="
     )
 

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -18,14 +18,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
-from tests.typing import ClientSessionGenerator
-
 from . import (
     TEST_CAMERA_DEVICE_IDENTIFIER,
     TEST_CONFIG_ENTRY_ID,
     create_mock_motioneye_client,
     setup_mock_motioneye_config_entry,
 )
+
+from tests.typing import ClientSessionGenerator
 
 TEST_MOVIES = {
     "mediaList": [
@@ -385,7 +385,6 @@ async def test_async_browse_media_images_success(
         ],
         "not_shown": 0,
     }
-
 
 
 async def test_media_proxy_image(

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -1,6 +1,7 @@
 """Test Local Media Source."""
 
 import logging
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -387,7 +388,7 @@ async def test_async_browse_media_images_success(
 
 
 async def test_media_proxy_image(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator
+    hass: HomeAssistant, hass_client: Any
 ) -> None:
     """Test fetching saved image media through the Home Assistant proxy."""
     client = create_mock_motioneye_client()

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -3,7 +3,6 @@
 import logging
 from unittest.mock import AsyncMock, Mock, patch
 
-from motioneye_client.client import MotionEyeClientPathError
 import pytest
 
 from homeassistant.components.media_source import (
@@ -439,8 +438,6 @@ async def test_async_resolve_media_failure(
         config_entry_id=config.entry_id,
         identifiers={(DOMAIN, f"{config.entry_id}_NOTINT")},
     )
-    client.get_movie_url = Mock(return_value="http://url")
-
     # URI doesn't contain necessary components.
     with pytest.raises(Unresolvable):
         await async_resolve_media(hass, f"{URI_SCHEME}{DOMAIN}/foo", None)
@@ -485,17 +482,7 @@ async def test_async_resolve_media_failure(
             None,
         )
 
-    # Playback URL raises exception.
-    client.get_movie_url = Mock(side_effect=MotionEyeClientPathError)
-    with pytest.raises(Unresolvable):
-        await async_resolve_media(
-            hass,
-            f"{URI_SCHEME}{DOMAIN}/{TEST_CONFIG_ENTRY_ID}#{device.id}#movies#/foo.mp4",
-            None,
-        )
-
     # Media path does not start with '/'
-    client.get_movie_url = Mock(side_effect=MotionEyeClientPathError)
     with pytest.raises(MediaSourceError):
         await async_resolve_media(
             hass,

--- a/tests/components/motioneye/test_media_source.py
+++ b/tests/components/motioneye/test_media_source.py
@@ -1,7 +1,6 @@
 """Test Local Media Source."""
 
 import logging
-from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -18,6 +17,8 @@ from homeassistant.components.motioneye.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
+
+from tests.typing import ClientSessionGenerator
 
 from . import (
     TEST_CAMERA_DEVICE_IDENTIFIER,
@@ -388,7 +389,7 @@ async def test_async_browse_media_images_success(
 
 
 async def test_media_proxy_image(
-    hass: HomeAssistant, hass_client: Any
+    hass: HomeAssistant, hass_client: ClientSessionGenerator
 ) -> None:
     """Test fetching saved image media through the Home Assistant proxy."""
     client = create_mock_motioneye_client()

--- a/tests/components/motioneye/test_web_hooks.py
+++ b/tests/components/motioneye/test_web_hooks.py
@@ -412,8 +412,12 @@ async def test_event_media_data(
     )
     assert resp.status == HTTPStatus.OK
     assert len(events) == 1
-    assert events[-1].data["file_url"].startswith(
-        f"/api/motioneye/media/{TEST_CONFIG_ENTRY_ID}/{TEST_CAMERA_ID}/movies/0/"
+    assert (
+        events[-1]
+        .data["file_url"]
+        .startswith(
+            f"/api/motioneye/media/{TEST_CONFIG_ENTRY_ID}/{TEST_CAMERA_ID}/movies/0/"
+        )
     )
     assert "?authSig=" in events[-1].data["file_url"]
     assert (
@@ -433,8 +437,12 @@ async def test_event_media_data(
     )
     assert resp.status == HTTPStatus.OK
     assert len(events) == 2
-    assert events[-1].data["file_url"].startswith(
-        f"/api/motioneye/media/{TEST_CONFIG_ENTRY_ID}/{TEST_CAMERA_ID}/images/0/"
+    assert (
+        events[-1]
+        .data["file_url"]
+        .startswith(
+            f"/api/motioneye/media/{TEST_CONFIG_ENTRY_ID}/{TEST_CAMERA_ID}/images/0/"
+        )
     )
     assert "?authSig=" in events[-1].data["file_url"]
     assert (

--- a/tests/components/motioneye/test_web_hooks.py
+++ b/tests/components/motioneye/test_web_hooks.py
@@ -399,9 +399,6 @@ async def test_event_media_data(
 
     events = async_capture_events(hass, f"{DOMAIN}.{EVENT_FILE_STORED}")
 
-    client.get_movie_url = Mock(return_value="http://movie-url")
-    client.get_image_url = Mock(return_value="http://image-url")
-
     # Test: Movie storage.
     client.is_file_type_image = Mock(return_value=False)
     resp = await hass_client.post(
@@ -415,13 +412,14 @@ async def test_event_media_data(
     )
     assert resp.status == HTTPStatus.OK
     assert len(events) == 1
-    assert events[-1].data["file_url"] == "http://movie-url"
+    assert events[-1].data["file_url"].startswith(
+        f"/api/motioneye/media/{TEST_CONFIG_ENTRY_ID}/{TEST_CAMERA_ID}/movies/0/"
+    )
+    assert "?authSig=" in events[-1].data["file_url"]
     assert (
         events[-1].data["media_content_id"]
         == f"media-source://motioneye/{TEST_CONFIG_ENTRY_ID}#{device.id}#movies#/dir/one"
     )
-    assert client.get_movie_url.call_args == call(TEST_CAMERA_ID, "/dir/one")
-
     # Test: Image storage.
     client.is_file_type_image = Mock(return_value=True)
     resp = await hass_client.post(
@@ -435,12 +433,14 @@ async def test_event_media_data(
     )
     assert resp.status == HTTPStatus.OK
     assert len(events) == 2
-    assert events[-1].data["file_url"] == "http://image-url"
+    assert events[-1].data["file_url"].startswith(
+        f"/api/motioneye/media/{TEST_CONFIG_ENTRY_ID}/{TEST_CAMERA_ID}/images/0/"
+    )
+    assert "?authSig=" in events[-1].data["file_url"]
     assert (
         events[-1].data["media_content_id"]
         == f"media-source://motioneye/{TEST_CONFIG_ENTRY_ID}#{device.id}#images#/dir/two"
     )
-    assert client.get_image_url.call_args == call(TEST_CAMERA_ID, "/dir/two")
 
     # Test: Invalid file type.
     resp = await hass_client.post(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update the motionEye integration to support motionEye 0.44 session-based authentication.

The corresponding client-side implementation was merged in
motioneye-project/motioneye-client#221 and is available in
`motioneye-client==0.4.0`. This PR updates the Home Assistant dependency
to that released version.

The integration-side changes use the authenticated client for current
snapshots and saved image/movie media instead of relying on legacy signed
motionEye URLs for those paths. The changes also support per-camera Motion
stream credentials exposed by motionEye 0.44.

Real-world validation was performed against:

- Home Assistant 2026.9.1
- motionEye 0.44.0
- 12 cameras
- live camera views working
- popup camera preview working
- per-camera Motion stream authentication verified
- current snapshots working
- saved JPEG listing, thumbnails and full images working
- MP4 recording and playback validated in Home Assistant Media with two test recordings

The current movie proxy still uses the bytes-returning media API provided by
`motioneye-client==0.4.0`. Streaming movie responses and preserving upstream
Range/status headers requires a corresponding streamed-media API in
motioneye-client and is intentionally not hidden by buffering changes in Core.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #174660
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

- Upstream client PR: motioneye-project/motioneye-client#221
- Dependency compare: https://github.com/motioneye-project/motioneye-client/compare/v0.3.14...v0.4.0

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr