### PR TITLE
Bump qingping-ble to 1.1.6

### DIFF
--- a/homeassistant/components/qingping/manifest.json
+++ b/homeassistant/components/qingping/manifest.json
@@ -21,5 +21,5 @@
   "documentation": "https://www.home-assistant.io/integrations/qingping",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["qingping-ble==1.1.5"]
+  "requirements": ["qingping-ble==1.1.6"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2941,7 +2941,7 @@ qbittorrent-api==2026.5.1
 qbusmqttapi==1.5.1
 
 # homeassistant.components.qingping
-qingping-ble==1.1.5
+qingping-ble==1.1.6
 
 # homeassistant.components.qnap
 qnapstats==0.4.0


### PR DESCRIPTION
## Proposed change

Bump `qingping-ble` from 1.1.5 to 1.1.6.

This release fixes [Bluetooth-Devices/qingping-ble#96](https://github.com/Bluetooth-Devices/qingping-ble/issues/96) via [Bluetooth-Devices/qingping-ble#117](https://github.com/Bluetooth-Devices/qingping-ble/pull/117): BLE TLV id `0x18` was being misread as CO2 on the CGP22C (Qingping CO2 Temp RH). `0x18` is actually a static 2-byte hardware capability bitmap and is always `0x0122` (= 290) on that device, so every CGP22C user's CO2 sensor has been pinned at a constant 290 ppm since `qingping-ble` 1.1.2, regardless of firmware version. Qingping (`@tengfeili-qingping`) confirmed against their internal BLE protocol spec in [Bluetooth-Devices/qingping-ble#115](https://github.com/Bluetooth-Devices/qingping-ble/issues/115) that `0x18` is not a sensor reading and CO2 is always broadcast as TLV `0x13`.

Diff: [v1.1.5...v1.1.6](https://github.com/Bluetooth-Devices/qingping-ble/compare/v1.1.5...v1.1.6)

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR is related to issue: [Bluetooth-Devices/qingping-ble#115](https://github.com/Bluetooth-Devices/qingping-ble/issues/115)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.

If the code communicates with devices, web services, or third-party tools:

- [x] New or updated dependencies have been added to `requirements_all.txt`. The change is a single version-string bump with no new dependency, so it was applied directly to match the exact diff shape `script.gen_requirements_all` produces for this kind of change (same pattern as the prior `1.1.4` → `1.1.5` bump), rather than running the full generator in this environment.
- [x] For the updated dependency a diff between library versions is linked above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
