### PR TITLE
Add Hob appliance type to Home Connect event sensors

### DIFF
--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -226,7 +226,7 @@ EVENT_SENSORS = (
         options=EVENT_OPTIONS,
         default_value="off",
         translation_key="alarm_clock_elapsed",
-        appliance_types=("Oven", "Cooktop"),
+        appliance_types=("Oven", "Cooktop", "Hob"),
     ),
     HomeConnectSensorEntityDescription(
         key=EventKey.BSH_COMMON_EVENT_FAVORITE_001_EXTERNAL_TRIGGER,
@@ -234,7 +234,7 @@ EVENT_SENSORS = (
         options=EVENT_OPTIONS,
         default_value="off",
         translation_key="favorite_short_press",
-        appliance_types=("Hood", "Cooktop"),
+        appliance_types=("Hood", "Cooktop", "Hob"),
     ),
     HomeConnectSensorEntityDescription(
         key=EventKey.BSH_COMMON_EVENT_FAVORITE_002_EXTERNAL_TRIGGER,
@@ -242,7 +242,7 @@ EVENT_SENSORS = (
         options=EVENT_OPTIONS,
         default_value="off",
         translation_key="favorite_long_press",
-        appliance_types=("Hood", "Cooktop"),
+        appliance_types=("Hood", "Cooktop", "Hob"),
     ),
     HomeConnectSensorEntityDescription(
         key=EventKey.COOKING_OVEN_EVENT_PREHEAT_FINISHED,
@@ -250,7 +250,7 @@ EVENT_SENSORS = (
         options=EVENT_OPTIONS,
         default_value="off",
         translation_key="preheat_finished",
-        appliance_types=("Oven", "Cooktop"),
+        appliance_types=("Oven", "Cooktop", "Hob"),
     ),
     HomeConnectSensorEntityDescription(
         key=EventKey.COOKING_OVEN_EVENT_REGULAR_PREHEAT_FINISHED,

--- a/tests/components/home_connect/snapshots/test_sensor.ambr
+++ b/tests/components/home_connect/snapshots/test_sensor.ambr
@@ -3975,6 +3975,68 @@
     'state': 'off',
   })
 # ---
+# name: test_all_entities[sensor.hob_alarm_clock_elapsed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'confirmed',
+        'off',
+        'present',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.hob_alarm_clock_elapsed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Alarm clock elapsed',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Alarm clock elapsed',
+    'platform': 'home_connect',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'alarm_clock_elapsed',
+    'unique_id': 'BOSCH-HCS000000-68A40E000000-BSH.Common.Event.AlarmClockElapsed',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.hob_alarm_clock_elapsed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Hob Alarm clock elapsed',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'confirmed',
+        'off',
+        'present',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.hob_alarm_clock_elapsed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_all_entities[sensor.hob_door-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -4035,6 +4097,130 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'closed',
+  })
+# ---
+# name: test_all_entities[sensor.hob_favorite_long_press-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'confirmed',
+        'off',
+        'present',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.hob_favorite_long_press',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Favorite long press',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Favorite long press',
+    'platform': 'home_connect',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'favorite_long_press',
+    'unique_id': 'BOSCH-HCS000000-68A40E000000-BSH.Common.Event.Favorite.002.ExternalTrigger',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.hob_favorite_long_press-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Hob Favorite long press',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'confirmed',
+        'off',
+        'present',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.hob_favorite_long_press',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[sensor.hob_favorite_short_press-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'confirmed',
+        'off',
+        'present',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.hob_favorite_short_press',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Favorite short press',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Favorite short press',
+    'platform': 'home_connect',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'favorite_short_press',
+    'unique_id': 'BOSCH-HCS000000-68A40E000000-BSH.Common.Event.Favorite.001.ExternalTrigger',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.hob_favorite_short_press-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Hob Favorite short press',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'confirmed',
+        'off',
+        'present',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.hob_favorite_short_press',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---
 # name: test_all_entities[sensor.hob_operation_state-entry]
@@ -4109,6 +4295,68 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'ready',
+  })
+# ---
+# name: test_all_entities[sensor.hob_pre_heat_finished-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'confirmed',
+        'off',
+        'present',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.hob_pre_heat_finished',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Pre-heat finished',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Pre-heat finished',
+    'platform': 'home_connect',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'preheat_finished',
+    'unique_id': 'BOSCH-HCS000000-68A40E000000-Cooking.Oven.Event.PreheatFinished',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.hob_pre_heat_finished-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Hob Pre-heat finished',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'confirmed',
+        'off',
+        'present',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.hob_pre_heat_finished',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---
 # name: test_all_entities[sensor.hood_door-entry]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Event sensors are matched to appliances by exact string comparison on the appliance type:

