### PR TITLE
Apply entity read permissions to logbook and recorder statistics

### DIFF
--- a/homeassistant/auth/permissions/__init__.py
+++ b/homeassistant/auth/permissions/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "PermissionLookup",
     "PolicyPermissions",
     "PolicyType",
+    "entity_permission_filter",
     "filter_entity_ids_by_permission",
     "merge_policies",
 ]
@@ -37,6 +38,19 @@ def filter_entity_ids_by_permission(
         return list(entity_ids)
     check_entity = user.permissions.check_entity
     return [entity_id for entity_id in entity_ids if check_entity(entity_id, key)]
+
+
+def entity_permission_filter(user: User, key: str) -> Callable[[str], bool] | None:
+    """Return a check for the given policy key, or None when nothing is denied.
+
+    Callers that filter results one by one use the None to skip the check
+    altogether, so an admin or a user with blanket access pays for a single
+    boolean test rather than a lookup per item.
+    """
+    if user.is_admin or user.permissions.access_all_entities(key):
+        return None
+    check_entity = user.permissions.check_entity
+    return lambda entity_id: check_entity(entity_id, key)
 
 
 class AbstractPermissions:

--- a/homeassistant/components/logbook/processor.py
+++ b/homeassistant/components/logbook/processor.py
@@ -12,6 +12,9 @@ from sqlalchemy.engine import Result
 from sqlalchemy.engine.row import Row
 from sqlalchemy.orm import Session
 
+from homeassistant.auth.models import User
+from homeassistant.auth.permissions import entity_permission_filter
+from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.filters import Filters
 from homeassistant.components.recorder.models import (
@@ -111,8 +114,8 @@ class LogbookRun:
     entity_name_cache: EntityNameCache
     include_entity_name: bool
     timestamp: bool
-    # Per-entity read check, or None when the caller may read everything.
-    entity_filter: Callable[[str], bool] | None = None
+    # The caller entries are filtered for, or None to return everything.
+    user: User | None = None
     memoize_new_contexts: bool = True
     # True when this run will switch to a live stream; gates population of
     # context_user_ids (wasted work for one-shot REST/get_events callers).
@@ -137,7 +140,7 @@ class EventProcessor:
         timestamp: bool = False,
         include_entity_name: bool = True,
         for_live_stream: bool = False,
-        entity_filter: Callable[[str], bool] | None = None,
+        user: User | None = None,
     ) -> None:
         """Init the event stream."""
         assert not (context_id and (entity_ids or device_ids)), (
@@ -158,7 +161,7 @@ class EventProcessor:
             entity_name_cache=EntityNameCache(self.hass),
             include_entity_name=include_entity_name,
             timestamp=timestamp,
-            entity_filter=entity_filter,
+            user=user,
             for_live_stream=for_live_stream,
         )
         self.context_augmenter = ContextAugmenter(self.logbook_run)
@@ -278,9 +281,13 @@ class EventProcessor:
             query_parent_user_ids,
         )
         # A request without entity_ids covers everything, so entries the caller
-        # may not read are dropped here rather than at the query. The check is
-        # skipped entirely for callers that may read every entity.
-        if (entity_filter := self.logbook_run.entity_filter) is not None:
+        # may not read are dropped here rather than at the query. Permissions
+        # are resolved per batch rather than held from when the processor was
+        # built, because a live stream outlives a change to them. A caller that
+        # may read every entity resolves to None and is not filtered at all.
+        if (user := self.logbook_run.user) is not None and (
+            entity_filter := entity_permission_filter(user, POLICY_READ)
+        ) is not None:
             return _filter_readable_entries(entries, entity_filter)
 
         return list(entries)

--- a/homeassistant/components/logbook/processor.py
+++ b/homeassistant/components/logbook/processor.py
@@ -111,6 +111,8 @@ class LogbookRun:
     entity_name_cache: EntityNameCache
     include_entity_name: bool
     timestamp: bool
+    # Per-entity read check, or None when the caller may read everything.
+    entity_filter: Callable[[str], bool] | None = None
     memoize_new_contexts: bool = True
     # True when this run will switch to a live stream; gates population of
     # context_user_ids (wasted work for one-shot REST/get_events callers).
@@ -135,6 +137,7 @@ class EventProcessor:
         timestamp: bool = False,
         include_entity_name: bool = True,
         for_live_stream: bool = False,
+        entity_filter: Callable[[str], bool] | None = None,
     ) -> None:
         """Init the event stream."""
         assert not (context_id and (entity_ids or device_ids)), (
@@ -155,6 +158,7 @@ class EventProcessor:
             entity_name_cache=EntityNameCache(self.hass),
             include_entity_name=include_entity_name,
             timestamp=timestamp,
+            entity_filter=entity_filter,
             for_live_stream=for_live_stream,
         )
         self.context_augmenter = ContextAugmenter(self.logbook_run)
@@ -265,16 +269,63 @@ class EventProcessor:
         query_parent_user_ids: dict[bytes, bytes] | None = None,
     ) -> list[dict[str, Any]]:
         """Humanify rows."""
