### PR TITLE
Scope Coolmaster unique IDs per config entry

### DIFF
--- a/homeassistant/components/coolmaster/__init__.py
+++ b/homeassistant/components/coolmaster/__init__.py
@@ -3,9 +3,9 @@
 from pycoolmasternet_async import CoolMasterNet
 
 from homeassistant.const import CONF_HOST, CONF_PORT, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import CONF_SEND_WAKEUP_PROMPT, CONF_SWING_SUPPORT, DOMAIN
 from .coordinator import CoolmasterConfigEntry, CoolmasterDataUpdateCoordinator
@@ -44,9 +44,53 @@ async def async_setup_entry(hass: HomeAssistant, entry: CoolmasterConfigEntry) -
     coordinator = CoolmasterDataUpdateCoordinator(hass, entry, coolmaster, info)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
+    await _async_migrate_unique_ids(hass, entry)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+async def _async_migrate_unique_ids(
+    hass: HomeAssistant, entry: CoolmasterConfigEntry
+) -> None:
+    """Migrate entities and devices to config-entry-scoped unique IDs.
+
+    Unique IDs used to be the raw unit ID (e.g. L5.002). Unit IDs are only
+    unique within a single CoolMasterNet device, so two devices reporting
+    the same unit IDs collided and the second device's entities were
+    silently dropped.
+    """
+    prefix = f"{entry.entry_id}-"
+
+    @callback
+    def _migrate(entity_entry: er.RegistryEntry) -> dict[str, str] | None:
+        if entity_entry.unique_id.startswith(prefix):
+            return None
+        return {"new_unique_id": f"{prefix}{entity_entry.unique_id}"}
+
+    await er.async_migrate_entries(hass, entry.entry_id, _migrate)
+
+    unit_ids = set(entry.runtime_data.data)
+    dev_reg = dr.async_get(hass)
+    for device in dr.async_entries_for_config_entry(dev_reg, entry.entry_id):
+        new_identifiers = {
+            (domain, f"{prefix}{ident}")
+            if domain == DOMAIN and ident in unit_ids
+            else (domain, ident)
+            for domain, ident in device.identifiers
+        }
+        if new_identifiers != device.identifiers:
+            dev_reg.async_update_device(device.id, new_identifiers=new_identifiers)
+        elif not any(
+            domain == DOMAIN and ident.startswith(prefix)
+            for domain, ident in device.identifiers
+        ):
+            # The device was claimed by another config entry before unique
+            # IDs were scoped per entry (identifier collision); this entry's
+            # own device will be created on platform setup.
+            dev_reg.async_update_device(
+                device.id, remove_config_entry_id=entry.entry_id
+            )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: CoolmasterConfigEntry) -> bool:
@@ -61,5 +105,6 @@ async def async_remove_config_entry_device(
 ) -> bool:
     """Remove a config entry from a device."""
     return not device_entry.identifiers.intersection(
-        (DOMAIN, unit_id) for unit_id in config_entry.runtime_data.data
+        (DOMAIN, f"{config_entry.entry_id}-{unit_id}")
+        for unit_id in config_entry.runtime_data.data
     )

--- a/homeassistant/components/coolmaster/__init__.py
+++ b/homeassistant/components/coolmaster/__init__.py
@@ -70,27 +70,19 @@ async def _async_migrate_unique_ids(
 
     await er.async_migrate_entries(hass, entry.entry_id, _migrate)
 
-    unit_ids = set(entry.runtime_data.data)
     dev_reg = dr.async_get(hass)
     for device in dr.async_entries_for_config_entry(dev_reg, entry.entry_id):
+        # Prefix every identifier owned by this entry, including units that
+        # are currently not reported (e.g. offline), so a returning unit
+        # reuses its migrated device instead of creating a duplicate.
         new_identifiers = {
-            (domain, f"{prefix}{ident}")
-            if domain == DOMAIN and ident in unit_ids
-            else (domain, ident)
+            (domain, ident)
+            if domain != DOMAIN or ident.startswith(prefix)
+            else (domain, f"{prefix}{ident}")
             for domain, ident in device.identifiers
         }
         if new_identifiers != device.identifiers:
             dev_reg.async_update_device(device.id, new_identifiers=new_identifiers)
-        elif not any(
-            domain == DOMAIN and ident.startswith(prefix)
-            for domain, ident in device.identifiers
-        ):
-            # The device was claimed by another config entry before unique
-            # IDs were scoped per entry (identifier collision); this entry's
-            # own device will be created on platform setup.
-            dev_reg.async_update_device(
-                device.id, remove_config_entry_id=entry.entry_id
-            )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: CoolmasterConfigEntry) -> bool:

