### PR TITLE
Bump probatio to 0.12.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -52,7 +52,7 @@ orjson==3.11.9
 packaging>=23.1
 paho-mqtt==2.1.0
 Pillow==12.3.0
-probatio==0.11.4
+probatio==0.12.0
 propcache==0.5.2
 psutil-home-assistant==0.0.1
 PyJWT==2.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
   "ulid-transform==2.2.9",
   "urllib3>=2.0",
   "uv==0.12.10",
-  "probatio==0.11.4",
+  "probatio==0.12.0",
   "yarl==1.24.5",
   "webrtc-models==0.3.0",
   "zeroconf==0.151.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ mutagen==1.48.1
 orjson==3.11.9
 packaging>=23.1
 Pillow==12.3.0
-probatio==0.11.4
+probatio==0.12.0
 propcache==0.5.2
 psutil-home-assistant==0.0.1
 PyJWT==2.13.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update `probatio` from 0.11.4 to 0.12.0.

- Release: https://github.com/frenck/probatio/releases/tag/v0.12.0
- PyPI: https://pypi.org/project/probatio/0.12.0/
- Diff: https://github.com/frenck/probatio/compare/v0.11.4...v0.12.0

This is a core dependency rather than an integration one, so the pin lives in `pyproject.toml`, with `requirements.txt` and `homeassistant/package_constraints.txt` regenerated from it. Nothing in `requirements_all.txt` changes.

The release fixes serializing a dataclass schema to a field list, calling a callable default in `DefaultTo` and `SetTo`, running a nested `Schema` subclass's overridden `__call__`, and merging extend keys by the literal underneath their marker. It also types the substitution factory instead of widening it to `Any`.

It carries two breaking changes, neither of which reaches us. `additional_constraints` is rejected when it names no field, and that argument is not used anywhere in the codebase. A required dataclass field keeps its default, and no schema here is built from a dataclass. The adjacent fix for serializing a dataclass schema does touch `to_field_list`, which config flows use through `helpers/data_entry_flow.py` and `helpers/config_validation.py`, so that is where the testing was aimed.

**No changes are needed in Home Assistant for this bump.** Since probatio is installed in place of voluptuous for the whole codebase, verification went wider than an integration bump usually does: `tests/helpers` together with the config, config entries and data entry flow tests is 4281 passed, and config validation, LLM, selector, data entry flow, config, websocket API and hassfest is 936 passed. The integrations using `to_openapi` and the conversation tests were run on both versions and come back with the same failures on each, all of them pre-existing here. `python3 -m script.hassfest` reports 1518 integrations and none invalid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
