### PR TITLE
Add subentry flow class with automatic reload

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -3747,15 +3747,28 @@ class ConfigSubentryFlowManager(
         if unique_id is not None and not isinstance(unique_id, str):
             raise HomeAssistantError("unique_id must be a string")
 
-        self.hass.config_entries.async_add_subentry(
-            entry,
-            ConfigSubentry(
-                data=MappingProxyType(result["data"]),
-                subentry_type=subentry_type,
-                title=result["title"],
-                unique_id=unique_id,
-            ),
-        )
+        automatic_reload = False
+        if isinstance(flow, ConfigSubentryFlowWithReload):
+            automatic_reload = flow.automatic_reload
+        if automatic_reload and entry.update_listeners:
+            raise ValueError(
+                "Config entry update listeners should not be"
+                " used with ConfigSubentryFlowWithReload"
+            )
+
+        if (
+            self.hass.config_entries.async_add_subentry(
+                entry,
+                ConfigSubentry(
+                    data=MappingProxyType(result["data"]),
+                    subentry_type=subentry_type,
+                    title=result["title"],
+                    unique_id=unique_id,
+                ),
+            )
+            and automatic_reload is True
+        ):
+            self.hass.config_entries.async_schedule_reload(entry.entry_id)
 
         return result
 
@@ -3934,6 +3947,18 @@ class ConfigSubentryFlow(
         if subentry_id not in entry.subentries:
             raise UnknownSubEntry(subentry_id)
         return entry.subentries[subentry_id]
+
+
+class ConfigSubentryFlowWithReload(ConfigSubentryFlow):
+    """Automatic reloading class for subentry flow.
+
+    Triggers an automatic reload of the config entry when the flow ends with
+    calling `async_create_entry`.
+    It's not allowed to use this class if the integration uses config entry
+    update listeners.
+    """
+
+    automatic_reload: bool = True
 
 
 class OptionsFlowManager(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3182,6 +3182,103 @@ async def test_entry_subentry_unsupported(
         )
 
 
+@pytest.mark.parametrize(
+    (
+        "subentry_flow_base_class",
+        "number_of_update_listeners",
+        "expected_configure_result",
+        "expected_number_of_unloads",
+    ),
+    [
+        (config_entries.ConfigSubentryFlow, 0, does_not_raise(), 0),
+        (config_entries.ConfigSubentryFlowWithReload, 0, does_not_raise(), 1),
+        (config_entries.ConfigSubentryFlow, 1, does_not_raise(), 0),
+        (
+            config_entries.ConfigSubentryFlowWithReload,
+            1,
+            pytest.raises(
+                ValueError,
+                match=(
+                    "Config entry update listeners should not"
+                    " be used with ConfigSubentryFlowWithReload"
+                ),
+            ),
+            0,
+        ),
+    ],
+)
+async def test_entry_subentry_automatic_reload(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    subentry_flow_base_class: type[config_entries.ConfigSubentryFlow],
+    number_of_update_listeners: int,
+    expected_configure_result: AbstractContextManager,
+    expected_number_of_unloads: int,
+) -> None:
+    """Test subentry flow with automatic reload."""
+
+    async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+        """Mock setup entry."""
+        for _ in range(number_of_update_listeners):
+            entry.add_update_listener(Mock())
+        return True
+
+    unload_entry_mock = AsyncMock(return_value=True)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=async_setup_entry,
+            async_unload_entry=unload_entry_mock,
+        ),
+    )
+    mock_platform(hass, "test.config_flow", None)
+    entry = MockConfigEntry(domain="test", data={})
+    entry.add_to_manager(manager)
+    assert await manager.async_setup(entry.entry_id)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        class SubentryFlowHandler(subentry_flow_base_class):
+            """Test subentry flow handler."""
+
+            async def async_step_user(self, user_input=None):
+                return self.async_create_entry(
+                    title="Mock title",
+                    data={},
+                    unique_id="test",
+                )
+
+        @classmethod
+        @callback
+        def async_get_supported_subentry_types(
+            cls, config_entry: ConfigEntry
+        ) -> dict[str, type[config_entries.ConfigSubentryFlow]]:
+            return {"test": TestFlow.SubentryFlowHandler}
+
+    with mock_config_flow("test", TestFlow):
+        flow = await manager.subentries.async_create_flow(
+            (entry.entry_id, "test"), context={"source": "test"}, data=None
+        )
+
+        flow.handler = (entry.entry_id, "test")  # Set to keep reference to config entry
+        with expected_configure_result:
+            await manager.subentries.async_finish_flow(
+                flow,
+                {
+                    "data": {},
+                    "title": "Mock title",
+                    "type": data_entry_flow.FlowResultType.CREATE_ENTRY,
+                    "unique_id": "test",
+                },
+            )
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert len(unload_entry_mock.mock_calls) == expected_number_of_unloads
+
+
 async def test_entry_setup_succeed(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
 
Adds  a new class for subentry flow that automatically reloads the integration when a subentry is created. It is based on the already existing `OptionsFlowWithReload`. 

The reason for this is that integrations that implement subentries usually also implement an update listener. In case of for example Xbox, this conflicts with the OAuth implementation, which updates the config entry with updated authentication tokens every hour, resulting in a reload of the integration although it is unnecessary. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