-        return list(
-            _humanify(
-                self.hass,
-                rows,
-                self.ent_reg,
-                self.logbook_run,
-                self.context_augmenter,
-                query_parent_user_ids,
-            )
+        entries = _humanify(
+            self.hass,
+            rows,
+            self.ent_reg,
+            self.logbook_run,
+            self.context_augmenter,
+            query_parent_user_ids,
         )
+        # A request without entity_ids covers everything, so entries the caller
+        # may not read are dropped here rather than at the query. The check is
+        # skipped entirely for callers that may read every entity.
+        if (entity_filter := self.logbook_run.entity_filter) is not None:
+            return _filter_readable_entries(entries, entity_filter)
+
+        return list(entries)
+
+
+# Everything an augmented context says about the entity that triggered an
+# entry. The remaining context keys name an integration, a service or a user,
+# which say nothing about the entity itself.
+_DENIED_CONTEXT_KEYS = (
+    CONTEXT_ENTITY_ID,
+    CONTEXT_ENTITY_ID_NAME,
+    CONTEXT_STATE,
+    CONTEXT_NAME,
+    CONTEXT_MESSAGE,
+    CONTEXT_SOURCE,
+)
+
+
+def _filter_readable_entries(
+    entries: Generator[dict[str, Any]], entity_filter: Callable[[str], bool]
+) -> list[dict[str, Any]]:
+    """Return the entries a caller is allowed to read.
+
+    An entry that belongs to no entity, a plain event for example, carries no
+    entity to test and stays. The entity an entry was triggered by is a
+    different one than the entry's own, so its attribution is dropped by itself
+    and the entry survives without pointing at something the caller cannot see.
+    """
+    readable: list[dict[str, Any]] = []
+
+    for entry in entries:
+        if (entity_id := entry.get(LOGBOOK_ENTRY_ENTITY_ID)) and not entity_filter(
+            entity_id
+        ):
+            continue
+
+        if (context_entity_id := entry.get(CONTEXT_ENTITY_ID)) and not entity_filter(
+            context_entity_id
+        ):
+            for key in _DENIED_CONTEXT_KEYS:
+                entry.pop(key, None)
+
+        readable.append(entry)
+
+    return readable
 
 
 def _exposed_state_attributes(

--- a/homeassistant/components/logbook/rest_api.py
+++ b/homeassistant/components/logbook/rest_api.py
@@ -8,10 +8,7 @@ from typing import Any
 from aiohttp import web
 import voluptuous as vol
 
-from homeassistant.auth.permissions import (
-    entity_permission_filter,
-    filter_entity_ids_by_permission,
-)
+from homeassistant.auth.permissions import filter_entity_ids_by_permission
 from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.components.http import KEY_HASS, KEY_HASS_USER, HomeAssistantView
 from homeassistant.components.recorder import get_instance
@@ -114,7 +111,7 @@ class LogbookView(HomeAssistantView):
             context_id,
             timestamp=False,
             include_entity_name=True,
-            entity_filter=entity_permission_filter(user, POLICY_READ),
+            user=user,
         )
 
         def json_events() -> web.Response:

--- a/homeassistant/components/logbook/rest_api.py
+++ b/homeassistant/components/logbook/rest_api.py
@@ -8,7 +8,12 @@ from typing import Any
 from aiohttp import web
 import voluptuous as vol
 
-from homeassistant.components.http import KEY_HASS, HomeAssistantView
+from homeassistant.auth.permissions import (
+    entity_permission_filter,
+    filter_entity_ids_by_permission,
+)
+from homeassistant.auth.permissions.const import POLICY_READ
+from homeassistant.components.http import KEY_HASS, KEY_HASS_USER, HomeAssistantView
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.filters import Filters
 from homeassistant.core import HomeAssistant, callback
@@ -94,6 +99,12 @@ class LogbookView(HomeAssistantView):
                 "Can't combine entity with context_id", HTTPStatus.BAD_REQUEST
             )
 
+        user = request[KEY_HASS_USER]
+        if entity_ids:
+            entity_ids = filter_entity_ids_by_permission(user, entity_ids, POLICY_READ)
+            if not entity_ids:
+                return self.json([])
+
         event_types = async_determine_event_types(hass, entity_ids, None)
         event_processor = EventProcessor(
             hass,
@@ -103,6 +114,7 @@ class LogbookView(HomeAssistantView):
             context_id,
             timestamp=False,
             include_entity_name=True,
+            entity_filter=entity_permission_filter(user, POLICY_READ),
         )
 
         def json_events() -> web.Response:

--- a/homeassistant/components/logbook/websocket_api.py
+++ b/homeassistant/components/logbook/websocket_api.py
@@ -9,10 +9,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.auth.permissions import (
-    entity_permission_filter,
-    filter_entity_ids_by_permission,
-)
+from homeassistant.auth.permissions import filter_entity_ids_by_permission
 from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.components import websocket_api
 from homeassistant.components.recorder import get_instance
