### PR TITLE
Unifi/reconfiguration

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -31,7 +31,7 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import SectionConfig, section
+from homeassistant.data_entry_flow import AbortFlow, SectionConfig, section
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.typing import DiscoveryInfoType
@@ -113,15 +113,15 @@ class UnifiFlowHandler(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "service_unavailable"
 
             else:
-                if (
-                    self.source == SOURCE_REAUTH
-                    and (
+                if self.source == SOURCE_REAUTH:
+                    if (
                         (reauth_unique_id := self._get_reauth_entry().unique_id)
                         is not None
-                    )
-                    and reauth_unique_id in self.sites
-                ):
-                    return await self.async_step_site({CONF_SITE_ID: reauth_unique_id})
+                    ) and reauth_unique_id in self.sites:
+                        return await self.async_step_site(
+                            {CONF_SITE_ID: reauth_unique_id}
+                        )
+                    raise AbortFlow("unknown_site_id")
 
                 return await self.async_step_site()
 

--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -19,7 +19,6 @@ import voluptuous as vol
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
     ConfigEntry,
-    ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
     OptionsFlow,
@@ -132,20 +131,8 @@ class UnifiFlowHandler(ConfigFlow, domain=DOMAIN):
             unique_id = user_input[CONF_SITE_ID]
             self.config[CONF_SITE_ID] = self.sites[unique_id].name
 
-            config_entry = await self.async_set_unique_id(unique_id)
-            abort_reason = "configuration_updated"
-
-            if config_entry:
-                if (
-                    config_entry.state is ConfigEntryState.LOADED
-                    and (hub := config_entry.runtime_data)
-                    and hub.available
-                ):
-                    return self.async_abort(reason="already_configured")
-
-                return self.async_update_and_abort(
-                    config_entry, data=self.config, reason=abort_reason
-                )
+            await self.async_set_unique_id(unique_id)
+            self._abort_if_unique_id_configured()
 
             site_nice_name = self.sites[unique_id].description
             return self.async_create_entry(title=site_nice_name, data=self.config)

--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -6,7 +6,8 @@ Reauthentication when issue with credentials are reported.
 Configuration of options through options flow.
 """
 
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 import operator
 import socket
 from types import MappingProxyType
@@ -17,6 +18,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
+    ConfigEntry,
     ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
@@ -89,40 +91,13 @@ class UnifiFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle a flow initialized by the user."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            self.config = {
-                CONF_HOST: user_input[CONF_HOST],
-                CONF_USERNAME: user_input[CONF_USERNAME],
-                CONF_PASSWORD: user_input[CONF_PASSWORD],
-                CONF_PORT: user_input.get(CONF_PORT),
-                CONF_VERIFY_SSL: user_input.get(CONF_VERIFY_SSL),
-                CONF_SITE_ID: DEFAULT_SITE_ID,
-            }
+            self.config = _config_from_input(user_input)
 
-            try:
-                hub = await get_unifi_api(self.hass, MappingProxyType(self.config))
-                await hub.sites.update()
-                self.sites = hub.sites
-
-            except AuthenticationRequired:
-                errors["base"] = "faulty_credentials"
-
-            except CannotConnect:
-                errors["base"] = "service_unavailable"
-
-            else:
-                if self.source == SOURCE_REAUTH:
-                    if (
-                        (reauth_unique_id := self._get_reauth_entry().unique_id)
-                        is not None
-                    ) and reauth_unique_id in self.sites:
-                        return await self.async_step_site(
-                            {CONF_SITE_ID: reauth_unique_id}
-                        )
-                    raise AbortFlow("unknown_site_id")
-
+            with _catch_unifi_api_flow_errors(errors):
+                self.sites = await self._async_update_sites(self.config)
                 return await self.async_step_site()
 
         if not (host := self.config.get(CONF_HOST, "")) and await _async_discover_unifi(
@@ -130,7 +105,7 @@ class UnifiFlowHandler(ConfigFlow, domain=DOMAIN):
         ):
             host = "unifi"
 
-        data = self.reauth_schema or {
+        data = {
             vol.Required(CONF_HOST, default=host): str,
             vol.Required(CONF_USERNAME): str,
             vol.Required(CONF_PASSWORD): str,
@@ -159,10 +134,6 @@ class UnifiFlowHandler(ConfigFlow, domain=DOMAIN):
 
             config_entry = await self.async_set_unique_id(unique_id)
             abort_reason = "configuration_updated"
-
-            if self.source == SOURCE_REAUTH:
-                config_entry = self._get_reauth_entry()
-                abort_reason = "reauth_successful"
 
             if config_entry:
                 if (
@@ -193,23 +164,49 @@ class UnifiFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Trigger a reauthentication flow."""
         reauth_entry = self._get_reauth_entry()
-
         self.context["title_placeholders"] = {
             CONF_HOST: reauth_entry.data[CONF_HOST],
             CONF_NAME: reauth_entry.title,
         }
 
-        self.reauth_schema = {
-            vol.Required(CONF_HOST, default=reauth_entry.data[CONF_HOST]): str,
-            vol.Required(CONF_USERNAME, default=reauth_entry.data[CONF_USERNAME]): str,
+        return await self.async_step_reconfigure()
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a reconfiguration flow."""
+        config_entry = self._get_reauth_or_reconfigure_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            config_data = _config_from_input(user_input)
+
+            with _catch_unifi_api_flow_errors(errors):
+                sites = await self._async_update_sites(config_data)
+
+                if (
+                    (unique_id := config_entry.unique_id) is not None
+                ) and unique_id in sites:
+                    config_data[CONF_SITE_ID] = sites[unique_id].name
+                    return self.async_update_reload_and_abort(
+                        config_entry, data_updates=config_data
+                    )
+                raise AbortFlow("unknown_site_id")
+
+        schema = {
+            vol.Required(CONF_HOST, default=config_entry.data[CONF_HOST]): str,
+            vol.Required(CONF_USERNAME, default=config_entry.data[CONF_USERNAME]): str,
             vol.Required(CONF_PASSWORD): str,
-            vol.Required(CONF_PORT, default=reauth_entry.data[CONF_PORT]): int,
+            vol.Required(CONF_PORT, default=config_entry.data[CONF_PORT]): int,
             vol.Required(
-                CONF_VERIFY_SSL, default=reauth_entry.data[CONF_VERIFY_SSL]
+                CONF_VERIFY_SSL, default=config_entry.data[CONF_VERIFY_SSL]
             ): bool,
         }
-
-        return await self.async_step_user()
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(schema),
+            errors=errors,
+        )
 
     @override
     async def async_step_integration_discovery(
@@ -254,6 +251,19 @@ class UnifiFlowHandler(ConfigFlow, domain=DOMAIN):
         self.context["configuration_url"] = f"https://{host}"
 
         return await self.async_step_user()
+
+    async def _async_update_sites(self, data: Mapping[str, Any]) -> Sites:
+        """Get updated sites through UniFi API."""
+        hub = await get_unifi_api(self.hass, MappingProxyType(data))
+        await hub.sites.update()
+        return hub.sites
+
+    @callback
+    def _get_reauth_or_reconfigure_entry(self) -> ConfigEntry:
+        """Return the config entry the current flow is modifying."""
+        if self.source == SOURCE_REAUTH:
+            return self._get_reauth_entry()
+        return self._get_reconfigure_entry()
 
 
 class UnifiOptionsFlowHandler(OptionsFlow):
@@ -403,3 +413,26 @@ async def _async_discover_unifi(hass: HomeAssistant) -> str | None:
         return await hass.async_add_executor_job(socket.gethostbyname, "unifi")
     except socket.gaierror:
         return None
+
+
+def _config_from_input(user_input: dict[str, Any]) -> dict[str, Any]:
+    """Build config entry data from user input."""
+    return {
+        CONF_HOST: user_input[CONF_HOST],
+        CONF_USERNAME: user_input[CONF_USERNAME],
+        CONF_PASSWORD: user_input[CONF_PASSWORD],
+        CONF_PORT: user_input.get(CONF_PORT),
+        CONF_VERIFY_SSL: user_input.get(CONF_VERIFY_SSL),
+        CONF_SITE_ID: DEFAULT_SITE_ID,
+    }
+
+
+@contextmanager
+def _catch_unifi_api_flow_errors(errors: dict[str, str]) -> Iterator[None]:
+    """Map UniFi API exceptions to config flow form errors."""
+    try:
+        yield
+    except AuthenticationRequired:
+        errors["base"] = "faulty_credentials"
+    except CannotConnect:
+        errors["base"] = "service_unavailable"

--- a/homeassistant/components/unifi/quality_scale.yaml
+++ b/homeassistant/components/unifi/quality_scale.yaml
@@ -58,12 +58,7 @@ rules:
   entity-translations: done
   exception-translations: todo
   icon-translations: done
-  reconfiguration-flow:
-    status: todo
-    comment: |
-      The user flow currently allows updating existing config entry data
-      (host/credentials), which should be handled by a dedicated
-      async_step_reconfigure instead.
+  reconfiguration-flow: done
   repair-issues: todo
   stale-devices:
     status: todo

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -4,7 +4,8 @@
       "already_configured": "UniFi Network site is already configured",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "configuration_updated": "Configuration updated",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "unknown_site_id": "Previously configured UniFi Network site can no longer be found"
     },
     "error": {
       "faulty_credentials": "[%key:common::config_flow::error::invalid_auth%]",

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -5,6 +5,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "configuration_updated": "Configuration updated",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "unknown_site_id": "Previously configured UniFi Network site can no longer be found"
     },
     "error": {
@@ -14,6 +15,24 @@
     },
     "flow_title": "{name} ({host})",
     "step": {
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "site": "[%key:component::unifi::config::step::user::data::site%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+        },
+        "data_description": {
+          "host": "[%key:component::unifi::config::step::user::data_description::host%]",
+          "password": "[%key:component::unifi::config::step::user::data_description::password%]",
+          "port": "[%key:component::unifi::config::step::user::data_description::port%]",
+          "username": "[%key:component::unifi::config::step::user::data_description::username%]",
+          "verify_ssl": "[%key:component::unifi::config::step::user::data_description::verify_ssl%]"
+        },
+        "title": "[%key:component::unifi::config::step::user::title%]"
+      },
       "site": {
         "data": {
           "site": "Site ID"

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -386,6 +386,41 @@ async def test_reauth_flow_update_configuration_on_not_loaded_entry(
     assert config_entry.data[CONF_PASSWORD] == "new_pass"
 
 
+@pytest.mark.parametrize(
+    "site_payload",
+    [
+        [
+            {"name": "site2", "role": "admin", "desc": "site2 name", "_id": "2"},
+        ]
+    ],
+)
+async def test_abort_reauth_flow_on_site_id_mismatch(
+    hass: HomeAssistant, config_entry_setup: MockConfigEntry
+) -> None:
+    """Verify reauth flow aborts when original site can no longer be found."""
+    config_entry = config_entry_setup
+
+    result = await config_entry.start_reauth_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_HOST: "1.2.3.4",
+            CONF_USERNAME: "new_name",
+            CONF_PASSWORD: "new_pass",
+            CONF_PORT: 1234,
+            CONF_VERIFY_SSL: True,
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unknown_site_id"
+    assert config_entry.data[CONF_SITE_ID] == "site_id"
+
+
 @pytest.mark.parametrize("client_payload", [CLIENTS])
 @pytest.mark.parametrize("device_payload", [DEVICES])
 @pytest.mark.parametrize("wlan_payload", [WLANS])

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -229,7 +229,8 @@ async def test_flow_aborts_configuration_updated(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
 
     with patch("homeassistant.components.unifi.async_setup_entry") and patch(
-        "homeassistant.components.unifi.UnifiHub.available", new_callable=PropertyMock
+        "homeassistant.components.unifi.UnifiHub.available",
+        new_callable=PropertyMock,
     ) as ws_mock:
         ws_mock.return_value = False
         result = await hass.config_entries.flow.async_configure(
@@ -319,7 +320,7 @@ async def test_reauth_flow_update_configuration(
     result = await config_entry.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "reconfigure"
 
     context = next(
         flow["context"]
@@ -366,7 +367,7 @@ async def test_reauth_flow_update_configuration_on_not_loaded_entry(
     result = await config_entry.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "reconfigure"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -403,7 +404,108 @@ async def test_abort_reauth_flow_on_site_id_mismatch(
     result = await config_entry.start_reauth_flow(hass)
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_HOST: "1.2.3.4",
+            CONF_USERNAME: "new_name",
+            CONF_PASSWORD: "new_pass",
+            CONF_PORT: 1234,
+            CONF_VERIFY_SSL: True,
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unknown_site_id"
+    assert config_entry.data[CONF_SITE_ID] == "site_id"
+
+
+async def test_reconfigure_flow_update_configuration(
+    hass: HomeAssistant, config_entry_setup: MockConfigEntry
+) -> None:
+    """Verify reconfigure flow can update hub configuration."""
+    config_entry = config_entry_setup
+
+    result = await config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    with patch(
+        "homeassistant.components.unifi.UnifiHub.available", new_callable=PropertyMock
+    ) as ws_mock:
+        ws_mock.return_value = False
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_HOST: "1.2.3.4",
+                CONF_USERNAME: "new_name",
+                CONF_PASSWORD: "new_pass",
+                CONF_PORT: 1234,
+                CONF_VERIFY_SSL: True,
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data[CONF_HOST] == "1.2.3.4"
+    assert config_entry.data[CONF_USERNAME] == "new_name"
+    assert config_entry.data[CONF_PASSWORD] == "new_pass"
+
+
+async def test_reconfigure_flow_update_configuration_on_not_loaded_entry(
+    hass: HomeAssistant, config_entry_factory: ConfigEntryFactoryType
+) -> None:
+    """Verify reconfigure flow can update hub configuration on a not loaded entry."""
+    with patch(
+        "homeassistant.components.unifi.get_unifi_api",
+        side_effect=CannotConnect,
+    ):
+        config_entry = await config_entry_factory()
+
+    result = await config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_HOST: "1.2.3.4",
+            CONF_USERNAME: "new_name",
+            CONF_PASSWORD: "new_pass",
+            CONF_PORT: 1234,
+            CONF_VERIFY_SSL: True,
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert config_entry.data[CONF_HOST] == "1.2.3.4"
+    assert config_entry.data[CONF_USERNAME] == "new_name"
+    assert config_entry.data[CONF_PASSWORD] == "new_pass"
+
+
+@pytest.mark.parametrize(
+    "site_payload",
+    [
+        [
+            {"name": "site2", "role": "admin", "desc": "site2 name", "_id": "2"},
+        ]
+    ],
+)
+async def test_abort_reconfigure_flow_on_site_id_mismatch(
+    hass: HomeAssistant, config_entry_setup: MockConfigEntry
+) -> None:
+    """Verify reconfigure flow aborts when original site can no longer be found."""
+    config_entry = config_entry_setup
+
+    result = await config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -2,7 +2,7 @@
 
 import socket
 from typing import Any
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -36,8 +36,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.device_registry import format_mac
-
-from .conftest import ConfigEntryFactoryType
 
 from tests.common import MockConfigEntry
 
@@ -218,36 +216,6 @@ async def test_flow_raise_already_configured(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
-@pytest.mark.usefixtures("config_entry_setup")
-async def test_flow_aborts_configuration_updated(hass: HomeAssistant) -> None:
-    """Test config flow aborts since a connected config entry already exists."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-
-    with patch("homeassistant.components.unifi.async_setup_entry") and patch(
-        "homeassistant.components.unifi.UnifiHub.available",
-        new_callable=PropertyMock,
-    ) as ws_mock:
-        ws_mock.return_value = False
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_HOST: "1.2.3.4",
-                CONF_USERNAME: "username",
-                CONF_PASSWORD: "password",
-                CONF_PORT: 12345,
-                CONF_VERIFY_SSL: True,
-            },
-        )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "configuration_updated"
-
-
 @pytest.mark.parametrize(
     ("side_effect", "error"),
     [
@@ -332,43 +300,6 @@ async def test_reauth_flow_update_configuration(
         "name": config_entry.title,
     }
 
-    with patch(
-        "homeassistant.components.unifi.UnifiHub.available", new_callable=PropertyMock
-    ) as ws_mock:
-        ws_mock.return_value = False
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_HOST: "1.2.3.4",
-                CONF_USERNAME: "new_name",
-                CONF_PASSWORD: "new_pass",
-                CONF_PORT: 1234,
-                CONF_VERIFY_SSL: True,
-            },
-        )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reauth_successful"
-    assert config_entry.data[CONF_HOST] == "1.2.3.4"
-    assert config_entry.data[CONF_USERNAME] == "new_name"
-    assert config_entry.data[CONF_PASSWORD] == "new_pass"
-
-
-async def test_reauth_flow_update_configuration_on_not_loaded_entry(
-    hass: HomeAssistant, config_entry_factory: ConfigEntryFactoryType
-) -> None:
-    """Verify reauth flow can update hub configuration on a not loaded entry."""
-    with patch(
-        "homeassistant.components.unifi.get_unifi_api",
-        side_effect=CannotConnect,
-    ):
-        config_entry = await config_entry_factory()
-
-    result = await config_entry.start_reauth_flow(hass)
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure"
-
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
@@ -427,43 +358,6 @@ async def test_reconfigure_flow_update_configuration(
 ) -> None:
     """Verify reconfigure flow can update hub configuration."""
     config_entry = config_entry_setup
