### PR TITLE
Type the sql domain data with a HassKey

### DIFF
--- a/homeassistant/components/sql/const.py
+++ b/homeassistant/components/sql/const.py
@@ -1,10 +1,20 @@
 """Adds constants for SQL integration."""
 
 import re
+from typing import TYPE_CHECKING
 
 from homeassistant.const import Platform
+from homeassistant.util.hass_dict import HassKey
+
+if TYPE_CHECKING:
+    from .models import SQLData
 
 DOMAIN = "sql"
+
+# One SQLData holds the shared session makers and the shutdown listener for
+# every config entry, so it is shared rather than owned by any one entry.
+DOMAIN_DATA: HassKey[SQLData] = HassKey(DOMAIN)
+
 PLATFORMS = [Platform.SENSOR]
 
 CONF_COLUMN_NAME = "column"

--- a/homeassistant/components/sql/util.py
+++ b/homeassistant/components/sql/util.py
@@ -1,5 +1,4 @@
 """Utils for sql."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 from datetime import date
 from decimal import Decimal
@@ -22,7 +21,7 @@ from homeassistant.exceptions import HomeAssistantError, TemplateError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.template import Template
 
-from .const import DB_URL_RE, DOMAIN
+from .const import DB_URL_RE, DOMAIN, DOMAIN_DATA
 from .models import SQLData
 
 _LOGGER = logging.getLogger(__name__)
@@ -172,8 +171,7 @@ def validate_query(
 @callback
 def _async_get_or_init_domain_data(hass: HomeAssistant) -> SQLData:
     """Get or initialize domain data."""
-    if DOMAIN in hass.data:
-        sql_data: SQLData = hass.data[DOMAIN]
+    if (sql_data := hass.data.get(DOMAIN_DATA)) is not None:
         return sql_data
 
     session_makers_by_db_url: dict[str, scoped_session] = {}
@@ -194,8 +192,9 @@ def _async_get_or_init_domain_data(hass: HomeAssistant) -> SQLData:
         EVENT_HOMEASSISTANT_STOP, _shutdown_db_engines
     )
 
-    sql_data = SQLData(cancel_shutdown, session_makers_by_db_url)
-    hass.data[DOMAIN] = sql_data
+    sql_data = hass.data[DOMAIN_DATA] = SQLData(
+        cancel_shutdown, session_makers_by_db_url
+    )
     return sql_data
 
 


### PR DESCRIPTION
## Proposed change

Converts the `sql` integration's domain data to a typed `HassKey`, and removes the `# pylint: disable=home-assistant-use-runtime-data` marker from `util.py`.

`SQLData` already exists in `.models`, so this is a single `HassKey` wrapping an existing class rather than a new dataclass — the same shape as the `dlna_dms` conversion. `SQLData` is imported under `TYPE_CHECKING` in `const.py`, since `HassKey[SQLData]` only needs the type at check time and `config_flow.py` imports `const`; a runtime import would pull sqlalchemy into that path unnecessarily.

`entry.runtime_data` is not appropriate here: one `SQLData` holds the session makers shared across every config entry plus a single shutdown listener, so it is deliberately not per-entry.

No behaviour change is intended. The existing tests do not reach into `hass.data`, so none needed updating.

Verified locally against `dev`:

- `ruff check` and `ruff format --check` — clean
- `pylint` — no `W7405`. Confirmed the check is actually live by reintroducing the legacy pattern and seeing it fire
- `mypy homeassistant/components/sql` — no errors in the integration
- `pytest tests/components/sql` — identical to the unmodified tree

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
