### PR TITLE
Add async_retry_migration to Config Entries

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2447,6 +2447,25 @@ class ConfigEntries:
             entry.state is ConfigEntryState.LOADED  # type: ignore[comparison-overlap]
         )
 
+    async def async_retry_migration(self, entry_id: str) -> None:
+        """Retry migration for a config entry.
+
+        This should only be called from repairs flows that was
+        created to handle non-recoverable migration errors.
+        """
+        entry = self.async_get_known_entry(entry_id)
+        if entry.state is ConfigEntryState.MIGRATION_ERROR:
+            # Config entry was never loaded so we can set state and start setup to try again
+            entry._async_set_state(self.hass, ConfigEntryState.NOT_LOADED, None)  # noqa: SLF001
+            await self.async_setup(entry_id)
+            return
+
+        raise OperationNotAllowed(
+            f"The config entry '{entry.title}' ({entry.domain}) with entry_id"
+            f" '{entry.entry_id}' cannot retry the migration as it is not in the"
+            f" 'migration_error' state but is in the state {entry.state}"
+        )
+
     async def async_unload(self, entry_id: str, _lock: bool = True) -> bool:
         """Unload a config entry."""
         entry = self.async_get_known_entry(entry_id)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2463,7 +2463,7 @@ class ConfigEntries:
         raise OperationNotAllowed(
             f"The config entry '{entry.title}' ({entry.domain}) with entry_id"
             f" '{entry.entry_id}' cannot retry the migration as it is not in the"
-            f" 'migration_error' state but is in the state {entry.state}"
+            f" state '{ConfigEntryState.MIGRATION_ERROR}' but is in the state {entry.state}"
         )
 
     async def async_unload(self, entry_id: str, _lock: bool = True) -> bool:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3540,7 +3540,7 @@ async def test_entry_reload_from_migration_error(
     hass: HomeAssistant,
     manager: config_entries.ConfigEntries,
 ) -> None:
-    """Test that we can reload an entry."""
+    """Test that we can recover from a migration error."""
     entry = MockConfigEntry(domain="comp")
     entry.add_to_hass(hass)
 
@@ -3604,6 +3604,43 @@ async def test_entry_reload_from_migration_error(
     assert len(async_setup_entry.mock_calls) == 1
     assert len(async_migrate_entry.mock_calls) == 3
     assert entry.state is config_entries.ConfigEntryState.LOADED
+
+
+async def test_entry_reload_from_migration_error_fails(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+) -> None:
+    """Start from migration error fails when in wrong state."""
+    entry = MockConfigEntry(domain="comp")
+    entry.add_to_hass(hass)
+
+    async_setup = AsyncMock(return_value=True)
+    async_setup_entry = AsyncMock(return_value=True)
+    async_unload_entry = AsyncMock(return_value=True)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "comp",
+            async_setup=async_setup,
+            async_setup_entry=async_setup_entry,
+            async_unload_entry=async_unload_entry,
+        ),
+    )
+    mock_platform(hass, "comp.config_flow", None)
+
+    result = await async_setup_component(hass, "comp", {})
+    await hass.async_block_till_done()
+
+    assert result is True
+    assert entry.state is config_entries.ConfigEntryState.LOADED
+
+    with pytest.raises(
+        config_entries.OperationNotAllowed,
+        match="cannot retry the migration as it is not in the state"
+        " 'ConfigEntryState.MIGRATION_ERROR' but is in the state ConfigEntryState.LOADED",
+    ):
+        await manager.async_retry_migration(entry.entry_id)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3567,7 +3567,9 @@ async def test_entry_reload_from_migration_error(
         VERSION = 2
         MINOR_VERSION = 1
 
-        async def async_step_user(self, user_input=None):
+        async def async_step_user(
+            self, user_input: dict[str, Any] | None = None
+        ) -> FlowResult:
             """Test user step."""
             return self.async_create_entry(title="title", data={})
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3536,6 +3536,76 @@ async def test_entry_reload_not_loaded(
     assert entry.state is config_entries.ConfigEntryState.LOADED
 
 
+async def test_entry_reload_from_migration_error(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+) -> None:
+    """Test that we can reload an entry."""
+    entry = MockConfigEntry(domain="comp")
+    entry.add_to_hass(hass)
+
+    async_setup = AsyncMock(return_value=True)
+    async_setup_entry = AsyncMock(return_value=True)
+    async_unload_entry = AsyncMock(return_value=True)
+    async_migrate_entry = AsyncMock(side_effect=[False, False, True])
+
+    mock_integration(
+        hass,
+        MockModule(
+            "comp",
+            async_setup=async_setup,
+            async_setup_entry=async_setup_entry,
+            async_unload_entry=async_unload_entry,
+            async_migrate_entry=async_migrate_entry,
+        ),
+    )
+    mock_platform(hass, "comp.config_flow", None)
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        VERSION = 2
+        MINOR_VERSION = 1
+
+        async def async_step_user(self, user_input=None):
+            """Test user step."""
+            return self.async_create_entry(title="title", data={})
+
+    with (
+        mock_config_flow("comp", TestFlow),
+    ):
+        result = await async_setup_component(hass, "comp", {})
+        await hass.async_block_till_done()
+
+    assert result is True
+    assert entry.state is config_entries.ConfigEntryState.MIGRATION_ERROR
+
+    with (
+        mock_config_flow("comp", TestFlow),
+    ):
+        await manager.async_retry_migration(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert len(async_unload_entry.mock_calls) == 0
+    assert len(async_setup.mock_calls) == 1
+    assert len(async_setup_entry.mock_calls) == 0
+    assert len(async_migrate_entry.mock_calls) == 2
+    assert entry.version == 1
+    assert entry.state is config_entries.ConfigEntryState.MIGRATION_ERROR
+
+    with (
+        mock_config_flow("comp", TestFlow),
+    ):
+        await manager.async_retry_migration(entry.entry_id)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert len(async_unload_entry.mock_calls) == 0
+    assert len(async_setup.mock_calls) == 1
+    assert len(async_setup_entry.mock_calls) == 1
+    assert len(async_migrate_entry.mock_calls) == 3
+    assert entry.state is config_entries.ConfigEntryState.LOADED
+
+
 @pytest.mark.parametrize(
     "state",
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change


## Proposed change
Add `async_retry_migration()` to Config Entries.

To be used by repairs to be able to resolve the `migration_error` state by the config entry as raised by a failed migration.

It is not limited by repairs, so it can be used elsewhere too (except it's mentioned in docstring that it's its purpose)

Related discussion: https://github.com/home-assistant/architecture/discussions/1464

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3299
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository. 