### PR TITLE
Guard against out-of-spec values from Matter devices

### DIFF
--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -118,6 +118,12 @@ class MatterEventEntity(MatterEntity, EventEntity):
         """Call on NodeEvent."""
         if data.endpoint_id != self._endpoint.endpoint_id:
             return
+
+        # event ids are only unique within a cluster, and an endpoint can host
+        # more clusters than the switch this entity was made for
+        if data.cluster_id != clusters.Switch.id:
+            return
+
         event_type: str | None = EVENT_TYPES_MAP.get(data.event_id)
         if data.event_id == clusters.Switch.Events.MultiPressComplete.event_id:
             # multi press event
@@ -125,10 +131,8 @@ class MatterEventEntity(MatterEntity, EventEntity):
             event_type = f"multi_press_{presses}"
 
         if event_type is None:
-            # event ids are only unique within a cluster, so an endpoint that
-            # hosts more than the switch cluster can send us ids we cannot map
             LOGGER.debug(
-                "Ignoring event id %s for %s, it is not a switch event",
+                "Ignoring unknown switch event id %s for %s",
                 data.event_id,
                 self.entity_id,
             )

--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -16,6 +16,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import LOGGER
 from .entity import MatterEntity, MatterEntityDescription
 from .helpers import MatterConfigEntry
 from .models import MatterDiscoverySchema
@@ -117,12 +118,21 @@ class MatterEventEntity(MatterEntity, EventEntity):
         """Call on NodeEvent."""
         if data.endpoint_id != self._endpoint.endpoint_id:
             return
+        event_type: str | None = EVENT_TYPES_MAP.get(data.event_id)
         if data.event_id == clusters.Switch.Events.MultiPressComplete.event_id:
             # multi press event
             presses = (data.data or {}).get("totalNumberOfPressesCounted", 1)
             event_type = f"multi_press_{presses}"
-        else:
-            event_type = EVENT_TYPES_MAP[data.event_id]
+
+        if event_type is None:
+            # event ids are only unique within a cluster, so an endpoint that
+            # hosts more than the switch cluster can send us ids we cannot map
+            LOGGER.debug(
+                "Ignoring event id %s for %s, it is not a switch event",
+                data.event_id,
+                self.entity_id,
+            )
+            return
 
         if event_type not in self.event_types:
             # this should not happen, but guard for bad things

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -239,7 +239,7 @@ class MatterLight(MatterEntity, LightEntity):
 
         return hs_color
 
-    def _get_color_temperature(self) -> int:
+    def _get_color_temperature(self) -> int | None:
         """Get color temperature from matter."""
 
         color_temp = self.get_matter_attribute_value(
@@ -247,10 +247,8 @@ class MatterLight(MatterEntity, LightEntity):
         )
 
         if color_temp is None:
-            # the caller only uses a value above zero, so a device that
-            # reports null has no color temperature to show
             LOGGER.debug("Got no color temperature for %s", self.entity_id)
