### PR TITLE
Raise a repair when a Teslemetry vehicle's Bluetooth key is rejected

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Callable
 from functools import partial
+import inspect
 from pathlib import Path
 from typing import Any, Final, cast
 
@@ -14,12 +15,14 @@ from tesla_fleet_api.exceptions import (
     Forbidden,
     InvalidToken,
     LoginRequired,
+    NotOnWhitelistFault,
     PrivateKeyError,
     SubscriptionRequired,
     TeslaFleetError,
 )
 from tesla_fleet_api.router import VehicleRouter
 from tesla_fleet_api.tesla import EnergySiteRouter
+from tesla_fleet_api.tesla.vehicle.bluetooth import VehicleBluetooth
 from tesla_fleet_api.teslemetry import EnergySite, Teslemetry, Vehicle
 from teslemetry_stream import TeslemetryStream, TeslemetryStreamAuthenticationError
 from teslemetry_stream.const import SseTopic
@@ -62,6 +65,7 @@ from .const import (
     CLIENT_ID,
     CONF_VIN,
     DOMAIN,
+    ISSUE_TYPE_BLE_KEY_REJECTED,
     LOGGER,
     POWERWALL_KEY_FILE,
     RSA_PARENT_KEY,
@@ -305,10 +309,51 @@ _BLE_KEY_ERRORS: Final = (
 )
 
 
+class _KeyRejectionWatcher:
+    """Proxy a BLE vehicle backend to observe a genuine key-whitelist rejection.
+
+    VehicleRouter fails over to its cloud secondary on any primary exception,
+    including NotOnWhitelistFault, so a revoked key would otherwise never
+    surface anywhere. This watches for it as commands pass through the real
+    backend instead of adding a separate probe or poll.
+    """
+
+    def __init__(
+        self,
+        vehicle: VehicleBluetooth,
+        on_rejected: Callable[[], None],
+        on_accepted: Callable[[], None],
+    ) -> None:
+        """Initialize the watcher."""
+        self._vehicle = vehicle
+        self._on_rejected = on_rejected
+        self._on_accepted = on_accepted
+
+    def __getattr__(self, name: str) -> Any:
+        """Forward attribute access to the wrapped vehicle, watching calls."""
+        attr = getattr(self._vehicle, name)
+        if not callable(attr):
+            return attr
+
+        async def _watched(*args: Any, **kwargs: Any) -> Any:
+            try:
+                result = attr(*args, **kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+            except NotOnWhitelistFault:
+                self._on_rejected()
+                raise
+            self._on_accepted()
+            return result
+
+        return _watched
+
+
 async def _async_resolve_vehicle_api(
     hass: HomeAssistant,
     entry: TeslemetryConfigEntry,
     vin: str,
+    vehicle_name: str,
     cloud_vehicle: Vehicle,
 ) -> Vehicle | VehicleRouter:
     """Return the API a vehicle's platforms should call."""
@@ -345,7 +390,35 @@ async def _async_resolve_vehicle_api(
         bluetooth_vehicle.set_device(device)
         return True
 
-    return VehicleRouter(bluetooth_vehicle, cloud_vehicle, health=_in_range)
+    issue_id = f"{ISSUE_TYPE_BLE_KEY_REJECTED}_{vin}"
+
+    @callback
+    def _on_rejected() -> None:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=ISSUE_TYPE_BLE_KEY_REJECTED,
+            translation_placeholders={"vehicle": vehicle_name},
+            data={
+                "entry_id": entry.entry_id,
+                "vin": vin,
+                "issue_type": ISSUE_TYPE_BLE_KEY_REJECTED,
+                "vehicle": vehicle_name,
+            },
+        )
+
+    @callback
+    def _on_accepted() -> None:
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+    watched_vehicle = _KeyRejectionWatcher(
+        bluetooth_vehicle, _on_rejected, _on_accepted
+    )
+
+    return VehicleRouter(watched_vehicle, cloud_vehicle, health=_in_range)
 
 
 def _find_energy_subentry_id(entry: TeslemetryConfigEntry, site_id: int) -> str | None:
@@ -604,6 +677,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 hass,
                 entry,
                 vin,
+                product["display_name"] or vin,
                 vehicle,
             )
 

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -265,6 +265,13 @@ class VehicleSubentryFlowHandler(ConfigSubentryFlow):
             ),
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Re-run Bluetooth pairing for an already added vehicle."""
+        self._vin = self._get_reconfigure_subentry().data[CONF_VIN]
+        return await self.async_step_scan()
+
     async def async_step_scan(
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
@@ -336,6 +343,12 @@ class VehicleSubentryFlowHandler(ConfigSubentryFlow):
             assert self._address is not None
             assert self._vin is not None
         await self._async_disconnect()
+        if self.source == SOURCE_RECONFIGURE:
+            return self.async_update_and_abort(
+                self._get_entry(),
+                self._get_reconfigure_subentry(),
+                data_updates={CONF_ADDRESS: self._address},
+            )
         return self.async_create_entry(
             title=self._title or self._vin,
             data={CONF_VIN: self._vin, CONF_ADDRESS: self._address},

--- a/homeassistant/components/teslemetry/const.py
+++ b/homeassistant/components/teslemetry/const.py
@@ -2,6 +2,7 @@
 
 from enum import StrEnum
 import logging
+from typing import Final
 
 DOMAIN = "teslemetry"
 
@@ -48,12 +49,17 @@ ENERGY_HISTORY_FIELDS = [
 ]
 
 
+# A Bluetooth key the vehicle has stopped accepting, detected locally at
+# runtime rather than from vehicle metadata (see VEHICLE_ISSUE_LEARN_MORE).
+ISSUE_TYPE_BLE_KEY_REJECTED: Final = "ble_key_rejected"
+
 # Vehicle metadata "issue" values that map to an actionable repair issue, with
 # an optional "learn more" URL the user can visit to resolve it. The "no_data"
 # issue is intentionally ignored as it is not user-actionable.
 VEHICLE_ISSUE_LEARN_MORE: dict[str, str | None] = {
     "key": "https://teslemetry.com/key",
     "streaming_toggle": None,
+    ISSUE_TYPE_BLE_KEY_REJECTED: None,
 }
 
 

--- a/homeassistant/components/teslemetry/const.py
+++ b/homeassistant/components/teslemetry/const.py
@@ -59,7 +59,6 @@ ISSUE_TYPE_BLE_KEY_REJECTED: Final = "ble_key_rejected"
 VEHICLE_ISSUE_LEARN_MORE: dict[str, str | None] = {
     "key": "https://teslemetry.com/key",
     "streaming_toggle": None,
-    ISSUE_TYPE_BLE_KEY_REJECTED: None,
 }
 
 

--- a/homeassistant/components/teslemetry/repairs.py
+++ b/homeassistant/components/teslemetry/repairs.py
@@ -2,14 +2,20 @@
 
 from homeassistant.components.repairs import (
     ConfirmRepairFlow,
+    FlowType,
     RepairsFlow,
     RepairsFlowResult,
 )
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_RECONFIGURE, ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from . import TeslemetryConfigEntry
-from .const import VEHICLE_ISSUE_LEARN_MORE
+from .const import (
+    CONF_VIN,
+    ISSUE_TYPE_BLE_KEY_REJECTED,
+    SUBENTRY_TYPE_VEHICLE,
+    VEHICLE_ISSUE_LEARN_MORE,
+)
 
 
 class VehicleMetadataRepairFlow(RepairsFlow):
@@ -56,6 +62,52 @@ class VehicleMetadataRepairFlow(RepairsFlow):
         )
 
 
+class BleKeyRejectedRepairFlow(RepairsFlow):
+    """Hand a rejected Bluetooth key off to the vehicle's reconfigure flow."""
+
+    def __init__(self, entry: TeslemetryConfigEntry, vin: str, vehicle: str) -> None:
+        """Create flow."""
+        self.entry = entry
+        self.vin = vin
+        self.placeholders = {"vehicle": vehicle}
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> RepairsFlowResult:
+        """Handle the first step of a fix flow."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> RepairsFlowResult:
+        """Start the vehicle's Bluetooth reconfigure flow and hand off to it."""
+        if user_input is not None:
+            subentry_id = next(
+                (
+                    subentry.subentry_id
+                    for subentry in self.entry.subentries.values()
+                    if subentry.subentry_type == SUBENTRY_TYPE_VEHICLE
+                    and subentry.data.get(CONF_VIN) == self.vin
+                ),
+                None,
+            )
+            if subentry_id is None:
+                return self.async_abort(reason="vehicle_removed")
+            next_flow = await self.hass.config_entries.subentries.async_init(
+                (self.entry.entry_id, SUBENTRY_TYPE_VEHICLE),
+                context={"source": SOURCE_RECONFIGURE, "subentry_id": subentry_id},
+            )
+            return self.async_create_entry(
+                data={},
+                next_flow=(FlowType.CONFIG_SUBENTRIES_FLOW, next_flow["flow_id"]),
+            )
+
+        return self.async_show_form(
+            step_id="confirm",
+            description_placeholders=self.placeholders,
+        )
+
+
 async def async_create_fix_flow(
     hass: HomeAssistant,
     issue_id: str,
@@ -71,6 +123,8 @@ async def async_create_fix_flow(
         and (entry := hass.config_entries.async_get_entry(entry_id)) is not None
         and entry.state is ConfigEntryState.LOADED
     ):
+        if issue_type == ISSUE_TYPE_BLE_KEY_REJECTED:
+            return BleKeyRejectedRepairFlow(entry, vin, vehicle)
         return VehicleMetadataRepairFlow(entry, vin, issue_type, vehicle)
 
     return ConfirmRepairFlow()

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -1296,6 +1296,20 @@
     }
   },
   "issues": {
+    "ble_key_rejected": {
+      "fix_flow": {
+        "abort": {
+          "vehicle_removed": "This vehicle's Bluetooth pairing was removed before the fix could run."
+        },
+        "step": {
+          "confirm": {
+            "description": "{vehicle} has stopped accepting commands over its local Bluetooth key, so Home Assistant is sending commands through the cloud instead. This usually means the key was removed from the vehicle's Locks screen.\n\nSelect **Submit** to re-pair the Bluetooth key.",
+            "title": "[%key:component::teslemetry::issues::ble_key_rejected::title%]"
+          }
+        }
+      },
+      "title": "Re-pair the Bluetooth key for {vehicle}"
+    },
     "key": {
       "fix_flow": {
         "error": {

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -1405,6 +1405,77 @@ async def test_subentry_add_flow_entry_not_loaded(hass: HomeAssistant) -> None:
     assert result["reason"] == "entry_not_loaded"
 
 
+async def test_subentry_reconfigure_updates_address(hass: HomeAssistant) -> None:
+    """Reconfigure re-scans and re-pairs an already added vehicle, updating its address."""
+    entry = await _setup_paired_entry(hass)
+    subentry = next(iter(entry.get_subentries_of_type(SUBENTRY_TYPE_VEHICLE)))
+    new_address = "11:22:33:44:55:66"
+
+    vehicle = _mock_vehicle(on_whitelist=True)
+    info = _discovered_info()
+    info.address = new_address
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry.config_flow.async_discovered_service_info",
+            return_value=[info],
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.async_get_ble_parent",
+            return_value=_mock_ble_parent(vehicle),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry.subentry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "scan"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    updated = entry.subentries[subentry.subentry_id]
+    assert updated.unique_id == VIN
+    assert updated.data == {CONF_VIN: VIN, CONF_ADDRESS: new_address}
+    vehicle.connect.assert_awaited_once()
+    vehicle.disconnect.assert_awaited_once()
+
+
+async def test_subentry_reconfigure_device_not_found(hass: HomeAssistant) -> None:
+    """Reconfigure re-shows the scan form when the vehicle cannot be found."""
+    entry = await _setup_paired_entry(hass)
+    subentry = next(iter(entry.get_subentries_of_type(SUBENTRY_TYPE_VEHICLE)))
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry.config_flow.async_discovered_service_info",
+            return_value=[],
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.async_get_ble_parent",
+            return_value=MagicMock(),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry.subentry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "scan"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "scan"
+    assert result["errors"] == {"base": "device_not_found"}
+    # The stored address is untouched by a failed re-scan.
+    assert entry.subentries[subentry.subentry_id].data == {
+        CONF_VIN: VIN,
+        CONF_ADDRESS: ADDRESS,
+    }
+
+
 SITE_ID = 123456
 WALL_CONNECTOR_SITE_ID = 555555
 HOST = "192.168.91.1"

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -2314,6 +2314,28 @@ async def test_ble_key_rejection_clears_when_key_works_again(
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
 
 
+async def test_ble_key_rejection_survives_metadata_refresh(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
+    """A locally-raised key rejection must not be cleared by a metadata refresh that never reports it."""
+    async with _paired_entry(hass, MagicMock(return_value=MagicMock())) as (
+        router,
+        bluetooth_vehicle,
+        _cloud,
+    ):
+        entry = hass.config_entries.async_entries(DOMAIN)[0]
+        issue_id = f"{ISSUE_TYPE_BLE_KEY_REJECTED}_{VIN}"
+
+        bluetooth_vehicle.flash_lights.side_effect = NotOnWhitelistFault()
+        assert await router.flash_lights() == CLOUD_RESULT
+        assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+
+        await entry.runtime_data.metadata_coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+
+
 async def test_vehicle_paired_but_never_seen(hass: HomeAssistant) -> None:
     """A paired vehicle never seen by Bluetooth is built without a device handle."""
     entry = _entry_with_ble()

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -19,6 +19,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from tesla_fleet_api.exceptions import (
     BluetoothCommandFailed,
+    BluetoothTimeout,
     BluetoothTransportError,
     BluetoothUnconfirmedCommand,
     Forbidden,
@@ -26,6 +27,7 @@ from tesla_fleet_api.exceptions import (
     InvalidResponse,
     InvalidToken,
     LoginRequired,
+    NotOnWhitelistFault,
     PrivateKeyError,
     RateLimited,
     SubscriptionRequired,
@@ -45,6 +47,7 @@ from homeassistant.components.teslemetry.const import (
     CONF_SITE_ID,
     CONF_VIN,
     DOMAIN,
+    ISSUE_TYPE_BLE_KEY_REJECTED,
     SUBENTRY_TYPE_ENERGY_SITE,
     SUBENTRY_TYPE_VEHICLE,
 )
@@ -81,7 +84,11 @@ from homeassistant.exceptions import (
     OAuth2TokenRequestReauthError,
     OAuth2TokenRequestTransientError,
 )
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
@@ -2211,6 +2218,100 @@ async def test_vehicle_router_fails_over_on_stale_cache_hit(
 
         bluetooth_vehicle.flash_lights.assert_awaited_once()
         cloud.assert_awaited_once()
+
+
+async def test_ble_key_rejection_raises_repair_issue(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
+    """A genuine key rejection over Bluetooth raises a per-vehicle repair issue."""
+    async with _paired_entry(hass, MagicMock(return_value=MagicMock())) as (
+        router,
+        bluetooth_vehicle,
+        _cloud,
+    ):
+        bluetooth_vehicle.flash_lights.side_effect = NotOnWhitelistFault()
+
+        assert await router.flash_lights() == CLOUD_RESULT
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    issue_id = f"{ISSUE_TYPE_BLE_KEY_REJECTED}_{VIN}"
+    issue = issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert issue is not None
+    assert issue.translation_key == ISSUE_TYPE_BLE_KEY_REJECTED
+    assert issue.data == {
+        "entry_id": entry.entry_id,
+        "vin": VIN,
+        "issue_type": ISSUE_TYPE_BLE_KEY_REJECTED,
+        "vehicle": "Test",
+    }
+
+
+@pytest.mark.parametrize(
+    "unreachable_error",
+    [
+        pytest.param(BluetoothTimeout(), id="asleep_or_out_of_range_timeout"),
+        pytest.param(BluetoothTransportError(), id="transport_failure"),
+        pytest.param(BleakError("no route"), id="unreachable"),
+    ],
+)
+async def test_ble_key_rejection_not_raised_when_unreachable(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    unreachable_error: Exception,
+) -> None:
+    """A vehicle that is merely asleep, out of range or unreachable is not a key rejection."""
+    async with _paired_entry(hass, MagicMock(return_value=MagicMock())) as (
+        router,
+        bluetooth_vehicle,
+        _cloud,
+    ):
+        bluetooth_vehicle.flash_lights.side_effect = unreachable_error
+
+        assert await router.flash_lights() == CLOUD_RESULT
+
+    issue_id = f"{ISSUE_TYPE_BLE_KEY_REJECTED}_{VIN}"
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
+
+
+async def test_ble_key_rejection_not_raised_when_out_of_range(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
+    """A vehicle out of Bluetooth range never reaches the primary, so nothing is raised."""
+    async with _paired_entry(hass, MagicMock(return_value=None)) as (
+        router,
+        bluetooth_vehicle,
+        _cloud,
+    ):
+        # Even a mock that would reject the key must never be reached.
+        bluetooth_vehicle.flash_lights.side_effect = NotOnWhitelistFault()
+
+        assert await router.flash_lights() == CLOUD_RESULT
+        bluetooth_vehicle.flash_lights.assert_not_called()
+
+    issue_id = f"{ISSUE_TYPE_BLE_KEY_REJECTED}_{VIN}"
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
+
+
+async def test_ble_key_rejection_clears_when_key_works_again(
+    hass: HomeAssistant, issue_registry: ir.IssueRegistry
+) -> None:
+    """The repair issue clears once a command succeeds over Bluetooth again."""
+    async with _paired_entry(hass, MagicMock(return_value=MagicMock())) as (
+        router,
+        bluetooth_vehicle,
+        _cloud,
+    ):
+        issue_id = f"{ISSUE_TYPE_BLE_KEY_REJECTED}_{VIN}"
+
+        bluetooth_vehicle.flash_lights.side_effect = NotOnWhitelistFault()
+        assert await router.flash_lights() == CLOUD_RESULT
+        assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+
+        bluetooth_vehicle.flash_lights.side_effect = None
+        bluetooth_vehicle.flash_lights.return_value = BLE_RESULT
+        assert await router.flash_lights() == BLE_RESULT
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
 
 
 async def test_vehicle_paired_but_never_seen(hass: HomeAssistant) -> None:

--- a/tests/components/teslemetry/test_repairs.py
+++ b/tests/components/teslemetry/test_repairs.py
@@ -2,29 +2,36 @@
 
 from copy import deepcopy
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.repairs import ConfirmRepairFlow
-from homeassistant.components.teslemetry.const import DOMAIN
+from homeassistant.components.repairs import ConfirmRepairFlow, FlowType
+from homeassistant.components.teslemetry.const import (
+    CONF_VIN,
+    DOMAIN,
+    ISSUE_TYPE_BLE_KEY_REJECTED,
+    SUBENTRY_TYPE_VEHICLE,
+)
 from homeassistant.components.teslemetry.coordinator import METADATA_INTERVAL
 from homeassistant.components.teslemetry.repairs import async_create_fix_flow
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState, ConfigSubentryData
+from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 
-from . import setup_platform
+from . import mock_config_entry, setup_platform
 from .const import METADATA
 
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.repairs import process_repair_fix_flow, start_repair_fix_flow
 from tests.typing import ClientSessionGenerator
 
 VEHICLE_VIN = "LRW3F7EK4NC700000"
+VEHICLE_ADDRESS = "AA:BB:CC:DD:EE:FF"
 
 
 def _metadata_with_issue(issue: str | None) -> dict[str, Any]:
@@ -39,6 +46,68 @@ def _metadata_without_vehicle() -> dict[str, Any]:
     metadata = deepcopy(METADATA)
     del metadata["vehicles"][VEHICLE_VIN]
     return metadata
+
+
+def _entry_with_ble() -> MockConfigEntry:
+    """Return a config entry whose vehicle subentry is already BLE-paired."""
+    entry = mock_config_entry()
+    return MockConfigEntry(
+        domain=entry.domain,
+        version=entry.version,
+        minor_version=entry.minor_version,
+        unique_id=entry.unique_id,
+        data=dict(entry.data),
+        subentries_data=[
+            ConfigSubentryData(
+                subentry_type=SUBENTRY_TYPE_VEHICLE,
+                unique_id=VEHICLE_VIN,
+                title="Test",
+                data={CONF_VIN: VEHICLE_VIN, CONF_ADDRESS: VEHICLE_ADDRESS},
+            )
+        ],
+    )
+
+
+async def _setup_ble_paired_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Set up an entry whose vehicle subentry is already BLE-paired."""
+    entry = _entry_with_ble()
+    entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.teslemetry.async_ble_device_from_address",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.components.teslemetry.helpers.TeslaBluetooth"
+        ) as mock_parent,
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+    ):
+        mock_parent.return_value.get_private_key = AsyncMock()
+        mock_parent.return_value.vehicles.createBluetooth.return_value = AsyncMock()
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _create_ble_key_rejected_issue(hass: HomeAssistant, entry: MockConfigEntry) -> str:
+    """Raise the Bluetooth key rejection issue for the paired vehicle and return its id."""
+    issue_id = f"{ISSUE_TYPE_BLE_KEY_REJECTED}_{VEHICLE_VIN}"
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        issue_id,
+        is_fixable=True,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key=ISSUE_TYPE_BLE_KEY_REJECTED,
+        translation_placeholders={"vehicle": "Test"},
+        data={
+            "entry_id": entry.entry_id,
+            "vin": VEHICLE_VIN,
+            "issue_type": ISSUE_TYPE_BLE_KEY_REJECTED,
+            "vehicle": "Test",
+        },
+    )
+    return issue_id
 
 
 def _metadata_with_vehicle_access(access: bool) -> dict[str, Any]:
@@ -215,3 +284,58 @@ async def test_repair_invalid_data_returns_confirm_flow(
     """Test invalid repair flow data falls back to a confirm flow."""
     flow = await async_create_fix_flow(hass, "key_VIN", data)
     assert isinstance(flow, ConfirmRepairFlow)
+
+
+async def test_ble_key_rejected_fix_flow_starts_reconfigure(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the fix flow for a rejected Bluetooth key hands off to the reconfigure flow."""
+    assert await async_setup_component(hass, "repairs", {})
+    client = await hass_client()
+
+    entry = await _setup_ble_paired_entry(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    issue_id = _create_ble_key_rejected_issue(hass, entry)
+
+    result = await start_repair_fix_flow(client, DOMAIN, issue_id)
+    flow_id = result["flow_id"]
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+
+    result = await process_repair_fix_flow(client, flow_id, json={})
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    # The repairs framework clears the issue once its own fix flow completes;
+    # it is re-raised if a real command is rejected again after this.
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
+
+    next_flow_type, next_flow_id = result["next_flow"]
+    assert next_flow_type == FlowType.CONFIG_SUBENTRIES_FLOW
+
+    subentry_flow = hass.config_entries.subentries.async_get(next_flow_id)
+    assert subentry_flow["handler"] == (entry.entry_id, SUBENTRY_TYPE_VEHICLE)
+    assert subentry_flow["step_id"] == "scan"
+
+
+async def test_ble_key_rejected_fix_flow_aborts_if_vehicle_removed(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test the fix flow aborts if the vehicle subentry was removed before the fix ran."""
+    assert await async_setup_component(hass, "repairs", {})
+    client = await hass_client()
+
+    entry = await _setup_ble_paired_entry(hass)
+    issue_id = _create_ble_key_rejected_issue(hass, entry)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_VEHICLE)[0].subentry_id
+    with patch.object(hass.config_entries, "async_schedule_reload"):
+        assert hass.config_entries.async_remove_subentry(entry, subentry_id)
+        await hass.async_block_till_done()
+
+    result = await start_repair_fix_flow(client, DOMAIN, issue_id)
+    flow_id = result["flow_id"]
+
+    result = await process_repair_fix_flow(client, flow_id, json={})
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "vehicle_removed"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a repair that tells an owner when a vehicle's Bluetooth key has stopped being accepted and hands them into the vehicle's Bluetooth reconfigure flow to re-pair it. `VehicleRouter` fails over from its Bluetooth primary to the cloud secondary on any exception, including `NotOnWhitelistFault`, so a revoked key previously degraded silently with no indication anything was wrong or that re-pairing would fix it. A small proxy around the Bluetooth backend observes a genuine rejection as commands pass through it, without adding a probe or a poll, and distinguishes it from the vehicle merely being asleep or out of Bluetooth range. The repair issue is raised and cleared per vehicle using the same shape already used for other vehicle issues, and its fix flow starts the vehicle's reconfigure flow and hands off to it through the repairs framework's `next_flow` mechanism rather than duplicating the scan-and-pair steps. This builds on #181986's reconfigure flow, so the diff here will shrink to just this change once that merges.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