```python
HomeConnectEventSensor(appliance_coordinator, description)
for description in EVENT_SENSORS
if description.appliance_types
and appliance_coordinator.data.info.type in description.appliance_types
```

Four event sensor descriptions target cooktops with the string `"Cooktop"`:

| Sensor | `appliance_types` before |
| --- | --- |
| `alarm_clock_elapsed` | `("Oven", "Cooktop")` |
| `favorite_short_press` | `("Hood", "Cooktop")` |
| `favorite_long_press` | `("Hood", "Cooktop")` |
| `preheat_finished` | `("Oven", "Cooktop")` |

The Home Connect API reports hobs with the type **`"Hob"`**, not `"Cooktop"`. Before this
change, the string `"Hob"` did not appear anywhere in the integration, so none of these four
entities were ever created for a hob.

This repository's own fixtures already reflect the real API value: `tests/fixtures/appliances.json`
contains an appliance with `"type": "Hob"`, and no appliance with `"type": "Cooktop"` exists in any
fixture. Only `fixtures/available_commands.json` is keyed by `"Cooktop"`. The mismatch goes unnoticed
at runtime because `HomeAppliance.type` is typed as a plain `str` rather than `ApplianceType`, so the
value returned by the API is never validated against the enum (which has `COOKTOP = "Cooktop"` and no
`"Hob"` member).

This PR adds `"Hob"` alongside `"Cooktop"` in the four descriptions. The snapshot for
`test_all_entities` is updated accordingly: the existing `Hob` fixture appliance now yields
`sensor.hob_alarm_clock_elapsed`, `sensor.hob_favorite_short_press`, `sensor.hob_favorite_long_press`
and `sensor.hob_pre_heat_finished`.

### Verified on real hardware

Tested against a Bosch **PVW81CHB1E** (`enumber` `PVW81CHB1E/72`), which the API reports as:

```json
{ "type": "Hob", "brand": "Bosch", "vib": "PVW81CHB1E", "connected": true }
```

With the fix applied, `sensor.<hob>_alarm_clock_elapsed` is created and works end to end. Raw event
stream after setting `BSH.Common.Setting.AlarmClock` to 30 seconds:

```
16:41:32  EVENT  BSH.Common.Event.AlarmClockElapsed = BSH.Common.EnumType.EventPresentState.Present
16:41:52  EVENT  BSH.Common.Event.AlarmClockElapsed = BSH.Common.EnumType.EventPresentState.Confirmed
16:41:52  EVENT  BSH.Common.Event.AlarmClockElapsed = BSH.Common.EnumType.EventPresentState.Off
```

Resulting entity history:

```
16:41:32  present
16:41:52  confirmed
16:41:52  off
```

This confirms that the API does deliver `EVENT` messages for `Hob` appliances, and that these four
sensors were simply unreachable because of the type string.

### Note on the favourite button

On this particular appliance the favourite button is assigned to "Smart Home trigger" for both short
and long press in the Home Connect app, yet no `BSH.Common.Event.Favorite.001.ExternalTrigger` or
`.002.` message is ever emitted on the API event stream — only `BSH.Common.Status.LocalControlActive`.
So this PR does not, on its own, make the favourite button usable on that model; the event does not
appear to be exposed by the public API for it, which matches what was observed in #159791. The type
fix is still required for these sensors to exist at all, and `alarm_clock_elapsed` is demonstrably
functional, as shown above.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #159791, and PR #178761 which introduced these sensors using `"Cooktop"`
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Happy to also add `"Hob"` handling elsewhere (for example aligning `available_commands.json`, or
mapping `Hob` to `ApplianceType.COOKTOP` upstream in `aiohomeconnect`) if you would prefer the
equivalence to be expressed in one place rather than per description.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