-
-    result = await config_entry.start_reconfigure_flow(hass)
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "reconfigure"
-
-    with patch(
-        "homeassistant.components.unifi.UnifiHub.available", new_callable=PropertyMock
-    ) as ws_mock:
-        ws_mock.return_value = False
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_HOST: "1.2.3.4",
-                CONF_USERNAME: "new_name",
-                CONF_PASSWORD: "new_pass",
-                CONF_PORT: 1234,
-                CONF_VERIFY_SSL: True,
-            },
-        )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "reconfigure_successful"
-    assert config_entry.data[CONF_HOST] == "1.2.3.4"
-    assert config_entry.data[CONF_USERNAME] == "new_name"
-    assert config_entry.data[CONF_PASSWORD] == "new_pass"
-
-
-async def test_reconfigure_flow_update_configuration_on_not_loaded_entry(
-    hass: HomeAssistant, config_entry_factory: ConfigEntryFactoryType
-) -> None:
-    """Verify reconfigure flow can update hub configuration on a not loaded entry."""
-    with patch(
-        "homeassistant.components.unifi.get_unifi_api",
-        side_effect=CannotConnect,
-    ):
-        config_entry = await config_entry_factory()
 
     result = await config_entry.start_reconfigure_flow(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The UniFi integration can no longer be reconfigured by adding the site again through the _Add integration_ flow. Instead, the integration can be reconfigured using the dedicated reconfiguration flow.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The changes in this PR allow users to reconfigure their UniFi integration when it's already added, through a dedicated [reconfiguration flow](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/reconfiguration-flow/). Previously this was theoretically achievable by adding the site again through the initial configuration flow, which is now no longer permitted as it's considered a duplicate entry. I'm considering that a breaking change as I'm assuming some users were aware of this and depended on it.

The PR restructures the `UnifiFlowHandler` to reduce some duplication and hopefully make it a bit easier to maintain. The reauthentication flow essentially reuses the reconfiguration flow. Neither go into the site configuration as it should not be possible to pick a different site through either flow. This also allows the site step to simply reject duplicate entries.

Happy to address any feedback.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: [Issue #3479](https://github.com/orgs/home-assistant/discussions/3479)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
