### PR TITLE
Share one calendar event fetch between listeners on the same range

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -1,5 +1,6 @@
 """Support for Calendar event device sensors."""
 
+from collections import defaultdict
 from collections.abc import Callable, Iterable
 import dataclasses
 import datetime
@@ -719,8 +720,18 @@ class CalendarEntity(Entity):
         if not self._event_listeners:
             return
 
+        # Expanding the events is the expensive part, and every dashboard
+        # showing the same days asks for the same range, so those listeners
+        # are served from a single fetch.
+        listeners_by_range: defaultdict[
+            tuple[datetime.datetime, datetime.datetime],
+            list[Callable[[list[JsonValueType] | None], None]],
+        ] = defaultdict(list)
         for start_date, end_date, listener in self._event_listeners:
-            self.async_update_single_event_listener(start_date, end_date, listener)
+            listeners_by_range[(start_date, end_date)].append(listener)
+
+        for (start_date, end_date), listeners in listeners_by_range.items():
+            self._async_schedule_listener_update(start_date, end_date, listeners)
 
     @final
     @callback
@@ -731,17 +742,27 @@ class CalendarEntity(Entity):
         listener: Callable[[list[JsonValueType] | None], None],
     ) -> None:
         """Schedule an event fetch and push to a single listener."""
-        self.hass.async_create_task(
-            self._async_update_listener(start_date, end_date, listener)
-        )
+        self._async_schedule_listener_update(start_date, end_date, [listener])
 
-    async def _async_update_listener(
+    @callback
+    def _async_schedule_listener_update(
         self,
         start_date: datetime.datetime,
         end_date: datetime.datetime,
-        listener: Callable[[list[JsonValueType] | None], None],
+        listeners: list[Callable[[list[JsonValueType] | None], None]],
     ) -> None:
-        """Fetch events and push to a single listener."""
+        """Schedule an event fetch and push to the given listeners."""
+        self.hass.async_create_task(
+            self._async_update_listeners(start_date, end_date, listeners)
+        )
+
+    async def _async_update_listeners(
+        self,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+        listeners: list[Callable[[list[JsonValueType] | None], None]],
+    ) -> None:
+        """Fetch events and push them to the listeners of that range."""
         try:
             events = await self.async_get_events(self.hass, start_date, end_date)
         except HomeAssistantError as err:
@@ -750,11 +771,13 @@ class CalendarEntity(Entity):
                 self.entity_id,
                 err,
             )
-            listener(None)
+            for listener in listeners:
+                listener(None)
             return
 
         event_list: list[JsonValueType] = [event.as_dict() for event in events]
-        listener(event_list)
+        for listener in listeners:
+            listener(event_list)
 
     async def async_get_events(
         self,

--- a/tests/components/calendar/test_init.py
+++ b/tests/components/calendar/test_init.py
@@ -761,6 +761,42 @@ async def test_websocket_handle_subscribe_calendar_events(
     assert events[0]["recurrence_id"] == "20260415"
 
 
+async def test_websocket_subscribers_share_one_fetch(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    test_entities: list[MockCalendarEntity],
+) -> None:
+    """Test subscribers watching the same range share a single event fetch."""
+    entity = test_entities[0]
+    start = dt_util.now()
+    end = start + timedelta(days=1)
+
+    for _ in range(3):
+        client = await hass_ws_client(hass)
+        await client.send_json_auto_id(
+            {
+                "type": "calendar/event/subscribe",
+                "entity_id": "calendar.calendar_1",
+                "start": start.isoformat(),
+                "end": end.isoformat(),
+            }
+        )
+        assert (await client.receive_json())["success"]
+        assert (await client.receive_json())["type"] == "event"
+
+    entity.async_get_events.reset_mock()
+
+    entity.create_event(
+        start=start + timedelta(hours=2),
+        end=start + timedelta(hours=3),
+        summary="New Event",
+    )
+    entity.async_write_ha_state()
+    await hass.async_block_till_done()
+
+    assert entity.async_get_events.call_count == 1
+
+
 async def test_websocket_subscribe_updates_on_state_change(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Calendar entities keep one event listener per subscribing frontend card, and every refresh ran a separate `async_get_events()` expansion for each of them, on the event loop. The expansion is the expensive part: the reporter measured 0.86 to 1.26 seconds per call on a calendar with recurrence rules, regardless of how much of the requested window actually contains events, because every call rebuilds the whole timeline.

With listeners piling up over the lifetime of the instance, that turns into a periodic stall that grows with uptime. In the report: 225 listeners on a single entity, 450 expansions over two refresh cycles, stalls growing about 4 seconds per hour, until the Supervisor watchdog missed two consecutive API responses and forced a restart, roughly every 18 hours.

Calendar cards ask for boundary aligned windows, so listeners overwhelmingly share the exact same range. Those now share a single fetch, which makes the refresh cost scale with the number of distinct windows instead of the number of subscribers.

This does not address the listener accumulation itself. `connection.async_handle_close` does unsubscribe on disconnect, and I have no reproduction for how the list grows to 225 entries for four cards, so that part is left alone. The cost of a refresh no longer depends on it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181943
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
