### PR TITLE
Type the zerproc domain data with HassKeys

### DIFF
--- a/homeassistant/components/zerproc/__init__.py
+++ b/homeassistant/components/zerproc/__init__.py
@@ -1,21 +1,18 @@
 """Zerproc lights integration."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .const import DATA_ADDRESSES, DATA_DISCOVERY_SUBSCRIPTION, DOMAIN
+from .const import DATA_ADDRESSES, DATA_DISCOVERY_SUBSCRIPTION
 
 PLATFORMS = [Platform.LIGHT]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Zerproc from a config entry."""
-    if DOMAIN not in hass.data:
-        hass.data[DOMAIN] = {}
-    if DATA_ADDRESSES not in hass.data[DOMAIN]:
-        hass.data[DOMAIN][DATA_ADDRESSES] = set()
+    if DATA_ADDRESSES not in hass.data:
+        hass.data[DATA_ADDRESSES] = set()
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -25,10 +22,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     # Stop discovery
-    unregister_discovery = hass.data[DOMAIN].pop(DATA_DISCOVERY_SUBSCRIPTION, None)
+    unregister_discovery = hass.data.pop(DATA_DISCOVERY_SUBSCRIPTION, None)
     if unregister_discovery:
         unregister_discovery()
 
-    hass.data.pop(DOMAIN, None)
+    hass.data.pop(DATA_ADDRESSES, None)
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/zerproc/const.py
+++ b/homeassistant/components/zerproc/const.py
@@ -1,6 +1,16 @@
 """Constants for the Zerproc integration."""
 
+from homeassistant.core import CALLBACK_TYPE
+from homeassistant.util.hass_dict import HassKey
+
 DOMAIN = "zerproc"
 
-DATA_ADDRESSES = "addresses"
-DATA_DISCOVERY_SUBSCRIPTION = "discovery_subscription"
+# Addresses of the lights discovered so far. Shared by every config entry so
+# that recurring discovery does not add the same light twice.
+DATA_ADDRESSES: HassKey[set[str]] = HassKey(f"{DOMAIN}_addresses")
+
+# Cancels the recurring discovery. Registered by the light platform and called
+# when the entry unloads.
+DATA_DISCOVERY_SUBSCRIPTION: HassKey[CALLBACK_TYPE] = HassKey(
+    f"{DOMAIN}_discovery_subscription"
+)

--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -1,5 +1,4 @@
 """Zerproc light platform."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 from datetime import timedelta
 import logging
@@ -34,14 +33,12 @@ async def discover_entities(hass: HomeAssistant) -> list[ZerprocLight]:
 
     # Filter out already discovered lights
     new_lights = [
-        light
-        for light in lights
-        if light.address not in hass.data[DOMAIN][DATA_ADDRESSES]
+        light for light in lights if light.address not in hass.data[DATA_ADDRESSES]
     ]
 
     entities = []
     for light in new_lights:
-        hass.data[DOMAIN][DATA_ADDRESSES].add(light.address)
+        hass.data[DATA_ADDRESSES].add(light.address)
         entities.append(ZerprocLight(light))
 
     return entities
@@ -71,7 +68,7 @@ async def async_setup_entry(
     hass.async_create_task(discover())
 
     # Perform recurring discovery of new devices
-    hass.data[DOMAIN][DATA_DISCOVERY_SUBSCRIPTION] = async_track_time_interval(
+    hass.data[DATA_DISCOVERY_SUBSCRIPTION] = async_track_time_interval(
         hass, discover, DISCOVERY_INTERVAL
     )
 

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -129,7 +129,7 @@ async def test_init(hass: HomeAssistant, mock_entry) -> None:
     assert mock_light_1.disconnect.called
     assert mock_light_2.disconnect.called
 
-    assert hass.data[DOMAIN]["addresses"] == {"AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66"}
+    assert hass.data[DATA_ADDRESSES] == {"AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66"}
 
 
 async def test_discovery_exception(hass: HomeAssistant, mock_entry) -> None:
@@ -145,19 +145,19 @@ async def test_discovery_exception(hass: HomeAssistant, mock_entry) -> None:
         await hass.async_block_till_done()
 
     # The exception should be captured and no entities should be added
-    assert len(hass.data[DOMAIN]["addresses"]) == 0
+    assert len(hass.data[DATA_ADDRESSES]) == 0
 
 
 async def test_remove_entry(hass: HomeAssistant, mock_light, mock_entry) -> None:
     """Test platform setup."""
-    assert hass.data[DOMAIN][DATA_ADDRESSES] == {"AA:BB:CC:DD:EE:FF"}
-    assert DATA_DISCOVERY_SUBSCRIPTION in hass.data[DOMAIN]
+    assert hass.data[DATA_ADDRESSES] == {"AA:BB:CC:DD:EE:FF"}
+    assert DATA_DISCOVERY_SUBSCRIPTION in hass.data
 
     with patch.object(mock_light, "disconnect") as mock_disconnect:
         await hass.config_entries.async_remove(mock_entry.entry_id)
 
     assert mock_disconnect.called
-    assert DOMAIN not in hass.data
+    assert DATA_ADDRESSES not in hass.data
 
 
 async def test_remove_entry_exceptions_caught(

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -158,6 +158,7 @@ async def test_remove_entry(hass: HomeAssistant, mock_light, mock_entry) -> None
 
     assert mock_disconnect.called
     assert DATA_ADDRESSES not in hass.data
+    assert DATA_DISCOVERY_SUBSCRIPTION not in hass.data
 
 
 async def test_remove_entry_exceptions_caught(


### PR DESCRIPTION
## Proposed change

Replaces `zerproc`'s untyped `hass.data[DOMAIN]` dict with typed `HassKey` entries, and removes the `# pylint: disable=home-assistant-use-runtime-data` marker from both modules.

`hass.data[DOMAIN]` held two unrelated values behind string keys. They are now two typed keys rather than one key wrapping a new dataclass, because their lifetimes genuinely differ: the address set is shared across every config entry and created at setup, while the discovery subscription is per-run and popped on unload. That matches the existing conversions — `meteo_france` maps one key to a bare `set`, `dlna_dms` maps one key to a class that already existed; neither introduced a dataclass.

`DOMAIN` is retained in `light.py`, where it is still used for the `DeviceInfo` identifiers, and dropped from `__init__.py` where it no longer has a use.

`entry.runtime_data` is not appropriate here: the discovered-address set is deliberately shared between config entries so that recurring discovery does not add the same light twice, and `runtime_data` is per-entry.

No behaviour change is intended.

The existing tests in `tests/components/zerproc/test_light.py` reached into `hass.data` directly and are updated to match. Note that one assertion used a bare `"addresses"` string literal while another used the constant, so both forms needed updating. No new tests were added — the change is behaviour-preserving and the existing assertions already cover both keys across setup, discovery failure, and entry removal.

Verified locally against `dev`:

- `pytest tests/components/zerproc` — 10 passed, identical to the unmodified tree (the 9 teardown errors are a translation-completeness check that fails on a fresh clone without generated translation artifacts, and are present before this change too)
- `ruff check` and `ruff format --check` — clean
- `pylint` — no `W7405`. Confirmed the check is actually live by removing the same marker from an unconverted integration, which reports `W7405` as expected
- `mypy homeassistant/components/zerproc` — no errors in `zerproc`

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
