### PR TITLE
Bump pylutron to 0.4.4

### DIFF
--- a/homeassistant/components/lutron/manifest.json
+++ b/homeassistant/components/lutron/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["pylutron"],
-  "requirements": ["pylutron==0.4.2"],
+  "requirements": ["pylutron==0.4.4"],
   "single_config_entry": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2403,7 +2403,7 @@ pylitterbot==2025.6.5
 pylutron-caseta==0.29.0
 
 # homeassistant.components.lutron
-pylutron==0.4.2
+pylutron==0.4.4
 
 # homeassistant.components.mailgun
 pymailgunner==1.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `pylutron` from 0.4.2 to 0.4.4 for the `lutron` integration.

0.4.4 fixes a reconnect regression that has been present since `pylutron` 0.4.2 shipped in HA 2026.8: once connected, the reader thread gave up if the *first* reconnect attempt after a drop failed, so any network outage longer than a few seconds left the integration permanently dead while every entity stayed "available". It now keeps retrying.

0.4.3 additionally parses `SIVOIA_QED` outputs as shades, so the older Sivoia QED shade interfaces are classified as covers instead of surfacing as lights whose brightness is the shade position.

Note the changes in 0.4.3 do not introduce any behavior changes in the Lutron component as it will still treat SIVOIA_QED shades as lights which works fine.

**Changes between versions**

- [thecynic/pylutron#138](https://github.com/thecynic/pylutron/pull/138) — Keep reconnecting after a failed retry once connected (0.4.4)
- [thecynic/pylutron#136](https://github.com/thecynic/pylutron/pull/136) — Treat `SIVOIA_QED` outputs as shades (0.4.3)
- [thecynic/pylutron#137](https://github.com/thecynic/pylutron/pull/137) — Run CI on `pull_request` instead of `pull_request_target` (0.4.3, CI only)

**Links**

- PyPI: https://pypi.org/project/pylutron/0.4.4/
- Release notes: https://github.com/thecynic/pylutron/releases/tag/0.4.4 and https://github.com/thecynic/pylutron/releases/tag/0.4.3
- Full diff: https://github.com/thecynic/pylutron/compare/0.4.2...0.4.4

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #181995 (addresses the library reconnect bug described in that issue; the `async_setup_entry` error handling and `async_unload_entry` disconnect gaps are not covered here)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