--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -82,7 +82,7 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
         """Initialize the climate device."""
         super().__init__(coordinator, unit_id)
         self._attr_hvac_modes = supported_modes
-        self._attr_unique_id = unit_id
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-{unit_id}"
 
     @property
     @override

--- a/homeassistant/components/coolmaster/coordinator.py
+++ b/homeassistant/components/coolmaster/coordinator.py
@@ -25,6 +25,8 @@ class CoolmasterDataUpdateCoordinator(
 ):
     """Class to manage fetching Coolmaster data."""
 
+    config_entry: CoolmasterConfigEntry
+
     def __init__(
         self,
         hass: HomeAssistant,

--- a/homeassistant/components/coolmaster/entity.py
+++ b/homeassistant/components/coolmaster/entity.py
@@ -24,15 +24,18 @@ class CoolmasterEntity(CoordinatorEntity[CoolmasterDataUpdateCoordinator]):
         super().__init__(coordinator)
         self._unit_id: str = unit_id
         self._unit = coordinator.data[self._unit_id]
+        entry_id = coordinator.config_entry.entry_id
         self._attr_device_info: DeviceInfo = DeviceInfo(
-            identifiers={(DOMAIN, unit_id)},
+            identifiers={(DOMAIN, f"{entry_id}-{unit_id}")},
             manufacturer="CoolAutomation",
             model="CoolMasterNet",
             name=unit_id,
             sw_version=coordinator.info["version"],
         )
         if hasattr(self, "entity_description"):
-            self._attr_unique_id: str = f"{unit_id}-{self.entity_description.key}"
+            self._attr_unique_id: str = (
+                f"{entry_id}-{unit_id}-{self.entity_description.key}"
+            )
 
     @callback
     @override

--- a/tests/components/coolmaster/test_init.py
+++ b/tests/components/coolmaster/test_init.py
@@ -1,12 +1,30 @@
 """The test for the Coolmaster integration."""
 
+from unittest.mock import patch
+
+from homeassistant.components.climate import HVACMode
 from homeassistant.components.coolmaster.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
+from .conftest import CoolMasterNetMock
+
+from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
+
+
+def _mock_config_entry(host: str) -> MockConfigEntry:
+    """Create a mock Coolmaster config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": host,
+            "port": 1234,
+            "supported_modes": [HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT],
+        },
+    )
 
 
 async def test_load_entry(
@@ -37,7 +55,7 @@ async def test_registry_cleanup(
 ) -> None:
     """Test being able to remove a disconnected device."""
     entry_id = load_int.entry_id
-    live_id = "L1.100"
+    live_id = f"{entry_id}-L1.100"
     dead_id = "L2.200"
 
     assert (
@@ -85,3 +103,128 @@ async def test_registry_cleanup(
         device_registry.async_get_device_by_identifier((DOMAIN, dead_id), entry_id)
         is None
     )
+
+
+async def test_migrate_unique_ids(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test migration of raw unit ID unique IDs to config-entry-scoped ones."""
+    config_entry = _mock_config_entry("1.2.3.4")
+    config_entry.add_to_hass(hass)
+
+    # Simulate a pre-migration install: device and entities registered
+    # with raw unit IDs.
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "L1.100")},
+        manufacturer="CoolAutomation",
+        model="CoolMasterNet",
+        name="L1.100",
+    )
+    climate_entity = entity_registry.async_get_or_create(
+        "climate",
+        DOMAIN,
+        "L1.100",
+        config_entry=config_entry,
+        device_id=device.id,
+        suggested_object_id="l1_100",
+    )
+    sensor_entity = entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "L1.100-error_code",
+        config_entry=config_entry,
+        device_id=device.id,
+    )
+
+    with patch(
+        "homeassistant.components.coolmaster.CoolMasterNet",
+        new=CoolMasterNetMock,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    prefix = f"{config_entry.entry_id}-"
+    migrated_climate = entity_registry.async_get(climate_entity.entity_id)
+    assert migrated_climate is not None
+    assert migrated_climate.unique_id == f"{prefix}L1.100"
+    migrated_sensor = entity_registry.async_get(sensor_entity.entity_id)
+    assert migrated_sensor is not None
+    assert migrated_sensor.unique_id == f"{prefix}L1.100-error_code"
+
+    migrated_device = device_registry.async_get(device.id)
+    assert migrated_device is not None
+    assert migrated_device.identifiers == {(DOMAIN, f"{prefix}L1.100")}
+
+
+async def test_multiple_bridges_with_same_unit_ids(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    unit_count: int,
+) -> None:
+    """Test two bridges reporting the same unit IDs don't collide.
+
+    Unique IDs used to be the raw unit ID, so the second bridge's
+    entities were silently dropped.
+    """
+    entry1 = _mock_config_entry("1.2.3.4")
+    entry1.add_to_hass(hass)
+    entry2 = _mock_config_entry("4.3.2.1")
+    entry2.add_to_hass(hass)
+
+    # Simulate the pre-migration collision: entry1's entity registered with
+    # a raw unit ID unique ID, and the device claimed by both entries due
+    # to the identifier collision.
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry1.entry_id,
+        identifiers={(DOMAIN, "L1.100")},
+        manufacturer="CoolAutomation",
+        model="CoolMasterNet",
+        name="L1.100",
+    )
+    device_registry.async_get_or_create(
+        config_entry_id=entry2.entry_id,
+        identifiers={(DOMAIN, "L1.100")},
+    )
+    entity_registry.async_get_or_create(
+        "climate",
+        DOMAIN,
+        "L1.100",
+        config_entry=entry1,
+        device_id=device.id,
+    )
+
+    with patch(
+        "homeassistant.components.coolmaster.CoolMasterNet",
+        new=CoolMasterNetMock,
+    ):
+        # Setting up the first entry sets up the whole domain, including
+        # the second entry.
+        await hass.config_entries.async_setup(entry1.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry1.state is ConfigEntryState.LOADED
+    assert entry2.state is ConfigEntryState.LOADED
+
+    # Every unit appears once per bridge.
+    assert hass.states.async_entity_ids_count() == unit_count * 4 * 2
+    for entry in (entry1, entry2):
+        assert (
+            len(er.async_entries_for_config_entry(entity_registry, entry.entry_id))
+            == unit_count * 4
+        )
+        assert (
+            len(dr.async_entries_for_config_entry(device_registry, entry.entry_id))
+            == unit_count
+        )
+
+    # The formerly shared device now belongs to entry1 alone, with a
+    # config-entry-scoped identifier.
+    shared_device = device_registry.async_get(device.id)
+    assert shared_device is not None
+    assert shared_device.identifiers == {(DOMAIN, f"{entry1.entry_id}-L1.100")}
+    entry2_devices = dr.async_entries_for_config_entry(device_registry, entry2.entry_id)
+    assert device.id not in {device_entry.id for device_entry in entry2_devices}

--- a/tests/components/coolmaster/test_init.py
+++ b/tests/components/coolmaster/test_init.py
@@ -114,14 +114,22 @@ async def test_migrate_unique_ids(
     config_entry = _mock_config_entry("1.2.3.4")
     config_entry.add_to_hass(hass)
 
-    # Simulate a pre-migration install: device and entities registered
-    # with raw unit IDs.
+    # Simulate a pre-migration install: devices and entities registered
+    # with raw unit IDs, including a device whose unit is not currently
+    # reported by the bridge (e.g. offline).
     device = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "L1.100")},
         manufacturer="CoolAutomation",
         model="CoolMasterNet",
         name="L1.100",
