### PR TITLE
Retry Lutron setup on network errors instead of failing the entry

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -70,7 +70,10 @@ async def async_setup_entry(
     try:
         await hass.async_add_executor_job(lutron_client.load_xml_db)
         lutron_client.connect()
-    except LutronException as ex:
+    except (LutronException, OSError) as ex:
+        # load_xml_db() fetches the XML database with urllib, and connect() re-raises
+        # whatever the reader thread caught, so an unreachable repeater surfaces as
+        # OSError rather than LutronException.
         raise ConfigEntryNotReady(f"Failed to connect to Lutron repeater: {ex}") from ex
 
     _LOGGER.debug("Connected to main repeater at %s", host)

--- a/tests/components/lutron/test_init.py
+++ b/tests/components/lutron/test_init.py
@@ -79,12 +79,7 @@ async def test_setup_entry_not_ready(
     method: str,
     error: Exception,
 ) -> None:
-    """Test that a transient network failure retries setup instead of failing it.
-
-    load_xml_db() fetches the XML database with urllib and connect() re-raises what
-    the reader thread caught, so an unreachable or still-booting repeater raises
-    OSError rather than LutronException. Both must land in SETUP_RETRY.
-    """
+    """Test that transient connection failures retry setup."""
     mock_config_entry.add_to_hass(hass)
 
     getattr(mock_lutron, method).side_effect = error

--- a/tests/components/lutron/test_init.py
+++ b/tests/components/lutron/test_init.py
@@ -2,6 +2,7 @@
 
 from typing import Any, cast
 from unittest.mock import MagicMock
+from urllib.error import URLError
 
 from pylutron import LutronException
 import pytest
@@ -51,17 +52,42 @@ async def test_unload_entry(
     await hass.async_block_till_done()
 
 
-@pytest.mark.parametrize("method", ["load_xml_db", "connect"])
+@pytest.mark.parametrize(
+    ("method", "error"),
+    [
+        pytest.param(
+            "load_xml_db",
+            LutronException("load_xml_db failed"),
+            id="load_xml_db_lutron",
+        ),
+        pytest.param(
+            "load_xml_db",
+            URLError(OSError(111, "Connection refused")),
+            id="load_xml_db_urlerror",
+        ),
+        pytest.param(
+            "load_xml_db", TimeoutError("timed out"), id="load_xml_db_timeout"
+        ),
+        pytest.param("connect", LutronException("connect failed"), id="connect_lutron"),
+        pytest.param("connect", OSError(113, "No route to host"), id="connect_oserror"),
+    ],
+)
 async def test_setup_entry_not_ready(
     hass: HomeAssistant,
     mock_lutron: MagicMock,
     mock_config_entry: MockConfigEntry,
     method: str,
+    error: Exception,
 ) -> None:
-    """Test setting up the integration when Lutron repeater is not ready."""
+    """Test that a transient network failure retries setup instead of failing it.
+
+    load_xml_db() fetches the XML database with urllib and connect() re-raises what
+    the reader thread caught, so an unreachable or still-booting repeater raises
+    OSError rather than LutronException. Both must land in SETUP_RETRY.
+    """
     mock_config_entry.add_to_hass(hass)
 
-    getattr(mock_lutron, method).side_effect = LutronException(f"{method} failed")
+    getattr(mock_lutron, method).side_effect = error
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`async_setup_entry` only mapped `LutronException` to `ConfigEntryNotReady`, but neither
call in that `try` block is limited to `LutronException`:

- `load_xml_db()` fetches `DbXmlInfo.xml` over HTTP with `urllib`, so an unreachable or
  still-booting repeater raises `urllib.error.URLError` — an `OSError`, not a
  `LutronException`.
- `connect()` re-raises whatever the reader thread stored, which is a plain `OSError` for
  a failed TCP connect (`OSError: [Errno 113] Connect call failed` in the reporter's log).

Either one left the entry in `setup_error` with no automatic retry, so a user reloading
right after a network blip — or Home Assistant starting while the repeater is still
booting — was stuck until they reloaded by hand.

Catching `OSError` as well turns both into a normal `ConfigEntryNotReady` retry. `OSError`
covers `URLError`, `HTTPError` and `TimeoutError`.

`test_setup_entry_not_ready` is extended to cover each realistic failure: `load_xml_db`
raising `LutronException` / `URLError` / `TimeoutError`, and `connect` raising
`LutronException` / `OSError`. Reverting the source change fails exactly the three
`OSError` cases and leaves the two `LutronException` cases passing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #181995 (point 2)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