@@ -295,7 +292,6 @@ async def ws_event_stream(
             _async_send_empty_response(connection, msg_id, start_time, end_time)
             return
 
-    entity_filter = entity_permission_filter(connection.user, POLICY_READ)
     event_types = async_determine_event_types(hass, entity_ids, device_ids)
     # A past end_time makes this a one-shot fetch that never goes live.
     will_go_live = not (end_time and end_time <= utc_now)
@@ -308,7 +304,7 @@ async def ws_event_stream(
         timestamp=True,
         include_entity_name=False,
         for_live_stream=will_go_live,
-        entity_filter=entity_filter,
+        user=connection.user,
     )
 
     if end_time and end_time <= utc_now:
@@ -519,7 +515,7 @@ async def ws_get_events(
         context_id,
         timestamp=True,
         include_entity_name=False,
-        entity_filter=entity_permission_filter(connection.user, POLICY_READ),
+        user=connection.user,
     )
 
     connection.send_message(

--- a/homeassistant/components/logbook/websocket_api.py
+++ b/homeassistant/components/logbook/websocket_api.py
@@ -9,6 +9,11 @@ from typing import Any
 
 import voluptuous as vol
 
+from homeassistant.auth.permissions import (
+    entity_permission_filter,
+    filter_entity_ids_by_permission,
+)
+from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.components import websocket_api
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.websocket_api import ActiveConnection, messages
@@ -283,10 +288,14 @@ async def ws_event_stream(
     entity_ids = msg.get("entity_ids")
     if entity_ids:
         entity_ids = async_filter_entities(hass, entity_ids)
+        entity_ids = filter_entity_ids_by_permission(
+            connection.user, entity_ids, POLICY_READ
+        )
         if not entity_ids and not device_ids:
             _async_send_empty_response(connection, msg_id, start_time, end_time)
             return
 
+    entity_filter = entity_permission_filter(connection.user, POLICY_READ)
     event_types = async_determine_event_types(hass, entity_ids, device_ids)
     # A past end_time makes this a one-shot fetch that never goes live.
     will_go_live = not (end_time and end_time <= utc_now)
@@ -299,6 +308,7 @@ async def ws_event_stream(
         timestamp=True,
         include_entity_name=False,
         for_live_stream=will_go_live,
+        entity_filter=entity_filter,
     )
 
     if end_time and end_time <= utc_now:
@@ -491,6 +501,9 @@ async def ws_get_events(
     context_id = msg.get("context_id")
     if entity_ids:
         entity_ids = async_filter_entities(hass, entity_ids)
+        entity_ids = filter_entity_ids_by_permission(
+            connection.user, entity_ids, POLICY_READ
+        )
         if not entity_ids and not device_ids:
             # Everything has been filtered away
             connection.send_result(msg["id"], [])
@@ -506,6 +519,7 @@ async def ws_get_events(
         context_id,
         timestamp=True,
         include_entity_name=False,
+        entity_filter=entity_permission_filter(connection.user, POLICY_READ),
     )
 
     connection.send_message(

--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -1,12 +1,16 @@
 """The Recorder websocket API."""
 
 import asyncio
+from collections.abc import Callable
 from datetime import datetime as dt
 import logging
 from typing import Any, Literal, cast
 
 import voluptuous as vol
 
+from homeassistant.auth.models import User
+from homeassistant.auth.permissions import entity_permission_filter
+from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.components import websocket_api
 from homeassistant.components.websocket_api import messages
 from homeassistant.core import HomeAssistant, callback, valid_entity_id
@@ -123,6 +127,19 @@ UNIT_SCHEMA = vol.Schema(
 )
 
 
+def _statistic_id_read_filter(user: User) -> Callable[[str], bool] | None:
+    """Return a check for the statistic ids a user may read, or None for all.
+
+    Statistic ids of entity backed statistics are entity ids, so the entity
+    read policy applies to them. External statistics are a `domain:object_id`
+    pair with no entity behind them, which leaves no policy to test.
+    """
+    if (check_entity := entity_permission_filter(user, POLICY_READ)) is None:
+        return None
+
+    return lambda statistic_id: ":" in statistic_id or check_entity(statistic_id)
+
+
 @callback
 def async_setup(hass: HomeAssistant) -> None:
     """Set up the recorder websocket API."""
@@ -182,6 +199,12 @@ async def ws_get_statistic_during_period(
 
     start_time, end_time = resolve_period(cast(StatisticPeriod, msg))
 
+    statistic_id: str = msg["statistic_id"]
+    check_statistic_id = _statistic_id_read_filter(connection.user)
+    if check_statistic_id is not None and not check_statistic_id(statistic_id):
+        connection.send_result(msg["id"], {})
+        return
+
     connection.send_message(
         await get_instance(hass).async_add_executor_job(
             _ws_get_statistic_during_period,
@@ -189,7 +212,7 @@ async def ws_get_statistic_during_period(
             msg["id"],
             start_time,
             end_time,
-            msg["statistic_id"],
+            statistic_id,
             msg.get("types"),
             msg.get("units"),
         )
@@ -250,6 +273,18 @@ async def ws_handle_get_statistics_during_period(
 
     if (types := msg.get("types")) is None:
         types = {"change", "last_reset", "max", "mean", "min", "state", "sum"}
+
+    statistic_ids: set[str] = set(msg["statistic_ids"])
+    if (check_statistic_id := _statistic_id_read_filter(connection.user)) is not None:
+        statistic_ids = {
+            statistic_id
+            for statistic_id in statistic_ids
+            if check_statistic_id(statistic_id)
+        }
+        if not statistic_ids:
+            connection.send_result(msg["id"], {})
+            return
+
     connection.send_message(
         await get_instance(hass).async_add_executor_job(
             _ws_get_statistics_during_period,
@@ -257,7 +292,7 @@ async def ws_handle_get_statistics_during_period(
             msg["id"],
             start_time,
             end_time,
-            set(msg["statistic_ids"]),
+            statistic_ids,
             msg.get("period"),
             msg.get("units"),
             types,
@@ -293,14 +328,20 @@ def _ws_get_list_statistic_ids(
     hass: HomeAssistant,
     msg_id: int,
     statistic_type: Literal["mean", "sum"] | None = None,
+    check_statistic_id: Callable[[str], bool] | None = None,
 ) -> bytes:
     """Fetch a list of available statistic_id and convert them to JSON.
 
     Runs in the executor.
     """
-    return json_bytes(
-        messages.result_message(msg_id, list_statistic_ids(hass, None, statistic_type))
-    )
+    statistic_ids = list_statistic_ids(hass, None, statistic_type)
+    if check_statistic_id is not None:
+        statistic_ids = [
+            metadata
+            for metadata in statistic_ids
+            if check_statistic_id(metadata["statistic_id"])
+        ]
+    return json_bytes(messages.result_message(msg_id, statistic_ids))
 
 
 async def ws_handle_list_statistic_ids(
@@ -313,6 +354,7 @@ async def ws_handle_list_statistic_ids(
             hass,
             msg["id"],
             msg.get("statistic_type"),
+            _statistic_id_read_filter(connection.user),
         )
     )
 
@@ -417,6 +459,12 @@ async def ws_get_statistics_metadata(
     statistic_ids = msg.get("statistic_ids")
     statistic_ids_set_or_none = set(statistic_ids) if statistic_ids else None
     metadata = await async_list_statistic_ids(hass, statistic_ids_set_or_none)
+    if (check_statistic_id := _statistic_id_read_filter(connection.user)) is not None:
+        metadata = [
+            statistic_metadata
+            for statistic_metadata in metadata
+            if check_statistic_id(statistic_metadata["statistic_id"])
+        ]
     connection.send_result(msg["id"], metadata)
 
 

--- a/tests/components/logbook/test_init.py
+++ b/tests/components/logbook/test_init.py
@@ -58,7 +58,7 @@ from .common import (
     simulate_thermostat_context_chain,
 )
 
-from tests.common import MockConfigEntry, async_capture_events, mock_platform
+from tests.common import MockConfigEntry, MockUser, async_capture_events, mock_platform
 from tests.components.recorder.common import (
     async_recorder_block_till_done,
     async_wait_recording_done,
@@ -390,6 +390,84 @@ async def test_logbook_view_invalid_end_date_time(
         f"/api/logbook/{dt_util.utcnow().isoformat()}?end_time=INVALID"
     )
     assert response.status == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.usefixtures("recorder_mock", "set_utc")
+async def test_logbook_view_filters_unauthorized_entities(
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    hass_read_only_access_token: str,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test the logbook view filters by per-entity read permissions."""
+    assert not hass_read_only_user.is_admin
+    hass_read_only_user.mock_policy(
+        {"entities": {"entity_ids": {"switch.allowed": True}}}
+    )
+    await async_setup_component(hass, DOMAIN, {})
+    await async_recorder_block_till_done(hass)
+
+    hass.states.async_set("switch.allowed", STATE_OFF)
+    hass.states.async_set("switch.allowed", STATE_ON)
+    hass.states.async_set("switch.forbidden", STATE_OFF)
+    hass.states.async_set("switch.forbidden", STATE_ON)
+    await async_wait_recording_done(hass)
+
+    client = await hass_client(hass_read_only_access_token)
+    start = dt_util.utcnow().date()
+    start_date = datetime(start.year, start.month, start.day, tzinfo=dt_util.UTC)
+
+    # Without entity_ids the logbook covers everything, so the entries
+    # themselves have to be filtered
+    response = await client.get(f"/api/logbook/{start_date.isoformat()}")
+    assert response.status == HTTPStatus.OK
+    response_json = await response.json()
+    assert [entry["entity_id"] for entry in response_json] == ["switch.allowed"]
+
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}?entity=switch.allowed,switch.forbidden"
+    )
+    assert response.status == HTTPStatus.OK
+    response_json = await response.json()
+    assert [entry["entity_id"] for entry in response_json] == ["switch.allowed"]
+
+    response = await client.get(
+        f"/api/logbook/{start_date.isoformat()}?entity=switch.forbidden"
+    )
+    assert response.status == HTTPStatus.OK
+    assert await response.json() == []
+
+
+@pytest.mark.usefixtures("recorder_mock", "set_utc")
+async def test_logbook_view_all_entities_for_unrestricted_users(
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    hass_read_only_access_token: str,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test a user with blanket read access sees every entity."""
+    assert not hass_read_only_user.is_admin
+    hass_read_only_user.mock_policy({"entities": {"all": {"read": True}}})
+    await async_setup_component(hass, DOMAIN, {})
+    await async_recorder_block_till_done(hass)
+
+    hass.states.async_set("switch.one", STATE_OFF)
+    hass.states.async_set("switch.one", STATE_ON)
+    hass.states.async_set("switch.two", STATE_OFF)
+    hass.states.async_set("switch.two", STATE_ON)
+    await async_wait_recording_done(hass)
+
+    client = await hass_client(hass_read_only_access_token)
+    start = dt_util.utcnow().date()
+    start_date = datetime(start.year, start.month, start.day, tzinfo=dt_util.UTC)
+
+    response = await client.get(f"/api/logbook/{start_date.isoformat()}")
+    assert response.status == HTTPStatus.OK
+    response_json = await response.json()
+    assert [entry["entity_id"] for entry in response_json] == [
+        "switch.one",
+        "switch.two",
+    ]
 
 
 @pytest.mark.usefixtures("recorder_mock", "set_utc")

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -50,7 +50,7 @@ from .common import (
     simulate_thermostat_context_chain,
 )
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry, MockUser, async_fire_time_changed
 from tests.components.recorder.common import (
     async_block_recorder,
     async_recorder_block_till_done,
@@ -3693,3 +3693,273 @@ async def test_logbook_stream_live_parent_service_call_only(
     assert len(heater_entries) == 1
     assert heater_entries[0]["state"] == "on"
     assert heater_entries[0]["context_user_id"] == user_id
+
+
+def _entity_ids(entries: list[dict[str, Any]]) -> list[str]:
+    """Return the entity ids of the entries that have one."""
+    return [entry["entity_id"] for entry in entries if "entity_id" in entry]
+
+
+async def test_get_events_filters_unauthorized_entities(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    hass_read_only_access_token: str,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test logbook/get_events filters by per-entity read permissions."""
+    assert not hass_read_only_user.is_admin
+    hass_read_only_user.mock_policy(
+        {"entities": {"entity_ids": {"light.allowed": True}}}
+    )
+    now = dt_util.utcnow()
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, domain, {})
+            for domain in ("homeassistant", "logbook")
+        ]
+    )
+    await async_recorder_block_till_done(hass)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+
+    hass.states.async_set("light.allowed", STATE_OFF)
+    await hass.async_block_till_done()
+    hass.states.async_set("light.allowed", STATE_ON)
+    await hass.async_block_till_done()
+    hass.states.async_set("light.forbidden", STATE_OFF)
+    await hass.async_block_till_done()
+    hass.states.async_set("light.forbidden", STATE_ON)
+    await hass.async_block_till_done()
+    await async_wait_recording_done(hass)
+
+    client = await hass_ws_client(access_token=hass_read_only_access_token)
+
+    # Without entity_ids every entity is in scope, so the entries are filtered
+    await client.send_json_auto_id(
+        {"type": "logbook/get_events", "start_time": now.isoformat()}
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert _entity_ids(response["result"]) == ["light.allowed"]
+    # An entry that belongs to no entity, the start message here, has no
+    # entity policy to test against and is kept
+    assert any("entity_id" not in entry for entry in response["result"])
+
+    await client.send_json_auto_id(
+        {
+            "type": "logbook/get_events",
+            "start_time": now.isoformat(),
+            "entity_ids": ["light.allowed", "light.forbidden"],
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert _entity_ids(response["result"]) == ["light.allowed"]
+
+    await client.send_json_auto_id(
+        {
+            "type": "logbook/get_events",
+            "start_time": now.isoformat(),
+            "entity_ids": ["light.forbidden"],
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == []
+
+
+async def test_get_events_all_entities_for_unrestricted_users(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    hass_read_only_access_token: str,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a user with blanket read access sees every entity."""
+    assert not hass_read_only_user.is_admin
+    hass_read_only_user.mock_policy({"entities": {"all": {"read": True}}})
+    now = dt_util.utcnow()
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, domain, {})
+            for domain in ("homeassistant", "logbook")
+        ]
+    )
+    await async_recorder_block_till_done(hass)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+
+    hass.states.async_set("light.one", STATE_OFF)
+    await hass.async_block_till_done()
+    hass.states.async_set("light.one", STATE_ON)
+    await hass.async_block_till_done()
+    hass.states.async_set("light.two", STATE_OFF)
+    await hass.async_block_till_done()
+    hass.states.async_set("light.two", STATE_ON)
+    await hass.async_block_till_done()
+    await async_wait_recording_done(hass)
+
+    client = await hass_ws_client(access_token=hass_read_only_access_token)
+    await client.send_json_auto_id(
+        {"type": "logbook/get_events", "start_time": now.isoformat()}
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert _entity_ids(response["result"]) == ["light.one", "light.two"]
+
+
+async def test_event_stream_filters_unauthorized_entities(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    hass_read_only_access_token: str,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test logbook/event_stream filters by per-entity read permissions."""
+    assert not hass_read_only_user.is_admin
+    hass_read_only_user.mock_policy(
+        {"entities": {"entity_ids": {"light.allowed": True}}}
+    )
+    now = dt_util.utcnow()
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, domain, {})
+            for domain in ("homeassistant", "logbook")
+        ]
+    )
+    await async_recorder_block_till_done(hass)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(access_token=hass_read_only_access_token)
+    await client.send_json_auto_id(
+        {"type": "logbook/event_stream", "start_time": now.isoformat()}
+    )
+    response = await asyncio.wait_for(client.receive_json(), 2)
+    assert response["success"]
+
+    # The historical batch carries the start message, which has no entity
+    response = await asyncio.wait_for(client.receive_json(), 2)
+    assert _entity_ids(response["event"]["events"]) == []
+
+    # End of the historical events
+    response = await asyncio.wait_for(client.receive_json(), 2)
+    assert response["event"]["events"] == []
+
+    hass.states.async_set("light.forbidden", STATE_OFF)
+    hass.states.async_set("light.forbidden", STATE_ON)
+    hass.states.async_set("light.allowed", STATE_OFF)
+    hass.states.async_set("light.allowed", STATE_ON)
+    await hass.async_block_till_done()
+
+    response = await asyncio.wait_for(client.receive_json(), 2)
+    assert _entity_ids(response["event"]["events"]) == ["light.allowed"]
+
+
+async def test_get_events_filters_unauthorized_context_entities(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    hass_read_only_access_token: str,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the entity an entry was triggered by is filtered as well."""
+    assert not hass_read_only_user.is_admin
+    hass_read_only_user.mock_policy(
+        {"entities": {"entity_ids": {"switch.allowed": True}}}
+    )
+    now = dt_util.utcnow()
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, domain, {})
+            for domain in ("homeassistant", "logbook")
+        ]
+    )
+    await async_recorder_block_till_done(hass)
+
+    context = core.Context(
+        id="01GTDGKBCH00GW0X276W5TEDDD",
+        user_id="b400facee45711eaa9308bfd3d19e474",
+    )
+    hass.states.async_set("climate.forbidden", STATE_OFF, context=context)
+    await hass.async_block_till_done()
+    hass.states.async_set("climate.forbidden", STATE_ON, context=context)
+    await hass.async_block_till_done()
+    hass.states.async_set("switch.allowed", STATE_OFF, context=context)
+    await hass.async_block_till_done()
+    hass.states.async_set("switch.allowed", STATE_ON, context=context)
+    await hass.async_block_till_done()
+    await async_wait_recording_done(hass)
+
+    client = await hass_ws_client(access_token=hass_read_only_access_token)
+    await client.send_json_auto_id(
+        {"type": "logbook/get_events", "start_time": now.isoformat()}
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    assert _entity_ids(response["result"]) == ["switch.allowed"]
+    # The entry itself is readable, the entity it was triggered by is not
+    for entry in response["result"]:
+        assert "context_entity_id" not in entry
+        assert "context_entity_id_name" not in entry
+        assert "context_state" not in entry
+
+
+async def test_get_events_filters_unauthorized_context_description(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    hass_read_only_access_token: str,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test what a denied context entity is described by is filtered as well."""
+    assert not hass_read_only_user.is_admin
+    hass_read_only_user.mock_policy(
+        {"entities": {"entity_ids": {"switch.allowed": True}}}
+    )
+    now = dt_util.utcnow()
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, domain, {})
+            for domain in ("homeassistant", "logbook")
+        ]
+    )
+    await async_recorder_block_till_done(hass)
+
+    context = core.Context(
+        id="01GTDGKBCH00GW0X276W5TEDDD",
+        user_id="b400facee45711eaa9308bfd3d19e474",
+    )
+    hass.bus.async_fire(
+        EVENT_AUTOMATION_TRIGGERED,
+        {
+            ATTR_NAME: "Secret automation",
+            ATTR_ENTITY_ID: "automation.forbidden",
+            "source": "state of binary_sensor.forbidden",
+        },
+        context=context,
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("switch.allowed", STATE_OFF, context=context)
+    await hass.async_block_till_done()
+    hass.states.async_set("switch.allowed", STATE_ON, context=context)
+    await hass.async_block_till_done()
+    await async_wait_recording_done(hass)
+
+    client = await hass_ws_client(access_token=hass_read_only_access_token)
+    await client.send_json_auto_id(
+        {"type": "logbook/get_events", "start_time": now.isoformat()}
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    assert _entity_ids(response["result"]) == ["switch.allowed"]
+    # The name, the message and the source all describe the automation the
+    # caller may not read, and the source names another denied entity
+    for entry in response["result"]:
+        assert "context_entity_id" not in entry
+        assert "context_name" not in entry
+        assert "context_message" not in entry
+        assert "context_source" not in entry
+        assert "binary_sensor.forbidden" not in str(entry)
+        assert "Secret automation" not in str(entry)

--- a/tests/components/logbook/test_websocket_api.py
+++ b/tests/components/logbook/test_websocket_api.py
@@ -3963,3 +3963,56 @@ async def test_get_events_filters_unauthorized_context_description(
         assert "context_source" not in entry
         assert "binary_sensor.forbidden" not in str(entry)
         assert "Secret automation" not in str(entry)
+
+
+async def test_event_stream_follows_revoked_permissions(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    hass_read_only_access_token: str,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test an open stream follows a permission change."""
+    assert not hass_read_only_user.is_admin
+    hass_read_only_user.mock_policy({"entities": {"all": {"read": True}}})
+    now = dt_util.utcnow()
+    await asyncio.gather(
+        *[
+            async_setup_component(hass, domain, {})
+            for domain in ("homeassistant", "logbook")
+        ]
+    )
+    await async_recorder_block_till_done(hass)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(access_token=hass_read_only_access_token)
+    await client.send_json_auto_id(
+        {"type": "logbook/event_stream", "start_time": now.isoformat()}
+    )
+    response = await asyncio.wait_for(client.receive_json(), 2)
+    assert response["success"]
+
+    # Historical batch, then the end of the historical events
+    await asyncio.wait_for(client.receive_json(), 2)
+    response = await asyncio.wait_for(client.receive_json(), 2)
+    assert response["event"]["events"] == []
+
+    hass.states.async_set("light.kitchen", STATE_OFF)
+    hass.states.async_set("light.kitchen", STATE_ON)
+    await hass.async_block_till_done()
+
+    response = await asyncio.wait_for(client.receive_json(), 2)
+    assert _entity_ids(response["event"]["events"]) == ["light.kitchen"]
+
+    # Take the access away while the stream is open
+    hass_read_only_user.mock_policy({"entities": {"entity_ids": {}}})
+
+    hass.states.async_set("light.kitchen", STATE_OFF)
+    hass.states.async_set("light.kitchen", STATE_ON)
+    hass.states.async_set("light.hallway", STATE_OFF)
+    hass.states.async_set("light.hallway", STATE_ON)
+    await hass.async_block_till_done()
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(client.receive_json(), 1)

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -53,7 +53,7 @@ from .common import (
 )
 from .conftest import InstrumentedMigration
 
-from tests.common import async_fire_time_changed
+from tests.common import MockUser, async_fire_time_changed
 from tests.typing import (
     RecorderInstanceContextManager,
     RecorderInstanceGenerator,
@@ -4808,3 +4808,161 @@ async def test_entity_options_ws(
     response = await client.receive_json()
     assert response["success"]
     assert response["result"] == {"recording_disabled_by": None}
+
+
+async def _async_record_statistics(hass: HomeAssistant) -> None:
+    """Record statistics for two sensors and one external source."""
+    now = get_start_time(dt_util.utcnow())
+    await async_setup_component(hass, "sensor", {})
+    await async_recorder_block_till_done(hass)
+
+    attributes = {
+        "device_class": "energy",
+        "state_class": "total",
+        "unit_of_measurement": "kWh",
+        "last_reset": None,
+    }
+    hass.states.async_set(
+        "sensor.allowed", 10, attributes=attributes, timestamp=now.timestamp()
+    )
+    hass.states.async_set(
+        "sensor.forbidden", 10, attributes=attributes, timestamp=now.timestamp()
+    )
+    await async_wait_recording_done(hass)
+    do_adhoc_statistics(hass, start=now)
+    await async_wait_recording_done(hass)
+
+    async_add_external_statistics(
+        hass,
+        {
+            "mean_type": StatisticMeanType.NONE,
+            "has_sum": True,
+            "name": "Total imported energy",
+            "source": "test",
+            "statistic_id": "test:total_energy_import",
+            "unit_class": "energy",
+            "unit_of_measurement": "kWh",
+        },
+        (
+            {
+                # External statistics are recorded on the hour
+                "start": now.replace(minute=0, second=0, microsecond=0),
+                "last_reset": None,
+                "state": 0,
+                "sum": 2,
+            },
+        ),
+    )
+    await async_wait_recording_done(hass)
+
+
+async def test_statistics_filter_unauthorized_entities(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    hass_read_only_access_token: str,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the statistics read commands apply per-entity read permissions."""
+    assert not hass_read_only_user.is_admin
+    hass_read_only_user.mock_policy(
+        {"entities": {"entity_ids": {"sensor.allowed": True}}}
+    )
+    await _async_record_statistics(hass)
+
+    client = await hass_ws_client(access_token=hass_read_only_access_token)
+
+    # An id the user may not read is not listed, an external statistic has no
+    # entity behind it and stays
+    await client.send_json_auto_id({"type": "recorder/list_statistic_ids"})
+    response = await client.receive_json()
+    assert response["success"]
+    assert {result["statistic_id"] for result in response["result"]} == {
+        "sensor.allowed",
+        "test:total_energy_import",
+    }
+
+    await client.send_json_auto_id(
+        {
+            "type": "recorder/get_statistics_metadata",
+            "statistic_ids": [
+                "sensor.allowed",
+                "sensor.forbidden",
+                "test:total_energy_import",
+            ],
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert {result["statistic_id"] for result in response["result"]} == {
+        "sensor.allowed",
+        "test:total_energy_import",
+    }
+
+    now = get_start_time(dt_util.utcnow())
+    await client.send_json_auto_id(
+        {
+            "type": "recorder/statistics_during_period",
+            "start_time": now.isoformat(),
+            "statistic_ids": ["sensor.allowed", "sensor.forbidden"],
+            "period": "5minute",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert set(response["result"]) == {"sensor.allowed"}
+
+    await client.send_json_auto_id(
+        {
+            "type": "recorder/statistics_during_period",
+            "start_time": now.isoformat(),
+            "statistic_ids": ["sensor.forbidden"],
+            "period": "5minute",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == {}
+
+    await client.send_json_auto_id(
+        {
+            "type": "recorder/statistic_during_period",
+            "statistic_id": "sensor.forbidden",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == {}
+
+    await client.send_json_auto_id(
+        {
+            "type": "recorder/statistic_during_period",
+            "statistic_id": "sensor.allowed",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] != {}
+
+
+async def test_statistics_all_entities_for_unrestricted_users(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    hass_read_only_access_token: str,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a user with blanket read access sees every statistic."""
+    assert not hass_read_only_user.is_admin
+    hass_read_only_user.mock_policy({"entities": {"all": {"read": True}}})
+    await _async_record_statistics(hass)
+
+    client = await hass_ws_client(access_token=hass_read_only_access_token)
+    await client.send_json_auto_id({"type": "recorder/list_statistic_ids"})
+    response = await client.receive_json()
+    assert response["success"]
+    assert {result["statistic_id"] for result in response["result"]} == {
+        "sensor.allowed",
+        "sensor.forbidden",
+        "test:total_energy_import",
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`history` filters the entities it hands back by the caller's per-entity read policy, using `filter_entity_ids_by_permission` in `history/websocket_api.py`. The logbook and the statistics read commands never learned that, so an account with a restrictive entity policy could read data there for entities it cannot see through `get_states`, `subscribe_entities` or `history/history_during_period`. This brings those two in line.

**Where the filter sits**

For the logbook, filtering the request is not enough: `entity_ids` is optional, and a request without it covers every entity. The containment point that holds is the produced entries, so `EventProcessor` takes an optional per-entity check and `humanify()` applies it to the entries it hands out. That covers the REST view, `logbook/get_events`, the historical part of `logbook/event_stream` and its live entries, since the live consumer calls `humanify()` too. When `entity_ids` is supplied it is filtered up front as well, so a fully filtered request answers without touching the database. Entries that belong to no entity, a plain event for example, carry nothing to test and are kept.

An entry also carries the entity that triggered it, which is a different entity than its own. For an entry the caller may read whose context entity it may not, the attribution is dropped and the entry stays: `context_entity_id`, `context_entity_id_name` and `context_state`, plus `context_name`, `context_message` and `context_source`, because the describers put the context entity's name into those and the automation describer copies the trigger source verbatim, which usually names an entity. `context_domain`, `context_service`, `context_event_type` and `context_user_id` name an integration, a service or a user and are kept.

There is a limit worth naming: if the context entity itself is readable while its trigger source text mentions an entity that is not, that text still goes out. That is free text rather than a field, and it is how the logbook already behaves.

For the statistics commands, `_statistic_id_read_filter` in `recorder/websocket_api.py` keeps the filtering at the API boundary rather than in the data layer. Statistic ids of entity backed statistics are entity ids, so the entity policy applies to them. External statistics are a `domain:object_id` pair with no entity behind them, so there is no policy to test and they pass through: entity ids cannot contain a colon, and `valid_statistic_id` requires one, so the two cannot be confused. `list_statistic_ids` and `get_statistics_metadata` filter what they return, while the two `*_during_period` commands filter the ids in the request and answer with an empty result when nothing is left.

**The admin fast path**

`entity_permission_filter` is added next to `filter_entity_ids_by_permission` in `homeassistant/auth/permissions/__init__.py`. It returns `None` when the user is an administrator or has blanket read access, and callers use that to skip the filtering entirely. So the common case pays for one boolean test per request rather than a lookup per entry, and the logbook branches once per batch rather than once per row. Nothing changes for those users, including the shape of the responses.

**Noticed while working here, not touched**

- `recorder/validate_statistics` and `recorder/update_statistics_issues` do not require an administrator, unlike the other write side commands in that file. The first returns validation results keyed by `statistic_id`, so a restricted account can learn ids it cannot otherwise read whenever there are issues to report. The second changes state despite how it reads.
- `energy/fossil_energy_consumption` takes `energy_statistic_ids` plus a `co2_statistic_id` and returns statistics derived data without filtering. It is the closest sibling to the commands in this PR.
- `weather/subscribe_forecast` streams forecast data for an entity without a read check.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
