### PR TITLE
Guard KNX climate fan_mode against out-of-range step values

### DIFF
--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -554,7 +554,7 @@ class _KnxClimate(ClimateEntity, _KnxEntityBase):
 
     @property
     @override
-    def fan_mode(self) -> str:
+    def fan_mode(self) -> str | None:
         """Return the fan setting."""
 
         fan_speed = self._device.current_fan_speed
@@ -563,6 +563,10 @@ class _KnxClimate(ClimateEntity, _KnxEntityBase):
             return self.fan_zero_mode
 
         if self._device.fan_speed_mode is FanSpeedMode.STEP:
+            # DPT 5.010 fits any 1-byte value (0-255), so a gateway may report
+            # a step beyond the configured fan_max_step
+            if fan_speed >= len(self._attr_fan_modes):
+                return None
             return self._attr_fan_modes[fan_speed]
 
         # Find the closest fan mode percentage

--- a/tests/components/knx/test_climate.py
+++ b/tests/components/knx/test_climate.py
@@ -502,6 +502,45 @@ async def test_fan_speed_3_steps(hass: HomeAssistant, knx: KNXTestKit) -> None:
     knx.assert_state("climate.test", HVACMode.HEAT, fan_mode="off")
 
 
+@pytest.mark.parametrize("raw_value", [0x04, 0xFF])
+async def test_fan_speed_step_out_of_range(
+    hass: HomeAssistant, knx: KNXTestKit, raw_value: int
+) -> None:
+    """Test that fan step values beyond fan_max_step don't crash the entity."""
+    await knx.setup_integration(
+        {
+            ClimateSchema.PLATFORM: {
+                CONF_NAME: "test",
+                ClimateSchema.CONF_TEMPERATURE_ADDRESS: "1/2/3",
+                ClimateSchema.CONF_TARGET_TEMPERATURE_ADDRESS: "1/2/4",
+                ClimateSchema.CONF_TARGET_TEMPERATURE_STATE_ADDRESS: "1/2/5",
+                ClimateSchema.CONF_FAN_SPEED_ADDRESS: "1/2/6",
+                ClimateSchema.CONF_FAN_SPEED_STATE_ADDRESS: "1/2/7",
+                ClimateConf.FAN_SPEED_MODE: "step",
+                ClimateConf.FAN_MAX_STEP: 3,
+            }
+        }
+    )
+
+    # read states state updater
+    await knx.assert_read("1/2/3")
+    await knx.assert_read("1/2/5")
+
+    # StateUpdater initialize state
+    await knx.receive_response("1/2/5", RAW_FLOAT_22_0)
+    await knx.receive_response("1/2/3", RAW_FLOAT_21_0)
+
+    # Query status
+    await knx.assert_read("1/2/7")
+
+    # a gateway may report a step value beyond the configured fan_max_step
+    await knx.receive_write("1/2/7", (raw_value,))
+    await hass.async_block_till_done()
+
+    # the invalid telegram is published without breaking the state write
+    knx.assert_state("climate.test", HVACMode.HEAT, fan_mode=None)
+
+
 async def test_fan_speed_2_steps(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX climate fan speed 2 steps."""
     await knx.setup_integration(


### PR DESCRIPTION
## Breaking change

<!-- If your PR contains a breaking change for existing users, it is important
to tell them what breaks, how to make it work again and why we did this.
This piece of text is published with the release notes, so it helps if you
write it towards our users, not us.
Note: Remove this section if this PR is NOT a breaking change. -->

## Proposed change

<!-- Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug
or resolves a feature request, be sure to link to that issue in the
additional information section. -->

knx climate entities in step mode (DPT 5.010) crash with IndexError when the gateway reports a fan step above the configured fan_max_step, the traceback hits climate.py line 566 on every fan status update and the entity stops updating its state, i hit it on a CoolMaster KNX gateway that encodes fan speeds as 1..4 while the entity builds a 4-entry list (indices 0-3)

DPT 5.010 decodes the raw 1-byte telegram value (0-255, unbounded), but the fan_mode property indexed straight into _attr_fan_modes with it, so any device value past the configured max killed the state write, the sibling hvac_mode property already falls back gracefully for unknown controller modes, this does the same for fan steps: out-of-range values now report an unknown fan mode and the entity keeps updating

### Steps to reproduce

1. run `.venv/bin/python -m pytest tests/components/knx/test_climate.py -k test_fan_speed_step_out_of_range -q` on dev without the fix
2. Expected: fan_mode returns None for out-of-range step values, the entity keeps updating
3. Actual (raw output on untouched dev): `IndexError: list index out of range` at `homeassistant/components/knx/climate.py, line 566, in fan_mode`, 2 failed ([0x04] and [0xFF])

## Type of change

<!-- What type of change does your PR introduce to Home Assistant?
NOTE: Please, check only 1! box!
If your PR requires multiple boxes to be checked, you'll most likely need to
split it into multiple PRs. This makes things easier and faster to code review. -->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!-- Details are important, and help maintainers processing your PR.
Please be sure to fill out additional details, if applicable. -->

- This PR fixes or closes issue: fixes #181983
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look
for before merging your code.

AI tools are welcome, but contributors are responsible for *fully*
understanding the code before submitting a PR. Please follow our AI policy:
https://developers.home-assistant.io/docs/ai_policy -->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
