### PR TITLE
Skip the PS4 state write until the entity is added

### DIFF
--- a/homeassistant/components/ps4/media_player.py
+++ b/homeassistant/components/ps4/media_player.py
@@ -282,7 +282,12 @@ class PS4Device(MediaPlayerEntity):
             self._attr_media_content_type = media_type
 
             await self.hass.async_add_executor_job(self.update_list)
-            self.async_write_ha_state()
+
+            # Entities are added with update_before_add, so the poll that
+            # started this fetch can run before the entity has an entity_id.
+            # The platform writes the state it collected once it adds us.
+            if self.entity_id:
+                self.async_write_ha_state()
 
     def update_list(self) -> None:
         """Update Game List, Correct data if different."""

--- a/tests/components/ps4/test_media_player.py
+++ b/tests/components/ps4/test_media_player.py
@@ -1,7 +1,7 @@
 """Tests for the PS4 media player platform."""
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from pyps4_2ndscreen.credential import get_ddp_message
 from pyps4_2ndscreen.ddp import DEFAULT_UDP_PORT
@@ -25,6 +25,7 @@ from homeassistant.components.ps4.const import (
     GAMES_FILE,
     PS4_DATA,
 )
+from homeassistant.components.ps4.media_player import PS4Device
 from homeassistant.const import (
     ATTR_COMMAND,
     ATTR_ENTITY_ID,
@@ -603,3 +604,40 @@ async def test_title_data_fetched_from_poll(
     assert mock_state.state == STATE_PLAYING
     assert mock_attrs.get(ATTR_MEDIA_TITLE) == MOCK_TITLE_NAME
     assert mock_attrs.get(ATTR_MEDIA_CONTENT_TYPE) == MOCK_TITLE_TYPE
+
+
+async def test_title_data_fetched_before_entity_added(
+    hass: HomeAssistant, patch_get_status: MagicMock
+) -> None:
+    """Test fetching title data before the entity is added does not raise.
+
+    Entities are added with update_before_add, so the first poll runs while the
+    entity has no entity_id yet, and the fetch it starts can finish before the
+    entity is added.
+    """
+    patch_get_status.return_value = MOCK_STATUS_PLAYING
+
+    mock_result = MagicMock()
+    mock_result.name = MOCK_TITLE_NAME
+    mock_result.cover_art = MOCK_TITLE_ART_URL
+    mock_result.game_type = "not_an_app"
+
+    mock_entry = MockConfigEntry(
+        domain=ps4.DOMAIN, data=MOCK_DATA, version=VERSION, entry_id=MOCK_ENTRY_ID
+    )
+    mock_entity = PS4Device(
+        mock_entry,
+        MOCK_NAME,
+        MOCK_HOST,
+        MOCK_REGION,
+        MagicMock(async_get_ps_store_data=AsyncMock(return_value=mock_result)),
+        MOCK_CREDS,
+    )
+    mock_entity.hass = hass
+    assert mock_entity.entity_id is None
+
+    await mock_entity.async_get_title_data(MOCK_TITLE_ID, MOCK_TITLE_NAME)
+
+    # The data is kept, the platform writes it out when the entity is added
+    assert mock_entity.media_title == MOCK_TITLE_NAME
+    assert mock_entity.media_content_type == MediaType.GAME


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Entities are added with `update_before_add=True`, so the first `async_update` runs while the entity still has no `entity_id`. That update parses the status in an executor thread, and for a running title it starts a detached task to fetch the title data from the PS store. The task finishes with `async_write_ha_state()`, which raises `NoEntitySpecifiedError` when it gets there before the platform has added the entity:

```
File "homeassistant/components/ps4/media_player.py", line 285, in async_get_title_data
    self.async_write_ha_state()
homeassistant.exceptions.NoEntitySpecifiedError: No entity id specified for entity ha_ps4_name
```

Which of the two wins is a race, so this shows up as a flaky test rather than a reliable failure. It was hit on a loaded CI runner on an unrelated pull request, in the test that came with #179884.

The write is skipped while the entity has no id. Nothing is lost by that: the title, source, image and content type are already stored on the entity at that point, and the platform writes them out when it adds the entity. A fetch that lands after the entity was added writes the state exactly as before.

The test builds the entity and calls the fetch on it without adding it to a platform, which turns the window into something deterministic rather than something to be raced. It fails on dev with the error above.

`status_callback` calls `schedule_update_ha_state()` from the same worker thread context and looks similarly exposed, but it is only reached through the protocol callback that gets subscribed during `async_update`, once the entity exists, so it is left alone here.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
