### PR TITLE
Add options flow to collection_image

### DIFF
--- a/homeassistant/components/collection_image/config_flow.py
+++ b/homeassistant/components/collection_image/config_flow.py
@@ -7,7 +7,13 @@ import voluptuous as vol
 from homeassistant.components.image import DOMAIN as IMAGE_DOMAIN
 from homeassistant.components.media_player import BrowseError, MediaClass
 from homeassistant.components.media_source import URI_SCHEME, async_browse_media
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlowWithReload,
+)
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.selector import MediaSelector
 
 from .const import CONF_MEDIA, DOMAIN
@@ -23,57 +29,129 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 )
 
 
+async def _async_validate_media(
+    hass: HomeAssistant,
+    user_input: dict[str, Any],
+) -> tuple[str | None, dict[str, str], dict[str, str]]:
+    """Validate selected directories and return title and form errors."""
+    errors: dict[str, str] = {}
+    placeholders: dict[str, str] = {}
+    found_pictures = False
+    title = "Unnamed collection"
+
+    for user_media in user_input[CONF_MEDIA]:
+        if user_media["media_content_id"] == IMAGE_MEDIA_URI:
+            errors[CONF_MEDIA] = "invalid_selection"
+            placeholders["error"] = IMAGE_MEDIA_URI
+            break
+
+        try:
+            browse = await async_browse_media(
+                hass,
+                user_media["media_content_id"],
+            )
+        except BrowseError as err:
+            errors[CONF_MEDIA] = "failed_browse"
+            placeholders["error"] = str(err)
+            break
+
+        if (
+            not found_pictures
+            and browse.children
+            and any(item.media_class == MediaClass.IMAGE for item in browse.children)
+        ):
+            found_pictures = True
+            if browse.title:
+                title = f"{browse.title} collection"
+
+    if not errors and not found_pictures:
+        errors[CONF_MEDIA] = "selected_media_no_images"
+
+    return (title if not errors else None), errors, placeholders
+
+
+def _get_media(entry: ConfigEntry) -> list[Any]:
+    """Get media from options, or legacy config-entry data. Migrate to array if scalar."""
+    media: Any
+    if CONF_MEDIA in entry.options:
+        media = entry.options[CONF_MEDIA]
+    else:
+        media = entry.data[CONF_MEDIA]
+
+    return media if isinstance(media, list) else [media]
+
+
+class CollectionImageOptionsFlow(OptionsFlowWithReload):
+    """Handle Collection Image options."""
+
+    async def async_step_init(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Edit the collection's media directories."""
+        errors: dict[str, str] = {}
+        placeholders: dict[str, str] = {}
+
+        if user_input is not None:
+            _title, errors, placeholders = await _async_validate_media(
+                self.hass,
+                user_input,
+            )
+            if not errors:
+                return self.async_create_entry(
+                    title="",
+                    data=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA,
+                user_input or {CONF_MEDIA: _get_media(self.config_entry)},
+            ),
+            errors=errors,
+            description_placeholders=placeholders,
+        )
+
+
 class CollectionImageConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Collection Image."""
 
+    @staticmethod
+    @callback
+    @override
+    def async_get_options_flow(
+        _config_entry: ConfigEntry,
+    ) -> CollectionImageOptionsFlow:
+        """Return the options flow."""
+        return CollectionImageOptionsFlow()
+
     @override
     async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
+        self,
+        user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
-        """Handle the initial step."""
+        """Handle initial setup."""
         errors: dict[str, str] = {}
         placeholders: dict[str, str] = {}
-        found_pictures = False
-        title = "Unnamed collection"
+
         if user_input is not None:
-            user_media_list = user_input[CONF_MEDIA]
-            for user_media in user_media_list:
-                if user_media["media_content_id"] == IMAGE_MEDIA_URI:
-                    errors["media"] = "invalid_selection"
-                    placeholders["error"] = IMAGE_MEDIA_URI
-                    break
-                try:
-                    browse = await async_browse_media(
-                        self.hass, user_media["media_content_id"]
-                    )
-                except BrowseError as err:
-                    errors["media"] = "failed_browse"
-                    placeholders["error"] = str(err)
-                    break
-                else:
-                    if (
-                        not found_pictures
-                        and browse.children
-                        and any(
-                            item.media_class == MediaClass.IMAGE
-                            for item in browse.children
-                        )
-                    ):
-                        found_pictures = True
-                        if browse.title:
-                            title = f"{browse.title} collection"
-            if "media" not in errors:
-                if found_pictures:
-                    return self.async_create_entry(
-                        title=title,
-                        data=user_input,
-                    )
-                errors["media"] = "selected_media_no_images"
+            title, errors, placeholders = await _async_validate_media(
+                self.hass,
+                user_input,
+            )
+            if title is not None:
+                return self.async_create_entry(
+                    title=title,
+                    data={},
+                    options=user_input,
+                )
 
         return self.async_show_form(
             step_id="user",
             data_schema=self.add_suggested_values_to_schema(
-                STEP_USER_DATA_SCHEMA, user_input
+                STEP_USER_DATA_SCHEMA,
+                user_input,
             ),
             errors=errors,
             description_placeholders=placeholders,

--- a/homeassistant/components/collection_image/image.py
+++ b/homeassistant/components/collection_image/image.py
@@ -36,7 +36,10 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Collection Image image entities."""
-    media = entry.data[CONF_MEDIA]
+    if CONF_MEDIA in entry.options:
+        media = entry.options[CONF_MEDIA]
+    else:
+        media = entry.data[CONF_MEDIA]
     if isinstance(media, dict):
         content_ids = [media["media_content_id"]]
     else:

--- a/homeassistant/components/collection_image/strings.json
+++ b/homeassistant/components/collection_image/strings.json
@@ -23,6 +23,24 @@
       "message": "Error reading image from {path}: {error}"
     }
   },
+  "options": {
+    "error": {
+      "failed_browse": "[%key:component::collection_image::config::error::failed_browse%]",
+      "invalid_selection": "[%key:component::collection_image::config::error::invalid_selection%]",
+      "selected_media_no_images": "[%key:component::collection_image::config::error::selected_media_no_images%]"
+    },
+    "step": {
+      "init": {
+        "data": {
+          "media": "[%key:component::collection_image::config::step::user::data::media%]"
+        },
+        "data_description": {
+          "media": "[%key:component::collection_image::config::step::user::data_description::media%]"
+        },
+        "description": "Update the source media used for the collection."
+      }
+    }
+  },
   "services": {
     "select_first": {
       "description": "Update the image entity to the first image in the configured media.",

--- a/tests/components/collection_image/helpers.py
+++ b/tests/components/collection_image/helpers.py
@@ -1,5 +1,7 @@
 """Helper utilities for collection image tests."""
 
+from typing import Any
+
 from homeassistant.components.collection_image.const import CONF_MEDIA, DOMAIN
 from homeassistant.components.media_player import BrowseMedia, MediaClass
 from homeassistant.components.media_source import BrowseMediaSource
@@ -7,17 +9,17 @@ from homeassistant.components.media_source import BrowseMediaSource
 from tests.common import MockConfigEntry
 
 
-def data_from_uri(uri: str | list[str]) -> dict[str, str] | list[dict[str, str]]:
+def data_from_uri(uri: str | list[str]) -> dict[str, Any]:
     """Construct a data entry from one URI or a list of URIs."""
 
-    def media_item(content_id: str) -> dict[str, str]:
+    def media_item(content_id: str) -> dict[str, Any]:
         return {
             "media_content_id": content_id,
             "media_content_type": "",
             "metadata": {"a": "b"},
         }
 
-    media: dict[str, str] | list[dict[str, str]]
+    media: dict[str, Any] | list[dict[str, Any]]
     if isinstance(uri, str):
         media = media_item(uri)
     else:

--- a/tests/components/collection_image/helpers.py
+++ b/tests/components/collection_image/helpers.py
@@ -1,19 +1,20 @@
 """Helper utilities for collection image tests."""
 
-from homeassistant.components.collection_image.const import DOMAIN
+from homeassistant.components.collection_image.const import CONF_MEDIA, DOMAIN
 from homeassistant.components.media_player import BrowseMedia, MediaClass
 from homeassistant.components.media_source import BrowseMediaSource
 
 from tests.common import MockConfigEntry
 
 
-def config_entry_from_uri(uri: str | list[str]) -> MockConfigEntry:
-    """Construct a mock config entry from one URI or a list of URIs."""
+def data_from_uri(uri: str | list[str]) -> dict[str, str] | list[dict[str, str]]:
+    """Construct a data entry from one URI or a list of URIs."""
 
     def media_item(content_id: str) -> dict[str, str]:
         return {
             "media_content_id": content_id,
             "media_content_type": "",
+            "metadata": {"a": "b"},
         }
 
     media: dict[str, str] | list[dict[str, str]]
@@ -22,8 +23,13 @@ def config_entry_from_uri(uri: str | list[str]) -> MockConfigEntry:
     else:
         media = [media_item(item) for item in uri]
 
+    return {CONF_MEDIA: media}
+
+
+def config_entry_from_uri(uri: str | list[str]) -> MockConfigEntry:
+    """Construct a mock config entry from one URI or a list of URIs."""
     return MockConfigEntry(
-        data={"media": media},
+        data=data_from_uri(uri),
         domain=DOMAIN,
         title="Random Image",
     )

--- a/tests/components/collection_image/test_config_flow.py
+++ b/tests/components/collection_image/test_config_flow.py
@@ -1,14 +1,14 @@
 """Test the Collection Image config flow."""
 
-from unittest.mock import AsyncMock, patch
-
+from freezegun import freeze_time
 import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.collection_image.config_flow import IMAGE_MEDIA_URI
-from homeassistant.components.collection_image.const import DOMAIN
+from homeassistant.components.collection_image.const import CONF_MEDIA, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.util import slugify
 
 from .const import (
     MOCK_MEDIA_DIR_URI_1,
@@ -16,30 +16,11 @@ from .const import (
     MOCK_MEDIA_DIR_URI_BROWSE_ERROR,
     MOCK_MEDIA_DIR_URI_EMPTY,
 )
+from .helpers import data_from_uri
 
+from tests.common import MockConfigEntry
 
-@pytest.fixture
-def mock_setup_entry():
-    """Mock collection_image setup successfully."""
-
-    with patch(
-        "homeassistant.components.collection_image.async_setup_entry",
-        new=AsyncMock(return_value=True),
-    ) as mock_setup:
-        yield mock_setup
-
-
-def _data_from_uris(uris: list[str]) -> dict:
-    return {
-        "media": [
-            {
-                "media_content_id": uri,
-                "media_content_type": "",
-                "metadata": {"a": "b"},
-            }
-            for uri in uris
-        ]
-    }
+TEST_TIME = "2026-09-12T07:12:00+00:00"
 
 
 @pytest.mark.parametrize(
@@ -51,8 +32,9 @@ def _data_from_uris(uris: list[str]) -> dict:
     ],
 )
 @pytest.mark.usefixtures("mock_media_source")
+@freeze_time(TEST_TIME)
 async def test_config_flow(
-    hass: HomeAssistant, mock_setup_entry, uris: list[str], expected_title: str
+    hass: HomeAssistant, uris: list[str], expected_title: str
 ) -> None:
     """Test the config flow."""
 
@@ -62,14 +44,19 @@ async def test_config_flow(
     assert result.get("type") is FlowResultType.FORM
     assert result.get("errors") == {}
 
-    data = _data_from_uris(uris)
+    data = data_from_uri(uris)
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], data)
 
     assert result.get("type") is FlowResultType.CREATE_ENTRY
     assert result.get("title") == expected_title
-    assert result.get("data") == data
-    assert len(mock_setup_entry.mock_calls) == 1
+    assert result.get("data") == {}
+    assert result.get("options") == data
+
+    await hass.async_block_till_done()
+
+    state = hass.states.get(f"image.{slugify(expected_title)}")
+    assert state and state.state == TEST_TIME
 
 
 @pytest.mark.parametrize(
@@ -106,10 +93,10 @@ async def test_config_flow(
         ),
     ],
 )