-            return 0
+            return None
 
         LOGGER.debug(
             "Got color temperature %s for %s",
@@ -431,12 +429,14 @@ class MatterLight(MatterEntity, LightEntity):
         if self._supports_brightness:
             self._attr_brightness = self._get_brightness()
 
-        if (
-            self._supports_color_temperature
-            and (color_temperature := self._get_color_temperature()) > 0
-        ):
-            self._attr_color_temp_kelvin = color_util.color_temperature_mired_to_kelvin(
-                color_temperature
+        if self._supports_color_temperature:
+            # a device without a usable value has no color temperature to
+            # report, rather than the one it gave us last time
+            color_temperature = self._get_color_temperature()
+            self._attr_color_temp_kelvin = (
+                color_util.color_temperature_mired_to_kelvin(color_temperature)
+                if color_temperature
+                else None
             )
 
         if self._supports_color:

--- a/homeassistant/components/matter/light.py
+++ b/homeassistant/components/matter/light.py
@@ -246,7 +246,11 @@ class MatterLight(MatterEntity, LightEntity):
             clusters.ColorControl.Attributes.ColorTemperatureMireds
         )
 
-        assert color_temp is not None
+        if color_temp is None:
+            # the caller only uses a value above zero, so a device that
+            # reports null has no color temperature to show
+            LOGGER.debug("Got no color temperature for %s", self.entity_id)
+            return 0
 
         LOGGER.debug(
             "Got color temperature %s for %s",
@@ -261,8 +265,10 @@ class MatterLight(MatterEntity, LightEntity):
 
         level_control = self._endpoint.get_cluster(clusters.LevelControl)
 
-        # We should not get here if brightness is not supported.
-        assert level_control is not None
+        if level_control is None:
+            # we should not get here if brightness is not supported
+            LOGGER.debug("Got no level control cluster for %s", self.entity_id)
+            return None
 
         LOGGER.debug(
             "Got brightness %s for %s",
@@ -289,9 +295,15 @@ class MatterLight(MatterEntity, LightEntity):
             clusters.ColorControl.Attributes.ColorMode
         )
 
-        assert color_mode is not None
-
-        ha_color_mode = COLOR_MODE_MAP[color_mode]
+        if (ha_color_mode := COLOR_MODE_MAP.get(color_mode)) is None:
+            # ColorMode is nullable and a device is free to report a value
+            # outside of the enum, neither of which we can map to a color
+            LOGGER.debug(
+                "Got unexpected color mode (%s) for %s",
+                color_mode,
+                self.entity_id,
+            )
+            return ColorMode.UNKNOWN
 
         LOGGER.debug(
             "Got color mode (%s) for %s",

--- a/tests/components/matter/test_event.py
+++ b/tests/components/matter/test_event.py
@@ -119,3 +119,53 @@ async def test_generic_switch_multi_node(
     )
     state = hass.states.get("event.mock_generic_switch_button_1")
     assert state.attributes[ATTR_EVENT_TYPE] == "multi_press_2"
+
+
+@pytest.mark.parametrize("node_fixture", ["mock_generic_switch"])
+async def test_generic_switch_unknown_event(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test an event id that is not a switch event is ignored."""
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=59,
+            event_id=1,
+            event_number=0,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data=None,
+        ),
+    )
+    state = hass.states.get("event.mock_generic_switch_button")
+    last_event = state.state
+
+    # an endpoint that hosts more clusters than the switch can send an event
+    # id that is outside of the switch event id space
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=59,
+            event_id=7,
+            event_number=0,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data=None,
+        ),
+    )
+
+    state = hass.states.get("event.mock_generic_switch_button")
+    assert state.state == last_event
+    assert state.attributes[ATTR_EVENT_TYPE] == "initial_press"

--- a/tests/components/matter/test_event.py
+++ b/tests/components/matter/test_event.py
@@ -147,8 +147,7 @@ async def test_generic_switch_unknown_event(
     state = hass.states.get("event.mock_generic_switch_button")
     last_event = state.state
 
-    # an endpoint that hosts more clusters than the switch can send an event
-    # id that is outside of the switch event id space
+    # an event id outside of the switch event id space
     await trigger_subscription_callback(
         hass,
         matter_client,
@@ -158,6 +157,29 @@ async def test_generic_switch_unknown_event(
             endpoint_id=1,
             cluster_id=59,
             event_id=7,
+            event_number=0,
+            priority=1,
+            timestamp=0,
+            timestamp_type=0,
+            data=None,
+        ),
+    )
+
+    state = hass.states.get("event.mock_generic_switch_button")
+    assert state.state == last_event
+    assert state.attributes[ATTR_EVENT_TYPE] == "initial_press"
+
+    # an event id that another cluster on the same endpoint uses, here the
+    # door lock LockOperation event, which shares its id with a long press
+    await trigger_subscription_callback(
+        hass,
+        matter_client,
+        EventType.NODE_EVENT,
+        MatterNodeEvent(
+            node_id=matter_node.node_id,
+            endpoint_id=1,
+            cluster_id=257,
+            event_id=2,
             event_number=0,
             priority=1,
             timestamp=0,

--- a/tests/components/matter/test_light.py
+++ b/tests/components/matter/test_light.py
@@ -490,6 +490,31 @@ async def test_extended_color_light(
     matter_client.send_device_command.reset_mock()
 
 
+@pytest.mark.parametrize("node_fixture", ["color_temperature_light"])
+async def test_light_null_color_temperature(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+) -> None:
+    """Test a light that stops reporting a color temperature."""
+    entity_id = "light.mock_color_temperature_light"
+
+    set_node_attribute(matter_node, 1, 768, 7, 300)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes["color_temp_kelvin"] == 3333
+
+    set_node_attribute(matter_node, 1, 768, 7, NullValue)
+    await trigger_subscription_callback(hass, matter_client)
+
+    # the last known value is not the current one, so it is not reported
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes["color_temp_kelvin"] is None
+
+
 @pytest.mark.parametrize(
     "color_mode",
     [

--- a/tests/components/matter/test_light.py
+++ b/tests/components/matter/test_light.py
@@ -1,8 +1,10 @@
 """Test Matter lights."""
 
+from typing import Any
 from unittest.mock import MagicMock, call
 
 from chip.clusters import Objects as clusters
+from chip.clusters.Objects import NullValue
 from matter_server.client.models.node import MatterNode
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -486,3 +488,55 @@ async def test_extended_color_light(
         ]
     )
     matter_client.send_device_command.reset_mock()
+
+
+@pytest.mark.parametrize(
+    "color_mode",
+    [
+        pytest.param(NullValue, id="null"),
+        pytest.param(255, id="out_of_range"),
+    ],
+)
+@pytest.mark.parametrize("node_fixture", ["extended_color_light"])
+async def test_light_unexpected_color_mode(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+    color_mode: Any,
+) -> None:
+    """Test a light that reports a color mode we cannot map."""
+    entity_id = "light.mock_extended_color_light"
+
+    set_node_attribute(matter_node, 1, 768, 8, 0)
+    set_node_attribute(matter_node, 1, 8, 0, 128)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes["color_mode"] == ColorMode.HS
+
+    set_node_attribute(matter_node, 1, 768, 8, color_mode)
+    await trigger_subscription_callback(hass, matter_client)
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "on"
+    # the color the light is showing is anyone's guess, but it is still a light
+    assert state.attributes["color_mode"] == ColorMode.UNKNOWN
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": entity_id, "brightness": 128},
+        blocking=True,
+    )
+
+    assert matter_client.send_device_command.call_count == 1
+    assert matter_client.send_device_command.call_args == call(
+        node_id=matter_node.node_id,
+        endpoint_id=1,
+        command=clusters.LevelControl.Commands.MoveToLevelWithOnOff(
+            level=128,
+            transitionTime=0,
+        ),
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Two places in the integration looked up a device supplied value in a dict without a guard, so a device reporting something outside the expected range raised an unhandled exception inside a subscription callback. That propagates out through `_client_listen` and reloads the whole integration, which takes every Matter entity unavailable while it happens. A device that keeps reporting the same value hits it again after re-subscription, so the reload repeats.

**Switch events**

`EVENT_TYPES_MAP` covers the raw Switch event ids 0 to 6, and `EVENT_TYPES_MAP[data.event_id]` raised `KeyError` for anything else. Event ids are only unique within a cluster, so an endpoint that hosts more than the Switch cluster can hand us an id that is not a switch event at all. An unknown id is now ignored with a debug log line, in the same spirit as the guard right below it that skips event types a remote does not report as supported.

**Light attributes**

`ColorMode` is a nullable attribute, and a device is free to report a value that is not in the enum. `_get_color_mode` handled neither: a null tripped an `assert`, which is not a guard for device supplied data and is stripped under `python -O` anyway, and anything else raised `KeyError`. It now resolves to `ColorMode.UNKNOWN`, which the light platform already treats as "the light is in an unknown state", so the hue/saturation, XY and color temperature branches are skipped and the entity keeps working for on/off and brightness. The raw value is logged at debug level.

Two neighbouring helpers had the same shape and are guarded the same way: `_get_color_temperature` returns 0 for a null value, which the caller already skips since it only uses a value above zero, and `_get_brightness` returns `None` when the level control cluster is missing, which its caller already accepts.

Nothing changes for values that are in spec.

While the color mode is unknown the light platform reports no brightness in the state attributes, because it only exposes brightness for a color mode that carries one. The entity stays available and still takes brightness commands, which is what the new test asserts.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
