### PR TITLE
Make Nest climate turn_on idempotent

### DIFF
--- a/homeassistant/components/nest/climate.py
+++ b/homeassistant/components/nest/climate.py
@@ -298,6 +298,13 @@ class ThermostatEntity(ClimateEntity):
             ) from err
 
     @override
+    async def async_turn_on(self) -> None:
+        """Turn the entity on."""
+        if self.hvac_mode != HVACMode.OFF:
+            return
+        await super().async_turn_on()
+
+    @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         hvac_mode = self.hvac_mode

--- a/tests/components/nest/test_climate.py
+++ b/tests/components/nest/test_climate.py
@@ -23,17 +23,20 @@ from homeassistant.components.climate import (
     ATTR_PRESET_MODES,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
+    DOMAIN as CLIMATE_DOMAIN,
     FAN_LOW,
     FAN_OFF,
     FAN_ON,
     PRESET_ECO,
     PRESET_NONE,
     PRESET_SLEEP,
+    SERVICE_TURN_ON,
     ClimateEntityFeature,
     HVACAction,
     HVACMode,
 )
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
     STATE_UNAVAILABLE,
@@ -499,6 +502,88 @@ async def test_thermostat_set_hvac_mode(
     assert thermostat is not None
     assert thermostat.state == HVACMode.HEAT
     assert thermostat.attributes[ATTR_HVAC_ACTION] == HVACAction.HEATING
+
+
+@pytest.mark.parametrize(
+    ("sdm_mode", "expected_mode"),
+    [
+        ("COOL", HVACMode.COOL),
+        ("HEAT", HVACMode.HEAT),
+        ("HEATCOOL", HVACMode.HEAT_COOL),
+    ],
+)
+async def test_thermostat_turn_on_already_on(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    auth: FakeAuth,
+    create_device: CreateDevice,
+    sdm_mode: str,
+    expected_mode: HVACMode,
+) -> None:
+    """Test calling turn_on on a thermostat that is already running."""
+    create_device.create(
+        {
+            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
+                "mode": sdm_mode,
+            },
+        }
+    )
+    await setup_platform()
+
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.state == expected_mode
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "climate.my_thermostat"},
+        blocking=True,
+    )
+
+    assert auth.method is None
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.state == expected_mode
+
+
+async def test_thermostat_turn_on_from_off(
+    hass: HomeAssistant,
+    setup_platform: PlatformSetup,
+    auth: FakeAuth,
+    create_device: CreateDevice,
+) -> None:
+    """Test calling turn_on on a thermostat that is off."""
+    create_device.create(
+        {
+            "sdm.devices.traits.ThermostatHvac": {"status": "OFF"},
+            "sdm.devices.traits.ThermostatMode": {
+                "availableModes": ["HEAT", "COOL", "HEATCOOL", "OFF"],
+                "mode": "OFF",
+            },
+        }
+    )
+    await setup_platform()
+
+    thermostat = hass.states.get("climate.my_thermostat")
+    assert thermostat is not None
+    assert thermostat.state == HVACMode.OFF
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "climate.my_thermostat"},
+        blocking=True,
+    )
+
+    assert auth.method == "post"
+    assert auth.url == DEVICE_COMMAND
+    assert auth.json == {
+        "command": "sdm.devices.commands.ThermostatMode.SetMode",
+        "params": {"mode": "HEATCOOL"},
+    }
 
 
 async def test_thermostat_invalid_hvac_mode(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Make `ThermostatEntity.async_turn_on` in the Nest integration idempotent by returning early if the thermostat is already in an active HVAC mode (`self.hvac_mode != HVACMode.OFF`).

Reported in #181904, controlling a Nest thermostat via Alexa resulted in temperature voice commands (*"Alexa, set the temperature to 77"*) flipping the thermostat from `cool` mode to `heat_cool` mode, causing the setpoint to be dropped.

The trace revealed the following sequence:
```text
22:41:33.648 request[post json]={'command': 'sdm.devices.commands.ThermostatMode.SetMode', 'params': {'mode': 'HEATCOOL'}}
22:41:33.761 [homeassistant.components.climate] Check valid temperature 25 C (77 F) in range 10 C - 32 C
22:41:33.761 request[post json]={'command': 'sdm.devices.commands.ThermostatTemperatureSetpoint.SetCool', 'params': {'coolCelsius': 25.0}}
```

1. Nest advertises `ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF` based on available modes, which maps to `Alexa.PowerController` in the `alexa` integration.
2. In Alexa's smart home directive pipeline, temperature adjustments trigger an automatic `Alexa.PowerController.TurnOn` directive ~100ms before `SetTargetTemperature`.
3. `alexa` dispatches `climate.turn_on`. Because `ThermostatEntity` did not implement `async_turn_on`, it fell back to `ClimateEntity.async_turn_on`.
4. The fallback `# Fake turn on` logic selects the first supported mode in `(HEAT_COOL, HEAT, COOL)`. Since Nest thermostats support `HEAT_COOL`, it selected `HEAT_COOL` and sent `ThermostatMode.SetMode` to the Google SDM API.
5. 113ms later, the second directive arrived with a single setpoint (`SetCool` at 25°C). Because the thermostat had just transitioned to `HEATCOOL` mode (which requires a dual setpoint range), the Google SDM API rejected `SetCool`.

### The Solution
Nest is a push-based integration (`_attr_should_poll = False`) with real-time state updates via Google Cloud Pub/Sub. Implementing `async_turn_on` directly in `ThermostatEntity` to no-op when already active (`self.hvac_mode != HVACMode.OFF`) prevents unnecessary mode changes and API calls, allowing subsequent setpoint adjustments to succeed cleanly while preserving the fallback behavior when turning on from `OFF`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #181904
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
