### PR TITLE
Suppress the placeholder water temperature on Flo valves without the sensor

### DIFF
--- a/homeassistant/components/flo/const.py
+++ b/homeassistant/components/flo/const.py
@@ -10,3 +10,8 @@ FLO_HOME = "home"
 FLO_AWAY = "away"
 FLO_SLEEP = "sleep"
 FLO_MODES = [FLO_HOME, FLO_AWAY, FLO_SLEEP]
+
+# Valves without a water-temperature sensor report a fixed placeholder instead of
+# omitting tempF. No domestic supply reaches boiling, so a reading at or above
+# this is a sentinel rather than a measurement.
+IMPLAUSIBLE_WATER_TEMP_F = 212.0

--- a/homeassistant/components/flo/coordinator.py
+++ b/homeassistant/components/flo/coordinator.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN, IMPLAUSIBLE_WATER_TEMP_F, LOGGER
 
 type FloConfigEntry = ConfigEntry[FloRuntimeData]
 
@@ -144,9 +144,12 @@ class FloDeviceDataUpdateCoordinator(DataUpdateCoordinator):
         return self._device_information["telemetry"]["current"]["psi"]
 
     @property
-    def temperature(self) -> float:
-        """Return the current temperature in degrees F."""
-        return self._device_information["telemetry"]["current"]["tempF"]
+    def temperature(self) -> float | None:
+        """Return the current temperature in degrees F, or None if not measured."""
+        temperature = self._device_information["telemetry"]["current"]["tempF"]
+        if temperature is None or temperature >= IMPLAUSIBLE_WATER_TEMP_F:
+            return None
+        return temperature
 
     @property
     def humidity(self) -> float:

--- a/tests/components/flo/conftest.py
+++ b/tests/components/flo/conftest.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, CONTENT_TYPE_JSON
 
 from .common import TEST_EMAIL_ADDRESS, TEST_PASSWORD, TEST_TOKEN, TEST_USER_ID
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, load_fixture, load_json_object_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
@@ -26,7 +26,18 @@ def config_entry() -> MockConfigEntry:
 
 
 @pytest.fixture
-def aioclient_mock_fixture(aioclient_mock: AiohttpClientMocker) -> None:
+def device_info_response(request: pytest.FixtureRequest) -> str:
+    """Shutoff valve device info, with tempF overridden when parametrized."""
+    device_info = load_json_object_fixture("flo/device_info_response.json")
+    if hasattr(request, "param"):
+        device_info["telemetry"]["current"]["tempF"] = request.param
+    return json.dumps(device_info)
+
+
+@pytest.fixture
+def aioclient_mock_fixture(
+    aioclient_mock: AiohttpClientMocker, device_info_response: str
+) -> None:
     """Fixture to provide a aioclient mocker."""
     now = round(time.time())
     # Mocks the login response for flo.
@@ -56,7 +67,7 @@ def aioclient_mock_fixture(aioclient_mock: AiohttpClientMocker) -> None:
     # Mocks the devices for flo.
     aioclient_mock.get(
         "https://api-gw.meetflo.com/api/v2/devices/98765",
-        text=load_fixture("flo/device_info_response.json"),
+        text=device_info_response,
         status=HTTPStatus.OK,
         headers={"Content-Type": CONTENT_TYPE_JSON},
     )

--- a/tests/components/flo/test_sensor.py
+++ b/tests/components/flo/test_sensor.py
@@ -1,5 +1,7 @@
 """Test Flo by Moen sensor entities."""
 
+import json
+
 import pytest
 
 from homeassistant.components.homeassistant import (
@@ -7,7 +9,7 @@ from homeassistant.components.homeassistant import (
     SERVICE_UPDATE_ENTITY,
 )
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorStateClass
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
@@ -105,3 +107,40 @@ async def test_manual_update_entity(
         blocking=True,
     )
     assert aioclient_mock.call_count == call_count + 3
+
+
+@pytest.mark.parametrize("device_info_response", [225, 212, 220], indirect=True)
+@pytest.mark.usefixtures("aioclient_mock_fixture")
+async def test_water_temperature_placeholder_is_not_published(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """A valve with no temperature sensor reports a placeholder, not a reading."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("sensor.smart_water_shutoff_water_temperature").state
+        == STATE_UNKNOWN
+    )
+
+    # The detector measures ambient air and is unaffected.
+    assert hass.states.get("sensor.kitchen_sink_temperature").state == "61"
+
+
+@pytest.mark.parametrize("device_info_response", [211.9, 70], indirect=True)
+@pytest.mark.usefixtures("aioclient_mock_fixture")
+async def test_water_temperature_below_threshold_is_published(
+    hass: HomeAssistant, config_entry: MockConfigEntry, device_info_response: str
+) -> None:
+    """Anything below boiling is a real reading and is published."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    expected = json.loads(device_info_response)["telemetry"]["current"]["tempF"]
+    assert hass.states.get("sensor.smart_water_shutoff_water_temperature").state == str(
+        round(expected, 1)
+    )


### PR DESCRIPTION
## Proposed change

A Flo Smart Water Shutoff with no water-temperature sensor does not omit `tempF`
from its telemetry, it returns a constant placeholder. The coordinator passes it
through, so `sensor.*_water_temperature` publishes a fixed 225 °F carrying
`SensorDeviceClass.TEMPERATURE` and `SensorStateClass.MEASUREMENT`.

`FloDeviceDataUpdateCoordinator.temperature` now returns `None` at or above
boiling, so the sensor reports `unknown` instead of a placeholder.
`FloTemperatureSensor.native_value` already handles `None`.

The threshold is boiling rather than 225 so the check does not depend on the
exact placeholder value.

Detectors (`device_type == "puck_oem"`) share this property but measure ambient
air, which cannot reach 212 °F. The existing detector assertion of `61` is kept
in the new test to cover that.

Evidence is in #180671. One addition since that report: across 168 consecutive
hourly buckets from `/water/metrics`, `averageTempF` was `225` in 166 and `null`
in 2, with no other value. `averageWeatherTempF` over the same buckets takes 9
distinct values between 64 and 79 °F.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #180671
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
