### PR TITLE
Subscribe Withings webhooks after Home Assistant has started

### DIFF
--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -40,7 +40,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     Platform,
 )
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
@@ -48,6 +48,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     async_get_config_entry_implementation,
 )
 from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.start import async_at_started
 
 from .const import DEFAULT_TITLE, DOMAIN, LOGGER
 from .coordinator import (
@@ -164,22 +165,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: WithingsConfigEntry) -> 
                 async_call_later(hass, 30, webhook_manager.register_webhook)
             )
 
-    if cloud.async_active_subscription(hass):
-        if cloud.async_is_connected(hass):
-            entry.async_on_unload(
-                async_call_later(
-                    hass, WEBHOOK_REGISTER_DELAY, webhook_manager.register_webhook
-                )
-            )
-        entry.async_on_unload(
-            cloud.async_listen_connection_change(hass, manage_cloudhook)
-        )
-    else:
+    @callback
+    def _async_register_webhook_later(_: HomeAssistant) -> None:
+        """Register the webhook once Home Assistant answers for it."""
         entry.async_on_unload(
             async_call_later(
                 hass, WEBHOOK_REGISTER_DELAY, webhook_manager.register_webhook
             )
         )
+
+    if cloud.async_active_subscription(hass):
+        if cloud.async_is_connected(hass):
+            entry.async_on_unload(async_at_started(hass, _async_register_webhook_later))
+        entry.async_on_unload(
+            cloud.async_listen_connection_change(hass, manage_cloudhook)
+        )
+    else:
+        entry.async_on_unload(async_at_started(hass, _async_register_webhook_later))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -26,8 +26,8 @@ from homeassistant.components.cloud import CloudNotAvailable
 from homeassistant.components.webhook import async_generate_url
 from homeassistant.components.withings.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_WEBHOOK_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_WEBHOOK_ID, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
@@ -855,6 +855,30 @@ async def test_webhook_subscription_auth_failure(
         flow["handler"] == DOMAIN and flow["context"]["source"] == "reauth"
         for flow in flows
     )
+
+
+async def test_webhook_subscription_waits_for_start(
+    hass: HomeAssistant,
+    withings: AsyncMock,
+    webhook_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the webhook is only subscribed once Home Assistant has started."""
+    hass.set_state(CoreState.not_running)
+
+    await setup_integration(hass, webhook_config_entry)
+    await prepare_webhook_setup(hass, freezer)
+
+    # Withings validates the callback URL by calling it, which cannot work
+    # while our own HTTP server is still starting up
+    assert withings.subscribe_notification.call_count == 0
+
+    hass.set_state(CoreState.running)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+    await hass.async_block_till_done()
+    await prepare_webhook_setup(hass, freezer)
+
+    assert withings.subscribe_notification.call_count == 6
 
 
 async def test_webhook_subscription_invalid_params(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Withings validates a webhook subscription by sending an HTTP HEAD to the callback URL, so the request leaves for the internet and comes back into this instance. We started that one second after the config entry was set up, which on a slower host happens before Home Assistant's own HTTP server accepts connections. Withings then answers that the callback URL is absent or incorrect, and that branch deliberately does not retry, so the webhook stays unsubscribed for the whole uptime and the integration quietly falls back to polling.

The reporter has a reverse proxy logging `connection refused` on port 8123 at the same second as the rejection, and the same URL subscribes fine after startup finishes, on every restart.

Registration now waits for Home Assistant to have started. The HTTP server starts at `EVENT_HOMEASSISTANT_START`, so by `EVENT_HOMEASSISTANT_STARTED` there is something to answer the probe. For an entry that is added or reloaded while Home Assistant is running, `async_at_started` runs straight away, so nothing changes there.

The `WithingsInvalidParamsError` branch is left as it is on purpose. Not retrying is the right answer for a callback URL that really is wrong, which is what #162189 decided, and the fix belongs at the point where we ask Withings to call a server that is not up yet.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181813
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
