### PR TITLE
Include YAML hubs in the Modbus connections list

### DIFF
--- a/homeassistant/components/modbus/entity.py
+++ b/homeassistant/components/modbus/entity.py
@@ -16,7 +16,6 @@ from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_NAME,
     CONF_SCAN_INTERVAL,
-    CONF_SLAVE,
     CONF_STRUCTURE,
     CONF_UNIQUE_ID,
     STATE_OFF,
@@ -40,7 +39,6 @@ from .const import (
     CALL_TYPE_X_COILS,
     CALL_TYPE_X_REGISTER_HOLDINGS,
     CONF_DATA_TYPE,
-    CONF_DEVICE_ADDRESS,
     CONF_INPUT_TYPE,
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
@@ -63,7 +61,7 @@ from .const import (
     SIGNAL_STOP_ENTITY,
     DataType,
 )
-from .modbus import ModbusHub
+from .modbus import ModbusHub, entity_unit_id
 
 
 class ModbusBaseEntity(Entity):
@@ -80,10 +78,7 @@ class ModbusBaseEntity(Entity):
         """Initialize the Modbus binary sensor."""
 
         self._hub = hub
-        if (conf_slave := entry.get(CONF_SLAVE)) is not None:
-            self._device_address = conf_slave
-        else:
-            self._device_address = entry.get(CONF_DEVICE_ADDRESS, 1)
+        self._device_address = entity_unit_id(entry)
         self._address = int(entry[CONF_ADDRESS])
         self._input_type = entry[CONF_INPUT_TYPE]
         self._scan_interval = int(entry[CONF_SCAN_INTERVAL])

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     CONF_METHOD,
     CONF_NAME,
     CONF_PORT,
+    CONF_SLAVE,
     CONF_TIMEOUT,
     CONF_TYPE,
     EVENT_HOMEASSISTANT_STOP,
@@ -31,6 +32,7 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType
 
+from .connection import ModbusEndpoint
 from .const import (
     ATTR_ADDRESS,
     ATTR_HUB,
@@ -47,6 +49,7 @@ from .const import (
     CALL_TYPE_WRITE_REGISTERS,
     CONF_BAUDRATE,
     CONF_BYTESIZE,
+    CONF_DEVICE_ADDRESS,
     CONF_MSG_WAIT,
     CONF_PARITY,
     CONF_STOPBITS,
@@ -121,6 +124,26 @@ PB_CALL = [
         "values",
     ),
 ]
+
+
+def entity_unit_id(entity_config: dict[str, Any]) -> int:
+    """Return the unit an entity config addresses, defaulting to 1."""
+    if (conf_slave := entity_config.get(CONF_SLAVE)) is not None:
+        return int(conf_slave)
+    return int(entity_config.get(CONF_DEVICE_ADDRESS, 1))
+
+
+def _hub_endpoint(client_config: dict[str, Any]) -> ModbusEndpoint:
+    """Return the device a hub config addresses, keyed as a connection endpoint.
+
+    Keyed like `ModbusParams.endpoint`, so a hub and a shared connection to
+    one device can be told apart from two devices, even though the two links
+    are separate.
+    """
+    if client_config[CONF_TYPE] == SERIAL:
+        return ("serial", client_config[CONF_PORT])
+    transport = "udp" if client_config[CONF_TYPE] == UDP else "tcp"
+    return (transport, client_config[CONF_HOST].lower(), client_config[CONF_PORT])
 
 
 async def async_modbus_setup(
@@ -253,6 +276,7 @@ class ModbusHub:
         self.event_connected = asyncio.Event()
         self.hass = hass
         self.name = client_config[CONF_NAME]
+        self.endpoint = _hub_endpoint(client_config)
         self._config_type = client_config[CONF_TYPE]
         self.config_delay = client_config[CONF_DELAY]
         self._pb_request: dict[str, RunEntry] = {}
@@ -297,6 +321,19 @@ class ModbusHub:
             self._msg_wait = 30 / 1000
         else:
             self._msg_wait = 0
+
+        self.units = sorted(
+            {
+                entity_unit_id(entity_config)
+                for _, conf_key in PLATFORMS
+                for entity_config in client_config.get(conf_key, [])
+            }
+        )
+
+    @property
+    def connected(self) -> bool:
+        """Return whether the client currently holds a link to the device."""
+        return self._client is not None and self._client.connected
 
     def _log_error(self, text: str) -> None:
         if text == self._last_log_error:

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -133,19 +133,6 @@ def entity_unit_id(entity_config: dict[str, Any]) -> int:
     return int(entity_config.get(CONF_DEVICE_ADDRESS, 1))
 
 
-def _hub_endpoint(client_config: dict[str, Any]) -> ModbusEndpoint:
-    """Return the device a hub config addresses, keyed as a connection endpoint.
-
-    Keyed like `ModbusParams.endpoint`, so a hub and a shared connection to
-    one device can be told apart from two devices, even though the two links
-    are separate.
-    """
-    if client_config[CONF_TYPE] == SERIAL:
-        return ("serial", client_config[CONF_PORT])
-    transport = "udp" if client_config[CONF_TYPE] == UDP else "tcp"
-    return (transport, client_config[CONF_HOST].lower(), client_config[CONF_PORT])
-
-
 async def async_modbus_setup(
     hass: HomeAssistant,
     config: ConfigType,
@@ -276,7 +263,6 @@ class ModbusHub:
         self.event_connected = asyncio.Event()
         self.hass = hass
         self.name = client_config[CONF_NAME]
-        self.endpoint = _hub_endpoint(client_config)
         self._config_type = client_config[CONF_TYPE]
         self.config_delay = client_config[CONF_DELAY]
         self._pb_request: dict[str, RunEntry] = {}
@@ -293,8 +279,11 @@ class ModbusHub:
             "timeout": client_config[CONF_TIMEOUT],
             "retries": 3,
         }
+        # The endpoint is keyed like `ModbusParams.endpoint`, so that a hub and
+        # a shared connection to one device can be told apart from two devices
         if self._config_type == SERIAL:
             # serial configuration
+            self.endpoint: ModbusEndpoint = ("serial", client_config[CONF_PORT])
             if client_config[CONF_METHOD] == "ascii":
                 self._pb_params["framer"] = FramerType.ASCII
             else:
@@ -310,6 +299,11 @@ class ModbusHub:
         else:
             # network configuration
             self._pb_params["host"] = client_config[CONF_HOST]
+            self.endpoint = (
+                "udp" if self._config_type == UDP else "tcp",
+                client_config[CONF_HOST].lower(),
+                client_config[CONF_PORT],
+            )
             if self._config_type == RTUOVERTCP:
                 self._pb_params["framer"] = FramerType.RTU
             else:

--- a/homeassistant/components/modbus/services.py
+++ b/homeassistant/components/modbus/services.py
@@ -29,7 +29,9 @@ async def _async_reload_config(call: ServiceCall) -> None:
         hubs.clear()
         return
     LOGGER.debug("Modbus reloading")
-    await async_modbus_setup(hass, reload_config)
+    # Setup replaces the hubs only once it has new ones to replace them with
+    if not await async_modbus_setup(hass, reload_config):
+        hubs.clear()
 
 
 @callback

--- a/homeassistant/components/modbus/services.py
+++ b/homeassistant/components/modbus/services.py
@@ -26,6 +26,7 @@ async def _async_reload_config(call: ServiceCall) -> None:
     reload_config = await async_integration_yaml_config(hass, DOMAIN)
     if not reload_config:
         LOGGER.debug("Modbus not present anymore")
+        hubs.clear()
         return
     LOGGER.debug("Modbus reloading")
     await async_modbus_setup(hass, reload_config)

--- a/homeassistant/components/modbus/websocket_api.py
+++ b/homeassistant/components/modbus/websocket_api.py
@@ -22,33 +22,6 @@ def async_setup(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_list_connections)
 
 
-@callback
-def _async_list_connections(hass: HomeAssistant) -> list[dict[str, Any]]:
-    """Return the connections held over config entries, then those from YAML.
-
-    A YAML hub is a link of its own, not a hold on a shared connection, so it
-    is listed separately even when it addresses a device a config entry also
-    talks to.
-    """
-    return [
-        {
-            "endpoint": list(info.endpoint),
-            "connected": info.connected,
-            "source": SOURCE_CONFIG_ENTRY,
-            "units": info.units,
-        }
-        for info in async_get_connection_info(hass)
-    ] + [
-        {
-            "endpoint": list(hub.endpoint),
-            "connected": hub.connected,
-            "source": SOURCE_YAML,
-            "units": {name: hub.units},
-        }
-        for name, hub in hass.data.get(DATA_MODBUS_HUBS, {}).items()
-    ]
-
-
 @websocket_api.require_admin
 @websocket_api.websocket_command({vol.Required("type"): TYPE_LIST_CONNECTIONS})
 @callback
@@ -57,9 +30,33 @@ def websocket_list_connections(
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """List the connections, and which holders use units on each.
+    """List the connections held over config entries, then those from YAML.
 
-    The unit ids of a connection from a config entry are keyed by entry id,
-    those of one from YAML by hub name.
+    The unit ids of a connection are keyed by config entry id, or by hub name
+    for one from YAML. A YAML hub is a link of its own rather than a hold on a
+    shared connection, so it is listed separately even when it addresses a
+    device a config entry also talks to.
     """
-    connection.send_result(msg["id"], {"connections": _async_list_connections(hass)})
+    connection.send_result(
+        msg["id"],
+        {
+            "connections": [
+                {
+                    "endpoint": list(info.endpoint),
+                    "connected": info.connected,
+                    "source": SOURCE_CONFIG_ENTRY,
+                    "units": info.units,
+                }
+                for info in async_get_connection_info(hass)
+            ]
+            + [
+                {
+                    "endpoint": list(hub.endpoint),
+                    "connected": hub.connected,
+                    "source": SOURCE_YAML,
+                    "units": {name: hub.units},
+                }
+                for name, hub in hass.data.get(DATA_MODBUS_HUBS, {}).items()
+            ]
+        },
+    )

--- a/homeassistant/components/modbus/websocket_api.py
+++ b/homeassistant/components/modbus/websocket_api.py
@@ -8,14 +8,45 @@ from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
 
 from .connection import async_get_connection_info
+from .const import DATA_MODBUS_HUBS
 
 TYPE_LIST_CONNECTIONS: Final = "modbus/connections/list"
+
+SOURCE_CONFIG_ENTRY: Final = "config_entry"
+SOURCE_YAML: Final = "yaml"
 
 
 @callback
 def async_setup(hass: HomeAssistant) -> None:
     """Register the Modbus websocket commands."""
     websocket_api.async_register_command(hass, websocket_list_connections)
+
+
+@callback
+def _async_list_connections(hass: HomeAssistant) -> list[dict[str, Any]]:
+    """Return the connections held over config entries, then those from YAML.
+
+    A YAML hub is a link of its own, not a hold on a shared connection, so it
+    is listed separately even when it addresses a device a config entry also
+    talks to.
+    """
+    return [
+        {
+            "endpoint": list(info.endpoint),
+            "connected": info.connected,
+            "source": SOURCE_CONFIG_ENTRY,
+            "units": info.units,
+        }
+        for info in async_get_connection_info(hass)
+    ] + [
+        {
+            "endpoint": list(hub.endpoint),
+            "connected": hub.connected,
+            "source": SOURCE_YAML,
+            "units": {name: hub.units},
+        }
+        for name, hub in hass.data.get(DATA_MODBUS_HUBS, {}).items()
+    ]
 
 
 @websocket_api.require_admin
@@ -26,17 +57,9 @@ def websocket_list_connections(
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """List the connections, and which config entries hold units on each."""
-    connection.send_result(
-        msg["id"],
-        {
-            "connections": [
-                {
-                    "endpoint": list(info.endpoint),
-                    "connected": info.connected,
-                    "units": info.units,
-                }
-                for info in async_get_connection_info(hass)
-            ]
-        },
-    )
+    """List the connections, and which holders use units on each.
+
+    The unit ids of a connection from a config entry are keyed by entry id,
+    those of one from YAML by hub name.
+    """
+    connection.send_result(msg["id"], {"connections": _async_list_connections(hass)})

--- a/tests/components/modbus/fixtures/configuration_no_entities.yaml
+++ b/tests/components/modbus/fixtures/configuration_no_entities.yaml
@@ -1,0 +1,5 @@
+modbus:
+  type: "tcp"
+  host: "testHost"
+  port: 5001
+  name: "testModbus"

--- a/tests/components/modbus/test_websocket_api.py
+++ b/tests/components/modbus/test_websocket_api.py
@@ -343,18 +343,30 @@ async def test_the_endpoint_of_a_yaml_hub_follows_its_transport(
     assert result["connections"][0]["endpoint"] == endpoint
 
 
-async def test_a_yaml_hub_dropped_by_a_reload_is_not_listed(
+@pytest.mark.parametrize(
+    "fixture",
+    [
+        pytest.param("configuration_empty.yaml", id="modbus gone from yaml"),
+        pytest.param("configuration_no_entities.yaml", id="hub without entities"),
+    ],
+)
+async def test_a_yaml_hub_a_reload_leaves_behind_is_not_listed(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     mock_pymodbus: AsyncMock,
+    fixture: str,
 ) -> None:
-    """A reload that leaves no Modbus config leaves no connection behind."""
+    """A reload that sets no hub up again leaves no connection behind.
+
+    The reload closes the hubs before reading the new config, so one it does
+    not set up again is a link to a device nothing talks to.
+    """
     mock_pymodbus.connected = True
     assert await async_setup_component(
         hass, "modbus", {"modbus": [yaml_hub(TCP_TRANSPORT)]}
     )
 
-    yaml_path = get_fixture_path("configuration_empty.yaml", "modbus")
+    yaml_path = get_fixture_path(fixture, "modbus")
     with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
         await hass.services.async_call("modbus", SERVICE_RELOAD, blocking=True)
         await hass.async_block_till_done()

--- a/tests/components/modbus/test_websocket_api.py
+++ b/tests/components/modbus/test_websocket_api.py
@@ -8,15 +8,18 @@ from modbus_connection import ModbusTcpParams
 from modbus_connection.tmodbus import ModbusConnection
 import pytest
 
+from homeassistant import config as hass_config
 from homeassistant.components.modbus import async_get_unit
 from homeassistant.components.modbus.const import DATA_MODBUS_HUBS
 from homeassistant.config_entries import ConfigFlow
+from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
     MockConfigEntry,
     MockModule,
+    get_fixture_path,
     mock_config_flow,
     mock_integration,
     mock_platform,
@@ -338,3 +341,25 @@ async def test_the_endpoint_of_a_yaml_hub_follows_its_transport(
     result = (await client.receive_json())["result"]
 
     assert result["connections"][0]["endpoint"] == endpoint
+
+
+async def test_a_yaml_hub_dropped_by_a_reload_is_not_listed(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_pymodbus: AsyncMock,
+) -> None:
+    """A reload that leaves no Modbus config leaves no connection behind."""
+    mock_pymodbus.connected = True
+    assert await async_setup_component(
+        hass, "modbus", {"modbus": [yaml_hub(TCP_TRANSPORT)]}
+    )
+
+    yaml_path = get_fixture_path("configuration_empty.yaml", "modbus")
+    with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
+        await hass.services.async_call("modbus", SERVICE_RELOAD, blocking=True)
+        await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "modbus/connections/list"})
+
+    assert (await client.receive_json())["result"] == {"connections": []}

--- a/tests/components/modbus/test_websocket_api.py
+++ b/tests/components/modbus/test_websocket_api.py
@@ -1,6 +1,7 @@
 """Test the Modbus websocket API."""
 
 from collections.abc import Callable, Generator
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from modbus_connection import ModbusTcpParams
@@ -8,6 +9,7 @@ from modbus_connection.tmodbus import ModbusConnection
 import pytest
 
 from homeassistant.components.modbus import async_get_unit
+from homeassistant.components.modbus.const import DATA_MODBUS_HUBS
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -22,6 +24,35 @@ from tests.common import (
 from tests.typing import WebSocketGenerator
 
 type ConsumerFactory = Callable[[], MockConfigEntry]
+
+YAML_HUB_NAME = "yaml_hub"
+
+# The host is given in mixed case, as a shared connection folds the one it is
+# keyed by to lower case
+TCP_TRANSPORT = {"type": "tcp", "host": "Device.Local", "port": 502}
+
+SERIAL_TRANSPORT = {
+    "type": "serial",
+    "port": "/dev/ttyUSB0",
+    "baudrate": 9600,
+    "bytesize": 8,
+    "method": "rtu",
+    "parity": "E",
+    "stopbits": 1,
+}
+
+
+def yaml_hub(transport: dict[str, Any]) -> dict[str, Any]:
+    """Return a hub config on *transport*, with sensors on three units."""
+    return {
+        "name": YAML_HUB_NAME,
+        "sensors": [
+            {"name": "on unit 3", "address": 10, "slave": 3},
+            {"name": "on unit 2", "address": 11, "device_address": 2},
+            {"name": "on the default unit", "address": 12},
+        ],
+        **transport,
+    }
 
 
 class MockFlow(ConfigFlow):
@@ -76,6 +107,7 @@ async def test_list_connections(
             {
                 "endpoint": ["tcp", "device.local", 502],
                 "connected": False,
+                "source": "config_entry",
                 "units": {first.entry_id: [1], second.entry_id: [2]},
             }
         ]
@@ -104,6 +136,7 @@ async def test_a_connection_that_is_up_reports_itself_connected(
             {
                 "endpoint": ["tcp", "device.local", 502],
                 "connected": True,
+                "source": "config_entry",
                 "units": {entry.entry_id: [1]},
             }
         ]
@@ -185,3 +218,123 @@ async def test_one_entry_holding_two_units(
     result = (await client.receive_json())["result"]
 
     assert result["connections"][0]["units"] == {entry.entry_id: [1, 2]}
+
+
+async def test_a_yaml_hub_is_listed_with_the_units_its_entities_address(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_pymodbus: AsyncMock,
+) -> None:
+    """A hub is flagged as YAML and keyed by its name, having no config entry."""
+    mock_pymodbus.connected = True
+    assert await async_setup_component(
+        hass, "modbus", {"modbus": [yaml_hub(TCP_TRANSPORT)]}
+    )
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "modbus/connections/list"})
+    result = (await client.receive_json())["result"]
+
+    assert result == {
+        "connections": [
+            {
+                "endpoint": ["tcp", "device.local", 502],
+                "connected": True,
+                "source": "yaml",
+                "units": {YAML_HUB_NAME: [1, 2, 3]},
+            }
+        ]
+    }
+
+
+async def test_a_closed_yaml_hub_reports_itself_not_connected(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_pymodbus: AsyncMock,
+) -> None:
+    """The stop action drops the client, which is no longer a link."""
+    mock_pymodbus.connected = True
+    assert await async_setup_component(
+        hass, "modbus", {"modbus": [yaml_hub(TCP_TRANSPORT)]}
+    )
+    await hass.data[DATA_MODBUS_HUBS][YAML_HUB_NAME].async_close()
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "modbus/connections/list"})
+    result = (await client.receive_json())["result"]
+
+    assert result["connections"][0]["connected"] is False
+
+
+async def test_a_yaml_hub_is_listed_beside_a_connection_to_the_same_device(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    consumer: ConsumerFactory,
+    mock_pymodbus: AsyncMock,
+) -> None:
+    """A hub is a link of its own, so it is never folded into a shared one."""
+    mock_pymodbus.connected = False
+    assert await async_setup_component(
+        hass, "modbus", {"modbus": [yaml_hub(TCP_TRANSPORT)]}
+    )
+
+    entry = consumer()
+    await hass.config_entries.async_setup(entry.entry_id)
+    async_get_unit(hass, entry, ModbusTcpParams(host="device.local", port=502), 7)
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "modbus/connections/list"})
+    result = (await client.receive_json())["result"]
+
+    assert result["connections"] == [
+        {
+            "endpoint": ["tcp", "device.local", 502],
+            "connected": False,
+            "source": "config_entry",
+            "units": {entry.entry_id: [7]},
+        },
+        {
+            "endpoint": ["tcp", "device.local", 502],
+            "connected": False,
+            "source": "yaml",
+            "units": {YAML_HUB_NAME: [1, 2, 3]},
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("transport", "endpoint"),
+    [
+        pytest.param(TCP_TRANSPORT, ["tcp", "device.local", 502], id="tcp"),
+        pytest.param(
+            {**TCP_TRANSPORT, "type": "rtuovertcp"},
+            ["tcp", "device.local", 502],
+            id="rtuovertcp",
+        ),
+        pytest.param(
+            {**TCP_TRANSPORT, "type": "udp"}, ["udp", "device.local", 502], id="udp"
+        ),
+        pytest.param(SERIAL_TRANSPORT, ["serial", "/dev/ttyUSB0"], id="serial"),
+    ],
+)
+async def test_the_endpoint_of_a_yaml_hub_follows_its_transport(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_pymodbus: AsyncMock,
+    transport: dict[str, Any],
+    endpoint: list[str | int],
+) -> None:
+    """A hub is keyed by the device it addresses, as a shared connection is.
+
+    An RTU-over-TCP hub keys as TCP: the framing differs, the device does not.
+    """
+    mock_pymodbus.connected = True
+    assert await async_setup_component(
+        hass, "modbus", {"modbus": [yaml_hub(transport)]}
+    )
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id({"type": "modbus/connections/list"})
+    result = (await client.receive_json())["result"]
+
+    assert result["connections"][0]["endpoint"] == endpoint


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Modbus connections panel only knows about the connections shared between config entries, so a hub configured in YAML was invisible to it — even though it is a real open link with entities polling over it. `modbus/connections/list` now returns those hubs too, flagged `source: "yaml"`, keyed by hub name since there is no config entry to name, and carrying the unit ids its entities address.

A hub is never folded into a shared connection to the same device: the two are separate clients with separate locks, so one device can legitimately be listed twice. To make that comparison possible at all, a hub now keys the device it addresses the same way `ModbusParams.endpoint` does, which also means RTU-over-TCP keys as TCP — the framing differs, the device does not.

Part of https://github.com/OpenHomeFoundation/roadmap/issues/235


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: OpenHomeFoundation/roadmap#235
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: home-assistant/frontend#54134

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gAhZ9auwjmQaTg91efAD4
