### PR TITLE
Require admin for the synology_dsm reboot and shutdown actions

### DIFF
--- a/homeassistant/components/synology_dsm/services.py
+++ b/homeassistant/components/synology_dsm/services.py
@@ -4,9 +4,11 @@ import logging
 from typing import cast
 
 from synology_dsm.exceptions import SynologyDSMException
+import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.service import async_register_admin_service
 
 from .const import CONF_SERIAL, DOMAIN, SERVICE_REBOOT, SERVICE_SHUTDOWN, SERVICES
 from .coordinator import SynologyDSMConfigEntry
@@ -86,4 +88,13 @@ def async_setup_services(hass: HomeAssistant) -> None:
     """Service handler setup."""
 
     for service in SERVICES:
-        hass.services.async_register(DOMAIN, service, _service_handler)
+        # The call data is left as permissive as it has always been here, the
+        # helper would otherwise reject the optional serial with its default
+        # empty schema.
+        async_register_admin_service(
+            hass,
+            DOMAIN,
+            service,
+            _service_handler,
+            vol.Schema({}, extra=vol.ALLOW_EXTRA),
+        )

--- a/tests/components/synology_dsm/test_services.py
+++ b/tests/components/synology_dsm/test_services.py
@@ -1,0 +1,172 @@
+"""Tests for Synology DSM actions."""
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from homeassistant.components.synology_dsm.const import (
+    CONF_SERIAL,
+    DOMAIN,
+    SERVICE_REBOOT,
+    SERVICE_SHUTDOWN,
+)
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_MAC,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_USERNAME,
+)
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import Unauthorized, UnknownUser
+
+from .common import mock_dsm_hardware, mock_dsm_information
+from .consts import HOST, MACS, PASSWORD, PORT, SERIAL, USE_SSL, USERNAME
+
+from tests.common import MockConfigEntry, MockUser
+
+
+@pytest.fixture
+def mock_dsm() -> MagicMock:
+    """Mock a successful service."""
+    with patch("homeassistant.components.synology_dsm.common.SynologyDSM") as dsm:
+        dsm.login = AsyncMock(return_value=True)
+        dsm.update = AsyncMock(return_value=True)
+        dsm.surveillance_station.update = AsyncMock(return_value=True)
+        dsm.upgrade.update = AsyncMock(return_value=True)
+        dsm.network = Mock(
+            update=AsyncMock(return_value=True), macs=MACS, hostname=HOST
+        )
+        dsm.hardware = mock_dsm_hardware()
+        dsm.information = mock_dsm_information()
+        dsm.file = Mock(get_shared_folders=AsyncMock(return_value=None))
+        dsm.logout = AsyncMock(return_value=True)
+        dsm.system = Mock(
+            reboot=AsyncMock(return_value=True),
+            shutdown=AsyncMock(return_value=True),
+        )
+        yield dsm
+
+
+@pytest.fixture
+async def setup_dsm(hass: HomeAssistant, mock_dsm: MagicMock) -> MockConfigEntry:
+    """Set up a Synology DSM config entry."""
+    with (
+        patch(
+            "homeassistant.components.synology_dsm.common.SynologyDSM",
+            return_value=mock_dsm,
+        ),
+        patch("homeassistant.components.synology_dsm.PLATFORMS", []),
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                CONF_HOST: HOST,
+                CONF_PORT: PORT,
+                CONF_SSL: USE_SSL,
+                CONF_USERNAME: USERNAME,
+                CONF_PASSWORD: PASSWORD,
+                CONF_MAC: MACS[0],
+            },
+            unique_id=SERIAL,
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    return entry
+
+
+@pytest.mark.parametrize("service", [SERVICE_REBOOT, SERVICE_SHUTDOWN])
+@pytest.mark.usefixtures("setup_dsm")
+async def test_service_without_user_context(
+    hass: HomeAssistant,
+    mock_dsm: MagicMock,
+    service: str,
+) -> None:
+    """Test an action called without a user, as an automation does."""
+    await hass.services.async_call(DOMAIN, service, {}, blocking=True)
+
+    assert getattr(mock_dsm.system, service).call_count == 1
+
+
+@pytest.mark.parametrize("service", [SERVICE_REBOOT, SERVICE_SHUTDOWN])
+@pytest.mark.usefixtures("setup_dsm")
+async def test_service_as_admin(
+    hass: HomeAssistant,
+    mock_dsm: MagicMock,
+    hass_admin_user: MockUser,
+    service: str,
+) -> None:
+    """Test an admin user can call the action."""
+    await hass.services.async_call(
+        DOMAIN,
+        service,
+        {},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert getattr(mock_dsm.system, service).call_count == 1
+
+
+@pytest.mark.parametrize("service", [SERVICE_REBOOT, SERVICE_SHUTDOWN])
+@pytest.mark.usefixtures("setup_dsm")
+async def test_service_as_non_admin(
+    hass: HomeAssistant,
+    mock_dsm: MagicMock,
+    hass_read_only_user: MockUser,
+    service: str,
+) -> None:
+    """Test a non-admin user cannot call the action."""
+    with pytest.raises(Unauthorized):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            {},
+            blocking=True,
+            context=Context(user_id=hass_read_only_user.id),
+        )
+
+    assert getattr(mock_dsm.system, service).call_count == 0
+
+
+@pytest.mark.parametrize("service", [SERVICE_REBOOT, SERVICE_SHUTDOWN])
+@pytest.mark.usefixtures("setup_dsm")
+async def test_service_as_unknown_user(
+    hass: HomeAssistant,
+    mock_dsm: MagicMock,
+    service: str,
+) -> None:
+    """Test a user that no longer exists cannot call the action."""
+    with pytest.raises(UnknownUser):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            {},
+            blocking=True,
+            context=Context(user_id="i-am-not-a-user"),
+        )
+
+    assert getattr(mock_dsm.system, service).call_count == 0
+
+
+@pytest.mark.parametrize("service", [SERVICE_REBOOT, SERVICE_SHUTDOWN])
+@pytest.mark.usefixtures("setup_dsm")
+async def test_service_with_serial(
+    hass: HomeAssistant,
+    mock_dsm: MagicMock,
+    hass_admin_user: MockUser,
+    service: str,
+) -> None:
+    """Test the serial in the call data still resolves the device."""
+    await hass.services.async_call(
+        DOMAIN,
+        service,
+        {CONF_SERIAL: SERIAL},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+
+    assert getattr(mock_dsm.system, service).call_count == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `synology_dsm.reboot` and `synology_dsm.shutdown` actions now require an administrator.

Automations and scripts that run on their own triggers are not affected, because those calls carry no user. What changes is a call a non-admin user makes themselves: from a dashboard button, from developer tools, or by starting a script or automation by hand, since the user travels along with the call. Those now fail with "Unauthorized". If a non-admin has to be able to power cycle the NAS, let the automation run on its own trigger instead of being started by that user.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Both actions power cycle the user's NAS and were registered without any check on who is calling. #169226 made the same change for the destructive `hassio` actions, and this integration was not covered by it.

`SERVICES` holds exactly `reboot` and `shutdown`, so both entries in that loop are destructive and both go through `async_register_admin_service` now. `_service_handler` is untouched.

One thing worth a look while reviewing: these actions are registered without a schema today, so any call data is accepted and the handler reads the optional `serial` straight off `call.data`. The helper's default schema would reject that field, so the registration passes a schema that accepts anything, which keeps the call data exactly as permissive as it is now. A tighter schema matching `services.yaml`, with `serial` as an optional string, would be an improvement, but it would also start rejecting fields that are accepted today, so it is left out of this one.

The deprecation warning these actions log stays as it is, and the button entities it points at are unaffected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
