### PR TITLE
Fix UniFi Protect doorbell messages expiring after 60 seconds

### DIFF
--- a/homeassistant/components/unifiprotect/select.py
+++ b/homeassistant/components/unifiprotect/select.py
@@ -192,15 +192,14 @@ async def _set_paired_camera(obj: Light | Sensor, camera_id: str) -> None:
 async def _set_doorbell_message(obj: Camera, message: str) -> None:
     if message.startswith(DoorbellMessageType.CUSTOM_MESSAGE.value):
         message = message.rsplit(":", maxsplit=1)[-1]
+        # reset_at=None keeps the message up until it is changed
         await obj.set_lcd_message_public(
-            DoorbellMessageType.CUSTOM_MESSAGE, text=message
+            DoorbellMessageType.CUSTOM_MESSAGE, text=message, reset_at=None
         )
     elif message == TYPE_EMPTY_VALUE:
-        # Public API has no endpoint to clear the LCD message; fall back to
-        # the non-deprecated legacy helper.
-        await obj.set_lcd_text(None)
+        await obj.set_lcd_message_public(None)
     else:
-        await obj.set_lcd_message_public(DoorbellMessageType(message))
+        await obj.set_lcd_message_public(DoorbellMessageType(message), reset_at=None)
 
 
 async def _set_liveview(obj: Viewer, liveview_id: str) -> None:

--- a/homeassistant/components/unifiprotect/text.py
+++ b/homeassistant/components/unifiprotect/text.py
@@ -42,7 +42,10 @@ def _get_doorbell_current(obj: Camera) -> str | None:
 
 
 async def _set_doorbell_message(obj: Camera, message: str) -> None:
-    await obj.set_lcd_text(DoorbellMessageType.CUSTOM_MESSAGE, text=message)
+    # reset_at=None keeps the message up until it is changed
+    await obj.set_lcd_message_public(
+        DoorbellMessageType.CUSTOM_MESSAGE, text=message, reset_at=None
+    )
 
 
 CAMERA: tuple[ProtectTextEntityDescription, ...] = (

--- a/tests/components/unifiprotect/test_select.py
+++ b/tests/components/unifiprotect/test_select.py
@@ -649,8 +649,10 @@ async def test_select_set_option_camera_doorbell_custom(
             blocking=True,
         )
 
+        # reset_at=None keeps the message up; omitting it lets the NVR
+        # clear it after its own timeout
         mock_method.assert_called_once_with(
-            DoorbellMessageType.CUSTOM_MESSAGE, text="Test"
+            DoorbellMessageType.CUSTOM_MESSAGE, text="Test", reset_at=None
         )
 
 
@@ -666,14 +668,9 @@ async def test_select_set_option_camera_doorbell_unifi(
         hass, Platform.SELECT, doorbell, CAMERA_SELECTS[2]
     )
 
-    with (
-        patch_ufp_method(
-            doorbell, "set_lcd_message_public", new_callable=AsyncMock
-        ) as mock_public,
-        patch_ufp_method(
-            doorbell, "set_lcd_text", new_callable=AsyncMock
-        ) as mock_legacy,
-    ):
+    with patch_ufp_method(
+        doorbell, "set_lcd_message_public", new_callable=AsyncMock
+    ) as mock_method:
         await hass.services.async_call(
             "select",
             "select_option",
@@ -684,19 +681,9 @@ async def test_select_set_option_camera_doorbell_unifi(
             blocking=True,
         )
 
-        mock_public.assert_called_once_with(DoorbellMessageType.LEAVE_PACKAGE_AT_DOOR)
-
-        await hass.services.async_call(
-            "select",
-            "select_option",
-            {
-                ATTR_ENTITY_ID: entity_id,
-                ATTR_OPTION: "Default Message (Welcome)",
-            },
-            blocking=True,
+        mock_method.assert_called_once_with(
+            DoorbellMessageType.LEAVE_PACKAGE_AT_DOOR, reset_at=None
         )
-
-        mock_legacy.assert_called_once_with(None)
 
 
 async def test_select_set_option_camera_doorbell_default(
@@ -712,7 +699,7 @@ async def test_select_set_option_camera_doorbell_default(
     )
 
     with patch_ufp_method(
-        doorbell, "set_lcd_text", new_callable=AsyncMock
+        doorbell, "set_lcd_message_public", new_callable=AsyncMock
     ) as mock_method:
         await hass.services.async_call(
             "select",

--- a/tests/components/unifiprotect/test_text.py
+++ b/tests/components/unifiprotect/test_text.py
@@ -78,7 +78,7 @@ async def test_text_camera_set(
     )
 
     with patch_ufp_method(
-        doorbell, "set_lcd_text", new_callable=AsyncMock
+        doorbell, "set_lcd_message_public", new_callable=AsyncMock
     ) as mock_method:
         await hass.services.async_call(
             "text",
@@ -88,5 +88,5 @@ async def test_text_camera_set(
         )
 
         mock_method.assert_called_once_with(
-            DoorbellMessageType.CUSTOM_MESSAGE, text="Test test"
+            DoorbellMessageType.CUSTOM_MESSAGE, text="Test test", reset_at=None
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`set_lcd_text` defaulted to `reset_at=None`, which the console reads as "never expire". Its public replacement `set_lcd_message_public` defaults to omitting `resetAt`, and the console then applies `doorbell_settings.default_message_reset_timeout` instead. The migration dropped the argument, so doorbell messages set through the select entity disappear after 60 seconds. Passing `reset_at=None` restores the previous behaviour.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181649
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Regression introduced in 2026.6.0 by #171785; last working release 2026.5.4.

Verified against a UVC G6 Pro Entry on Protect 7.3: with `resetAt` omitted the message vanished after exactly 60 s, with `resetAt: null` it was still shown after 5 minutes.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