+@freeze_time(TEST_TIME)
 @pytest.mark.usefixtures("mock_media_source")
 async def test_config_flow_error(
     hass: HomeAssistant,
-    mock_setup_entry,
     uris: list[str],
     error: str,
     placeholders: dict,
@@ -122,37 +109,122 @@ async def test_config_flow_error(
     assert result.get("type") is FlowResultType.FORM
     assert result.get("errors") == {}
 
-    data = _data_from_uris(uris)
+    data = data_from_uri(uris)
     result = await hass.config_entries.flow.async_configure(result["flow_id"], data)
     await hass.async_block_till_done()
 
     assert result.get("type") is FlowResultType.FORM
     assert result.get("title") is None
     assert result.get("data") is None
+    assert result.get("options") is None
 
     media_key = next(
         key
         for key in result["data_schema"].schema
-        if getattr(key, "schema", key) == "media"
+        if getattr(key, "schema", key) == CONF_MEDIA
     )
     for idx, uri in enumerate(uris):
         assert media_key.description["suggested_value"][idx]["media_content_id"] == uri
         assert (
             media_key.description["suggested_value"][idx]["metadata"]
-            == data["media"][idx]["metadata"]
+            == data[CONF_MEDIA][idx]["metadata"]
         )
 
-    assert result.get("errors") == {"media": error}
+    assert result.get("errors") == {CONF_MEDIA: error}
     assert result.get("description_placeholders") == placeholders
-    assert len(mock_setup_entry.mock_calls) == 0
 
     # Try again successfully to ensure we can recover from errors
-    data = _data_from_uris([MOCK_MEDIA_DIR_URI_1])
+    data = data_from_uri([MOCK_MEDIA_DIR_URI_1])
     expected_title = "My pictures collection"
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], data)
 
     assert result.get("type") is FlowResultType.CREATE_ENTRY
     assert result.get("title") == expected_title