+    )
+    offline_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "L2.200")},
+        manufacturer="CoolAutomation",
+        model="CoolMasterNet",
+        name="L2.200",
     )
     climate_entity = entity_registry.async_get_or_create(
         "climate",
@@ -158,6 +166,12 @@ async def test_migrate_unique_ids(
     assert migrated_device is not None
     assert migrated_device.identifiers == {(DOMAIN, f"{prefix}L1.100")}
 
+    # The device of a unit the bridge is not currently reporting is
+    # migrated too, so the unit reuses it if it returns.
+    migrated_offline_device = device_registry.async_get(offline_device.id)
+    assert migrated_offline_device is not None
+    assert migrated_offline_device.identifiers == {(DOMAIN, f"{prefix}L2.200")}
+
 
 async def test_multiple_bridges_with_same_unit_ids(
     hass: HomeAssistant,
@@ -175,19 +189,15 @@ async def test_multiple_bridges_with_same_unit_ids(
     entry2 = _mock_config_entry("4.3.2.1")
     entry2.add_to_hass(hass)
 
-    # Simulate the pre-migration collision: entry1's entity registered with
-    # a raw unit ID unique ID, and the device claimed by both entries due
-    # to the identifier collision.
+    # Simulate the pre-migration collision: entry1's device and entity are
+    # registered with a raw unit ID, while entry2's entities were silently
+    # dropped by the unique ID collision and were never registered.
     device = device_registry.async_get_or_create(
         config_entry_id=entry1.entry_id,
         identifiers={(DOMAIN, "L1.100")},
         manufacturer="CoolAutomation",
         model="CoolMasterNet",
         name="L1.100",
-    )
-    device_registry.async_get_or_create(
-        config_entry_id=entry2.entry_id,
-        identifiers={(DOMAIN, "L1.100")},
     )
     entity_registry.async_get_or_create(
         "climate",
@@ -221,10 +231,10 @@ async def test_multiple_bridges_with_same_unit_ids(
             == unit_count
         )
 
-    # The formerly shared device now belongs to entry1 alone, with a
-    # config-entry-scoped identifier.
-    shared_device = device_registry.async_get(device.id)
-    assert shared_device is not None
-    assert shared_device.identifiers == {(DOMAIN, f"{entry1.entry_id}-L1.100")}
+    # entry1's pre-existing device was migrated to a config-entry-scoped
+    # identifier; entry2 created its own separate device for the same unit ID.
+    migrated_device = device_registry.async_get(device.id)
+    assert migrated_device is not None
+    assert migrated_device.identifiers == {(DOMAIN, f"{entry1.entry_id}-L1.100")}
     entry2_devices = dr.async_entries_for_config_entry(device_registry, entry2.entry_id)
     assert device.id not in {device_entry.id for device_entry in entry2_devices}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Coolmaster entity unique IDs and device identifiers are the raw CoolMasterNet unit ID (e.g. `L5.002`). Unit IDs are only unique within a single CoolMasterNet device, so with two (or more) CoolMasterNet devices configured, any unit IDs they share collide: the second device's entities are silently dropped ("already exists" in the entity platform), and its registry devices merge with the first bridge's devices. In my setup (two CoolMasterNet bridges, 4 + 7 indoor units, both reporting units as `L5.002`–`L5.00x`), only 7 of 11 zones appeared in Home Assistant.

This PR scopes unique IDs and device identifiers with the config entry ID:

- `climate` unique ID: `L5.002` → `<entry_id>-L5.002`
- described entities (sensor/binary_sensor/button): `L5.002-error_code` → `<entry_id>-L5.002-error_code`
- device identifiers: `(coolmaster, L5.002)` → `(coolmaster, <entry_id>-L5.002)`

Existing installs are migrated on setup (`er.async_migrate_entries` plus device registry identifier updates), so entity IDs, history, and customizations are preserved. Device registry links left stale by a pre-existing identifier collision (a device claimed by two config entries) are detached from the entry that no longer owns them; that entry's own device is then created normally by platform setup.

Verified live on a two-bridge installation: after the fix, all 11 zones are present, the first bridge's entities kept their entity IDs and history, and each registry device is linked to exactly one config entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Note: #181264 (quality scale / `entity-unique-id`) touches the same files; happy to rebase whichever lands second. That PR makes unique ID assignment unconditional but does not address the cross-device collision fixed here.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
