### PR TITLE
Preserve Ring listener credentials during reauth and reconfigure

### DIFF
--- a/homeassistant/components/ring/config_flow.py
+++ b/homeassistant/components/ring/config_flow.py
@@ -186,12 +186,14 @@ class RingConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                data = {
+                data_updates = {
                     CONF_USERNAME: user_input[CONF_USERNAME],
                     CONF_TOKEN: token,
                     CONF_DEVICE_ID: self.hardware_id,
                 }
-                return self.async_update_reload_and_abort(reauth_entry, data=data)
+                return self.async_update_reload_and_abort(
+                    reauth_entry, data_updates=data_updates
+                )
 
         return self.async_show_form(
             step_id="reauth_confirm",
@@ -229,12 +231,14 @@ class RingConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                data = {
+                data_updates = {
                     CONF_USERNAME: username,
                     CONF_TOKEN: token,
                     CONF_DEVICE_ID: self.hardware_id,
                 }
-                return self.async_update_reload_and_abort(reconfigure_entry, data=data)
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry, data_updates=data_updates
+                )
 
         return self.async_show_form(
             step_id="reconfigure",

--- a/tests/components/ring/test_config_flow.py
+++ b/tests/components/ring/test_config_flow.py
@@ -13,9 +13,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
-from tests.common import MockConfigEntry
 
 from .conftest import MOCK_HARDWARE_ID
+
+from tests.common import MockConfigEntry
 
 
 async def test_form(

--- a/tests/components/ring/test_config_flow.py
+++ b/tests/components/ring/test_config_flow.py
@@ -7,15 +7,15 @@ import ring_doorbell
 
 from homeassistant import config_entries
 from homeassistant.components.ring import DOMAIN
+from homeassistant.components.ring.const import CONF_LISTEN_CREDENTIALS
 from homeassistant.const import CONF_DEVICE_ID, CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
+from tests.common import MockConfigEntry
 
 from .conftest import MOCK_HARDWARE_ID
-
-from tests.common import MockConfigEntry
 
 
 async def test_form(
@@ -128,6 +128,14 @@ async def test_reauth(
     mock_ring_auth: Mock,
 ) -> None:
     """Test reauth flow."""
+    listen_credentials = {"gcm": {"android_id": "stored-android-id"}}
+    hass.config_entries.async_update_entry(
+        mock_added_config_entry,
+        data={
+            **mock_added_config_entry.data,
+            CONF_LISTEN_CREDENTIALS: listen_credentials,
+        },
+    )
     mock_added_config_entry.async_start_reauth(hass)
     await hass.async_block_till_done()
 
@@ -165,6 +173,7 @@ async def test_reauth(
         CONF_DEVICE_ID: MOCK_HARDWARE_ID,
         CONF_USERNAME: "foo@bar.com",
         CONF_TOKEN: "new-foobar",
+        CONF_LISTEN_CREDENTIALS: listen_credentials,
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -311,6 +320,15 @@ async def test_reconfigure(
 ) -> None:
     """Test the reconfigure config flow."""
 
+    listen_credentials = {"gcm": {"android_id": "stored-android-id"}}
+    hass.config_entries.async_update_entry(
+        mock_added_config_entry,
+        data={
+            **mock_added_config_entry.data,
+            CONF_LISTEN_CREDENTIALS: listen_credentials,
+        },
+    )
+
     assert mock_added_config_entry.data[CONF_DEVICE_ID] == MOCK_HARDWARE_ID
 
     result = await mock_added_config_entry.start_reconfigure_flow(hass)
@@ -328,6 +346,7 @@ async def test_reconfigure(
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "reconfigure_successful"
     assert mock_added_config_entry.data[CONF_DEVICE_ID] == "new-hardware-id"
+    assert mock_added_config_entry.data[CONF_LISTEN_CREDENTIALS] == listen_credentials
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Preserve Ring listener credentials and future unrelated config-entry fields when reauthentication or reconfiguration updates the Ring account token/device ID.

Both flows currently pass `data=` to `async_update_reload_and_abort()`, which replaces the entire data mapping and drops the stored `listen_token`. This changes them to `data_updates=`, updating only `username`, `token`, and `device_id`.

The saved FCM identity is independent from the Ring authorized-device hardware ID. After reconfiguration, the existing push token can be checked in and subscribed under the new Ring authorized device. If those credentials are no longer valid, `firebase-messaging` already falls back to a full registration.

Regression tests seed a sanitized `listen_token` and verify it survives both successful flows. All 12 Ring config-flow tests pass on Home Assistant Core 2026.9.2 / Python 3.14.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #182032
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