-    assert result.get("data") == data
-    assert len(mock_setup_entry.mock_calls) == 1
+    assert result.get("data") == {}
+    assert result.get("options") == data
+
+    state = hass.states.get(f"image.{slugify(expected_title)}")
+    assert state and state.state == TEST_TIME
+
+
+@pytest.mark.parametrize(
+    ("entry_data", "entry_options", "expected_uri"),
+    [
+        pytest.param(
+            data_from_uri([MOCK_MEDIA_DIR_URI_1]),
+            {},
+            MOCK_MEDIA_DIR_URI_1,
+            id="legacy-data-array",
+        ),
+        pytest.param(
+            data_from_uri(MOCK_MEDIA_DIR_URI_1),
+            {},
+            MOCK_MEDIA_DIR_URI_1,
+            id="legacy-data-scalar",
+        ),
+        pytest.param(
+            {},
+            data_from_uri([MOCK_MEDIA_DIR_URI_1]),
+            MOCK_MEDIA_DIR_URI_1,
+            id="options-only",
+        ),
+        pytest.param(
+            data_from_uri([MOCK_MEDIA_DIR_URI_2]),
+            data_from_uri([MOCK_MEDIA_DIR_URI_1]),
+            MOCK_MEDIA_DIR_URI_1,
+            id="options-overrides-data",
+        ),
+    ],
+)
+@freeze_time(TEST_TIME)
+@pytest.mark.usefixtures("mock_media_source")
+async def test_options_flow(
+    hass: HomeAssistant,
+    entry_data: dict,
+    entry_options: dict,
+    expected_uri: str,
+) -> None:
+    """Test options flow reads the effective media value and updates options."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test collection",
+        data=entry_data,
+        options=entry_options,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert result["errors"] == {}
+
+    media_key = next(
+        key
+        for key in result["data_schema"].schema
+        if getattr(key, "schema", key) == CONF_MEDIA
+    )
+    assert (
+        media_key.description["suggested_value"][0]["media_content_id"] == expected_uri
+    )
+
+    new_data = data_from_uri([MOCK_MEDIA_DIR_URI_2])
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        new_data,
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == ""
+    assert result["data"] == new_data
+
+    await hass.async_block_till_done()
+
+    updated_entry = hass.config_entries.async_get_entry(entry.entry_id)
+    assert updated_entry is not None
+    assert updated_entry.options == new_data
+
+    state = hass.states.get("image.test_collection")
+    assert state and state.state == TEST_TIME


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add options flow to collection_image. This allows user to change the selected media directories after creation. 

As there is only one option chosen during config_flow (media), and it is also modified by options_flow, this moves the primary media selection from being stored in config_entry.data to config_entry.options. 

Legacy entries are unaffected, as we fallback to .data when the value is not present in .options.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
