### PR TITLE
Match the known address first in Yale Access Bluetooth discovery

### DIFF
--- a/homeassistant/components/yalexs_ble/util.py
+++ b/homeassistant/components/yalexs_ble/util.py
@@ -37,13 +37,24 @@ def async_find_existing_service_info(
 ) -> BluetoothServiceInfoBleak | None:
     """Return the service info for the given local_name and address."""
     has_unique_local_name = local_name_is_unique(local_name)
+    by_local_name: BluetoothServiceInfoBleak | None = None
+
     for service_info in async_discovered_service_info(hass):
         device = service_info.device
-        if (
-            has_unique_local_name and device.name == local_name
-        ) or device.address == address:
+        if device.address == address:
             return service_info
-    return None
+
+        # The local name is all we have to go on when the address is hidden
+        # behind a system UUID, but anything can advertise that name, so it
+        # only counts when nothing answers to the address we were given.
+        if (
+            by_local_name is None
+            and has_unique_local_name
+            and device.name == local_name
+        ):
+            by_local_name = service_info
+
+    return by_local_name
 
 
 def short_address(address: str) -> str:

--- a/tests/components/yalexs_ble/__init__.py
+++ b/tests/components/yalexs_ble/__init__.py
@@ -41,6 +41,23 @@ LOCK_DISCOVERY_INFO_UUID_ADDRESS = BluetoothServiceInfoBleak(
     tx_power=-127,
 )
 
+SAME_LOCAL_NAME_DISCOVERY_INFO = BluetoothServiceInfoBleak(
+    name="M1012LU",
+    address="A8:51:AB:91:1C:FA",
+    rssi=-40,
+    manufacturer_data={
+        76: b"\x061\x00Z\x8f\x93\xb2\xec\x85\x06\x00i\x00\x02\x02Q\xed\x1d\xf0"
+    },
+    service_uuids=[],
+    service_data={},
+    source="local",
+    device=generate_ble_device(address="A8:51:AB:91:1C:FA", name="M1012LU"),
+    advertisement=generate_advertisement_data(),
+    time=0,
+    connectable=True,
+    tx_power=-127,
+)
+
 OLD_FIRMWARE_LOCK_DISCOVERY_INFO = BluetoothServiceInfoBleak(
     name="Aug",
     address="AA:BB:CC:DD:EE:FF",

--- a/tests/components/yalexs_ble/test_config_flow.py
+++ b/tests/components/yalexs_ble/test_config_flow.py
@@ -23,6 +23,7 @@ from . import (
     LOCK_DISCOVERY_INFO_UUID_ADDRESS,
     NOT_YALE_DISCOVERY_INFO,
     OLD_FIRMWARE_LOCK_DISCOVERY_INFO,
+    SAME_LOCAL_NAME_DISCOVERY_INFO,
     YALE_ACCESS_LOCK_DISCOVERY_INFO,
 )
 
@@ -577,6 +578,41 @@ async def test_integration_discovery_success(hass: HomeAssistant) -> None:
     }
     assert result2["result"].unique_id == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_integration_discovery_prefers_address(hass: HomeAssistant) -> None:
+    """Test integration discovery binds to the address it was handed."""
+    with patch(
+        "homeassistant.components.yalexs_ble.util.async_discovered_service_info",
+        # Another device is advertising the same cached local name, and it is
+        # seen before the lock itself
+        return_value=[
+            SAME_LOCAL_NAME_DISCOVERY_INFO,
+            YALE_ACCESS_LOCK_DISCOVERY_INFO,
+        ],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_INTEGRATION_DISCOVERY},
+            data={
+                "name": "Front Door",
+                "address": YALE_ACCESS_LOCK_DISCOVERY_INFO.address,
+                "key": "2fd51b8621c6a139eaffbedcb846b60f",
+                "slot": 66,
+                "serial": "M1XXX012LU",
+            },
+        )
+    assert result["type"] is FlowResultType.FORM
+
+    with patch(
+        "homeassistant.components.yalexs_ble.async_setup_entry",
+        return_value=True,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"][CONF_ADDRESS] == YALE_ACCESS_LOCK_DISCOVERY_INFO.address
 
 
 async def test_integration_discovery_device_not_found(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the Yale cloud integration hands a lock over through integration discovery, it passes the lock's exact address. `async_find_existing_service_info` matched on the local name first though, and `local_name_is_unique` only checks that the name is seven characters long, so the first device advertising that name won even when the lock itself was right there in the discovered advertisements.

In the report, a nearby Apple TV was advertising a cached name of `LC000LK`, and the lock's config entry ended up bound to the Apple TV's address instead of the lock's.

Matching on the local name is still needed: on macOS the system hides the address behind a UUID, so the name is the only thing to go on. So instead of dropping it, the address we were given wins, and the local name is used when nothing answers to that address.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181643
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
