### PR TITLE
Treat a running ViCare compressor as heating unless it cools

### DIFF
--- a/homeassistant/components/vicare/climate.py
+++ b/homeassistant/components/vicare/climate.py
@@ -220,12 +220,12 @@ class ViCareClimate(ViCareEntity, ClimateEntity):
                     phase = None
                     with suppress(PyViCareNotSupportedFeatureError):
                         phase = compressor.getPhase()
+                    # Devices do not agree on how to spell the phase, and
+                    # some do not expose one at all, so a running compressor
+                    # heats unless it says it is cooling.
                     if phase == "cooling":
                         cooling_active = True
-                    elif phase == "heating" or phase is None:
-                        # Phase is unset on hybrid devices that do not
-                        # expose it: fall back to HEATING to match the
-                        # pre-cooling-support behaviour.
+                    else:
                         heating_active = True
 
             if cooling_active:

--- a/tests/components/vicare/test_climate.py
+++ b/tests/components/vicare/test_climate.py
@@ -55,6 +55,9 @@ async def test_all_entities(
         ("cooling", True, HVACAction.COOLING),
         ("off", False, HVACAction.IDLE),
         ("ready", False, HVACAction.IDLE),
+        # Heat pumps that phrase their phase differently ("ready" while the
+        # compressor runs) are heating, not idle.
+        ("ready", True, HVACAction.HEATING),
         # Active compressor without a recognisable phase falls back to
         # HEATING (matches the pre-cooling-support behaviour for hybrid
         # devices that may not expose the phase property).


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Mapping the compressor phase for cooling support (#171945) only counts a compressor as heating when its phase reads `heating`, or when the device does not expose a phase at all. A Vitocal 150-A reports `active: true` with `phase: "ready"`, which is neither, so `hvac_action` stays `idle` while the unit is heating. The compressor binary sensor says `on` at the same moment, so the data is there, it is only the mapping that drops it.

That device's own `setPhase` command advertises `["off", "preparing", "not-ready", "ready"]`, so the `heating` branch cannot be reached on it at all and the action can never be anything but `idle`.

A running compressor now counts as heating unless its phase says it is cooling, which keeps cooling detection working and does not care which vocabulary a device uses. An inactive compressor is skipped before this point, so a device sitting in `ready` while idle is unaffected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181714
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
