### PR TITLE
Retry Lutron setup on network errors instead of failing the entry

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -70,7 +70,10 @@ async def async_setup_entry(
     try:
         await hass.async_add_executor_job(lutron_client.load_xml_db)
         lutron_client.connect()
-    except LutronException as ex:
+    except (LutronException, OSError) as ex:
+        # load_xml_db() fetches DbXmlInfo.xml over HTTP with urllib, which raises
+        # URLError (an OSError) rather than a LutronException when the repeater is
+        # unreachable, still booting, or refusing connections.
         raise ConfigEntryNotReady(f"Failed to connect to Lutron repeater: {ex}") from ex
 
     _LOGGER.debug("Connected to main repeater at %s", host)

--- a/tests/components/lutron/test_init.py
+++ b/tests/components/lutron/test_init.py
@@ -2,6 +2,7 @@
 
 from typing import Any, cast
 from unittest.mock import MagicMock
+from urllib.error import URLError
 
 from pylutron import LutronException
 import pytest
@@ -52,16 +53,29 @@ async def test_unload_entry(
 
 
 @pytest.mark.parametrize("method", ["load_xml_db", "connect"])
+@pytest.mark.parametrize(
+    "error",
+    [
+        LutronException("boom"),
+        # load_xml_db() fetches DbXmlInfo.xml with urllib, so a repeater that is
+        # unreachable or still booting surfaces as URLError, not LutronException.
+        URLError(OSError(111, "Connection refused")),
+        OSError(113, "No route to host"),
+        TimeoutError("timed out"),
+    ],
+    ids=["lutron", "urlerror", "oserror", "timeout"],
+)
 async def test_setup_entry_not_ready(
     hass: HomeAssistant,
     mock_lutron: MagicMock,
     mock_config_entry: MockConfigEntry,
     method: str,
+    error: Exception,
 ) -> None:
-    """Test setting up the integration when Lutron repeater is not ready."""
+    """Test that transient failures retry setup rather than failing the entry."""
     mock_config_entry.add_to_hass(hass)
 
-    getattr(mock_lutron, method).side_effect = LutronException(f"{method} failed")
+    getattr(mock_lutron, method).side_effect = error
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change

`async_setup_entry` only mapped `LutronException` to `ConfigEntryNotReady`. But `load_xml_db()` fetches `DbXmlInfo.xml` over HTTP with `urllib`, which raises `urllib.error.URLError` — an `OSError`, not a `LutronException` — when the repeater is unreachable, still booting, or refusing connections:

```
ERROR (MainThread) [homeassistant.components.lutron] Error setting up entry Lutron for lutron
  File "/usr/src/homeassistant/homeassistant/components/lutron/__init__.py", line 71, in async_setup_entry
    await hass.async_add_executor_job(lutron_client.load_xml_db)
  File "/usr/local/lib/python3.14/site-packages/pylutron/__init__.py", line 612, in load_xml_db
    with urllib.request.urlopen(req, timeout=60) as xmlfile:
urllib.error.URLError: <urlopen error [Errno 111] Connection refused>
```

That left the entry in `setup_error` with no automatic retry, so a user who reloaded right after a network blip — or whose HA started while the repeater was still booting — was stuck until they reloaded by hand again.

Catching `OSError` alongside `LutronException` makes it a normal `ConfigEntryNotReady` retry. `OSError` covers `URLError`, `HTTPError` and `TimeoutError`, which are the realistic failures from that call.

Reported in #181995 (point 2).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration
- [ ] New feature
- [ ] Deprecation
- [ ] Breaking change
- [ ] Code quality improvement

## Additional information

- Fixes part of #181995

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The existing `test_setup_entry_not_ready` is now parametrized over the error type as well as the failing method, covering `LutronException`, `URLError`, a bare `OSError` and `TimeoutError`. Reverting the change fails exactly the six new cases and leaves the original `LutronException` ones passing.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
