### PR TITLE
Add missing Xiaomi BLE impedance and stabilized descriptions

### DIFF
--- a/homeassistant/components/xiaomi_ble/binary_sensor.py
+++ b/homeassistant/components/xiaomi_ble/binary_sensor.py
@@ -101,6 +101,9 @@ BINARY_SENSOR_DESCRIPTIONS = {
         key=ExtendedBinarySensorDeviceClass.PRY_THE_DOOR,
         device_class=BinarySensorDeviceClass.TAMPER,
     ),
+    ExtendedBinarySensorDeviceClass.STABILIZED: BinarySensorEntityDescription(
+        key=ExtendedBinarySensorDeviceClass.STABILIZED,
+    ),
     ExtendedBinarySensorDeviceClass.TOOTHBRUSH: BinarySensorEntityDescription(
         key=ExtendedBinarySensorDeviceClass.TOOTHBRUSH,
     ),

--- a/homeassistant/components/xiaomi_ble/sensor.py
+++ b/homeassistant/components/xiaomi_ble/sensor.py
@@ -199,6 +199,13 @@ SENSOR_DESCRIPTIONS = {
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:omega",
     ),
+    # High frequency impedance sensor (ohm)
+    (ExtendedSensorDeviceClass.IMPEDANCE_HIGH, Units.OHM): SensorEntityDescription(
+        key=str(ExtendedSensorDeviceClass.IMPEDANCE_HIGH),
+        native_unit_of_measurement=Units.OHM,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:omega",
+    ),
     # Heart rate sensor (bpm)
     (ExtendedSensorDeviceClass.HEART_RATE, "bpm"): SensorEntityDescription(
         key=str(ExtendedSensorDeviceClass.HEART_RATE),

--- a/tests/components/xiaomi_ble/__init__.py
+++ b/tests/components/xiaomi_ble/__init__.py
@@ -148,6 +148,28 @@ MISCALE_V2_SERVICE_INFO = BluetoothServiceInfoBleak(
     tx_power=-127,
 )
 
+S400_SERVICE_INFO = BluetoothServiceInfoBleak(
+    name="MJTZC01YM",
+    address="50:FB:19:1B:B5:DC",
+    device=generate_ble_device("00:00:00:00:00:00", None),
+    rssi=-60,
+    manufacturer_data={},
+    service_data={
+        # Body Composition Scale S400, the last packet of a measurement, which
+        # carries the 250 kHz impedance and no weight or heart rate
+        "0000fe95-0000-1000-8000-00805f9b34fb": (
+            b"\x50\x50\xd9\x30\x01\xdc\xb5\x1b\x19\xfb\x50"
+            b"\x16\x6e\x09\x01\x00\x00\x20\x4e\x00\x00\x00\x00"
+        )
+    },
+    service_uuids=["0000fe95-0000-1000-8000-00805f9b34fb"],
+    source="local",
+    advertisement=generate_advertisement_data(local_name="Not it"),
+    time=0,
+    connectable=False,
+    tx_power=-127,
+)
+
 MISSING_PAYLOAD_ENCRYPTED = BluetoothServiceInfoBleak(
     name="LYWSD02MMC",
     address="A4:C1:38:56:53:84",

--- a/tests/components/xiaomi_ble/test_sensor.py
+++ b/tests/components/xiaomi_ble/test_sensor.py
@@ -22,6 +22,7 @@ from . import (
     MISCALE_V1_SERVICE_INFO,
     MISCALE_V2_SERVICE_INFO,
     MMC_T201_1_SERVICE_INFO,
+    S400_SERVICE_INFO,
     make_advertisement,
 )
 
@@ -692,7 +693,9 @@ async def test_miscale_v1_uuid(hass: HomeAssistant) -> None:
     inject_bluetooth_service_info_bleak(hass, MISCALE_V1_SERVICE_INFO)
 
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 3
+
+    assert hass.states.get("binary_sensor.mi_smart_scale_b5dc_stabilized").state == "on"
 
     mass_non_stabilized_sensor = hass.states.get(
         "sensor.mi_smart_scale_b5dc_weight_non_stabilized"
@@ -734,7 +737,12 @@ async def test_miscale_v2_uuid(hass: HomeAssistant) -> None:
     inject_bluetooth_service_info_bleak(hass, MISCALE_V2_SERVICE_INFO)
 
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 4
+
+    assert (
+        hass.states.get("binary_sensor.mi_body_composition_scale_b5dc_stabilized").state
+        == "on"
+    )
 
     mass_non_stabilized_sensor = hass.states.get(
         "sensor.mi_body_composition_scale_b5dc_weight_non_stabilized"
@@ -769,6 +777,32 @@ async def test_miscale_v2_uuid(hass: HomeAssistant) -> None:
     )
     assert impedance_sensor_attr[ATTR_UNIT_OF_MEASUREMENT] == "ohm"
     assert impedance_sensor_attr[ATTR_STATE_CLASS] == "measurement"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_body_composition_scale_s400(hass: HomeAssistant) -> None:
+    """Test the S400 scale, which reports impedance at two frequencies."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="50:FB:19:1B:B5:DC",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    inject_bluetooth_service_info_bleak(hass, S400_SERVICE_INFO)
+    await hass.async_block_till_done()
+
+    impedance_sensor = hass.states.get(
+        "sensor.body_composition_scale_b5dc_impedance_high"
+    )
+    assert impedance_sensor is not None
+    assert impedance_sensor.state == "500.0"
+    assert impedance_sensor.attributes[ATTR_UNIT_OF_MEASUREMENT] == "ohm"
+    assert impedance_sensor.attributes[ATTR_STATE_CLASS] == "measurement"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
@@ -844,7 +878,7 @@ async def test_sleepy_device(hass: HomeAssistant) -> None:
     inject_bluetooth_service_info_bleak(hass, MISCALE_V1_SERVICE_INFO)
 
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 3
 
     mass_non_stabilized_sensor = hass.states.get(
         "sensor.mi_smart_scale_b5dc_weight_non_stabilized"
@@ -895,7 +929,7 @@ async def test_sleepy_device_restore_state(hass: HomeAssistant) -> None:
     inject_bluetooth_service_info_bleak(hass, MISCALE_V1_SERVICE_INFO)
 
     await hass.async_block_till_done()
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 3
 
     mass_non_stabilized_sensor = hass.states.get(
         "sensor.mi_smart_scale_b5dc_weight_non_stabilized"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Body Composition Scale S400 measures impedance at two frequencies. The support that was added in #142705 covers the 50 kHz value (`impedance_low`), but not the 250 kHz one, which the library reports on the last packet of a measurement. That packet therefore raises a `KeyError` while mapping the sensors, and since that kills the whole update, none of the scale's sensors ever get a value.

The same packet also reports a `stabilized` binary sensor, which is missing from the binary sensor descriptions as well. That one fails on every Xiaomi scale, not just the S400: the binary sensor platform raises, the passive update processor logs it and moves on, and the entity never shows up. Existing Mi Smart Scale V1 and V2 users will see a `Stabilized` binary sensor appear once this lands.

The test uses a hand built unencrypted MiBeacon V5 advertisement for the S400 (product id `0x30D9`, object `0x6E16`), with the weight and heart rate fields at zero, which is what makes the scale report the high frequency impedance.

`asleep` and `wearing` are missing from the binary sensor descriptions too and will fail the same way for the bands that report them. There is no issue reported for those and I have nothing to test them against, so they are left alone here.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181954
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
