### PR TITLE
Abort Teslemetry Bluetooth vehicle setup when no Bluetooth is available

### DIFF
--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -36,6 +36,7 @@ from homeassistant.components.application_credentials import (
 from homeassistant.components.bluetooth import (
     async_discovered_service_info,
     async_request_active_scan,
+    async_scanner_count,
 )
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
@@ -227,6 +228,8 @@ class VehicleSubentryFlowHandler(ConfigSubentryFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
         """Select an account vehicle to add over Bluetooth, then pair it."""
+        if not async_scanner_count(self.hass, connectable=True):
+            return self.async_abort(reason="bluetooth_not_available")
         entry = self._get_entry()
         if entry.state is not ConfigEntryState.LOADED:
             return self.async_abort(reason="entry_not_loaded")

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -89,6 +89,7 @@
     "vehicle": {
       "abort": {
         "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+        "bluetooth_not_available": "At least one Bluetooth adapter or remote Bluetooth proxy must be configured to add a vehicle over Bluetooth.",
         "entry_not_loaded": "The Teslemetry configuration entry is not loaded. Please ensure it is set up correctly before adding a vehicle.",
         "no_vehicles": "Every vehicle in your Teslemetry account has already been added over Bluetooth."
       },

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -796,6 +796,7 @@ async def _start_pairing_at_scan(
     return result
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_pairing_already_whitelisted(hass: HomeAssistant) -> None:
     """The add flow creates the subentry when the key is already whitelisted."""
     entry = await _setup_account_entry(hass)
@@ -828,6 +829,7 @@ async def test_subentry_pairing_already_whitelisted(hass: HomeAssistant) -> None
     vehicle.disconnect.assert_awaited_once()
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_pairing_duplicate_vin_aborts(hass: HomeAssistant) -> None:
     """A second flow racing on the same VIN aborts with already_configured."""
     entry = await _setup_account_entry(hass)
@@ -866,6 +868,7 @@ async def test_subentry_pairing_duplicate_vin_aborts(hass: HomeAssistant) -> Non
     assert len(entry.get_subentries_of_type(SUBENTRY_TYPE_VEHICLE)) == 1
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_pairing_requires_key_approval(hass: HomeAssistant) -> None:
     """Pairing walks through instructions and key install when not whitelisted."""
     entry = await _setup_account_entry(hass)
@@ -913,6 +916,7 @@ async def test_subentry_pairing_requires_key_approval(hass: HomeAssistant) -> No
     vehicle.pair.assert_awaited_once()
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_scan_connect_fails(hass: HomeAssistant) -> None:
     """The scan step re-shows the form with an error when BLE connect fails."""
     entry = await _setup_account_entry(hass)
@@ -951,6 +955,7 @@ async def test_subentry_scan_connect_fails(hass: HomeAssistant) -> None:
     ],
     ids=["timeout", "transport", "rejected"],
 )
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_authorize_failure(
     hass: HomeAssistant, error: type[TeslaFleetError], expected: str
 ) -> None:
@@ -998,6 +1003,7 @@ async def test_subentry_authorize_failure(
     vehicle.pair.assert_awaited_once()
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_authorize_unexpected_error_disconnects(
     hass: HomeAssistant,
 ) -> None:
@@ -1029,6 +1035,7 @@ async def test_subentry_authorize_unexpected_error_disconnects(
     assert not entry.get_subentries_of_type(SUBENTRY_TYPE_VEHICLE)
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_authorize_existing_key_finishes(hass: HomeAssistant) -> None:
     """Approving the key after a timeout, then retrying, completes the pairing."""
     entry = await _setup_account_entry(hass)
@@ -1103,6 +1110,7 @@ async def test_subentry_authorize_existing_key_finishes(hass: HomeAssistant) -> 
         pytest.param(TimeoutError(), id="timeout_error"),
     ],
 )
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_handshake_error_recovers(
     hass: HomeAssistant, handshake_error: Exception
 ) -> None:
@@ -1145,6 +1153,7 @@ async def test_subentry_handshake_error_recovers(
     assert vehicle.disconnect.await_count == 2
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_pairing_abandoned(hass: HomeAssistant) -> None:
     """Abandoning the flow mid-pairing cancels the pair task and disconnects."""
     entry = await _setup_account_entry(hass)
@@ -1188,6 +1197,7 @@ async def test_subentry_pairing_abandoned(hass: HomeAssistant) -> None:
     assert not entry.get_subentries_of_type(SUBENTRY_TYPE_VEHICLE)
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_scan_device_not_found(hass: HomeAssistant) -> None:
     """The scan step re-shows the form with an error when no device is found."""
     entry = await _setup_account_entry(hass)
@@ -1225,6 +1235,7 @@ async def test_subentry_scan_device_not_found(hass: HomeAssistant) -> None:
         ),
     ],
 )
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_scan_key_load_recovers(
     hass: HomeAssistant, key_error: Exception
 ) -> None:
@@ -1266,6 +1277,7 @@ async def test_subentry_scan_key_load_recovers(
     vehicle.connect.assert_awaited_once()
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_scan_finds_device_after_active_scan(
     hass: HomeAssistant,
 ) -> None:
@@ -1306,6 +1318,7 @@ async def test_subentry_scan_finds_device_after_active_scan(
     vehicle.connect.assert_awaited_once()
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_add_flow_keeps_device_on_parent(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -1408,6 +1421,7 @@ async def test_subentry_add_flow_keeps_device_on_parent(
     assert all(entity.config_subentry_id is None for entity in bound_entities)
 
 
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_add_flow_no_available_vehicles(hass: HomeAssistant) -> None:
     """The add flow aborts when every account vehicle is already added."""
     entry = await _setup_paired_entry(hass)
@@ -1421,6 +1435,20 @@ async def test_subentry_add_flow_no_available_vehicles(hass: HomeAssistant) -> N
     assert result["reason"] == "no_vehicles"
 
 
+async def test_subentry_add_flow_no_bluetooth(hass: HomeAssistant) -> None:
+    """The add flow aborts immediately when no Bluetooth integration is set up."""
+    entry = await _setup_account_entry(hass)
+
+    result = await hass.config_entries.subentries.async_init(
+        (entry.entry_id, SUBENTRY_TYPE_VEHICLE),
+        context={"source": "user"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "bluetooth_not_available"
+
+
+@pytest.mark.usefixtures("enable_bluetooth")
 async def test_subentry_add_flow_entry_not_loaded(hass: HomeAssistant) -> None:
     """The add flow aborts when the parent entry is not loaded."""
     entry = mock_config_entry()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Teslemetry vehicle Bluetooth subentry add flow scans for and connects to a vehicle over Bluetooth, which Home Assistant cannot do at all when no Bluetooth adapter or remote proxy is configured, so the flow now aborts immediately at its first step with a translated reason in that case instead of proceeding into steps that can never succeed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
